### PR TITLE
Optionally mark messages as read

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -801,6 +801,9 @@
   "settingsAutocryptSection": {
     "message": "Autocrypt"
   },
+  "settingsOptionsSection": {
+    "message": "Options"
+  },
   "backupConfirmationMessage": {
     "message": "Exported files will contain your end-to-end Autocrypt setup! Keep them in a safe place or delete them as soon as possible.",
     "description": "Shown as a confirmation message before exporting a backup"

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -14,10 +14,16 @@ class DeltaChatController extends events.EventEmitter {
   /**
    * Created and owned by ipc on the backend
    */
-  constructor (cwd) {
+  constructor (cwd, saved) {
     super()
     this.cwd = cwd
     this._resetState()
+    if (!saved) throw new Error('Saved settings are a required argument to DeltaChatController')
+    this._saved = saved
+  }
+
+  updateSettings (saved) {
+    this._saved = saved
   }
 
   /**
@@ -436,7 +442,9 @@ class DeltaChatController extends events.EventEmitter {
       this._dc.markNoticedChat(selectedChat.id)
       selectedChat.freshMessageCounter = 0
     }
-    this._dc.markSeenMessages(selectedChat.messageIds)
+    if (this._saved.markRead) {
+      this._dc.markSeenMessages(selectedChat.messageIds)
+    }
 
     var messageIds = this._dc.getChatMessages(selectedChatId, C.DC_GCM_ADDDAYMARKER, 0)
     selectedChat.totalMessages = messageIds.length

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -47,6 +47,10 @@ function onReady (err, results) {
   const state = results.state
   app.logins = results.logins
 
+  var cwd = process.env.TEST_DIR || config.CONFIG_PATH
+  log('cwd', cwd)
+  ipc.init(cwd, state)
+
   localize.setup(app, state.saved.locale || app.getLocale())
   windows.main.init(state, { hidden })
   menu.init()
@@ -59,10 +63,6 @@ function onReady (err, results) {
     windows.main.send('uncaughtError', 'main', error)
   })
 }
-
-var cwd = process.env.TEST_DIR || config.CONFIG_PATH
-log('cwd', cwd)
-ipc.init(cwd)
 
 app.once('ipcReady', () => {
   log('Command line args:', argv)

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -17,12 +17,12 @@ const DeltaChat = require('./deltachat')
 const C = require('deltachat-node/constants')
 const setupNotifications = require('./notifications')
 
-function init (cwd) {
+function init (cwd, state) {
   // Events dispatched by buttons from the frontend
 
   const ipc = ipcMain
   const main = windows.main
-  const dc = new DeltaChat(cwd)
+  const dc = new DeltaChat(cwd, state.saved)
 
   ipc.once('ipcReady', function (e) {
     app.ipcReady = true
@@ -40,13 +40,12 @@ function init (cwd) {
     menu.init()
   })
 
-  // TODO: expose settings through UI
   var settings = {
     markRead: true,
     notifications: true,
     showNotificationContent: true
   }
-  setupNotifications(dc, settings)
+  setupNotifications(dc, state.saved)
 
   // Called once to get the conversations css string
   ipc.on('get-css', (e) => {
@@ -101,6 +100,10 @@ function init (cwd) {
   ipc.on('locale-data', (e, locale) => {
     if (locale) app.localeData = localize.setup(app, locale)
     e.returnValue = app.localeData
+  })
+
+  ipc.on('updateSettings', (e, saved) => {
+    dc.updateSettings(saved)
   })
 
   function dispatch (name, ...args) {

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -40,11 +40,6 @@ function init (cwd, state) {
     menu.init()
   })
 
-  var settings = {
-    markRead: true,
-    notifications: true,
-    showNotificationContent: true
-  }
   setupNotifications(dc, state.saved)
 
   // Called once to get the conversations css string

--- a/src/renderer/App.js
+++ b/src/renderer/App.js
@@ -15,6 +15,7 @@ class App extends React.Component {
       <IntlProvider locale={window.localeData.locale}>
         <ScreenController
           logins={remote.app.logins}
+          saved={state.saved}
           deltachat={state.deltachat} />
       </IntlProvider>
     )

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -17,12 +17,15 @@ class Home extends React.Component {
       screen: 'SplittedChatListAndView',
       screenProps: {},
       showAbout: false,
+      showSettings: false,
       message: false
     }
 
     this.changeScreen = this.changeScreen.bind(this)
     this.userFeedback = this.userFeedback.bind(this)
     this.onShowAbout = this.showAbout.bind(this, true)
+    this.onShowSettings = this.showSettings.bind(this, true)
+    this.onCloseSettings = this.showSettings.bind(this, false)
     this.onCloseAbout = this.showAbout.bind(this, false)
   }
 
@@ -57,9 +60,13 @@ class Home extends React.Component {
     this.setState({ showAbout })
   }
 
+  showSettings (showSettings) {
+    this.setState({ showSettings })
+  }
+
   render () {
-    const { logins, deltachat } = this.props
-    const { screen, screenProps, showAbout } = this.state
+    const { saved, logins, deltachat } = this.props
+    const { screen, screenProps, showAbout, showSettings } = this.state
 
     var Screen
     switch (screen) {
@@ -96,13 +103,16 @@ class Home extends React.Component {
         {!deltachat.ready
           ? <Login logins={logins} deltachat={deltachat} />
           : <Screen
+            saved={saved}
             screenProps={screenProps}
+            openSettings={this.onShowSettings}
             userFeedback={this.userFeedback}
             changeScreen={this.changeScreen}
             deltachat={deltachat}
           />
         }
         <dialogs.About isOpen={showAbout} onClose={this.onCloseAbout} />
+        <dialogs.Settings isOpen={showSettings} onClose={this.onCloseSettings} saved={saved} />
         <dialogs.ImexProgress />
       </div>
     )

--- a/src/renderer/components/MessageWrapper.js
+++ b/src/renderer/components/MessageWrapper.js
@@ -94,6 +94,7 @@ function render (props) {
 
   let key = message.id
   let body
+
   if (message.id === C.DC_MSG_ID_DAYMARKER) {
     key = message.daymarker.id
     body = (

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -3,7 +3,6 @@ const { ipcRenderer } = require('electron')
 const styled = require('styled-components').default
 const { InputGroup } = require('@blueprintjs/core')
 
-const Settings = require('./Settings')
 const dialogs = require('./dialogs')
 const Menu = require('./Menu')
 const ChatList = require('./ChatList')
@@ -44,13 +43,10 @@ class SplittedChatListAndView extends React.Component {
     super(props)
 
     this.state = {
-      settings: false,
       deadDropChat: false,
       queryStr: ''
     }
 
-    this.openSettings = this.openSettings.bind(this)
-    this.onCloseSettings = this.onCloseSettings.bind(this)
     this.onShowArchivedChats = this.showArchivedChats.bind(this, true)
     this.onHideArchivedChats = this.showArchivedChats.bind(this, false)
     this.onChatClick = this.onChatClick.bind(this)
@@ -88,23 +84,15 @@ class SplittedChatListAndView extends React.Component {
     this.searchChats(event.target.value)
   }
 
-  openSettings () {
-    this.setState({ settings: true })
-  }
-
-  onCloseSettings () {
-    this.setState({ settings: false })
-  }
-
   render () {
     const { deltachat } = this.props
     const { selectedChat, showArchivedChats } = deltachat
-    const { deadDropChat, settings } = this.state
+    const { deadDropChat } = this.state
 
     const tx = window.translate
 
     const menu = <Menu
-      openSettings={this.openSettings}
+      openSettings={this.props.openSettings}
       changeScreen={this.props.changeScreen}
       selectedChat={selectedChat}
       showArchivedChats={showArchivedChats}
@@ -138,7 +126,6 @@ class SplittedChatListAndView extends React.Component {
             </NavbarGroup>
           </Navbar>
         </NavbarWrapper>
-        <Settings isOpen={settings} onClose={this.onCloseSettings} />
         <dialogs.DeadDrop deadDropChat={deadDropChat} onClose={this.onDeadDropClose} />
         <BelowNavbar>
           <ChatList

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -30,8 +30,6 @@ class Settings extends React.Component {
       keyTransfer: false,
       saved: props.saved
     }
-    console.log(props)
-    console.log(this.state.saved)
     this.initiateKeyTransfer = this.initiateKeyTransfer.bind(this)
     this.onKeyTransferComplete = this.onKeyTransferComplete.bind(this)
     this.onBackupExport = this.onBackupExport.bind(this)
@@ -83,6 +81,7 @@ class Settings extends React.Component {
     this.state.saved[key] = value
     this.setState({ saved: this.state.saved })
     State.save({ saved: this.state.saved })
+    ipcRenderer.send('updateSettings', this.state.saved)
   }
 
   render () {

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -9,10 +9,13 @@ const {
   ButtonGroup,
   Classes,
   Button,
-  Dialog
+  Dialog,
+  Switch
 } = require('@blueprintjs/core')
 
-const dialogs = require('./dialogs')
+const KeyTransfer = require('./KeyTransfer')
+const confirmationDialog = require('./confirmationDialog')
+const State = require('../../lib/state')
 
 const SettingsDialog = styled.div`
   .bp3-card:not(:last-child){
@@ -24,12 +27,16 @@ class Settings extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      keyTransfer: false
+      keyTransfer: false,
+      saved: props.saved
     }
+    console.log(props)
+    console.log(this.state.saved)
     this.initiateKeyTransfer = this.initiateKeyTransfer.bind(this)
     this.onKeyTransferComplete = this.onKeyTransferComplete.bind(this)
     this.onBackupExport = this.onBackupExport.bind(this)
     this.onBackupImport = this.onBackupImport.bind(this)
+    this.handleSettingsChange = this.handleSettingsChange.bind(this)
   }
 
   onKeyTransferComplete () {
@@ -54,7 +61,7 @@ class Settings extends React.Component {
     var confirmOpts = {
       buttons: [tx('cancel'), tx('exportBackup')]
     }
-    dialogs.confirmation(tx('backupConfirmationMessage'), confirmOpts, response => {
+    confirmationDialog(tx('backupConfirmationMessage'), confirmOpts, response => {
       if (!response) return
       var opts = {
         title: tx('exportBackup'),
@@ -72,16 +79,22 @@ class Settings extends React.Component {
     this.setState({ keyTransfer: true })
   }
 
+  handleSettingsChange (key, value) {
+    this.state.saved[key] = value
+    this.setState({ saved: this.state.saved })
+    State.save({ saved: this.state.saved })
+  }
+
   render () {
     const { isOpen, onClose } = this.props
-    const { keyTransfer } = this.state
+    const { saved, keyTransfer } = this.state
 
     const tx = window.translate
     const title = tx('settingsTitle')
 
     return (
       <div>
-        <dialogs.KeyTransfer isOpen={keyTransfer} onClose={this.onKeyTransferComplete} />
+        <KeyTransfer isOpen={keyTransfer} onClose={this.onKeyTransferComplete} />
         <Dialog
           isOpen={isOpen}
           title={title}
@@ -91,7 +104,9 @@ class Settings extends React.Component {
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsAutocryptSection')}</H5>
               <p>{tx('autocryptDescription')}</p>
-              <Button onClick={this.initiateKeyTransfer}>{tx('initiateKeyTransferTitle')}</Button>
+              <Button onClick={this.initiateKeyTransfer}>
+                {tx('initiateKeyTransferTitle')}
+              </Button>
             </Card>
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsBackupSection')}</H5>
@@ -99,6 +114,14 @@ class Settings extends React.Component {
                 <Button onClick={this.onBackupExport}>{tx('exportBackup')}...</Button>
                 <Button onClick={this.onBackupImport}>{tx('importBackup')}...</Button>
               </ButtonGroup>
+            </Card>
+            <Card elevation={Elevation.ONE}>
+              <H5>{tx('settingsOptionsSection')}</H5>
+              <Switch
+                checked={saved.markRead}
+                label='Mark incoming messages as read'
+                onChange={() => this.handleSettingsChange('markRead', !this.state.saved.markRead)}
+              />
             </Card>
           </SettingsDialog>
         </Dialog>

--- a/src/renderer/components/dialogs/confirmationDialog.js
+++ b/src/renderer/components/dialogs/confirmationDialog.js
@@ -1,0 +1,15 @@
+const { remote } = require('electron')
+
+module.exports = function confirmation (message, opts, cb) {
+  if (!cb) cb = opts
+  if (!opts) opts = {}
+  const tx = window.translate
+  var defaultOpts = {
+    type: 'question',
+    message: message,
+    buttons: [tx('dialogs.confirmation.no'), tx('dialogs.confirmation.yes')]
+  }
+  remote.dialog.showMessageBox(Object.assign(defaultOpts, opts), response => {
+    cb(response === 1) // eslint-disable-line
+  })
+}

--- a/src/renderer/components/dialogs/index.js
+++ b/src/renderer/components/dialogs/index.js
@@ -23,4 +23,3 @@ module.exports = {
   About,
   Settings
 }
-

--- a/src/renderer/components/dialogs/index.js
+++ b/src/renderer/components/dialogs/index.js
@@ -1,5 +1,3 @@
-const { remote } = require('electron')
-
 const SetupMessage = require('./SetupMessage')
 const MessageDetail = require('./MessageDetail')
 const RenderMedia = require('./RenderMedia')
@@ -9,6 +7,8 @@ const KeyTransfer = require('./KeyTransfer')
 const QrCode = require('./QrCode')
 const ImexProgress = require('./ImexProgress')
 const About = require('./About')
+const Settings = require('./Settings')
+const confirmation = require('./confirmationDialog')
 
 module.exports = {
   confirmation,
@@ -20,19 +20,7 @@ module.exports = {
   KeyTransfer,
   QrCode,
   ImexProgress,
-  About
+  About,
+  Settings
 }
 
-function confirmation (message, opts, cb) {
-  if (!cb) cb = opts
-  if (!opts) opts = {}
-  const tx = window.translate
-  var defaultOpts = {
-    type: 'question',
-    message: message,
-    buttons: [tx('dialogs.confirmation.no'), tx('dialogs.confirmation.yes')]
-  }
-  remote.dialog.showMessageBox(Object.assign(defaultOpts, opts), response => {
-    cb(response === 1) // eslint-disable-line
-  })
-}

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -57,7 +57,9 @@ function getDefaultState () {
      * Also accessible via `require('application-config')('DeltaChat').filePath`
      */
     saved: {
-      markRead: true
+      markRead: true,
+      notifications: true,
+      showNotificationContent: true
     }
   }
 }

--- a/src/renderer/lib/state.js
+++ b/src/renderer/lib/state.js
@@ -56,7 +56,9 @@ function getDefaultState () {
      *
      * Also accessible via `require('application-config')('DeltaChat').filePath`
      */
-    saved: {}
+    saved: {
+      markRead: true
+    }
   }
 }
 
