### PR TITLE
render all available messages in a page, fixes #354

### DIFF
--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -426,9 +426,9 @@ class DeltaChatController {
   _messagesToRender (messageIds) {
     const countMessages = messageIds.length
     const messageIdsToRender = messageIds.splice(
-      countMessages - this._pages * PAGE_SIZE,
-      countMessages)
-
+      Math.max(countMessages - (this._pages * PAGE_SIZE), 0),
+      countMessages
+    )
     return messageIdsToRender.map(id => this._messageIdToJson(id))
   }
 


### PR DESCRIPTION
this was fun. TIL Array.splice takes negative numbers.

This was happening because all messages should have been rendered, but it was rendering another page the first time, because only 6 messages were getting rendered on the first time for chats that had more than 20 but less than 40 messages.
 Combined with #363 fixes the scrolling bug