### PR TITLE
Cleanup config and startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@blueprintjs/core": "^3.4.0",
     "application-config": "^1.0.1",
-    "arch": "^2.1.1",
     "conversations": "^2.0.2",
     "debounce": "^1.2.0",
     "deltachat-node": "^0.18.0",

--- a/src/config.js
+++ b/src/config.js
@@ -55,19 +55,6 @@ function getConfigPath () {
   }
 }
 
-function getPath (key) {
-  if (!process.versions.electron) {
-    // Node.js process
-    return ''
-  } else if (process.type === 'renderer') {
-    // Electron renderer process
-    return electron.remote.app.getPath(key)
-  } else {
-    // Electron main process
-    return electron.app.getPath(key)
-  }
-}
-
 function isTest () {
   return process.env.NODE_ENV === 'test'
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,5 @@
 const appConfig = require('application-config')('DeltaChat')
 const path = require('path')
-const electron = require('electron')
 
 const APP_NAME = 'DeltaChat'
 const APP_VERSION = require('../package.json').version

--- a/src/config.js
+++ b/src/config.js
@@ -5,11 +5,7 @@ const APP_NAME = 'DeltaChat'
 const APP_VERSION = require('../package.json').version
 
 const IS_TEST = isTest()
-const PORTABLE_PATH = IS_TEST
-  ? path.join(process.platform === 'win32' ? 'C:\\Windows\\Temp' : '/tmp', 'DeltaChatTest')
-  : path.join(path.dirname(process.execPath), 'Portable Settings')
 const IS_PRODUCTION = isProduction()
-const IS_PORTABLE = isPortable()
 
 const UI_HEADER_HEIGHT = 38
 const UI_MESSAGE_HEIGHT = 100
@@ -28,7 +24,6 @@ module.exports = {
 
   HOME_PAGE_URL: 'https://delta.chat',
 
-  IS_PORTABLE: IS_PORTABLE,
   IS_PRODUCTION: IS_PRODUCTION,
   IS_TEST: IS_TEST,
 
@@ -56,28 +51,6 @@ function getConfigPath () {
 
 function isTest () {
   return process.env.NODE_ENV === 'test'
-}
-
-function isPortable () {
-  if (IS_TEST) {
-    return true
-  }
-
-  if (process.platform !== 'win32' || !IS_PRODUCTION) {
-    // Fast path: Non-Windows platforms should not check for path on disk
-    return false
-  }
-
-  const fs = require('fs')
-
-  try {
-    // This line throws if the "Portable Settings" folder does not exist, and does
-    // nothing otherwise.
-    fs.accessSync(PORTABLE_PATH, fs.constants.R_OK | fs.constants.W_OK)
-    return true
-  } catch (err) {
-    return false
-  }
 }
 
 function isProduction () {

--- a/src/config.js
+++ b/src/config.js
@@ -24,8 +24,6 @@ module.exports = {
 
   CONFIG_PATH: getConfigPath(),
 
-  DELAYED_INIT: 3000 /* 3 seconds */,
-
   GITHUB_URL: 'https://github.com/deltachat/deltachat-desktop',
   GITHUB_URL_ISSUES: 'https://github.com/deltachat/deltachat-desktop/issues',
   GITHUB_URL_RAW: 'https://raw.githubusercontent.com/deltachat/deltachat-desktop/master',

--- a/src/config.js
+++ b/src/config.js
@@ -36,7 +36,6 @@ module.exports = {
 
   OS_SYSARCH: arch() === 'x64' ? 'x64' : 'ia32',
 
-  ROOT_PATH: path.join(__dirname, '..'),
   STATIC_PATH: path.join(__dirname, '..', 'static'),
 
   WINDOW_ABOUT: 'file://' + path.join(__dirname, '..', 'static', 'about.html'),

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,6 @@ const electron = require('electron')
 const arch = require('arch')
 
 const APP_NAME = 'DeltaChat'
-const APP_TEAM = 'DeltaChat'
 const APP_VERSION = require('../package.json').version
 
 const IS_TEST = isTest()
@@ -21,7 +20,6 @@ module.exports = {
   APP_FILE_ICON: path.join(__dirname, '..', 'static', 'DeltaChatFile'),
   APP_ICON: path.join(__dirname, '..', 'static', 'DeltaChat'),
   APP_NAME: APP_NAME,
-  APP_TEAM: APP_TEAM,
   APP_VERSION: APP_VERSION,
   APP_WINDOW_TITLE: APP_NAME + ' (BETA)',
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,6 @@
 const appConfig = require('application-config')('DeltaChat')
 const path = require('path')
 const electron = require('electron')
-const arch = require('arch')
 
 const APP_NAME = 'DeltaChat'
 const APP_VERSION = require('../package.json').version
@@ -33,8 +32,6 @@ module.exports = {
   IS_PORTABLE: IS_PORTABLE,
   IS_PRODUCTION: IS_PRODUCTION,
   IS_TEST: IS_TEST,
-
-  OS_SYSARCH: arch() === 'x64' ? 'x64' : 'ia32',
 
   STATIC_PATH: path.join(__dirname, '..', 'static'),
 

--- a/src/config.js
+++ b/src/config.js
@@ -35,7 +35,6 @@ module.exports = {
 
   STATIC_PATH: path.join(__dirname, '..', 'static'),
 
-  WINDOW_ABOUT: 'file://' + path.join(__dirname, '..', 'static', 'about.html'),
   WINDOW_MAIN: 'file://' + path.join(__dirname, '..', 'static', 'main.html'),
 
   WINDOW_INITIAL_BOUNDS: {

--- a/src/config.js
+++ b/src/config.js
@@ -17,7 +17,6 @@ const UI_HEADER_HEIGHT = 38
 const UI_MESSAGE_HEIGHT = 100
 
 module.exports = {
-  APP_FILE_ICON: path.join(__dirname, '..', 'static', 'DeltaChatFile'),
   APP_ICON: path.join(__dirname, '..', 'static', 'DeltaChat'),
   APP_NAME: APP_NAME,
   APP_VERSION: APP_VERSION,

--- a/src/config.js
+++ b/src/config.js
@@ -47,8 +47,8 @@ module.exports = {
 }
 
 function getConfigPath () {
-  if (IS_PORTABLE) {
-    return PORTABLE_PATH
+  if (IS_TEST) {
+    return path.join(process.platform === 'win32' ? 'C:\\Windows\\Temp' : '/tmp', 'DeltaChatTest')
   } else {
     return path.dirname(appConfig.filePath)
   }

--- a/src/config.js
+++ b/src/config.js
@@ -27,8 +27,6 @@ module.exports = {
 
   DELAYED_INIT: 3000 /* 3 seconds */,
 
-  DEFAULT_DOWNLOAD_PATH: getDefaultDownloadPath(),
-
   GITHUB_URL: 'https://github.com/deltachat/deltachat-desktop',
   GITHUB_URL_ISSUES: 'https://github.com/deltachat/deltachat-desktop/issues',
   GITHUB_URL_RAW: 'https://raw.githubusercontent.com/deltachat/deltachat-desktop/master',
@@ -62,14 +60,6 @@ function getConfigPath () {
     return PORTABLE_PATH
   } else {
     return path.dirname(appConfig.filePath)
-  }
-}
-
-function getDefaultDownloadPath () {
-  if (IS_PORTABLE) {
-    return path.join(getConfigPath(), 'Downloads')
-  } else {
-    return getPath('downloads')
   }
 }
 

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -14,7 +14,6 @@ const menu = require('./menu')
 const State = require('../renderer/lib/state')
 const windows = require('./windows')
 
-let shouldQuit = false
 let argv = sliceArgv(process.argv)
 
 if (config.IS_PRODUCTION) {
@@ -27,78 +26,72 @@ if (config.IS_PRODUCTION) {
 const hidden = argv.includes('--hidden') ||
   (process.platform === 'darwin' && app.getLoginItemSettings().wasOpenedAsHidden)
 
-if (!shouldQuit) {
-  init()
-}
+const ipcMain = electron.ipcMain
 
-function init () {
-  const ipcMain = electron.ipcMain
+app.ipcReady = false // main window has finished loading and IPC is ready
+app.isQuitting = false
 
-  app.ipcReady = false // main window has finished loading and IPC is ready
-  app.isQuitting = false
+parallel({
+  logins: (cb) => logins(config.CONFIG_PATH, cb),
+  appReady: (cb) => app.on('ready', () => cb(null)),
+  state: (cb) => State.load(cb)
+}, onReady)
 
-  parallel({
-    logins: (cb) => logins(config.CONFIG_PATH, cb),
-    appReady: (cb) => app.on('ready', () => cb(null)),
-    state: (cb) => State.load(cb)
-  }, onReady)
+function onReady (err, results) {
+  if (err) throw err
 
-  function onReady (err, results) {
-    if (err) throw err
+  const state = results.state
+  app.logins = results.logins
 
-    const state = results.state
-    app.logins = results.logins
+  localize.setup(app, state.saved.locale || app.getLocale())
+  windows.main.init(state, { hidden })
+  menu.init()
+  if (argv.indexOf('--debug') > -1) windows.main.toggleDevTools()
 
-    localize.setup(app, state.saved.locale || app.getLocale())
-    windows.main.init(state, { hidden })
-    menu.init()
-    if (argv.indexOf('--debug') > -1) windows.main.toggleDevTools()
-
-    // Report uncaught exceptions
-    process.on('uncaughtException', (err) => {
-      console.error(err)
-      const error = { message: err.message, stack: err.stack }
-      windows.main.dispatch('uncaughtError', 'main', error)
-    })
-  }
-
-  ipc.init()
-
-  app.once('ipcReady', function () {
-    log('Command line args:', argv)
-    console.timeEnd('init')
-
-    var win = windows.main.win
-    win.on('close', e => {
-      if (!app.isQuitting) {
-        e.preventDefault()
-        windows.main.hide()
-        quit(e)
-      }
-    })
-  })
-
-  function quit (e) {
-    if (app.isQuitting) return
-
-    app.isQuitting = true
-    e.preventDefault()
-    windows.main.dispatch('stateSaveImmediate') // try to save state on exit
-    ipcMain.once('stateSaved', () => app.quit())
-    setTimeout(() => {
-      console.error('Saving state took too long. Quitting.')
-      app.quit()
-    }, 4000) // quit after 4 secs, at most
-  }
-
-  app.on('before-quit', function (e) {
-    quit(e)
-  })
-
-  app.on('window-all-closed', function (e) {
-    quit(e)
+  // Report uncaught exceptions
+  process.on('uncaughtException', (err) => {
+    console.error(err)
+    const error = { message: err.message, stack: err.stack }
+    windows.main.dispatch('uncaughtError', 'main', error)
   })
 }
+
+ipc.init()
+
+app.once('ipcReady', function () {
+  log('Command line args:', argv)
+  console.timeEnd('init')
+
+  var win = windows.main.win
+  win.on('close', e => {
+    if (!app.isQuitting) {
+      e.preventDefault()
+      windows.main.hide()
+      quit(e)
+    }
+  })
+})
+
+function quit (e) {
+  if (app.isQuitting) return
+
+  app.isQuitting = true
+  e.preventDefault()
+  windows.main.dispatch('stateSaveImmediate') // try to save state on exit
+  ipcMain.once('stateSaved', () => app.quit())
+  setTimeout(() => {
+    console.error('Saving state took too long. Quitting.')
+    app.quit()
+  }, 4000) // quit after 4 secs, at most
+}
+
+app.on('before-quit', function (e) {
+  quit(e)
+})
+
+app.on('window-all-closed', function (e) {
+  quit(e)
+})
 
 // Remove leading args.
 // Production: 1 arg, eg: /Applications/DeltaChat.app/Contents/MacOS/DeltaChat

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -27,11 +27,6 @@ if (config.IS_PRODUCTION) {
 const hidden = argv.includes('--hidden') ||
   (process.platform === 'darwin' && app.getLoginItemSettings().wasOpenedAsHidden)
 
-if (process.platform === 'win32') {
-  const squirrelWin32 = require('./squirrel-win32')
-  shouldQuit = squirrelWin32.handleEvent(argv[0])
-}
-
 if (!shouldQuit && !config.IS_PORTABLE) {
   // Prevent multiple instances of app from running at same time. New instances
   // signal this instance and quit. Note: This feature creates a lock file in

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -27,30 +27,11 @@ if (config.IS_PRODUCTION) {
 const hidden = argv.includes('--hidden') ||
   (process.platform === 'darwin' && app.getLoginItemSettings().wasOpenedAsHidden)
 
-if (!shouldQuit && !config.IS_PORTABLE) {
-  // Prevent multiple instances of app from running at same time. New instances
-  // signal this instance and quit. Note: This feature creates a lock file in
-  // %APPDATA%\Roaming\DeltaChat so we do not do it for the Portable App since
-  // we want to be "silent" as well as "portable".
-  shouldQuit = app.makeSingleInstance(onAppOpen)
-  if (shouldQuit) {
-    app.quit()
-  }
-}
-
 if (!shouldQuit) {
   init()
 }
 
 function init () {
-  if (config.IS_PORTABLE) {
-    const path = require('path')
-    // Put all user data into the "Portable Settings" folder
-    app.setPath('userData', config.CONFIG_PATH)
-    // Put Electron crash files, etc. into the "Portable Settings\Temp" folder
-    app.setPath('temp', path.join(config.CONFIG_PATH, 'Temp'))
-  }
-
   const ipcMain = electron.ipcMain
 
   app.ipcReady = false // main window has finished loading and IPC is ready
@@ -117,17 +98,6 @@ function init () {
   app.on('window-all-closed', function (e) {
     quit(e)
   })
-}
-
-function onAppOpen (newArgv) {
-  newArgv = sliceArgv(newArgv)
-
-  if (app.ipcReady) {
-    log('Second app instance opened, but was prevented:', newArgv)
-    windows.main.show()
-  } else {
-    argv.push(...newArgv)
-  }
 }
 
 // Remove leading args.


### PR DESCRIPTION
There's a lot of configuration that's never used and I decided to remove the strange IS_PORTABLE code as well.

Imo, we need _two_ different app folders:

* one which the real app will use, which is handled by the `application-config` module, which sets that up correctly on corresponding OS (e.g. `~/.config/DeltaChat` on linux)
* one temporary test folder that doesn't conflict with a real installation, e.g. `/tmp/DeltaChat`