### PR TITLE
unselectable helper component

### DIFF
--- a/src/renderer/components/ChatList.js
+++ b/src/renderer/components/ChatList.js
@@ -2,6 +2,7 @@ const React = require('react')
 const C = require('deltachat-node/constants')
 const { ConversationListItem } = require('./conversations')
 const styled = require('styled-components').default
+const Unselectable = require('./helpers/Unselectable')
 
 const ChatListWrapper = styled.div`
   width: 30%;
@@ -58,12 +59,14 @@ class ChatList extends React.Component {
                 />)
             } else if (chat.id === C.DC_CHAT_ID_ARCHIVED_LINK) {
               return (
-                <div key={i} className='ShowArchivedChats'>
-                  <ConversationListItem
-                    onClick={this.props.onShowArchivedChats}
-                    name={chat.name}
-                    i18n={i18n} />
-                </div>
+                <Unselectable>
+                  <div key={i} className='ShowArchivedChats'>
+                    <ConversationListItem
+                      onClick={this.props.onShowArchivedChats}
+                      name={chat.name}
+                      i18n={i18n} />
+                  </div>
+                </Unselectable>
               )
             } else {
               return (

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -7,6 +7,7 @@ const dialogs = require('./dialogs')
 const ChatList = require('./ChatList')
 const ChatView = require('./ChatView')
 const Centered = require('./helpers/Centered')
+const Unselectable = require('./helpers/Unselectable')
 
 const {
   Alignment,
@@ -176,12 +177,14 @@ class SplittedChatListAndView extends React.Component {
                 chat={selectedChat}
                 deltachat={this.props.deltachat} />)
               : (
-                <Centered>
-                  <div className='window'>
-                    <h1>{tx('chatView.nochatselectedHeader')}</h1>
-                    <p>{tx('chatView.nochatselectedSuggestion')}</p>
-                  </div>
-                </Centered>
+                <Unselectable>
+                  <Centered>
+                    <div className='window '>
+                      <h1>{tx('chatView.nochatselectedHeader')}</h1>
+                      <p>{tx('chatView.nochatselectedSuggestion')}</p>
+                    </div>
+                  </Centered>
+                </Unselectable>
               )
           }
         </BelowNavbar>

--- a/src/renderer/components/dialogs/About.js
+++ b/src/renderer/components/dialogs/About.js
@@ -2,6 +2,7 @@ const React = require('react')
 const { remote } = require('electron')
 const { Classes, Dialog } = require('@blueprintjs/core')
 const { APP_VERSION } = require('../../../config')
+const Unselectable = require('../helpers/Unselectable')
 
 class ClickableLink extends React.Component {
   onClick () {
@@ -30,9 +31,11 @@ class AboutDialog extends React.Component {
         canOutsideClickClose={false}>
         <div className={Classes.DIALOG_BODY}>
           <p style={{ color: 'grey' }}>{`Version ${APP_VERSION}`}</p>
-          <p>Official Delta Chat Desktop app.</p>
-          <p>This software is licensed under <ClickableLink href='https://github.com/deltachat/deltachat-desktop/blob/master/LICENSE' text='GNU GPL version 3' />.</p>
-          <p>Source code is available on <ClickableLink href='https://github.com/deltachat/deltachat-desktop' text='GitHub' />.</p>
+          <Unselectable>
+            <p>Official Delta Chat Desktop app.</p>
+            <p>This software is licensed under <ClickableLink href='https://github.com/deltachat/deltachat-desktop/blob/master/LICENSE' text='GNU GPL version 3' />.</p>
+            <p>Source code is available on <ClickableLink href='https://github.com/deltachat/deltachat-desktop' text='GitHub' />.</p>
+          </Unselectable>
         </div>
       </Dialog>
     )

--- a/src/renderer/components/helpers/Unselectable.js
+++ b/src/renderer/components/helpers/Unselectable.js
@@ -1,0 +1,7 @@
+const styled = require('styled-components').default
+
+const Unselectable = styled.div`
+    user-select: none;
+    cursor: default;
+`
+module.exports = Unselectable


### PR DESCRIPTION
To make preventing stuff from being selected easier.
It doesn't feel professional if you can select stuff you normally couldn't select in an desktop app.