### PR TITLE
appdata: Added appstream data

### DIFF
--- a/static/chat.delta.desktop.appdata.xml
+++ b/static/chat.delta.desktop.appdata.xml
@@ -1,0 +1,56 @@
+<!--<?xml version="1.0" encoding="UTF-8"?>-->
+<component type="desktop">
+  <id>chat.delta.desktop</id>
+  <metadata_license>CC0</metadata_license>
+  <project_license>GPLv3</project_license>
+  <name>Delta Chat</name>
+  <summary>Delta Chat email-based messenger</summary>
+  
+  <description>
+The messenger with the broadest audience in the world.
+Free, independent, email compatible.
+  </description>
+  
+​  <launchable type="desktop-id">chat.delta.desktop</launchable>
+
+  <screenshots>
+    <screenshot type="default">
+      <image>https://github.com/deltachat/deltachat-desktop/raw/master/screenshot.png</image>
+    </screenshot>
+  </screenshots>
+
+  <kudos>
+  </kudos>
+
+ <url type="homepage">https://delta.chat/</url>
+
+  <releases>
+    <release version="v1.7.4" date="2018-11-07"/>
+    <release version="v1.7.3" date="2018-11-02"/>
+​  </releases>
+   
+ <update_contact>tobiasmue@gnome.org</update_contact>
+
+ <content_rating type="oars-1.0">
+    <content_attribute id="violence-cartoon">none</content_attribute>
+    <content_attribute id="violence-fantasy">none</content_attribute>
+    <content_attribute id="violence-realistic">none</content_attribute>
+    <content_attribute id="violence-bloodshed">none</content_attribute>
+    <content_attribute id="violence-sexual">none</content_attribute>
+    <content_attribute id="drugs-alcohol">none</content_attribute>
+    <content_attribute id="drugs-narcotics">none</content_attribute>
+    <content_attribute id="drugs-tobacco">none</content_attribute>
+    <content_attribute id="sex-nudity">none</content_attribute>
+    <content_attribute id="sex-themes">none</content_attribute>
+    <content_attribute id="language-profanity">none</content_attribute>
+    <content_attribute id="language-humor">none</content_attribute>
+    <content_attribute id="language-discrimination">none</content_attribute>
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-info">none</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+    <content_attribute id="social-location">none</content_attribute>
+    <content_attribute id="social-contacts">intense</content_attribute>
+    <content_attribute id="money-purchasing">none</content_attribute>
+    <content_attribute id="money-gambling">none</content_attribute>
+ </content_rating>
+</component>


### PR DESCRIPTION
These days consumers of desktop applications expect appstream data.
Such consumers are GNOME software or flathub. But Debian also likes
seeing those. This change brings such a file.

Note how I defined the appid to be chat.delta.desktop. This file also contains some release information. While manually maintaining this is not too much overhead, it might still be tiresome in the future. I couldn't figure out how to have a file generated with the current build infrastructure, if you want to call it that, so I opted for hard-coding it. It has some advantages in that the end-user visible release information can arguably be made more appealing when done manually...

This addresses the appstream part mentioned in https://github.com/deltachat/deltachat-desktop/issues/100

My main motivation is to get the app on flathub and to show that I'm trying to upstream the appdata file that I'll probably propose, I have created this PR.