### PR TITLE
Add About dialog

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -331,6 +331,14 @@
         "message": "Report an Issue...",
         "description": "Report an Issue... menu item label"
     },
+    "menu.help.about": {
+        "message": "About DeltaChat",
+        "description": "About menu item"
+    },
+    "aboutDeltaChat": {
+        "message": "About DeltaChat",
+        "description": "Window title on about dialog"
+    },
     "timestampFormat_M": {
         "message": "MMM D",
         "description": "Timestamp format string for displaying month and day (but not the year) of a date within the current year, ex: use 'MMM D' for 'Aug 8', or 'D MMM' for '8 Aug'."

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -153,6 +153,17 @@ class DeltaChatController {
   }
 
   /**
+   * Dispatched when showing the AboutDialog (owned by ScreenController)
+   */
+  getInfo () {
+    if (this.ready === true) {
+      return this._dc.getInfo()
+    } else {
+      return DeltaChat.getSystemInfo()
+    }
+  }
+
+  /**
    * Dispatched when sending a message in ChatView
    */
   sendMessage (chatId, text) {

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -153,7 +153,7 @@ class DeltaChatController {
   }
 
   /**
-   * Dispatched when showing the AboutDialog (owned by ScreenController)
+   * TODO: Currently not used
    */
   getInfo () {
     if (this.ready === true) {

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -54,6 +54,10 @@ function init (cwd) {
     e.returnValue = dispatch(...args)
   })
 
+  ipc.on('dispatchSyncNoRender', (e, ...args) => {
+    e.returnValue = dispatch(...args)
+  })
+
   // Calls the function without returning the value (async)
   ipc.on('dispatch', (e, ...args) => {
     dispatch(...args)

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -54,10 +54,6 @@ function init (cwd) {
     e.returnValue = dispatch(...args)
   })
 
-  ipc.on('dispatchSyncNoRender', (e, ...args) => {
-    e.returnValue = dispatch(...args)
-  })
-
   // Calls the function without returning the value (async)
   ipc.on('dispatch', (e, ...args) => {
     dispatch(...args)

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -150,6 +150,12 @@ function getMenuTemplate () {
           click: () => {
             electron.shell.openExternal(config.GITHUB_URL_ISSUES)
           }
+        },
+        {
+          translate: 'menu.help.about',
+          click: () => {
+            windows.main.send('showAboutDialog')
+          }
         }
       ]
     }

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -17,7 +17,6 @@ class Home extends React.Component {
       screen: 'SplittedChatListAndView',
       screenProps: {},
       showAbout: false,
-      aboutInfo: {},
       message: false
     }
 
@@ -53,19 +52,12 @@ class Home extends React.Component {
   }
 
   showAbout (showAbout) {
-    let aboutInfo = {}
-    if (showAbout) {
-      aboutInfo = ipcRenderer.sendSync(
-        'dispatchSync',
-        'getInfo'
-      )
-    }
-    this.setState({ showAbout, aboutInfo })
+    this.setState({ showAbout })
   }
 
   render () {
     const { logins, deltachat } = this.props
-    const { screen, screenProps, showAbout, aboutInfo } = this.state
+    const { screen, screenProps, showAbout } = this.state
 
     var Screen
     switch (screen) {
@@ -108,7 +100,7 @@ class Home extends React.Component {
             deltachat={deltachat}
           />
         }
-        { showAbout && (<AboutDialog info={aboutInfo} isOpen={showAbout} onClose={this.onCloseAbout} />) }
+        { showAbout && (<AboutDialog isOpen={showAbout} onClose={this.onCloseAbout} />) }
       </div>
     )
   }

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -56,7 +56,7 @@ class Home extends React.Component {
     let aboutInfo = {}
     if (showAbout) {
       aboutInfo = ipcRenderer.sendSync(
-        'dispatchSyncNoRender',
+        'dispatchSync',
         'getInfo'
       )
     }

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -84,8 +84,6 @@ class SplittedChatListAndView extends React.Component {
     this.setState({ deadDropChat: chat })
   }
 
-  componentDidMount () {}
-
   logout () {
     ipcRenderer.send('dispatch', 'logout')
   }

--- a/src/renderer/components/dialogs/About.js
+++ b/src/renderer/components/dialogs/About.js
@@ -3,7 +3,7 @@ const { Classes, Dialog, Collapse, Button } = require('@blueprintjs/core')
 const { version } = require('../../../../package.json')
 
 class AboutDialog extends React.Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
 
     this.state = {
@@ -33,10 +33,10 @@ class AboutDialog extends React.Component {
         onClose={onClose}
         canOutsideClickClose={false}>
         <div className={Classes.DIALOG_BODY}>
-          <p style={{color: 'grey'}}>{'version ' + version}</p>
+          <p style={{ color: 'grey' }}>{'version ' + version}</p>
           <p>Official Delta.Chat Desktop app.</p>
-          <p>This software is licensed under <a href="https://github.com/deltachat/deltachat-desktop/blob/master/LICENSE">GNU GPL version 3</a>.</p>
-          <p>Source code is available on <a href="https://github.com/deltachat/deltachat-desktop">GitHub</a>.</p>
+          <p>This software is licensed under <a href='https://github.com/deltachat/deltachat-desktop/blob/master/LICENSE'>GNU GPL version 3</a>.</p>
+          <p>Source code is available on <a href='https://github.com/deltachat/deltachat-desktop'>GitHub</a>.</p>
           <Button onClick={this.handleShowAdvanced}>{(this.state.showAdvanced ? '-' : '+') + ' ' + tx('login.advanced') }</Button>
           <Collapse isOpen={this.state.showAdvanced}>
             <ul>

--- a/src/renderer/components/dialogs/About.js
+++ b/src/renderer/components/dialogs/About.js
@@ -1,0 +1,30 @@
+const React = require('react')
+const { Classes, Dialog } = require('@blueprintjs/core')
+
+class AboutDialog extends React.Component {
+  render () {
+    const { isOpen, onClose, info } = this.props
+    const tx = window.translate
+
+    const rows = Object.keys(info).map(key => {
+      return { key, value: info[key] }
+    })
+
+    return (
+      <Dialog
+        isOpen={isOpen}
+        title={tx('aboutDeltaChat')}
+        icon='info-sign'
+        onClose={onClose}
+        canOutsideClickClose={false}>
+        <div className={Classes.DIALOG_BODY}>
+          {rows.map(row => {
+            return <div><div>{row.key}</div><div>{row.value}</div></div>
+          })}
+        </div>
+      </Dialog>
+    )
+  }
+}
+
+module.exports = AboutDialog

--- a/src/renderer/components/dialogs/About.js
+++ b/src/renderer/components/dialogs/About.js
@@ -1,29 +1,11 @@
 const React = require('react')
-const { Classes, Dialog, Collapse, Button } = require('@blueprintjs/core')
+const { Classes, Dialog } = require('@blueprintjs/core')
 const { version } = require('../../../../package.json')
 
 class AboutDialog extends React.Component {
-  constructor (props) {
-    super(props)
-
-    this.state = {
-      showAdvanced: false
-    }
-
-    this.handleShowAdvanced = this.handleShowAdvanced.bind(this)
-  }
-
-  handleShowAdvanced () {
-    this.setState({ showAdvanced: !this.state.showAdvanced })
-  }
-
   render () {
-    const { isOpen, onClose, info } = this.props
+    const { isOpen, onClose } = this.props
     const tx = window.translate
-
-    const rows = Object.keys(info).map(key => {
-      return { key, value: info[key] }
-    })
 
     return (
       <Dialog
@@ -34,18 +16,9 @@ class AboutDialog extends React.Component {
         canOutsideClickClose={false}>
         <div className={Classes.DIALOG_BODY}>
           <p style={{ color: 'grey' }}>{'version ' + version}</p>
-          <p>Official Delta.Chat Desktop app.</p>
+          <p>Official Delta Chat Desktop app.</p>
           <p>This software is licensed under <a href='https://github.com/deltachat/deltachat-desktop/blob/master/LICENSE'>GNU GPL version 3</a>.</p>
           <p>Source code is available on <a href='https://github.com/deltachat/deltachat-desktop'>GitHub</a>.</p>
-          <Button onClick={this.handleShowAdvanced}>{(this.state.showAdvanced ? '-' : '+') + ' ' + tx('login.advanced') }</Button>
-          <Collapse isOpen={this.state.showAdvanced}>
-            <ul>
-              {rows.map(row => {
-                return <li>{row.key + ': ' + row.value}</li>
-              })}
-            </ul>
-
-          </Collapse>
         </div>
       </Dialog>
     )

--- a/src/renderer/components/dialogs/About.js
+++ b/src/renderer/components/dialogs/About.js
@@ -1,7 +1,22 @@
 const React = require('react')
-const { Classes, Dialog } = require('@blueprintjs/core')
+const { Classes, Dialog, Collapse, Button } = require('@blueprintjs/core')
+const { version } = require('../../../../package.json')
 
 class AboutDialog extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      showAdvanced: false
+    }
+
+    this.handleShowAdvanced = this.handleShowAdvanced.bind(this)
+  }
+
+  handleShowAdvanced () {
+    this.setState({ showAdvanced: !this.state.showAdvanced })
+  }
+
   render () {
     const { isOpen, onClose, info } = this.props
     const tx = window.translate
@@ -18,9 +33,19 @@ class AboutDialog extends React.Component {
         onClose={onClose}
         canOutsideClickClose={false}>
         <div className={Classes.DIALOG_BODY}>
-          {rows.map(row => {
-            return <div><div>{row.key}</div><div>{row.value}</div></div>
-          })}
+          <p style={{color: 'grey'}}>{'version ' + version}</p>
+          <p>Official Delta.Chat Desktop app.</p>
+          <p>This software is licensed under <a href="https://github.com/deltachat/deltachat-desktop/blob/master/LICENSE">GNU GPL version 3</a>.</p>
+          <p>Source code is available on <a href="https://github.com/deltachat/deltachat-desktop">GitHub</a>.</p>
+          <Button onClick={this.handleShowAdvanced}>{(this.state.showAdvanced ? '-' : '+') + ' ' + tx('login.advanced') }</Button>
+          <Collapse isOpen={this.state.showAdvanced}>
+            <ul>
+              {rows.map(row => {
+                return <li>{row.key + ': ' + row.value}</li>
+              })}
+            </ul>
+
+          </Collapse>
         </div>
       </Dialog>
     )


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/103

Will leave this hanging for someone else to tweak the dialog. I'm not skilled enough and/or don't have enough creativity to make something out of the dialog.

Currently my thoughts are:

* add some tabs
* default tab shows basic and clean About information (desktop version, license, yada yada)
* click the second tab to get more information

Also see old PR https://github.com/deltachat/deltachat-desktop/pull/197