### PR TITLE
 Advanced account settings

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -112,7 +112,7 @@
         "description": "Information to the user when a contact was created successfully"
     },
     "autocryptKeyTransfer": {
-        "message": "Autocrypt Key Transfer",
+        "message": "Autocrypt Transfer",
         "description": "Dialog title during Autocrypt key transfer"
     },
     "setupMessageInfo": {
@@ -120,11 +120,11 @@
         "description": "Text for the autocrypt setup message"
     },
     "transferKey": {
-        "message": "Transfer Key",
+        "message": "Begin Transfer",
         "description": "Button label during Autocrypt key transfer"
     },
     "initiateKeyTransferTitle": {
-        "message": "Initiate Key Transfer",
+        "message": "Send Autocrypt Setup Message",
         "description": "Menu alternative to initiate key transfer"
     },
     "initiateKeyTransfer": {

--- a/_locales/en.json
+++ b/_locales/en.json
@@ -859,5 +859,8 @@
   },
   "encryptionInfoTitle": {
     "message": "Encryption Information"
+  },
+  "endToEndSetup": {
+    "message": "Prefer end-to-end encryption"
   }
 }

--- a/_locales/en.json
+++ b/_locales/en.json
@@ -860,7 +860,10 @@
   "encryptionInfoTitle": {
     "message": "Encryption Information"
   },
-  "endToEndSetup": {
+  "settingsEndToEndSetup": {
     "message": "Prefer end-to-end encryption"
+  },
+  "settingsMarkRead": {
+    "message": "Receive and send read receipts"
   }
 }

--- a/_locales/en.json
+++ b/_locales/en.json
@@ -839,5 +839,14 @@
   "forwardMessageTitle": {
     "message": "Forward Message",
     "description": "Title in the dialog for choosing a contact to forward to"
+  },
+  "settingsUpdateAccount": {
+    "message": "Update account"
+  },
+  "settingsAdvancedTitle": {
+    "message": "Advanced Settings"
+  },
+  "settingsAccountTitle": {
+    "message": "Update Account"
   }
 }

--- a/_locales/en.json
+++ b/_locales/en.json
@@ -841,12 +841,12 @@
     "description": "Title in the dialog for choosing a contact to forward to"
   },
   "settingsUpdateAccount": {
-    "message": "Update account"
+    "message": "Update Account Settings"
   },
   "settingsAdvancedTitle": {
     "message": "Advanced Settings"
   },
   "settingsAccountTitle": {
-    "message": "Update Account"
+    "message": "Account Settings"
   }
 }

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -372,7 +372,7 @@ class DeltaChatController extends events.EventEmitter {
     this._dc.importExport(C.DC_IMEX_EXPORT_BACKUP, directory)
   }
 
