### PR TITLE
Fix shell.openExternal()

### DIFF
--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -151,15 +151,13 @@ function getMenuTemplate () {
         {
           label: 'Learn more about ' + config.APP_NAME,
           click: () => {
-            const shell = require('./shell')
-            shell.openExternal(config.HOME_PAGE_URL)
+            electron.shell.openExternal(config.HOME_PAGE_URL)
           }
         },
         {
           label: 'Contribute on GitHub',
           click: () => {
-            const shell = require('./shell')
-            shell.openExternal(config.GITHUB_URL)
+            electron.shell.openExternal(config.GITHUB_URL)
           }
         },
         {
@@ -168,8 +166,7 @@ function getMenuTemplate () {
         {
           label: 'Report an Issue...',
           click: () => {
-            const shell = require('./shell')
-            shell.openExternal(config.GITHUB_URL_ISSUES)
+            electron.shell.openExternal(config.GITHUB_URL_ISSUES)
           }
         }
       ]


### PR DESCRIPTION
Fixes:

```
{ Error: Cannot find module './shell'
    at Module._resolveFilename (module.js:543:15)
    at Function.Module._resolveFilename (/home/lms/src/deltachat/deltachat-desktop/node_modules/electron/dist/resources/electron.asar/common/reset-search-paths.js:35:12)
    at Function.Module._load (module.js:473:25)
    at Module.require (module.js:586:17)
    at require (internal/module.js:11:18)
    at click (/home/lms/src/deltachat/deltachat-desktop/es5/main/menu.js:154:25)
    at MenuItem.click (/home/lms/src/deltachat/deltachat-desktop/node_modules/electron/dist/resources/electron.asar/browser/api/menu-item.js:55:9)
    at Function.executeCommand (/home/lms/src/deltachat/deltachat-desktop/node_modules/electron/dist/resources/electron.asar/browser/api/menu.js:29:13) code: 'MODULE_NOT_FOUND' }
```