### PR TITLE
Edit group

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -21,7 +21,23 @@
     },
     "createGroup": {
         "message": "Create Group",
-        "description": "Create group button label"
+        "description": "Create group menu item label"
+    },
+    "archiveGroup": {
+        "message": "Archive Group",
+        "description": "Archive group menu item label"
+    },
+    "deleteGroup": {
+        "message": "Delete Group",
+        "description": "Delete group menu item label"
+    },
+    "editGroup": {
+        "message": "Edit Group",
+        "description": "Edit group menu item label"
+    },
+    "save": {
+        "message": "Save",
+        "description": "Save button label (e.g. when editing groups)"
     },
     "groupName": {
         "message": "Group Name",

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -224,6 +224,23 @@ class DeltaChatController {
   }
 
   /**
+   * Dispatched when from EditGroup
+   */
+  getChatContacts (chatId) {
+    return this._dc.getChatContacts(chatId)
+  }
+
+  /**
+   * Dispatched from EditGroup
+   */
+  modifyGroup (chatId, name, contactIds) {
+    log('setting chat', chatId, 'name to', name)
+    this._dc.setChatName(chatId, name)
+    contactIds.forEach(id => this._dc.addContactToChat(chatId, id))
+    return true
+  }
+
+  /**
    * Dispatched from menu alternative in ChatView
    */
   deleteChat (chatId) {

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -6,6 +6,7 @@ const ChatList = require('./components/ChatList')
 const ChatView = require('./components/ChatView')
 const CreateChat = require('./components/CreateChat')
 const CreateGroup = require('./components/CreateGroup')
+const EditGroup = require('./components/EditGroup')
 const CreateContact = require('./components/CreateContact')
 
 class Home extends React.Component {
@@ -58,6 +59,9 @@ class Home extends React.Component {
         break
       case 'CreateGroup':
         Screen = CreateGroup
+        break
+      case 'EditGroup':
+        Screen = EditGroup
         break
       case 'ChatView':
         Screen = ChatView

--- a/src/renderer/components/CreateGroup.js
+++ b/src/renderer/components/CreateGroup.js
@@ -1,112 +1,24 @@
-const React = require('react')
 const { ipcRenderer } = require('electron')
+const GroupBase = require('./GroupBase')
 
-const ContactListItem = require('./ContactListItem')
-
-const {
-  Alignment,
-  Classes,
-  InputGroup,
-  ControlGroup,
-  Navbar,
-  NavbarGroup,
-  NavbarHeading,
-  Button
-} = require('@blueprintjs/core')
-
-class CreateGroup extends React.Component {
+class CreateGroup extends GroupBase {
   constructor (props) {
-    super(props)
-    this.state = {
-      group: {},
-      name: ''
-    }
+    super(props, {
+      buttonLabel: 'createGroup',
+      heading: 'createGroup'
+    })
   }
 
-  addToGroup (contactId) {
-    const group = this.state.group
-    group[contactId] = true
-    this.setState({ group })
-  }
-
-  removeFromGroup (contactId) {
-    const group = this.state.group
-    delete group[contactId]
-    this.setState({ group })
-  }
-
-  shouldComponentUpdate (nextProps, nextState) {
-    // we don't care about the props for now, really.
-    return (this.state !== nextState)
-  }
-
-  contactInGroup (contactId) {
-    return !!this.state.group[contactId]
-  }
-
-  toggleContact (contactId) {
-    if (this.contactInGroup(contactId)) {
-      this.removeFromGroup(contactId)
-    } else {
-      this.addToGroup(contactId)
-    }
-  }
-
-  createGroup () {
+  onSubmit () {
     const contactIds = Object.keys(this.state.group)
-    ipcRenderer.sendSync('dispatchSync', 'createUnverifiedGroup', this.state.name, contactIds)
+    ipcRenderer.sendSync(
+      'dispatchSync',
+      'createUnverifiedGroup',
+      this.state.name,
+      contactIds
+    )
     this.props.changeScreen('ChatList')
   }
-
-  handleNameChange (e) {
-    this.setState({ name: e.target.value })
-  }
-
-  isButtonDisabled () {
-    if (!this.state.name.length) return true
-    if (!Object.keys(this.state.group).length) return true
-    return false
-  }
-
-  render () {
-    const { deltachat } = this.props
-    const tx = window.translate
-
-    return (
-      <div>
-        <Navbar fixedToTop>
-          <NavbarGroup align={Alignment.LEFT}>
-            <Button className={Classes.MINIMAL} icon='undo' onClick={this.props.changeScreen} />
-            <NavbarHeading>{tx('createGroup')}</NavbarHeading>
-          </NavbarGroup>
-        </Navbar>
-        <div className='window'>
-          <div>
-            <ControlGroup fill vertical={false}>
-              <InputGroup
-                type='text'
-                id='name'
-                value={this.state.name}
-                onChange={this.handleNameChange.bind(this)}
-                placeholder={tx('groupName')} />
-              <Button
-                disabled={this.isButtonDisabled()}
-                onClick={this.createGroup.bind(this)}
-                text={tx('createGroup')} />
-            </ControlGroup>
-          </div>
-          {deltachat.contacts.map(contact => {
-            return (
-              <ContactListItem
-                color={this.contactInGroup(contact.id) ? 'green' : ''}
-                onClick={this.toggleContact.bind(this, contact.id)}
-                contact={contact}
-              />
-            )
-          })}
-        </div>
-      </div>
-    )
-  }
 }
+
 module.exports = CreateGroup

--- a/src/renderer/components/EditGroup.js
+++ b/src/renderer/components/EditGroup.js
@@ -1,69 +1,26 @@
-const React = require('react')
 const { ipcRenderer } = require('electron')
+const GroupBase = require('./GroupBase')
 
-const ContactListItem = require('./ContactListItem')
-
-const {
-  Alignment,
-  Classes,
-  InputGroup,
-  ControlGroup,
-  Navbar,
-  NavbarGroup,
-  NavbarHeading,
-  Button
-} = require('@blueprintjs/core')
-
-class EditGroup extends React.Component {
+class EditGroup extends GroupBase {
   constructor (props) {
-    super(props)
-    const { chatId, chatName } = this.props.screenProps
+    const { chatId, chatName } = props.screenProps
     const group = {}
     const readOnly = ipcRenderer.sendSync(
       'dispatchSync',
       'getChatContacts',
       chatId
     ).filter(id => id !== 1)
-    readOnly.forEach(id => group[id] = true)
-    this.state = {
+    readOnly.forEach(id => { group[id] = true })
+    super(props, {
+      buttonLabel: 'save',
       group: group,
       name: chatName,
+      heading: 'editGroup',
       readOnly
-    }
+    })
   }
 
-  addToGroup (contactId) {
-    const group = this.state.group
-    group[contactId] = true
-    this.setState({ group })
-  }
-
-  removeFromGroup (contactId) {
-    const group = this.state.group
-    delete group[contactId]
-    this.setState({ group })
-  }
-
-  shouldComponentUpdate (nextProps, nextState) {
-    // we don't care about the props for now, really.
-    return (this.state !== nextState)
-  }
-
-  contactInGroup (contactId) {
-    return !!this.state.group[contactId]
-  }
-
-  toggleContact (contactId) {
-    if (this.state.readOnly.includes(contactId)) return
-
-    if (this.contactInGroup(contactId)) {
-      this.removeFromGroup(contactId)
-    } else {
-      this.addToGroup(contactId)
-    }
-  }
-
-  save () {
+  onSubmit () {
     const contactIds = Object.keys(this.state.group).filter(id => {
       return !this.state.readOnly.includes(Number(id))
     })
@@ -77,56 +34,6 @@ class EditGroup extends React.Component {
     )
     this.props.changeScreen('ChatList')
   }
-
-  handleNameChange (e) {
-    this.setState({ name: e.target.value })
-  }
-
-  isButtonDisabled () {
-    if (!this.state.name.length) return true
-    if (!Object.keys(this.state.group).length) return true
-    return false
-  }
-
-  render () {
-    const { deltachat } = this.props
-    const tx = window.translate
-
-    return (
-      <div>
-        <Navbar fixedToTop>
-          <NavbarGroup align={Alignment.LEFT}>
-            <Button className={Classes.MINIMAL} icon='undo' onClick={this.props.changeScreen} />
-            <NavbarHeading>{tx('editGroup')}</NavbarHeading>
-          </NavbarGroup>
-        </Navbar>
-        <div className='window'>
-          <div>
-            <ControlGroup fill vertical={false}>
-              <InputGroup
-                type='text'
-                id='name'
-                value={this.state.name}
-                onChange={this.handleNameChange.bind(this)}
-                placeholder={tx('groupName')} />
-              <Button
-                disabled={this.isButtonDisabled()}
-                onClick={this.save.bind(this)}
-                text={tx('save')} />
-            </ControlGroup>
-          </div>
-          {deltachat.contacts.map((contact) => {
-            return (
-              <ContactListItem
-                color={this.contactInGroup(contact.id) ? 'green' : ''}
-                onClick={this.toggleContact.bind(this, contact.id)}
-                contact={contact}
-              />
-            )
-          })}
-        </div>
-      </div>
-    )
-  }
 }
+
 module.exports = EditGroup

--- a/src/renderer/components/EditGroup.js
+++ b/src/renderer/components/EditGroup.js
@@ -1,0 +1,132 @@
+const React = require('react')
+const { ipcRenderer } = require('electron')
+
+const ContactListItem = require('./ContactListItem')
+
+const {
+  Alignment,
+  Classes,
+  InputGroup,
+  ControlGroup,
+  Navbar,
+  NavbarGroup,
+  NavbarHeading,
+  Button
+} = require('@blueprintjs/core')
+
+class EditGroup extends React.Component {
+  constructor (props) {
+    super(props)
+    const { chatId, chatName } = this.props.screenProps
+    const group = {}
+    const readOnly = ipcRenderer.sendSync(
+      'dispatchSync',
+      'getChatContacts',
+      chatId
+    ).filter(id => id !== 1)
+    readOnly.forEach(id => group[id] = true)
+    this.state = {
+      group: group,
+      name: chatName,
+      readOnly
+    }
+  }
+
+  addToGroup (contactId) {
+    const group = this.state.group
+    group[contactId] = true
+    this.setState({ group })
+  }
+
+  removeFromGroup (contactId) {
+    const group = this.state.group
+    delete group[contactId]
+    this.setState({ group })
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    // we don't care about the props for now, really.
+    return (this.state !== nextState)
+  }
+
+  contactInGroup (contactId) {
+    return !!this.state.group[contactId]
+  }
+
+  toggleContact (contactId) {
+    if (this.state.readOnly.includes(contactId)) return
+
+    if (this.contactInGroup(contactId)) {
+      this.removeFromGroup(contactId)
+    } else {
+      this.addToGroup(contactId)
+    }
+  }
+
+  save () {
+    const contactIds = Object.keys(this.state.group).filter(id => {
+      return !this.state.readOnly.includes(Number(id))
+    })
+    const { chatId } = this.props.screenProps
+    ipcRenderer.sendSync(
+      'dispatchSync',
+      'modifyGroup',
+      chatId,
+      this.state.name,
+      contactIds
+    )
+    this.props.changeScreen('ChatList')
+  }
+
+  handleNameChange (e) {
+    this.setState({ name: e.target.value })
+  }
+
+  isButtonDisabled () {
+    if (!this.state.name.length) return true
+    if (!Object.keys(this.state.group).length) return true
+    return false
+  }
+
+  render () {
+    const { deltachat } = this.props
+    const tx = window.translate
+
+    return (
+      <div>
+        <Navbar fixedToTop>
+          <NavbarGroup align={Alignment.LEFT}>
+            <Button className={Classes.MINIMAL} icon='undo' onClick={this.props.changeScreen} />
+            <NavbarHeading>{tx('editGroup')}</NavbarHeading>
+          </NavbarGroup>
+        </Navbar>
+        <div className='window'>
+          <div>
+            <ControlGroup fill vertical={false}>
+              <InputGroup
+                type='text'
+                id='name'
+                value={this.state.name}
+                onChange={this.handleNameChange.bind(this)}
+                placeholder={tx('groupName')} />
+              <Button
+                disabled={this.isButtonDisabled()}
+                onClick={this.save.bind(this)}
+                text={tx('save')} />
+            </ControlGroup>
+          </div>
+          {deltachat.contacts.map((contact) => {
+            return (
+              <ContactListItem
+                color={this.contactInGroup(contact.id) ? 'green' : ''}
+                onClick={this.toggleContact.bind(this, contact.id)}
+                contact={contact}
+              />
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+}
+module.exports = EditGroup

--- a/src/renderer/components/GroupBase.js
+++ b/src/renderer/components/GroupBase.js
@@ -1,0 +1,106 @@
+const React = require('react')
+const ContactListItem = require('./ContactListItem')
+const {
+  Alignment,
+  Classes,
+  InputGroup,
+  ControlGroup,
+  Navbar,
+  NavbarGroup,
+  NavbarHeading,
+  Button
+} = require('@blueprintjs/core')
+
+class GroupBase extends React.Component {
+  constructor (props, state) {
+    super(props)
+    this.state = state
+    this.state.group = this.state.group || {}
+    this.state.name = this.state.name || ''
+    this.state.readOnly = this.state.readOnly || []
+  }
+
+  addToGroup (contactId) {
+    const group = this.state.group
+    group[contactId] = true
+    this.setState({ group })
+  }
+
+  removeFromGroup (contactId) {
+    const group = this.state.group
+    delete group[contactId]
+    this.setState({ group })
+  }
+
+  shouldComponentUpdate (nextProps, nextState) {
+    // we don't care about the props for now, really.
+    return (this.state !== nextState)
+  }
+
+  contactInGroup (contactId) {
+    return !!this.state.group[contactId]
+  }
+
+  toggleContact (contactId) {
+    if (this.state.readOnly.includes(contactId)) return
+
+    if (this.contactInGroup(contactId)) {
+      this.removeFromGroup(contactId)
+    } else {
+      this.addToGroup(contactId)
+    }
+  }
+
+  handleNameChange (e) {
+    this.setState({ name: e.target.value })
+  }
+
+  isButtonDisabled () {
+    if (!this.state.name.length) return true
+    if (!Object.keys(this.state.group).length) return true
+    return false
+  }
+
+  render () {
+    const { deltachat } = this.props
+    const tx = window.translate
+
+    return (
+      <div>
+        <Navbar fixedToTop>
+          <NavbarGroup align={Alignment.LEFT}>
+            <Button className={Classes.MINIMAL} icon='undo' onClick={this.props.changeScreen} />
+            <NavbarHeading>{tx(this.state.heading)}</NavbarHeading>
+          </NavbarGroup>
+        </Navbar>
+        <div className='window'>
+          <div>
+            <ControlGroup fill vertical={false}>
+              <InputGroup
+                type='text'
+                id='name'
+                value={this.state.name}
+                onChange={this.handleNameChange.bind(this)}
+                placeholder={tx('groupName')} />
+              <Button
+                disabled={this.isButtonDisabled()}
+                onClick={this.onSubmit.bind(this)}
+                text={tx(this.state.buttonLabel)} />
+            </ControlGroup>
+          </div>
+          {deltachat.contacts.map((contact) => {
+            return (
+              <ContactListItem
+                color={this.contactInGroup(contact.id) ? 'green' : ''}
+                onClick={this.toggleContact.bind(this, contact.id)}
+                contact={contact}
+              />
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+}
+
+module.exports = GroupBase


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/26

I started by copying functionality from `CreateGroup` to `EditGroup` and then refactored the common code into a `GroupBase` component.

The edit screen looks the same, but have different heading and different label on the button.

In edit mode, already existing group members cannot be de-selected, only contacts that haven't yet been added to the group can be toggled. When "Save" button is clicked, the group name is applied and the newly selected contacts are added to the group.

Also, I removed the error handling completely, disabling the button if no group name is set, or if no contacts have been selected. So the user can either add/modify name, and select contacts to enable the button or bail out with the arrow in the upper left corner.