@@ -64,8 +66,8 @@ function getDefaultState () {
 function setupStateSaved (cb) {
   const saved = {
     locale: null,
-    credentials: {},
-    version: config.APP_VERSION /* make sure we can upgrade gracefully later */
+    version: config.APP_VERSION,
+    markRead: true
   }
   cb(null, saved)
 }
@@ -83,7 +85,8 @@ function load (cb) {
   function onSavedState (err, saved) {
     if (err) return cb(err)
     const state = getDefaultState()
-    state.saved = saved
+    // override default savable settings with saved ones
+    state.saved = Object.assign(state.saved, saved)
 
     cb(null, state)
   }
@@ -95,8 +98,6 @@ function saveImmediate (state, cb) {
 
   // Clean up, so that we're not saving any pending state
   const copy = Object.assign({}, state.saved)
-  // Remove torrents pending addition to the list, where we haven't finished
-  // reading the torrent file or file(s) to seed & don't have an infohash
 
   appConfig.write(copy, (err) => {
     if (err) console.error(err)

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -38,6 +38,12 @@ function setupIpc () {
   ipcRenderer.on('stateSave', (e) => State.save(state))
   ipcRenderer.on('stateSaveImmediate', (e) => State.saveImmediate(state))
 
+  ipcRenderer.on('updateSettings', (e, key, value) => {
+    console.log('got', key, value)
+    // state.saved[key] = value
+    //State.save(state)
+  })
+
   ipcRenderer.on('chooseLanguage', onChooseLanguage)
   ipcRenderer.on('windowBoundsChanged', onWindowBoundsChanged)
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -38,12 +38,6 @@ function setupIpc () {
   ipcRenderer.on('stateSave', (e) => State.save(state))
   ipcRenderer.on('stateSaveImmediate', (e) => State.saveImmediate(state))
 
-  ipcRenderer.on('updateSettings', (e, key, value) => {
-    console.log('got', key, value)
-    // state.saved[key] = value
-    //State.save(state)
-  })
-
   ipcRenderer.on('chooseLanguage', onChooseLanguage)
   ipcRenderer.on('windowBoundsChanged', onWindowBoundsChanged)
 


### PR DESCRIPTION
This allows users to set in the settings whether or not they want messages to be marked read (or not). Default is `true`

It includes some refactoring of the settings screen -- more incoming on refactoring our dialogs to have a DialogController along with a ScreenController, probably next week.

fixes #324 

![screenshot from 2018-12-11 15-24-38](https://user-images.githubusercontent.com/633012/49837383-030f8480-fd5b-11e8-8f03-ab52eae5b594.png)
