### PR TITLE
mark messages seen when fetched

### DIFF
--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -445,6 +445,7 @@ class DeltaChatController {
     const ids = selectedChat.messageIds
     var messageIds = ids.splice(ids.length - this._pages * PAGE_SIZE, ids.length)
     selectedChat.messages = messageIds.map((id) => this._messageIdToJson(id))
+    this._dc.markSeenMessages(messageIds)
     return selectedChat
   }
 


### PR DESCRIPTION
 fixes #214  (mostly)

right now it'll mark them as seen if the user fetches them, but we don't have a reliable way right now to mark them when they're on screen -- feeling like one way to make this more reliable would be to reduce the 'messages per page size' (right now it is 20)