### PR TITLE
Forwarding messages

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -823,5 +823,9 @@
   "newMessageNotification": {
     "message": "New Message!",
     "description": "Shown as a placeholder when notification details are turned off"
+  },
+  "forwardMessageTitle": {
+    "message": "Forward Message",
+    "description": "Title in the dialog for choosing a contact to forward to"
   }
 }

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -379,7 +379,6 @@ class DeltaChatController extends events.EventEmitter {
       configuring: this.configuring,
       credentials: this.credentials,
       ready: this.ready,
-      contacts: this._contacts(),
       blockedContacts: this._blockedContacts(),
       showArchivedChats,
       chatList,
@@ -509,6 +508,12 @@ class DeltaChatController extends events.EventEmitter {
     this._render()
   }
 
+  forwardMessage (msgId, contactId) {
+    var chatId = this._dc.getChatIdByContactId(contactId)
+    this._dc.forwardMessages(msgId, chatId)
+    this.selectChat(chatId)
+  }
+
   _blockedContacts (...args) {
     if (!this._dc) return []
     return this._dc.getBlockedContacts(...args).map(id => {
@@ -516,13 +521,8 @@ class DeltaChatController extends events.EventEmitter {
     })
   }
 
-  /**
-   * Internal
-   * Returns contacts in json format
-   */
-  _contacts (...args) {
-    if (!this._dc) return []
-    return this._dc.getContacts(...args).map(id => {
+  getContacts (listFlags, queryStr) {
+    return this._dc.getContacts(listFlags, queryStr).map(id => {
       return this._dc.getContact(id).toJson()
     })
   }

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -522,7 +522,8 @@ class DeltaChatController extends events.EventEmitter {
   }
 
   getContacts (listFlags, queryStr) {
-    return this._dc.getContacts(listFlags, queryStr).map(id => {
+    var distinctIds = Array.from(new Set(this._dc.getContacts(listFlags, queryStr)))
+    return distinctIds.map(id => {
       return this._dc.getContact(id).toJson()
     })
   }

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -9,6 +9,7 @@ const EditGroup = require('./components/EditGroup')
 const CreateContact = require('./components/CreateContact')
 const SplittedChatListAndView = require('./components/SplittedChatListAndView')
 const dialogs = require('./components/dialogs')
+const ContactList = require('./components/ContactList')
 
 class Home extends React.Component {
   constructor (props) {
@@ -81,6 +82,9 @@ class Home extends React.Component {
         break
       case 'EditGroup':
         Screen = EditGroup
+        break
+      case 'ContactList':
+        Screen = ContactList
         break
       case 'UnblockContacts':
         Screen = UnblockContacts

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -173,23 +173,31 @@ class ChatView extends React.Component {
     this.setState({ dialogProps: false })
   }
 
+  onForward (forwardMessage) {
+    this.setState({ dialogProps: { forwardMessage } })
+  }
+
   render () {
     const { dialogProps, messageDetail } = this.state
     const { chat } = this.props
 
     return (
       <ChatViewWrapper ref={this.ChatViewWrapperRef}>
-        <dialogs.SetupMessage
-          userFeedback={this.props.userFeedback}
-          setupMessage={dialogProps.setupMessage}
-          onClose={this.onCloseDialog}
-        />
         <RenderMediaWrapper>
           <dialogs.RenderMedia
             message={dialogProps.attachmentMessage}
             onClose={this.onCloseDialog}
           />
         </RenderMediaWrapper>
+        <dialogs.SetupMessage
+          userFeedback={this.props.userFeedback}
+          setupMessage={dialogProps.setupMessage}
+          onClose={this.onCloseDialog}
+        />
+        <dialogs.ForwardMessage
+          forwardMessage={dialogProps.forwardMessage}
+          onClose={this.onCloseDialog}
+        />
         <dialogs.MessageDetail
           onDelete={this.onDeleteMessage.bind(this, messageDetail)}
           chat={chat}
@@ -200,6 +208,10 @@ class ChatView extends React.Component {
           <ConversationContext>
             {chat.messages.map(rawMessage => {
               var message = MessageWrapper.convert(rawMessage)
+              message.onReply = () => {
+                console.log('reply to', message)
+              }
+              message.onForward = this.onForward.bind(this, message)
               return MessageWrapper.render({
                 message,
                 chat,

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -125,8 +125,8 @@ class Composer extends React.Component {
   }
 
   focusInputMessage () {
-    let el = document.querySelector(`.${ComposerWrapper.styledComponentId} input`)
-    if (!el) return console.log(`Didn't find .ComposerWrapper input element`)
+    let el = document.querySelector(`.${ComposerWrapper.styledComponentId} textarea`)
+    if (!el) return console.log(`Didn't find .ComposerWrapper textarea element`)
     el.focus()
   }
 

--- a/src/renderer/components/ContactList.js
+++ b/src/renderer/components/ContactList.js
@@ -1,0 +1,61 @@
+const React = require('react')
+const { ipcRenderer } = require('electron')
+const C = require('deltachat-node/constants')
+
+const { RenderContact } = require('./Contact')
+const SearchInput = require('./SearchInput.js')
+
+class ContactList extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      queryStr: '',
+      showVerifiedContacts: false
+    }
+    this.handleSearch = this.handleSearch.bind(this)
+    this.search = this.search.bind(this)
+  }
+
+  handleSearch (event) {
+    this.search(event.target.value)
+  }
+
+  search (queryStr) {
+    this.setState({ queryStr })
+  }
+
+  componentDidMount () {
+    this.search('')
+  }
+
+  _getContacts () {
+    const listFlags = this.state.showVerifiedContacts ? C.DC_GCL_VERIFIED_ONLY : 0
+    const contacts = ipcRenderer.sendSync(
+      'dispatchSync', 'getContacts', listFlags, this.state.queryStr
+    )
+    return contacts
+  }
+
+  render () {
+    const { childProps, onContactClick } = this.props
+    const contacts = this._getContacts()
+    return <div>
+      <SearchInput
+        onChange={this.handleSearch}
+        value={this.state.queryStr}
+      />
+      {contacts.map((contact) => {
+        var props = childProps ? childProps(contact) : {}
+        return (
+          <RenderContact
+            key={contact.id}
+            onClick={() => onContactClick(contact)}
+            contact={contact}
+            {...props}
+          />
+        )
+      })}
+    </div>
+  }
+}
+module.exports = ContactList

--- a/src/renderer/components/CreateChat.js
+++ b/src/renderer/components/CreateChat.js
@@ -10,7 +10,7 @@ const {
   Button
 } = require('@blueprintjs/core')
 
-const { RenderContact } = require('./Contact')
+const ContactList = require('./ContactList')
 const NavbarWrapper = require('./NavbarWrapper')
 
 class CreateChat extends React.Component {
@@ -55,7 +55,7 @@ class CreateChat extends React.Component {
   }
 
   render () {
-    const { deltachat } = this.props
+    const { contacts } = this.props
     const tx = window.translate
 
     return (
@@ -73,13 +73,10 @@ class CreateChat extends React.Component {
             <button onClick={this.onCreateGroup}>{tx('newGroup')}</button>
             <button onClick={this.onCreateVerifiedGroup}>{tx('newVerifiedGroup')}</button>
             <button onClick={this.onCreateContact}>{tx('addContact')}</button>
-            {deltachat.contacts.map((contact) => {
-              return (<RenderContact
-                contact={contact}
-                onClick={this.chooseContact.bind(this)}
-              />
-              )
-            })}
+            <ContactList
+              contacts={contacts}
+              onContactClick={this.chooseContact.bind(this)}
+            />
           </div>
         </div>
       </div>

--- a/src/renderer/components/GroupBase.js
+++ b/src/renderer/components/GroupBase.js
@@ -102,7 +102,6 @@ class GroupBase extends React.Component {
 
   render () {
     const {
-      deltachat,
       showQrVerifyCodeButton,
       showQrInviteCodeButton,
       qrCode

--- a/src/renderer/components/GroupBase.js
+++ b/src/renderer/components/GroupBase.js
@@ -13,9 +13,9 @@ const {
   Button
 } = require('@blueprintjs/core')
 
-const { RenderContact } = require('./Contact')
 const { QrCode } = require('./dialogs')
 const NavbarWrapper = require('./NavbarWrapper')
+const ContactList = require('./ContactList')
 
 class GroupBase extends React.Component {
   constructor (props, state) {
@@ -49,7 +49,8 @@ class GroupBase extends React.Component {
     return !!this.state.group[contactId]
   }
 
-  toggleContact (contactId) {
+  toggleContact (contact) {
+    var contactId = contact.id
     if (this.contactInGroup(contactId)) {
       this.removeFromGroup(contactId)
     } else {
@@ -100,8 +101,8 @@ class GroupBase extends React.Component {
   }
 
   render () {
-    const contacts = this._getContacts()
     const {
+      deltachat,
       showQrVerifyCodeButton,
       showQrInviteCodeButton,
       qrCode
@@ -121,13 +122,6 @@ class GroupBase extends React.Component {
         </NavbarWrapper>
         <div className='window'>
           <div className='GroupBase'>
-            <div className='SelectGroupImage'>
-              <img className='GroupImage' src={image} onClick={this.onSelectGroupImage.bind(this)} />
-              <button disabled={!this.state.image} className='RemoveGroupImage' onClick={this.onRemoveImage.bind(this)}>{tx('remove')}</button>
-            </div>
-            { showQrVerifyCodeButton && (<button onClick={this.onShowQrVerifyCode.bind(this)}>{tx('showQrVerifyCode')}</button>) }
-            { showQrInviteCodeButton && (<button onClick={this.onShowQrInviteCode.bind(this)}>{tx('showQrInviteCode')}</button>) }
-            <QrCode qrCode={qrCode} onClose={this.closeQrCode} />
             <ControlGroup fill vertical={false}>
               <InputGroup
                 type='text'
@@ -140,27 +134,23 @@ class GroupBase extends React.Component {
                 onClick={this.onSubmit.bind(this)}
                 text={tx(this.state.buttonLabel)} />
             </ControlGroup>
-            {contacts.map((contact) => {
-              return (
-                <RenderContact
-                  color={this.contactInGroup(contact.id) ? 'green' : ''}
-                  onClick={this.toggleContact.bind(this, contact.id)}
-                  contact={contact}
-                />
-              )
-            })}
+            <div className='SelectGroupImage'>
+              <img className='GroupImage' src={image} onClick={this.onSelectGroupImage.bind(this)} />
+              <button disabled={!this.state.image} className='RemoveGroupImage' onClick={this.onRemoveImage.bind(this)}>{tx('remove')}</button>
+            </div>
+            { showQrVerifyCodeButton && (<button onClick={this.onShowQrVerifyCode.bind(this)}>{tx('showQrVerifyCode')}</button>) }
+            { showQrInviteCodeButton && (<button onClick={this.onShowQrInviteCode.bind(this)}>{tx('showQrInviteCode')}</button>) }
+            <QrCode qrCode={qrCode} onClose={this.closeQrCode} />
+            <ContactList
+              childProps={(contact) => {
+                return { color: this.contactInGroup(contact.id) ? 'green' : '' }
+              }}
+              onContactClick={this.toggleContact.bind(this)}
+            />
           </div>
         </div>
       </div>
     )
-  }
-
-  _getContacts () {
-    const { contacts } = this.props.deltachat
-    if (this.state.showVerifiedContacts) {
-      return contacts.filter(c => c.isVerified === true)
-    }
-    return contacts
   }
 }
 

--- a/src/renderer/components/MessageWrapper.js
+++ b/src/renderer/components/MessageWrapper.js
@@ -186,14 +186,6 @@ class RenderMessage extends React.Component {
 }
 
 function convert (message) {
-  message.onReply = () => {
-    console.log('reply to', message)
-  }
-
-  message.onForward = () => {
-    console.log('forward to')
-  }
-
   message.onDownload = () => {
     var defaultPath = path.join(remote.app.getPath('downloads'), path.basename(message.msg.file))
     remote.dialog.showSaveDialog({

--- a/src/renderer/components/SearchInput.js
+++ b/src/renderer/components/SearchInput.js
@@ -1,0 +1,14 @@
+const React = require('react')
+const { InputGroup } = require('@blueprintjs/core')
+
+module.exports = function (props) {
+  const tx = window.translate
+  return <InputGroup
+    type='search'
+    aria-label={tx('searchAriaLabel')}
+    large
+    placeholder={tx('searchPlaceholder')}
+    leftIcon='search'
+    {...props}
+  />
+}

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -1,13 +1,13 @@
 const React = require('react')
 const { ipcRenderer } = require('electron')
 const styled = require('styled-components').default
-const { InputGroup } = require('@blueprintjs/core')
 
 const dialogs = require('./dialogs')
 const Menu = require('./Menu')
 const ChatList = require('./ChatList')
 const ChatView = require('./ChatView')
 const Centered = require('./helpers/Centered')
+const SearchInput = require('./SearchInput.js')
 
 const Unselectable = require('./helpers/Unselectable')
 const StyleVariables = require('./style-variables')
@@ -104,14 +104,9 @@ class SplittedChatListAndView extends React.Component {
           <Navbar fixedToTop>
             <NavbarGroup align={Alignment.LEFT}>
               { showArchivedChats && (<Button className={Classes.MINIMAL} icon='undo' onClick={this.onHideArchivedChats} />) }
-              <InputGroup
-                type='search'
-                aria-label={tx('searchAriaLabel')}
-                large
-                placeholder={tx('searchPlaceholder')}
-                value={this.state.queryStr}
+              <SearchInput
                 onChange={this.handleSearchChange}
-                leftIcon='search'
+                value={this.state.queryStr}
               />
             </NavbarGroup>
             <NavbarGroup align={Alignment.RIGHT}>

--- a/src/renderer/components/dialogs/ForwardMessage.js
+++ b/src/renderer/components/dialogs/ForwardMessage.js
@@ -25,7 +25,7 @@ class ForwardMessageDialog extends React.Component {
     return (
       <Dialog
         isOpen={isOpen}
-        title={'Forward Message'}
+        title={tx('forwardMessageTitle')}
         icon='info-sign'
         onClose={onClose}>
         <div className={Classes.DIALOG_BODY}>

--- a/src/renderer/components/dialogs/ForwardMessage.js
+++ b/src/renderer/components/dialogs/ForwardMessage.js
@@ -1,0 +1,42 @@
+const React = require('react')
+const { ipcRenderer } = require('electron')
+const {
+  Classes,
+  Dialog
+} = require('@blueprintjs/core')
+
+const ContactList = require('../ContactList')
+
+class ForwardMessageDialog extends React.Component {
+  onContactClick (contact) {
+    ipcRenderer.send('dispatch',
+      'forwardMessage',
+      this.props.forwardMessage.msg.id,
+      contact.id
+    )
+    this.props.onClose()
+  }
+
+  render () {
+    const { contacts, forwardMessage, onClose } = this.props
+    const tx = window.translate
+    var isOpen = !!forwardMessage
+
+    return (
+      <Dialog
+        isOpen={isOpen}
+        title={'Forward Message'}
+        icon='info-sign'
+        onClose={onClose}>
+        <div className={Classes.DIALOG_BODY}>
+          <ContactList
+            contacts={contacts}
+            onContactClick={this.onContactClick.bind(this)}
+          />
+        </div>
+      </Dialog>
+    )
+  }
+}
+
+module.exports = ForwardMessageDialog

--- a/src/renderer/components/dialogs/index.js
+++ b/src/renderer/components/dialogs/index.js
@@ -9,6 +9,7 @@ const ImexProgress = require('./ImexProgress')
 const About = require('./About')
 const Settings = require('./Settings')
 const confirmation = require('./confirmationDialog')
+const ForwardMessage = require('./ForwardMessage')
 
 module.exports = {
   confirmation,
@@ -21,5 +22,6 @@ module.exports = {
   QrCode,
   ImexProgress,
   About,
-  Settings
+  Settings,
+  ForwardMessage
 }


### PR DESCRIPTION
This implements forwarding messages when clicking the context menu in a message and hitting 'forward message.'

A dialog window pops up with the list of contacts. When a contact is clicked, the dialog closes and the message is forwarded to that person.

This also implements a Search input box when selecting a contact, for filtering the contact list based on a search term


* :relaxed:   refactor: Contacts are retrieved using a synchronous model so we don't have to pass contacts and re-render everything every time someone types in the contact search box
* :tada: bonus!: This search function is abstracted out into it's own `ContactList` component and reused for searching for contacts when creating a new group and creating a new chat 
* :see_no_evil:  hack!: The contact list was getting multiple contacts with the same id when using get_contacts with a search query. This was causing many contacts with the same name to show up when searching for a contact. I [implemented a hack on our side to fix this](https://github.com/deltachat/deltachat-desktop/pull/412/commits/b150fd103d92f9d99903f1190557dedf89bfe1f0) but ideally this would be fixed by making core return only distinct queries. What do you think @r10s ?

 