### PR TITLE
Fix DC_MSG_GIF case

### DIFF
--- a/src/renderer/chatview.js
+++ b/src/renderer/chatview.js
@@ -72,7 +72,8 @@ class Message extends React.Component {
   render () {
     const {message} = this.props
     switch (message.msg.type) {
-      case CONSTANTS.DC_MSG_IMAGE || CONSTANTS.DC_MSG_GIF:
+      case CONSTANTS.DC_MSG_IMAGE:
+      case CONSTANTS.DC_MSG_GIF:
         return (<div key={message.id}> <img src={message.msg.file} /></div>)
       default:
         return (<div key={message.id}> {message.msg.text} </div>)


### PR DESCRIPTION
Compare with:


```js
const C = require('deltachat-node/constants')

function test (type) {
  switch (type) {
    case C.DC_MSG_IMAGE || C.DC_MSG_GIF:
      console.log(type + ' is an image')
      break
    default:
      console.log(type + ' not an image')
  }
}

function test2 (type) {
  switch (type) {
    case C.DC_MSG_IMAGE:
    case C.DC_MSG_GIF:
      console.log(type + ' is an image')
      break
    default:
      console.log(type + ' not an image')
  }
}

test(C.DC_MSG_IMAGE)
test(C.DC_MSG_GIF)
test2(C.DC_MSG_IMAGE)
test2(C.DC_MSG_GIF)
```

```
20 is an image
21 not an image
20 is an image
21 is an image
```