### PR TITLE
Deaddrop

### DIFF
--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -386,7 +386,7 @@ class DeltaChatController {
       return dc.getContact(id).toJson()
     })
     if (chatId === C.DC_CHAT_ID_DEADDROP) {
-      const msg = dc.getMessage(chat.messageIds[0])
+      const msg = dc.getMessage(chat.messageIds[chat.messageIds.length - 1])
       const fromId = msg && msg.getFromId()
 
       if (!fromId) {


### PR DESCRIPTION
@r10s i wonder if this makes more sense -- we should be getting the *last* message received from the chat and displaying that contact as the 'dead drop', not the *first* message 