### PR TITLE
Make emojis work on incoming messages

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -462,5 +462,9 @@
     "language.zh_CN": {
         "message": "Chinese",
         "description": "Menu alternative in Preferences -> Choose Language..."
+    },
+    "emojiAlt": {
+        "message": "Emoji of $1$",
+        "description": "Used with aria-label for emojis"
     }
 }

--- a/conversations/ts/util/emoji.ts
+++ b/conversations/ts/util/emoji.ts
@@ -5,7 +5,7 @@ const instance = new EmojiConvertor();
 instance.init_unified();
 instance.init_colons();
 instance.img_sets.apple.path =
-  'node_modules/emoji-datasource-apple/img/apple/64/';
+  '../node_modules/deltachat-emoji/img/';
 instance.include_title = true;
 instance.replace_mode = 'img';
 instance.supports_css = false; // needed to avoid spans with background-image

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "array-differ": "^2.0.3",
     "debounce": "^1.2.0",
     "deltachat-node": "^0.22.0",
+    "deltachat-emoji": "^1.0.0",
     "emoji-js-clean": "^4.0.0",
     "filesize": "^3.6.1",
     "google-libphonenumber": "^3.1.15",


### PR DESCRIPTION
Below follows _all_ emojis that can be sent from `deltachat-android` (yes, I clicked through all of them):

Emoji size also depends on length of message. If only sending a few emojis, they will be larger. But if you send with text or a lot of emojis, the smaller size will be picked.

![screenshot from 2018-10-27 13-47-46](https://user-images.githubusercontent.com/308049/47614365-3ba31980-da9f-11e8-8dd6-b05e106f2d16.png)

![screenshot from 2018-10-27 13-47-55](https://user-images.githubusercontent.com/308049/47614368-41006400-da9f-11e8-9ba5-3388322eefeb.png)

![screenshot from 2018-10-28 10-54-14](https://user-images.githubusercontent.com/308049/47614411-dbf93e00-da9f-11e8-8488-90fc625cd555.png)

