### PR TITLE
[wip] Add About dialog

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -255,6 +255,14 @@
         "message": "Report an Issue...",
         "description": "Report an Issue... menu item label"
     },
+    "menu.help.about": {
+        "message": "About DeltaChat",
+        "description": "About menu item"
+    },
+    "aboutDeltaChat": {
+        "message": "About DeltaChat",
+        "description": "Window title on about dialog"
+    },
     "timestampFormat_M": {
         "message": "MMM D",
         "description": "Timestamp format string for displaying month and day (but not the year) of a date within the current year, ex: use 'MMM D' for 'Aug 8', or 'D MMM' for '8 Aug'."

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -146,6 +146,13 @@ class DeltaChatController {
   }
 
   /**
+   * Dispatched when showing the AboutDialog in SplittedChatListAndView
+   */
+  getInfo () {
+    return this._dc.getInfo()
+  }
+
+  /**
    * Dispatched when sending a message in ChatView
    */
   sendMessage (chatId, text) {

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -58,6 +58,10 @@ function init (cwd) {
     e.returnValue = ret
   })
 
+  ipc.on('dispatchSyncNoRender', (e, ...args) => {
+    e.returnValue = dispatch(...args)
+  })
+
   // Calls the function without returning the value (async)
   ipc.on('dispatch', (e, ...args) => {
     dispatch(...args)

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -158,6 +158,12 @@ function getMenuTemplate () {
           click: () => {
             electron.shell.openExternal(config.GITHUB_URL_ISSUES)
           }
+        },
+        {
+          translate: 'menu.help.about',
+          click: () => {
+            windows.main.send('showAboutDialog')
+          }
         }
       ]
     }

--- a/src/renderer/components/dialogs/About.js
+++ b/src/renderer/components/dialogs/About.js
@@ -1,0 +1,43 @@
+const React = require('react')
+const { Classes, Dialog, HTMLTable } = require('@blueprintjs/core')
+
+class AboutDialog extends React.Component {
+  render () {
+    const { isOpen, onClose, info } = this.props
+    const tx = window.translate
+
+    const rows = Object.keys(info).map(key => {
+      return { key, value: info[key] }
+    })
+
+    return (
+      <Dialog
+        isOpen={isOpen}
+        title={tx('aboutDeltaChat')}
+        icon='info-sign'
+        onClose={onClose}
+        canOutsideClickClose={false}>
+        <div className={Classes.DIALOG_BODY}>
+          <HTMLTable bordered='true' condensed='true' striped='true'>
+            <thead>
+              <tr>
+                <th>Setting</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(row => {
+                return <tr>
+                  <td>{row.key}</td>
+                  <td>{row.value}</td>
+                </tr>
+              })}
+            </tbody>
+          </HTMLTable>
+        </div>
+      </Dialog>
+    )
+  }
+}
+
+module.exports = AboutDialog


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/103

Currently looks really crappy since long values doesn't break properly and are rendered outside the dialog. But at least we have the complete flow and data ready.

![screenshot from 2018-10-21 04-27-26](https://user-images.githubusercontent.com/308049/47262465-c016fa80-d4e9-11e8-8b67-b1ed83839da5.png)

What's left:

- [ ] fix layout (css, or replace table with something better, suggestions welcome, basically `hilfe!`)
- [ ] the user _must_ be logged in to get the info so the menu alternative must be disabled when logged out
- [ ] `the_underscore_keys` should be translated

cc @karissa @Jikstra @hpk42 