### PR TITLE
Deploy on Mac for Travis (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ language: node_js
 node_js:
   - 10
 
-os: 
+os:
   - osx
-  - linux
 
 addons:
   apt:
@@ -32,6 +31,13 @@ script:
   - npm run build
   - npm test
   - npm run test-integration
+
+deploy:
+  provider: script
+  script: npm run dist-ci
+  on:
+    all_branches: true
+  skip_cleanup: true
 
 notifications:
   email: false


### PR DESCRIPTION
It might be worth a shot to start building versions for Mac again. We need to test different emails, other than `deltachat.de`, to find out if it's a problem with certificates or not.