### PR TITLE
Fix broken integration test

### DIFF
--- a/conversations/ts/components/conversation/Linkify.tsx
+++ b/conversations/ts/components/conversation/Linkify.tsx
@@ -4,7 +4,7 @@ import LinkifyIt from 'linkify-it';
 
 import { RenderTextCallback } from '../../types/Util';
 
-const linkify = LinkifyIt(null, {multiDashDomains: true});
+const linkify = LinkifyIt();
 
 interface Props {
   text: string;

--- a/conversations/ts/components/conversation/Linkify.tsx
+++ b/conversations/ts/components/conversation/Linkify.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
+import LinkifyIt from 'linkify-it';
+
 import { RenderTextCallback } from '../../types/Util';
 
-const LinkifyIt = require('linkify-it')
-
-const linkify = LinkifyIt({ multiDashDomains: true });
+const linkify = LinkifyIt(null, {multiDashDomains: true});
 
 interface Props {
   text: string;

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -22,6 +22,14 @@ pipeline {
         sh 'npm test'
       }
     }
+    stage('Integration Tests') {
+      steps {
+        sh '/usr/bin/xvfb-chromium &'
+        sh 'sleep 5'
+        sh 'export DISPLAY=:99'
+        sh 'npm run test-integration'
+      }
+    }
     stage('Deploy') {
       when { branch 'master' }
       environment {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/filesize": "^3.6.0",
     "@types/google-libphonenumber": "^7.4.17",
     "@types/jquery": "^3.3.19",
+    "@types/linkify-it": "^2.0.3",
     "@types/lodash": "^4.14.117",
     "@types/mocha": "^5.2.5",
     "@types/qs": "^6.5.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "google-libphonenumber": "^3.1.15",
     "insert-css": "^2.0.0",
     "intl-tel-input": "^14.0.1",
-    "linkify-it": "git+https://github.com/Jikstra/linkify-it.git#feature_add_option_to_allow_double_dash_domains",
+    "linkify-it": "^2.0.3",
     "lodash": "^4.17.11",
     "lodash.merge": "^4.6.1",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Actually, the whole app was broken. Took me over 4 hours to find this :grin: 

![screenshot from 2018-11-26 04-40-50](https://user-images.githubusercontent.com/308049/48991911-83b46b00-f135-11e8-99d7-af98689e5b66.png)


@Jikstra You have to be careful when you have branches on forks as dependencies (I have done this multiple times myself and it's really easy to mess things up). I'm not exactly sure what you did, but I'm guessing you force pushed one of your own branches, removing code from the `feature_add_option_to_allow_double_dash_domains` branch.

Somewhere around here:

![screenshot from 2018-11-26 04-33-44](https://user-images.githubusercontent.com/308049/48991758-aabe6d00-f134-11e8-945f-03c3ae82376f.png)

This PR unbreaks the app. I'll squash this, so it will be one commit on master. Undoing this change and fixing the original problem should be easy. In this order do:

* fix the `feature_add_option_to_allow_double_dash_domains` so it's correct and push that to your fork
* _revert_ the _squashed_ commit from this PR


