### PR TITLE
Chat tweaks

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -16,16 +16,16 @@
         "description": "Displayed when a chat request is recieved"
     },
     "addContact": {
-        "message": "Add Contact",
+        "message": "Add contact",
         "description": "Add contact button label"
     },
     "name": {
         "message": "Name",
         "description": "Name label in Add Contact view"
     },
-    "createGroup": {
-        "message": "Create Group",
-        "description": "Create group menu item label"
+    "newGroup": {
+        "message": "New group",
+        "description": "New group button and text label"
     },
     "archiveGroup": {
         "message": "Archive Group",

--- a/_locales/en.json
+++ b/_locales/en.json
@@ -59,9 +59,9 @@
         "message": "Group name required.",
         "description": "Information to user when creating group with empty name"
     },
-    "addChat": {
-        "message": "Create Chat",
-        "description": "Create chat menu item label"
+    "newChat": {
+        "message": "New chat",
+        "description": "New chat button and text label"
     },
     "archiveChat": {
         "message": "Archive Chat",

--- a/src/renderer/components/CreateChat.js
+++ b/src/renderer/components/CreateChat.js
@@ -57,7 +57,7 @@ class CreateChat extends React.Component {
         <Navbar fixedToTop>
           <NavbarGroup align={Alignment.LEFT}>
             <Button className={Classes.MINIMAL} icon='undo' onClick={this.props.changeScreen} />
-            <NavbarHeading>{tx('addChat')}</NavbarHeading>
+            <NavbarHeading>{tx('newChat')}</NavbarHeading>
           </NavbarGroup>
         </Navbar>
         <div className='window'>

--- a/src/renderer/components/CreateChat.js
+++ b/src/renderer/components/CreateChat.js
@@ -62,8 +62,8 @@ class CreateChat extends React.Component {
         </Navbar>
         <div className='window'>
           <div className='CreateChat'>
+            <button onClick={this.onCreateGroup}>{tx('newGroup')}</button>
             <button onClick={this.onCreateContact}>{tx('addContact')}</button>
-            <button onClick={this.onCreateGroup}>{tx('createGroup')}</button>
             {deltachat.contacts.map((contact) => {
               return (<ContactListItem
                 contact={contact}

--- a/src/renderer/components/CreateGroup.js
+++ b/src/renderer/components/CreateGroup.js
@@ -4,8 +4,8 @@ const GroupBase = require('./GroupBase')
 class CreateGroup extends GroupBase {
   constructor (props) {
     super(props, {
-      buttonLabel: 'createGroup',
-      heading: 'createGroup'
+      buttonLabel: 'newGroup',
+      heading: 'newGroup'
     })
   }
 

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -151,7 +151,7 @@ class SplittedChatListAndView extends React.Component {
     const deleteMsg = isGroup ? tx('deleteGroup') : tx('deleteChat')
 
     const menu = (<Menu>
-      <MenuItem icon='plus' text={tx('addChat')} onClick={this.onCreateChat} />
+      <MenuItem icon='plus' text={tx('newChat')} onClick={this.onCreateChat} />
       {selectedChat && !showArchivedChats ? <MenuItem icon='import' text={archiveMsg} onClick={this.onArchiveChat.bind(this, selectedChat, true)} /> : null}
       {selectedChat && showArchivedChats ? <MenuItem icon='export' text={unArchiveMsg} onClick={this.onArchiveChat.bind(this, selectedChat, false)} /> : null}
       {selectedChat ? <MenuItem icon='delete' text={deleteMsg} onClick={this.onDeleteChat.bind(this, selectedChat)} /> : null}


### PR DESCRIPTION
This changes some language resources so we use the same naming as in android, e.g.

* `New chat` instead of `Create Chat`
* `New group` instead of `Create Group`
* `Add contact` instead of `Add Contact`
* `New group` button comes before `Add contact` button on `New chat` page/screen

Compare with:

![screenshot from 2018-11-06 23-07-37](https://user-images.githubusercontent.com/308049/48096922-d4acff80-e218-11e8-9a9e-2c7ca14bc43c.png)