-  getAdvancedSettings() {
+  getAdvancedSettings () {
     return {
       addr: this._dc.getConfig('addr'),
       mailUser: this._dc.getConfig('mail_user'),

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -372,6 +372,13 @@ class DeltaChatController extends events.EventEmitter {
     this._dc.importExport(C.DC_IMEX_EXPORT_BACKUP, directory)
   }
 
+  getAdvancedSettings() {
+    return {
+      addr: this._dc.getConfig('addr'),
+      mailPw: this._dc.getConfig('mail_pw')
+    }
+  }
+
   /**
    * Returns the state in json format
    */

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -372,6 +372,10 @@ class DeltaChatController extends events.EventEmitter {
     this._dc.importExport(C.DC_IMEX_EXPORT_BACKUP, directory)
   }
 
+  setConfig (key, value) {
+    return this._dc.setConfig(key, String(value))
+  }
+
   getAdvancedSettings () {
     return {
       addr: this._dc.getConfig('addr'),
@@ -384,7 +388,8 @@ class DeltaChatController extends events.EventEmitter {
       sendPw: this._dc.getConfig('send_pw'),
       sendServer: this._dc.getConfig('send_server'),
       sendPort: this._dc.getConfig('send_port'),
-      sendSecurity: this._dc.getConfig('send_security')
+      sendSecurity: this._dc.getConfig('send_security'),
+      e2ee_enabled: this._dc.getConfig('e2ee_enabled')
     }
   }
 

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -381,11 +381,14 @@ class DeltaChatController extends events.EventEmitter {
     return this._dc.setConfig(key, String(value))
   }
 
+  getConfig (key) {
+    return this._dc.getConfig(key)
+  }
+
   getAdvancedSettings () {
     return {
       addr: this._dc.getConfig('addr'),
       mailUser: this._dc.getConfig('mail_user'),
-      mailPw: this._dc.getConfig('mail_pw'),
       mailServer: this._dc.getConfig('mail_server'),
       mailPort: this._dc.getConfig('mail_port'),
       mailSecurity: this._dc.getConfig('mail_security'),

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -130,13 +130,16 @@ class DeltaChatController extends events.EventEmitter {
    * Dispatched when logging out from ChatList
    */
   logout () {
-    this._dc.close()
-    this._dc = null
-
+    this.close()
     this._resetState()
 
     log('Logged out')
     if (typeof this._render === 'function') this._render()
+  }
+
+  close () {
+    this._dc.close()
+    this._dc = null
   }
 
   /**

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -138,6 +138,7 @@ class DeltaChatController extends events.EventEmitter {
   }
 
   close () {
+    if (!this._dc) return
     this._dc.close()
     this._dc = null
   }

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -65,6 +65,7 @@ class DeltaChatController extends events.EventEmitter {
       log(event, data1, data2)
       if (event === 2041) {
         log('DC_EVENT_CONFIGURE_PROGRESS', data1)
+        this.emit('DC_EVENT_CONFIGURE_PROGRESS', data1, data2)
         if (Number(data1) === 0) { // login failed
           this.logout()
         }
@@ -119,8 +120,8 @@ class DeltaChatController extends events.EventEmitter {
       log.error(error)
     })
 
-    dc.on('DC_EVENT_NETWORK_ERROR', (error) => {
-      this.emit('DC_EVENT_NETWORK_ERROR', error)
+    dc.on('DC_EVENT_ERROR_NETWORK', (first, error) => {
+      this.emit('DC_EVENT_ERROR_NETWORK', first, error)
       log.error(error)
     })
   }

--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -375,7 +375,16 @@ class DeltaChatController extends events.EventEmitter {
   getAdvancedSettings() {
     return {
       addr: this._dc.getConfig('addr'),
-      mailPw: this._dc.getConfig('mail_pw')
+      mailUser: this._dc.getConfig('mail_user'),
+      mailPw: this._dc.getConfig('mail_pw'),
+      mailServer: this._dc.getConfig('mail_server'),
+      mailPort: this._dc.getConfig('mail_port'),
+      mailSecurity: this._dc.getConfig('mail_security'),
+      sendUser: this._dc.getConfig('send_user'),
+      sendPw: this._dc.getConfig('send_pw'),
+      sendServer: this._dc.getConfig('send_server'),
+      sendPort: this._dc.getConfig('send_port'),
+      sendSecurity: this._dc.getConfig('send_security')
     }
   }
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -126,6 +126,7 @@ function init (cwd, state) {
 
   ipc.on('updateCredentials', (e, credentials) => {
     var dir = path.join(os.tmpdir(), Date.now().toString())
+    if (!credentials.mailPw) credentials.mailPw = dc.getConfig('mail_pw')
     var tmp = new DeltaChat(dir, state.saved)
 
     tmp.on('DC_EVENT_CONFIGURE_PROGRESS', function (data1) {

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -22,6 +22,7 @@ function init (cwd, state) {
 
   const ipc = ipcMain
   const main = windows.main
+  console.log(state)
   const dc = new DeltaChat(cwd, state.saved)
 
   ipc.once('ipcReady', function (e) {
@@ -114,6 +115,10 @@ function init (cwd, state) {
 
   ipc.on('updateSettings', (e, saved) => {
     dc.updateSettings(saved)
+  })
+
+  ipc.on('retrieveAdvancedSettingsObj', (e, ...args) => {
+    windows.main.send('retrieveAdvancedSettingsObjResp', dc.getAdvancedSettings())
   })
 
   function dispatch (name, ...args) {

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -131,6 +131,7 @@ function init (cwd, state) {
     tmp.on('DC_EVENT_CONFIGURE_PROGRESS', function (data1) {
       if (Number(data1) === 0) { // login failed
         windows.main.send('error', 'Login failed')
+        tmp.close()
       }
     })
 
@@ -142,6 +143,7 @@ function init (cwd, state) {
       if (tmpJson.ready) {
         dc.login(credentials, render, txCoreStrings())
         windows.main.send('success', 'Configuration success!')
+        tmp.close()
       }
     }
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -7,7 +7,9 @@ const {
   ipcMain
 } = require('electron')
 
+const path = require('path')
 const fs = require('fs')
+const os = require('os')
 
 const localize = require('../localize')
 const menu = require('./menu')
@@ -22,7 +24,6 @@ function init (cwd, state) {
 
   const ipc = ipcMain
   const main = windows.main
-  console.log(state)
   const dc = new DeltaChat(cwd, state.saved)
 
   ipc.once('ipcReady', function (e) {
@@ -63,11 +64,17 @@ function init (cwd, state) {
   })
 
   dc.on('DC_EVENT_ERROR', (error) => {
-    windows.main.send('error', error.toString())
+    windows.main.send('error', error)
   })
 
-  dc.on('DC_EVENT_NETWORK_ERROR', (first, error) => {
-    windows.main.send('error', error.toString())
+  dc.on('DC_EVENT_ERROR_NETWORK', (first, error) => {
+    windows.main.send('error', error)
+  })
+
+  dc.on('DC_EVENT_CONFIGURE_PROGRESS', function (data1) {
+    if (Number(data1) === 0) { // login failed
+      windows.main.send('error', 'Login failed!')
+    }
   })
 
   // Calls a function directly in the deltachat-node instance and returns the
@@ -117,8 +124,28 @@ function init (cwd, state) {
     dc.updateSettings(saved)
   })
 
-  ipc.on('retrieveAdvancedSettingsObj', (e, ...args) => {
-    windows.main.send('retrieveAdvancedSettingsObjResp', dc.getAdvancedSettings())
+  ipc.on('updateCredentials', (e, credentials) => {
+    var dir = path.join(os.tmpdir(), Date.now().toString())
+    var tmp = new DeltaChat(dir, state.saved)
+
+    tmp.on('DC_EVENT_CONFIGURE_PROGRESS', function (data1) {
+      if (Number(data1) === 0) { // login failed
+        windows.main.send('error', 'Login failed')
+      }
+    })
+
+    function fakeRender () {
+      var json = dc.render()
+      var tmpJson = tmp.render()
+      json.configuring = tmpJson.configuring
+      windows.main.send('render', json)
+      if (tmpJson.ready) {
+        dc.login(credentials, render, txCoreStrings())
+        windows.main.send('success', 'Configuration success!')
+      }
+    }
+
+    tmp.login(credentials, fakeRender, txCoreStrings())
   })
 
   function dispatch (name, ...args) {

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -1,6 +1,18 @@
 const React = require('react')
 const { ipcRenderer } = require('electron')
+const styled = require('styled-components').default
 
+const {
+  Alignment,
+  Navbar,
+  NavbarGroup,
+  NavbarHeading,
+  Callout,
+  Button
+} = require('@blueprintjs/core')
+
+const NavbarWrapper = require('./components/NavbarWrapper')
+const ClickableLink = require('./components/helpers/ClickableLink')
 const UnblockContacts = require('./components/UnblockContacts')
 const Login = require('./components/Login')
 const CreateChat = require('./components/CreateChat')
@@ -105,7 +117,9 @@ class Home extends React.Component {
           </div>
         )}
         {!deltachat.ready
-          ? <Login logins={logins} deltachat={deltachat} />
+          ? <LoginScreen logins={logins}>
+            <Login loading={deltachat.configuring} />
+          </LoginScreen>
           : <Screen
             saved={saved}
             screenProps={screenProps}
@@ -121,6 +135,46 @@ class Home extends React.Component {
       </div>
     )
   }
+}
+
+
+const LoginWrapper = styled.div`
+  .window {
+    height: auto;
+  }
+`
+
+function LoginScreen (props) {
+  const tx = window.translate
+  const children = props.children
+
+  function onClickLogin (login) {
+    ipcRenderer.send('login', { addr: login, mailPw: true })
+  }
+
+  return (
+    <LoginWrapper>
+      <NavbarWrapper>
+        <Navbar fixedToTop>
+          <NavbarGroup align={Alignment.LEFT}>
+            <NavbarHeading>{tx('login.welcome')}</NavbarHeading>
+          </NavbarGroup>
+        </Navbar>
+      </NavbarWrapper>
+      <div className='window'>
+        <Callout intent='danger' title='Single folder incompatibility'>
+          To improve the user experience with Delta Chat using multiple devices, we experimentally changed the behaviour of Delta Chat. Therefore, beginning with this release, we aren't compatible with the <b>old android client</b> which you can currently find in the f-droid store. Please use the <b>new development</b> version. You can find it <ClickableLink href='https://github.com/deltachat/deltachat-android-ii/releases'>here</ClickableLink>.
+        </Callout>
+        <ul>
+          {props.logins.map((login) => <li key={login}>
+            <Button onClick={() => onClickLogin(login)}> {login}</Button>
+          </li>
+          )}
+        </ul>
+        {children}
+      </div>
+    </LoginWrapper>
+  )
 }
 
 module.exports = Home

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -34,7 +34,9 @@ class Home extends React.Component {
 
     this.changeScreen = this.changeScreen.bind(this)
     this.onError = this.onError.bind(this)
+    this.onSuccess = this.onSuccess.bind(this)
     this.userFeedback = this.userFeedback.bind(this)
+    this.userFeedbackClick = this.userFeedbackClick.bind(this)
     this.openDialog = this.openDialog.bind(this)
     this.closeDialog = this.closeDialog.bind(this)
     this.onShowAbout = this.showAbout.bind(this, true)
@@ -46,16 +48,18 @@ class Home extends React.Component {
   }
 
   userFeedback (message) {
-    var self = this
-    setTimeout(function () {
-      self.setState({ message: false })
-    }, 3000)
-    self.setState({ message })
+    if (message !== false && this.state.message) return // one at a time, cowgirl
+    this.setState({ message })
+  }
+
+  userFeedbackClick () {
+    this.userFeedback(false)
   }
 
   componentDidMount () {
     var self = this
     ipcRenderer.on('error', this.onError)
+    ipcRenderer.on('success', this.onSuccess)
     ipcRenderer.on('showAboutDialog', this.onShowAbout)
     ipcRenderer.on('DC_EVENT_IMEX_FILE_WRITTEN', (_event, filename) => {
       self.userFeedback({ type: 'success', text: `${filename} created.` })
@@ -69,11 +73,16 @@ class Home extends React.Component {
   componentWillUnmount () {
     ipcRenderer.removeListener('showAboutDialog', this.onShowAbout)
     ipcRenderer.removeListener('error', this.onError)
+    ipcRenderer.removeListener('success', this.onSuccess)
   }
 
   onError (event, error) {
     const text = error ? error.toString() : 'Unknown'
     this.userFeedback({ type: 'error', text })
+  }
+
+  onSuccess (event, text) {
+    this.userFeedback({ type: 'success', text })
   }
 
   showAbout (showAbout) {
@@ -124,7 +133,8 @@ class Home extends React.Component {
     return (
       <div>
         {this.state.message && (
-          <div className={classNames}>
+          <div onClick={this.userFeedbackClick}
+            className={classNames}>
             {this.state.message.text}
           </div>
         )}

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -65,6 +65,10 @@ class Home extends React.Component {
     })
   }
 
+  handleLogin (credentials) {
+    ipcRenderer.send('login', credentials)
+  }
+
   componentWillUnmount () {
     ipcRenderer.removeListener('showAboutDialog', this.onShowAbout)
   }
@@ -108,6 +112,7 @@ class Home extends React.Component {
 
     var type = this.state.message.type
     var classNames = `user-feedback ${type}`
+    const tx = window.translate
 
     return (
       <div>
@@ -118,7 +123,11 @@ class Home extends React.Component {
         )}
         {!deltachat.ready
           ? <LoginScreen logins={logins}>
-            <Login loading={deltachat.configuring} />
+            <Login onSubmit={this.handleLogin}
+              loading={deltachat.configuring}>
+              <Button type='submit' text={tx('login.button')} />
+              <Button type='cancel' text={tx('login.cancel')} />
+            </Login>
           </LoginScreen>
           : <Screen
             saved={saved}
@@ -130,13 +139,17 @@ class Home extends React.Component {
           />
         }
         <dialogs.About isOpen={showAbout} onClose={this.onCloseAbout} />
-        <dialogs.Settings isOpen={showSettings} onClose={this.onCloseSettings} saved={saved} />
+        <dialogs.Settings
+          userFeedback={this.userFeedback}
+          deltachat={deltachat}
+          isOpen={showSettings}
+          onClose={this.onCloseSettings}
+          saved={saved} />
         <dialogs.ImexProgress />
       </div>
     )
   }
 }
-
 
 const LoginWrapper = styled.div`
   .window {

--- a/src/renderer/components/Login.js
+++ b/src/renderer/components/Login.js
@@ -29,16 +29,16 @@ class Login extends React.Component {
   _defaultCredentials () {
     return {
       addr: process.env.DC_ADDR || this.props.addr || '',
-      mailUser: '',
+      mailUser: this.props.mailUser || '',
       mailPw: process.env.DC_MAIL_PW || this.props.mailPw || '',
-      mailServer: '',
-      mailPort: '',
-      mailSecurity: '',
-      sendUser: '',
-      sendPw: '',
-      sendServer: '',
-      sendPort: '',
-      sendSecurity: ''
+      mailServer: this.props.mailServer || '',
+      mailPort: this.props.mailPort || '',
+      mailSecurity: this.props.mailSecurity || '',
+      sendUser: this.props.sendUser || '',
+      sendPw: this.props.sendPw || '',
+      sendServer: this.props.sendServer || '',
+      sendPort: this.props.sendPort || '',
+      sendSecurity: this.props.sendSecurity || ''
     }
   }
 

--- a/src/renderer/components/Login.js
+++ b/src/renderer/components/Login.js
@@ -28,9 +28,9 @@ class Login extends React.Component {
 
   _defaultCredentials () {
     return {
-      addr: process.env.DC_ADDR ? process.env.DC_ADDR : '',
+      addr: process.env.DC_ADDR || this.props.addr || '',
       mailUser: '',
-      mailPw: process.env.DC_MAIL_PW ? process.env.DC_MAIL_PW : '',
+      mailPw: process.env.DC_MAIL_PW || this.props.mailPw || '',
       mailServer: '',
       mailPort: '',
       mailSecurity: '',
@@ -48,8 +48,7 @@ class Login extends React.Component {
   }
 
   handleSubmit (event) {
-    if (this.props.onSubmit) this.props.onSubmit(this.state.credentials)
-    else ipcRenderer.send('login', this.state.credentials)
+    this.props.onSubmit(this.state.credentials)
     event.preventDefault()
   }
 
@@ -210,8 +209,18 @@ class Login extends React.Component {
             </div>
           </FormGroup>
         </Collapse>
-        <Button disabled={loading || (!addr || !mailPw)} type='submit' text={tx('login.button')} />
-        {loading && <Button text={tx('login.cancel')} onClick={this.cancelClick.bind(this)} />}
+        {React.Children.map(this.props.children, (child) => {
+          var props = {}
+          if (child.props.type === 'submit') {
+            props.disabled = loading || (!addr || !mailPw)
+          }
+          if (child.props.type === 'cancel') {
+            props.onClick = this.cancelClick.bind(this)
+            if (!loading) return
+          }
+          return React.cloneElement(child, props)
+        })}
+
       </form>
     )
   }

--- a/src/renderer/components/Login.js
+++ b/src/renderer/components/Login.js
@@ -1,28 +1,13 @@
 const React = require('react')
 const { ipcRenderer } = require('electron')
-const styled = require('styled-components').default
 
 const {
-  Alignment,
-  Navbar,
-  NavbarGroup,
-  NavbarHeading,
   Button,
   InputGroup,
   FormGroup,
   Collapse,
-  Intent,
-  Callout
+  Intent
 } = require('@blueprintjs/core')
-
-const ClickableLink = require('./helpers/ClickableLink')
-const NavbarWrapper = require('./NavbarWrapper')
-
-const LoginWrapper = styled.div`
-  .window {
-    height: auto;
-  }
-`
 
 class Login extends React.Component {
   constructor (props) {
@@ -63,7 +48,8 @@ class Login extends React.Component {
   }
 
   handleSubmit (event) {
-    ipcRenderer.send('login', this.state.credentials)
+    if (this.props.onSubmit) this.props.onSubmit(this.state.credentials)
+    else ipcRenderer.send('login', this.state.credentials)
     event.preventDefault()
   }
 
@@ -77,10 +63,6 @@ class Login extends React.Component {
     this.setState({ credentials: this._defaultCredentials() })
     event.preventDefault()
     event.stopPropagation()
-  }
-
-  onClickLogin (login) {
-    ipcRenderer.send('login', { addr: login, mailPw: true })
   }
 
   renderPasswordInput (keyShowPassword, keyValue) {
@@ -109,7 +91,7 @@ class Login extends React.Component {
   }
 
   render () {
-    const { logins, deltachat } = this.props
+    const { loading } = this.props
 
     const {
       addr,
@@ -128,131 +110,109 @@ class Login extends React.Component {
 
     const tx = window.translate
 
-    var loading = deltachat.configuring
-
     return (
-      <LoginWrapper>
-        <NavbarWrapper>
-          <Navbar fixedToTop>
-            <NavbarGroup align={Alignment.LEFT}>
-              <NavbarHeading>{tx('login.welcome')}</NavbarHeading>
-            </NavbarGroup>
-          </Navbar>
-        </NavbarWrapper>
-        <div className='window'>
-          <Callout intent='danger' title='Single folder incompatibility'>
-            To improve the user experience with Delta Chat using multiple devices, we experimentally changed the behaviour of Delta Chat. Therefore, beginning with this release, we aren't compatible with the <b>old android client</b> which you can currently find in the f-droid store. Please use the <b>new development</b> version. You can find it <ClickableLink href='https://github.com/deltachat/deltachat-android-ii/releases'>here</ClickableLink>.
-          </Callout>
-          <ul>
-            {logins.map((login) => <li key={login}>
-              <Button onClick={this.onClickLogin.bind(this, login)}> {login}</Button>
-            </li>
-            )}
-          </ul>
-          <form onSubmit={this.handleSubmit}>
-            <FormGroup label={tx('login.email')} placeholder='E-Mail Address' labelFor='email' labelInfo={`(${tx('login.required')})`}>
-              <InputGroup
-                id='addr'
-                type='text'
-                value={addr}
-                leftIcon='envelope'
-                onChange={this.handleCredentialsChange}
-              />
-            </FormGroup>
-            <FormGroup label={tx('login.mailPw')} placeholder='Password' labelFor='mailPw' labelInfo={`(${tx('login.required')})`}>
-              {this.renderPasswordInput('showPasswordMail', 'mailPw')}
-            </FormGroup>
-            <Button onClick={this.handleUISwitchStateProperty.bind(this, 'showAdvanced')}>{(showAdvanced ? '-' : '+') + ' ' + tx('login.advanced') }</Button>
-            <Collapse isOpen={showAdvanced}>
-              <h2>{tx('login.inbox')}</h2>
-              <FormGroup label={tx('login.mailUser')} placeholder='IMAP-Loginname' labelFor='mailUser' labelInfo={`(${tx('login.automatic')})`}>
-                <InputGroup
-                  id='mailUser'
-                  type='text'
-                  value={mailUser}
-                  leftIcon='envelope'
-                  onChange={this.handleCredentialsChange}
-                />
-              </FormGroup>
-              <FormGroup label={tx('login.mailServer')} placeholder='IMAP-Server' labelFor='mailServer' labelInfo={`(${tx('login.automatic')})`}>
-                <InputGroup
-                  id='mailServer'
-                  type='text'
-                  value={mailServer}
-                  leftIcon='envelope'
-                  onChange={this.handleCredentialsChange}
-                />
-              </FormGroup>
-              <FormGroup label={tx('login.mailPort')} placeholder='IMAP-Port' labelFor='mailPort' labelInfo={`(${tx('login.automatic')})`}>
-                <InputGroup
-                  id='mailPort'
-                  type='number'
-                  min='0'
-                  max='65535'
-                  value={mailPort}
-                  leftIcon='envelope'
-                  onChange={this.handleCredentialsChange}
-                />
-              </FormGroup>
-              <FormGroup label={tx('login.mailSecurity')} placeholder='Security' labelFor='mailSecurity' labelInfo={`(${tx('login.automatic')})`}>
-                <div className='bp3-select .modifier'>
-                  <select id='mailSecurity' value={mailSecurity} onChange={this.handleCredentialsChange}>
-                    <option value=''>{tx('login.security.automatic')}</option>
-                    <option value='ssl'>SSL/TLS</option>
-                    <option value='starttls'>STARTTLS</option>
-                    <option value='plain'>{tx('login.security.disable')}</option>
-                  </select>
-                </div>
-              </FormGroup>
-              <h2>{tx('login.outbox')}</h2>
-              <FormGroup label={tx('login.sendUser')} placeholder='SMTP-Loginname' labelFor='sendUser' labelInfo={`(${tx('login.automatic')})`}>
-                <InputGroup
-                  id='sendUser'
-                  type='text'
-                  value={sendUser}
-                  leftIcon='envelope'
-                  onChange={this.handleCredentialsChange}
-                />
-              </FormGroup>
-              <FormGroup label={tx('login.sendPw')} placeholder='SMTP-Password' labelFor='sendPw' labelInfo={`(${tx('login.automatic')})`}>
-                {this.renderPasswordInput('showPasswordSend', 'sendPw')}
-              </FormGroup>
-              <FormGroup label={tx('login.sendServer')} placeholder='SMTP-Server' labelFor='sendServer' labelInfo={`(${tx('login.automatic')})`}>
-                <InputGroup
-                  id='sendServer'
-                  type='text'
-                  value={sendServer}
-                  leftIcon='envelope'
-                  onChange={this.handleCredentialsChange}
-                />
-              </FormGroup>
-              <FormGroup label={tx('login.sendPort')} placeholder='SMTP-Port' labelFor='sendPort' labelInfo={`(${tx('login.automatic')})`}>
-                <InputGroup
-                  id='sendPort'
-                  type='number'
-                  min='0'
-                  max='65535'
-                  value={sendPort}
-                  leftIcon='envelope'
-                  onChange={this.handleCredentialsChange}
-                />
-              </FormGroup>
-              <FormGroup label={tx('login.sendSecurity')} placeholder='Security' labelFor='sendSecurity' labelInfo={`(${tx('login.automatic')})`}>
-                <div className='bp3-select .modifier'>
-                  <select id='sendSecurity' value={sendSecurity} onChange={this.handleCredentialsChange}>
-                    <option value=''>{tx('login.security.automatic')}</option>
-                    <option value='ssl'>SSL/TLS</option>
-                    <option value='starttls'>STARTTLS</option>
-                    <option value='plain'>{tx('login.security.disable')}</option>
-                  </select>
-                </div>
-              </FormGroup>
-            </Collapse>
-            <Button disabled={loading || (!addr || !mailPw)} type='submit' text={tx('login.button')} />
-            {loading && <Button text={tx('login.cancel')} onClick={this.cancelClick.bind(this)} />}
-          </form>
-        </div>
-      </LoginWrapper>
+      <form onSubmit={this.handleSubmit}>
+        <FormGroup label={tx('login.email')} placeholder='E-Mail Address' labelFor='email' labelInfo={`(${tx('login.required')})`}>
+          <InputGroup
+            id='addr'
+            type='text'
+            value={addr}
+            leftIcon='envelope'
+            onChange={this.handleCredentialsChange}
+          />
+        </FormGroup>
+        <FormGroup label={tx('login.mailPw')} placeholder='Password' labelFor='mailPw' labelInfo={`(${tx('login.required')})`}>
+          {this.renderPasswordInput('showPasswordMail', 'mailPw')}
+        </FormGroup>
+        <Button onClick={this.handleUISwitchStateProperty.bind(this, 'showAdvanced')}>{(showAdvanced ? '-' : '+') + ' ' + tx('login.advanced') }</Button>
+        <Collapse isOpen={showAdvanced}>
+          <h2>{tx('login.inbox')}</h2>
+          <FormGroup label={tx('login.mailUser')} placeholder='IMAP-Loginname' labelFor='mailUser' labelInfo={`(${tx('login.automatic')})`}>
+            <InputGroup
+              id='mailUser'
+              type='text'
+              value={mailUser}
+              leftIcon='envelope'
+              onChange={this.handleCredentialsChange}
+            />
+          </FormGroup>
+          <FormGroup label={tx('login.mailServer')} placeholder='IMAP-Server' labelFor='mailServer' labelInfo={`(${tx('login.automatic')})`}>
+            <InputGroup
+              id='mailServer'
+              type='text'
+              value={mailServer}
+              leftIcon='envelope'
+              onChange={this.handleCredentialsChange}
+            />
+          </FormGroup>
+          <FormGroup label={tx('login.mailPort')} placeholder='IMAP-Port' labelFor='mailPort' labelInfo={`(${tx('login.automatic')})`}>
+            <InputGroup
+              id='mailPort'
+              type='number'
+              min='0'
+              max='65535'
+              value={mailPort}
+              leftIcon='envelope'
+              onChange={this.handleCredentialsChange}
+            />
+          </FormGroup>
+          <FormGroup label={tx('login.mailSecurity')} placeholder='Security' labelFor='mailSecurity' labelInfo={`(${tx('login.automatic')})`}>
+            <div className='bp3-select .modifier'>
+              <select id='mailSecurity' value={mailSecurity} onChange={this.handleCredentialsChange}>
+                <option value=''>{tx('login.security.automatic')}</option>
+                <option value='ssl'>SSL/TLS</option>
+                <option value='starttls'>STARTTLS</option>
+                <option value='plain'>{tx('login.security.disable')}</option>
+              </select>
+            </div>
+          </FormGroup>
+          <h2>{tx('login.outbox')}</h2>
+          <FormGroup label={tx('login.sendUser')} placeholder='SMTP-Loginname' labelFor='sendUser' labelInfo={`(${tx('login.automatic')})`}>
+            <InputGroup
+              id='sendUser'
+              type='text'
+              value={sendUser}
+              leftIcon='envelope'
+              onChange={this.handleCredentialsChange}
+            />
+          </FormGroup>
+          <FormGroup label={tx('login.sendPw')} placeholder='SMTP-Password' labelFor='sendPw' labelInfo={`(${tx('login.automatic')})`}>
+            {this.renderPasswordInput('showPasswordSend', 'sendPw')}
+          </FormGroup>
+          <FormGroup label={tx('login.sendServer')} placeholder='SMTP-Server' labelFor='sendServer' labelInfo={`(${tx('login.automatic')})`}>
+            <InputGroup
+              id='sendServer'
+              type='text'
+              value={sendServer}
+              leftIcon='envelope'
+              onChange={this.handleCredentialsChange}
+            />
+          </FormGroup>
+          <FormGroup label={tx('login.sendPort')} placeholder='SMTP-Port' labelFor='sendPort' labelInfo={`(${tx('login.automatic')})`}>
+            <InputGroup
+              id='sendPort'
+              type='number'
+              min='0'
+              max='65535'
+              value={sendPort}
+              leftIcon='envelope'
+              onChange={this.handleCredentialsChange}
+            />
+          </FormGroup>
+          <FormGroup label={tx('login.sendSecurity')} placeholder='Security' labelFor='sendSecurity' labelInfo={`(${tx('login.automatic')})`}>
+            <div className='bp3-select .modifier'>
+              <select id='sendSecurity' value={sendSecurity} onChange={this.handleCredentialsChange}>
+                <option value=''>{tx('login.security.automatic')}</option>
+                <option value='ssl'>SSL/TLS</option>
+                <option value='starttls'>STARTTLS</option>
+                <option value='plain'>{tx('login.security.disable')}</option>
+              </select>
+            </div>
+          </FormGroup>
+        </Collapse>
+        <Button disabled={loading || (!addr || !mailPw)} type='submit' text={tx('login.button')} />
+        {loading && <Button text={tx('login.cancel')} onClick={this.cancelClick.bind(this)} />}
+      </form>
     )
   }
 }

--- a/src/renderer/components/Login.js
+++ b/src/renderer/components/Login.js
@@ -90,7 +90,7 @@ class Login extends React.Component {
   }
 
   render () {
-    const { loading } = this.props
+    const { addrDisabled, loading } = this.props
 
     const {
       addr,
@@ -114,6 +114,7 @@ class Login extends React.Component {
         <FormGroup label={tx('login.email')} placeholder='E-Mail Address' labelFor='email' labelInfo={`(${tx('login.required')})`}>
           <InputGroup
             id='addr'
+            disabled={addrDisabled}
             type='text'
             value={addr}
             leftIcon='envelope'

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -154,15 +154,14 @@ class Settings extends React.Component {
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsAutocryptSection')}</H5>
               <p>{tx('autocryptDescription')}</p>
-              <Button onClick={this.initiateKeyTransfer}>
-                {tx('initiateKeyTransferTitle')}
-              </Button>
-              <H5></H5>
               <Switch
                 checked={advancedSettings.e2ee_enabled}
                 label={tx('settingsEndToEndSetup')}
                 onChange={this.handleEncryptionToggle}
               />
+              <Button onClick={this.initiateKeyTransfer}>
+                {tx('initiateKeyTransferTitle')}
+              </Button>
             </Card>
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsBackupSection')}</H5>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -160,7 +160,7 @@ class Settings extends React.Component {
               </Button>
               <Switch
                 checked={advancedSettings.e2ee_enabled}
-                label={tx('endToEndSetup')}
+                label={tx('settingsEndToEndSetup')}
                 onChange={this.handleEncryptionToggle}
               />
             </Card>
@@ -175,7 +175,7 @@ class Settings extends React.Component {
               <H5>{tx('settingsOptionsSection')}</H5>
               <Switch
                 checked={saved && saved.markRead}
-                label='Mark incoming messages as read'
+                label={tx('settingsMarkRead')}
                 onChange={() => this.handleSettingsChange('markRead', !this.state.saved.markRead)}
               />
             </Card>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -38,6 +38,16 @@ class Settings extends React.Component {
     this.onBackupImport = this.onBackupImport.bind(this)
     this.handleSettingsChange = this.handleSettingsChange.bind(this)
     this.onLoginSubmit = this.onLoginSubmit.bind(this)
+    this.onAdvancedSettingsOpen = this.onAdvancedSettingsOpen.bind(this)
+    this.retrieveAdvancedSettingsObjResp = this.retrieveAdvancedSettingsObjResp.bind(this)
+  }
+
+  componentDidMount () {
+    ipcRenderer.on('retrieveAdvancedSettingsObjResp', this.retrieveAdvancedSettingsObjResp)
+  }
+
+  componentWillUnmount () {
+    ipcRenderer.removeListener('retrieveAdvancedSettingsObjResp', this.retrieveAdvancedSettingsObjResp)
   }
 
   onKeyTransferComplete () {
@@ -93,9 +103,20 @@ class Settings extends React.Component {
     this.props.userFeedback({ type: 'success', text: 'Account updated successfully' })
   }
 
+  onAdvancedSettingsOpen () {
+    ipcRenderer.send('retrieveAdvancedSettingsObj')
+  }
+
+  retrieveAdvancedSettingsObjResp (e, advancedSettingsObj) {
+    console.log('retrieveAdvancedSettingsObjResp', advancedSettingsObj)
+    this.setState({ advancedSettings: advancedSettingsObj })
+  }
+
   render () {
     const { deltachat, isOpen, onClose } = this.props
     const { advancedSettings, saved, keyTransfer } = this.state
+
+    console.log(deltachat.credentials)
 
     const tx = window.translate
     const title = tx('settingsTitle')
@@ -104,7 +125,7 @@ class Settings extends React.Component {
       <div>
         <KeyTransfer isOpen={keyTransfer} onClose={this.onKeyTransferComplete} />
         <Dialog
-          isOpen={advancedSettings}
+          isOpen={advancedSettings !== false}
           title={tx('settingsAccountTitle')}
           icon='settings'
           onClose={() => this.setState({ advancedSettings: false })}>
@@ -112,7 +133,7 @@ class Settings extends React.Component {
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsAccountTitle')}</H5>
               <Login
-                addr={deltachat.credentials.addr}
+                {...advancedSettings}
                 onSubmit={this.onLoginSubmit}
                 loading={deltachat.configuring}
                 addrDisabled>
@@ -130,7 +151,7 @@ class Settings extends React.Component {
           <SettingsDialog className={Classes.DIALOG_BODY}>
             <Card elevation={Elevation.ONE}>
               <H5>{deltachat.credentials.addr}</H5>
-              <Button onClick={() => this.setState({ advancedSettings: true })}>
+              <Button onClick={this.onAdvancedSettingsOpen}>
                 {tx('settingsAccountTitle')}
               </Button>
             </Card>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -105,10 +105,9 @@ class Settings extends React.Component {
     this.setState({ advancedSettings: { e2ee_enabled: val } })
   }
 
-  onLoginSubmit (event) {
-    console.log('what do we do here??')
-    // TODO: this should happen after whatever we did seems to be fine.
-    this.props.userFeedback({ type: 'success', text: 'Account updated successfully' })
+  onLoginSubmit (config) {
+    this.props.userFeedback(false)
+    ipcRenderer.send('updateCredentials', config)
   }
 
   render () {
@@ -158,6 +157,7 @@ class Settings extends React.Component {
               <Button onClick={this.initiateKeyTransfer}>
                 {tx('initiateKeyTransferTitle')}
               </Button>
+              <H5></H5>
               <Switch
                 checked={advancedSettings.e2ee_enabled}
                 label={tx('settingsEndToEndSetup')}

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -37,6 +37,7 @@ class Settings extends React.Component {
     this.onBackupExport = this.onBackupExport.bind(this)
     this.onBackupImport = this.onBackupImport.bind(this)
     this.handleSettingsChange = this.handleSettingsChange.bind(this)
+    this.onLoginSubmit = this.onLoginSubmit.bind(this)
   }
 
   onKeyTransferComplete () {
@@ -86,8 +87,14 @@ class Settings extends React.Component {
     ipcRenderer.send('updateSettings', this.state.saved)
   }
 
+  onLoginSubmit (event) {
+    console.log('what do we do here??')
+    // TODO: this should happen after whatever we did seems to be fine.
+    this.props.userFeedback({ type: 'success', text: 'Account updated successfully' })
+  }
+
   render () {
-    const { isOpen, onClose } = this.props
+    const { deltachat, isOpen, onClose } = this.props
     const { advancedSettings, saved, keyTransfer } = this.state
 
     const tx = window.translate
@@ -98,26 +105,34 @@ class Settings extends React.Component {
         <KeyTransfer isOpen={keyTransfer} onClose={this.onKeyTransferComplete} />
         <Dialog
           isOpen={advancedSettings}
-          title='AdvancedSettings'
-          icon='envelope'
+          title={tx('settingsAdvancedTitle')}
+          icon='settings'
           onClose={() => this.setState({ advancedSettings: false })}>
-          <Card elevation={Elevation.ONE}>
-            <H5>{tx('settingsBackupSection')}</H5>
-            <ButtonGroup>
-              <Button onClick={this.onBackupExport}>{tx('exportBackup')}...</Button>
-              <Button onClick={this.onBackupImport}>{tx('importBackup')}...</Button>
-            </ButtonGroup>
-          </Card>
-          <Card elevation={Elevation.ONE}>
-            <Login loading={false} />
-          </Card>
+          <SettingsDialog className={Classes.DIALOG_BODY}>
+            <Card elevation={Elevation.ONE}>
+              <H5>{tx('settingsAccountTitle')}</H5>
+              <Login
+                addr={deltachat.credentials.addr}
+                onSubmit={this.onLoginSubmit}
+                loading={deltachat.configuring}>
+                <Button type='submit' text={tx('settingsUpdateAccount')} />
+                <Button type='cancel' text={tx('login.cancel')} />
+              </Login>
+            </Card>
+          </SettingsDialog>
         </Dialog>
         <Dialog
-          isOpen={isOpen}
+          isOpen={isOpen && !keyTransfer && !advancedSettings}
           title={title}
-          icon='info-sign'
+          icon='settings'
           onClose={onClose}>
           <SettingsDialog className={Classes.DIALOG_BODY}>
+            <Card elevation={Elevation.ONE}>
+              <H5>{deltachat.credentials.addr}</H5>
+              <Button onClick={() => this.setState({ advancedSettings: true })}>
+                Account Settings
+              </Button>
+            </Card>
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsAutocryptSection')}</H5>
               <p>{tx('autocryptDescription')}</p>
@@ -126,7 +141,11 @@ class Settings extends React.Component {
               </Button>
             </Card>
             <Card elevation={Elevation.ONE}>
-              <Button onClick={() => this.setState({ advancedSettings: true })}>Advanced</Button>
+              <H5>{tx('settingsBackupSection')}</H5>
+              <ButtonGroup>
+                <Button onClick={this.onBackupExport}>{tx('exportBackup')}...</Button>
+                <Button onClick={this.onBackupImport}>{tx('importBackup')}...</Button>
+              </ButtonGroup>
             </Card>
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsOptionsSection')}</H5>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -1,7 +1,9 @@
 const React = require('react')
+const crypto = require('crypto')
 const { ipcRenderer, remote } = require('electron')
 const styled = require('styled-components').default
 
+const MAGIC_PW = crypto.randomBytes(8).toString('hex')
 const {
   Elevation,
   H5,
@@ -31,7 +33,8 @@ class Settings extends React.Component {
       keyTransfer: false,
       saved: props.saved,
       advancedSettings: {},
-      userDetails: false
+      userDetails: false,
+      mailPw: MAGIC_PW
     }
     this.initiateKeyTransfer = this.initiateKeyTransfer.bind(this)
     this.onKeyTransferComplete = this.onKeyTransferComplete.bind(this)
@@ -46,7 +49,6 @@ class Settings extends React.Component {
     if (this.props.isOpen && !prevProps.isOpen) {
       var advancedSettings = ipcRenderer.sendSync('dispatchSync', 'getAdvancedSettings')
       advancedSettings.e2ee_enabled = !!Number(advancedSettings.e2ee_enabled)
-      console.log(advancedSettings.e2ee_enabled)
       this.setState({ advancedSettings })
     }
   }
@@ -107,6 +109,7 @@ class Settings extends React.Component {
 
   onLoginSubmit (config) {
     this.props.userFeedback(false)
+    if (config.mailPw === MAGIC_PW) delete config.mailPw
     ipcRenderer.send('updateCredentials', config)
   }
 
@@ -130,6 +133,7 @@ class Settings extends React.Component {
               <H5>{tx('settingsAccountTitle')}</H5>
               <Login
                 {...advancedSettings}
+                mailPw={this.state.mailPw}
                 onSubmit={this.onLoginSubmit}
                 loading={deltachat.configuring}
                 addrDisabled>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -130,7 +130,7 @@ class Settings extends React.Component {
             <Card elevation={Elevation.ONE}>
               <H5>{deltachat.credentials.addr}</H5>
               <Button onClick={() => this.setState({ advancedSettings: true })}>
-                Account Settings
+                {tx('settingsAccountTitle')}
               </Button>
             </Card>
             <Card elevation={Elevation.ONE}>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -13,6 +13,7 @@ const {
   Switch
 } = require('@blueprintjs/core')
 
+const Login = require('../Login')
 const KeyTransfer = require('./KeyTransfer')
 const confirmationDialog = require('./confirmationDialog')
 const State = require('../../lib/state')
@@ -28,7 +29,8 @@ class Settings extends React.Component {
     super(props)
     this.state = {
       keyTransfer: false,
-      saved: props.saved
+      saved: props.saved,
+      advancedSettings: false
     }
     this.initiateKeyTransfer = this.initiateKeyTransfer.bind(this)
     this.onKeyTransferComplete = this.onKeyTransferComplete.bind(this)
@@ -86,7 +88,7 @@ class Settings extends React.Component {
 
   render () {
     const { isOpen, onClose } = this.props
-    const { saved, keyTransfer } = this.state
+    const { advancedSettings, saved, keyTransfer } = this.state
 
     const tx = window.translate
     const title = tx('settingsTitle')
@@ -94,6 +96,22 @@ class Settings extends React.Component {
     return (
       <div>
         <KeyTransfer isOpen={keyTransfer} onClose={this.onKeyTransferComplete} />
+        <Dialog
+          isOpen={advancedSettings}
+          title='AdvancedSettings'
+          icon='envelope'
+          onClose={() => this.setState({ advancedSettings: false })}>
+          <Card elevation={Elevation.ONE}>
+            <H5>{tx('settingsBackupSection')}</H5>
+            <ButtonGroup>
+              <Button onClick={this.onBackupExport}>{tx('exportBackup')}...</Button>
+              <Button onClick={this.onBackupImport}>{tx('importBackup')}...</Button>
+            </ButtonGroup>
+          </Card>
+          <Card elevation={Elevation.ONE}>
+            <Login loading={false} />
+          </Card>
+        </Dialog>
         <Dialog
           isOpen={isOpen}
           title={title}
@@ -108,11 +126,7 @@ class Settings extends React.Component {
               </Button>
             </Card>
             <Card elevation={Elevation.ONE}>
-              <H5>{tx('settingsBackupSection')}</H5>
-              <ButtonGroup>
-                <Button onClick={this.onBackupExport}>{tx('exportBackup')}...</Button>
-                <Button onClick={this.onBackupImport}>{tx('importBackup')}...</Button>
-              </ButtonGroup>
+              <Button onClick={() => this.setState({ advancedSettings: true })}>Advanced</Button>
             </Card>
             <Card elevation={Elevation.ONE}>
               <H5>{tx('settingsOptionsSection')}</H5>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -105,7 +105,7 @@ class Settings extends React.Component {
         <KeyTransfer isOpen={keyTransfer} onClose={this.onKeyTransferComplete} />
         <Dialog
           isOpen={advancedSettings}
-          title={tx('settingsAdvancedTitle')}
+          title={tx('settingsAccountTitle')}
           icon='settings'
           onClose={() => this.setState({ advancedSettings: false })}>
           <SettingsDialog className={Classes.DIALOG_BODY}>

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -114,7 +114,8 @@ class Settings extends React.Component {
               <Login
                 addr={deltachat.credentials.addr}
                 onSubmit={this.onLoginSubmit}
-                loading={deltachat.configuring}>
+                loading={deltachat.configuring}
+                addrDisabled>
                 <Button type='submit' text={tx('settingsUpdateAccount')} />
                 <Button type='cancel' text={tx('login.cancel')} />
               </Login>

--- a/src/renderer/components/dialogs/index.js
+++ b/src/renderer/components/dialogs/index.js
@@ -57,7 +57,7 @@ class Controller extends React.Component {
   }
 
   render () {
-    const { saved, userFeedback } = this.props
+    const { saved, userFeedback, deltachat } = this.props
     const { dialogs } = this.state
 
     return (
@@ -68,7 +68,8 @@ class Controller extends React.Component {
             isOpen: dialog.props !== false,
             onClose: () => this.close(name),
             userFeedback,
-            saved: saved,
+            saved,
+            deltachat,
             key: name
           }
 


### PR DESCRIPTION
This allows you to edit your account settings (like password, email address, and SMTP/IMAP) from the settings view.
fixes #249 

One TODO left:
@ralphtheninja @Jikstra one last thing to do: what should we do when the user hits 'update settings'? Do we need to just set the new config options? or do we login also? 


![screenshot from 2018-12-13 13-29-37](https://user-images.githubusercontent.com/633012/49968665-501a6480-fedb-11e8-897c-279a63241503.png)
![screenshot from 2018-12-13 13-29-29](https://user-images.githubusercontent.com/633012/49968666-501a6480-fedb-11e8-8c47-7480f0c9ecb2.png)
![screenshot from 2018-12-13 13-29-25](https://user-images.githubusercontent.com/633012/49968667-501a6480-fedb-11e8-9a74-04cba482c1d3.png)

EDIT:
Work left:
- [x] Don't need to enter password to update advanced settings (maybe fill password with some stars?)
- [x] Don't allow to change the e-mail
- [x] Get filled in settings and show them
- [x] actually save the submitted changes
- [x] check login/show error if something failed

