### PR TITLE
Use <video> element for video attachments

### DIFF
--- a/conversations/ts/components/conversation/Message.tsx
+++ b/conversations/ts/components/conversation/Message.tsx
@@ -441,8 +441,7 @@ export class Message extends React.Component<Props, State> {
         </div>
       );
     } else if (isVideo(attachment)) {
-      const { screenshot } = attachment;
-      if (imageBroken || !screenshot || !screenshot.url) {
+      if (imageBroken || !attachment.url) {
         return (
           <div
             role="button"
@@ -458,7 +457,7 @@ export class Message extends React.Component<Props, State> {
       }
 
       // Calculating height to prevent reflow when image loads
-      const height = Math.max(MINIMUM_IMG_HEIGHT, screenshot.height || 0);
+      const height = Math.max(MINIMUM_IMG_HEIGHT, 0);
 
       return (
         <div
@@ -474,12 +473,11 @@ export class Message extends React.Component<Props, State> {
               : null
           )}
         >
-          <img
+          <video
             onError={this.handleImageErrorBound}
             className="module-message__img-attachment"
-            alt={i18n('videoAttachmentAlt')}
             height={Math.min(MAXIMUM_IMG_HEIGHT, height)}
-            src={screenshot.url}
+            src={attachment.url}
           />
           <div
             className={classNames(

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -213,7 +213,7 @@ class RenderMessage extends React.Component {
       props.text = msg.text
     }
 
-    return (<Message {...props} />)
+    return (<div className='MessageWrapper'><Message {...props} /></div>)
   }
 }
 

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -204,7 +204,11 @@ class RenderMessage extends React.Component {
     }
 
     if (msg.file) {
-      props.attachment = { url: msg.file, contentType: convertContentType(message.filemime), filename: msg.text }
+      props.attachment = {
+        url: msg.file,
+        contentType: convertContentType(message.filemime),
+        filename: msg.text
+      }
     } else {
       props.text = msg.text
     }

--- a/static/main.css
+++ b/static/main.css
@@ -125,7 +125,6 @@ ul li button {
   float: right;
 }
 
-
 .Navbar img {
     height: 50px;
 }
@@ -146,8 +145,6 @@ ul li button {
 .bp3-overlay-open .bp3-transition-container {
   top: -50px !important;
 }
-
-
 
 .ChatList-NoChats {
   height: 52px;
@@ -176,4 +173,9 @@ ul li button {
 .module-message__author-default-avatar {
   position: static;
   margin-right: 8px;
+}
+
+.MessageWrapper .module-message__metadata {
+  margin-top: 10px;
+  margin-bottom: -7px;
 }


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/112

@#$%^@ the `<img>` tag, lets just use `<video>` and be done with it?

Result:

![screenshot from 2018-10-31 22-58-34](https://user-images.githubusercontent.com/308049/47821315-8e5f2880-dd60-11e8-967a-0fa084548232.png)


