### PR TITLE
Tweak login page + fix this._render is not a function

### DIFF
--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -85,7 +85,7 @@ class DeltaChatController {
     this.dc = null
     this.configuring = false
     this.ready = false
-    this._render()
+    if (typeof this._render === 'function') this._render()
   }
 
   init (credentials, render) {

--- a/src/renderer/components/Login.js
+++ b/src/renderer/components/Login.js
@@ -40,7 +40,7 @@ class Login extends React.Component {
 
   cancelClick (event) {
     ipcRenderer.send('dispatch', 'logout')
-    this.setState({ email: null, password: null })
+    this.setState({ email: '', password: '' })
     event.stopPropagation()
   }
 
@@ -77,8 +77,8 @@ class Login extends React.Component {
                 onChange={this.handleChange}
               />
             </FormGroup>
-            <Button text={tx('login.cancel')} onClick={this.cancelClick.bind(this)} />
             <Button disabled={loading} type='submit' text={tx('login.button')} />
+            <Button text={tx('login.cancel')} onClick={this.cancelClick.bind(this)} />
           </form>
         </div>
       </div>


### PR DESCRIPTION
* Moves login button to left of cancel
* Fixes `this._render` is not a function (only set once init has completed)
* Reset email and password to empty strings rather than null