### PR TITLE
Tweak group image and chat name margin

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -127,7 +127,12 @@ ul li button {
 }
 
 .Navbar img {
-    height: 50px;
+  height: 40px;
+  margin-left: 5px;
+}
+
+.Navbar .bp3-navbar-heading {
+  margin-left: 5px;
 }
 
 .Navbar .bp3-align-left {
@@ -146,8 +151,6 @@ ul li button {
 .bp3-overlay-open .bp3-transition-container {
   top: -50px !important;
 }
-
-
 
 .ChatList-NoChats {
   height: 52px;


### PR DESCRIPTION
Group name + no image, before:

![screenshot from 2018-11-16 22-44-04](https://user-images.githubusercontent.com/308049/48649314-8656e800-e9f2-11e8-9ff3-2dd819e7d1b0.png)

Group name + no image, after:

![screenshot from 2018-11-16 22-47-34](https://user-images.githubusercontent.com/308049/48649326-94a50400-e9f2-11e8-9574-1744b2da4d20.png)

Group name + image, before:

![screenshot from 2018-11-16 22-49-56](https://user-images.githubusercontent.com/308049/48649340-9e2e6c00-e9f2-11e8-8b11-b037d0af5221.png)

Group name + image, after:

![screenshot from 2018-11-16 22-49-15](https://user-images.githubusercontent.com/308049/48649350-a71f3d80-e9f2-11e8-930a-444ca7379013.png)
