### PR TITLE
fix: app properly closes when X is hit. fixes #95

### DIFF
--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -81,10 +81,6 @@ function init (state, options) {
   }, 1000))
 
   win.on('close', e => {
-    if (!app.isQuitting) {
-      e.preventDefault()
-      hide()
-    }
   })
 }
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -31,6 +31,8 @@ function setupIpc () {
   ipcRenderer.on('log', (e, ...args) => console.log(...args))
   ipcRenderer.on('error', (e, ...args) => console.error(...args))
   ipcRenderer.on('stateSave', (e) => State.save(state))
+  ipcRenderer.on('stateSaveImmediate', (e) => State.saveImmediate(state))
+
   ipcRenderer.on('chooseLanguage', onChooseLanguage)
   ipcRenderer.on('windowBoundsChanged', onWindowBoundsChanged)
 


### PR DESCRIPTION
The problem was that the main window wasn't properly propagating it's close event. Moved all close handling to the `main/index.js` file and made sure once the main window is closed, the app quits after state is saved.