### PR TITLE
more concrete version label

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ Please fill in as much as you can below (leaving out if not applicable is ok). T
 -->
 
 - Platform (linux/mac/windows):
-- Version:
+- Delta Chat Desktop Version:
 - Expected behavior:
 - Actual behavior:
 - Steps to reproduce the problem:


### PR DESCRIPTION
just wanted to file an issue and came over the "version" field.

i think, the version that is expected here is the _desktop_ version, not the version of the core or the version of the platform; so we should be more precise here.