### PR TITLE
Add padlock to messages + tweak conversation grey

### DIFF
--- a/conversations/stylesheets/_mixins.scss
+++ b/conversations/stylesheets/_mixins.scss
@@ -8,9 +8,9 @@
   outline: inherit;
 }
 
-@mixin color-svg($svg, $color) {
+@mixin color-svg($svg, $color, $size: 100%) {
   -webkit-mask: url($svg) no-repeat center;
-  -webkit-mask-size: 100%;
+  -webkit-mask-size: $size;
   background-color: $color;
 }
 

--- a/conversations/stylesheets/_modules.scss
+++ b/conversations/stylesheets/_modules.scss
@@ -526,13 +526,20 @@
   flex-grow: 1;
 }
 
-.module-message__metadata__shield-icon {
+.module-message__metadata__padlock-icon {
   width: 12px;
   height: 12px;
   display: inline-block;
-  margin-left: 6px;
-  margin-bottom: 2px;
-  @include color-svg('../images/shield.svg', $color-light-35);
+  margin-right: 2px;
+  margin-bottom: 3px;
+}
+
+.module-message__metadata__padlock-icon--incoming {
+  @include color-svg('../images/padlock.svg', $color-light-35, 125%);
+}
+
+.module-message__metadata__padlock-icon--outgoing {
+  @include color-svg('../images/padlock.svg', $color-core-green, 125%);
 }
 
 .module-message__metadata__status-icon {

--- a/conversations/stylesheets/_modules.scss
+++ b/conversations/stylesheets/_modules.scss
@@ -526,6 +526,15 @@
   flex-grow: 1;
 }
 
+.module-message__metadata__shield-icon {
+  width: 12px;
+  height: 12px;
+  display: inline-block;
+  margin-left: 6px;
+  margin-bottom: 2px;
+  @include color-svg('../images/shield.svg', $color-light-35);
+}
+
 .module-message__metadata__status-icon {
   width: 12px;
   height: 12px;

--- a/conversations/stylesheets/_variables.scss
+++ b/conversations/stylesheets/_variables.scss
@@ -65,7 +65,7 @@ $color-black-06: rgba($color-black, 0.6);
 
 $color-signal-blue-mix: mix($color-signal-blue-025, $color-white-04);
 
-$color-conversation-grey: #757575;
+$color-conversation-grey: #505050;
 $color-conversation-blue: #1976d2;
 $color-conversation-cyan: #00838f;
 $color-conversation-deep_orange: #bf360c;

--- a/conversations/ts/components/conversation/Message.tsx
+++ b/conversations/ts/components/conversation/Message.tsx
@@ -51,7 +51,7 @@ export interface Props {
   disableMenu?: boolean;
   text?: string;
   id?: string;
-  shield?: boolean;
+  padlock?: boolean;
   collapseMetadata?: boolean;
   direction: 'incoming' | 'outgoing';
   timestamp: number;
@@ -245,7 +245,7 @@ export class Message extends React.Component<Props, State> {
 
   public renderMetadata() {
     const {
-      shield,
+      padlock,
       attachment,
       collapseMetadata,
       direction,
@@ -279,6 +279,14 @@ export class Message extends React.Component<Props, State> {
             : null
         )}
       >
+        {padlock === true && status !== 'error' ? (
+          <div
+            className={classNames(
+              'module-message__metadata__padlock-icon',
+              `module-message__metadata__padlock-icon--${direction}`,
+            )}
+          />
+        ) : null}
         {showError ? (
           <span
             className={classNames(
@@ -301,13 +309,6 @@ export class Message extends React.Component<Props, State> {
             module="module-message__metadata__date"
           />
         )}
-        {shield === true && status !== 'error' ? (
-          <div
-            className={classNames(
-              'module-message__metadata__shield-icon',
-            )}
-          />
-        ) : null}
         {expirationLength && expirationTimestamp ? (
           <ExpireTimer
             direction={direction}

--- a/conversations/ts/components/conversation/Message.tsx
+++ b/conversations/ts/components/conversation/Message.tsx
@@ -51,6 +51,7 @@ export interface Props {
   disableMenu?: boolean;
   text?: string;
   id?: string;
+  shield?: boolean;
   collapseMetadata?: boolean;
   direction: 'incoming' | 'outgoing';
   timestamp: number;
@@ -244,6 +245,7 @@ export class Message extends React.Component<Props, State> {
 
   public renderMetadata() {
     const {
+      shield,
       attachment,
       collapseMetadata,
       direction,
@@ -299,6 +301,13 @@ export class Message extends React.Component<Props, State> {
             module="module-message__metadata__date"
           />
         )}
+        {shield === true && status !== 'error' ? (
+          <div
+            className={classNames(
+              'module-message__metadata__shield-icon',
+            )}
+          />
+        ) : null}
         {expirationLength && expirationTimestamp ? (
           <ExpireTimer
             direction={direction}

--- a/images/padlock.svg
+++ b/images/padlock.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="20"
+   height="20"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="lock2-in.svg"
+   inkscape:export-filename="/home/bpetersen/projects/deltachat-android/MessengerProj/src/main/res/drawable-mdpi/msg_encr_in.png"
+   inkscape:export-xdpi="54"
+   inkscape:export-ydpi="54">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1543"
+     inkscape:window-height="876"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="33.37544"
+     inkscape:cx="1.2941401"
+     inkscape:cy="10.170071"
+     inkscape:window-x="57"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="m 10.001953,4.8634301 c -2.3176609,0 -4.1972655,1.8776517 -4.1972655,4.1953125 l 0,2.0996014 -0.6992187,0 0,6.669919 9.7910152,0 0,-6.669919 -0.699218,0 0,-2.0996014 c 0,-2.3176608 -1.877653,-4.1953125 -4.195313,-4.1953125 z M 9.978516,6.6837426 c 1.271707,0 2.302734,1.0310268 2.302734,2.3027344 l 0,1.423825 -0.0039,0 0,0.748042 -4.6015624,0 0,-0.888666 -0.00195,0 0,-1.283201 c 0,-1.2717077 1.0329803,-2.3027344 2.3046875,-2.3027344 z"
+     id="path4"
+     style="fill:#9ea7b0;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -186,7 +186,7 @@ class RenderMessage extends React.Component {
     }
 
     const props = {
-      shield: msg.showPadlock,
+      padlock: msg.showPadlock,
       id,
       i18n: window.translate,
       conversationType,

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -185,7 +185,8 @@ class RenderMessage extends React.Component {
       console.log('show detail', message)
     }
 
-    var props = {
+    const props = {
+      shield: msg.showPadlock,
       id,
       i18n: window.translate,
       conversationType,


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/144 

Darkened the default grey to get a better contrast to the shield/padlock. Couldn't find a proper padlock so used the shield for now.

Result:

![screenshot from 2018-10-25 14-56-17](https://user-images.githubusercontent.com/308049/47502801-f5647500-d868-11e8-9cdc-aa830e587139.png)
