### PR TITLE
handle and show errors, including DC_EVENT_ERROR_NETWORK

### DIFF
--- a/src/main/deltachat.js
+++ b/src/main/deltachat.js
@@ -115,6 +115,12 @@ class DeltaChatController extends events.EventEmitter {
     })
 
     dc.on('DC_EVENT_ERROR', (error) => {
+      this.emit('DC_EVENT_ERROR', error)
+      log.error(error)
+    })
+
+    dc.on('DC_EVENT_NETWORK_ERROR', (error) => {
+      this.emit('DC_EVENT_NETWORK_ERROR', error)
       log.error(error)
     })
   }

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -61,6 +61,14 @@ function init (cwd, state) {
     windows.main.send('DC_EVENT_IMEX_PROGRESS', progress)
   })
 
+  dc.on('DC_EVENT_ERROR', (error) => {
+    windows.main.send('error', error.toString())
+  })
+
+  dc.on('DC_EVENT_NETWORK_ERROR', (error) => {
+    windows.main.send('error', error.toString())
+  })
+
   // Calls a function directly in the deltachat-node instance and returns the
   // value (sync)
   ipc.on('dispatchSync', (e, ...args) => {

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -65,7 +65,7 @@ function init (cwd, state) {
     windows.main.send('error', error.toString())
   })
 
-  dc.on('DC_EVENT_NETWORK_ERROR', (error) => {
+  dc.on('DC_EVENT_NETWORK_ERROR', (first, error) => {
     windows.main.send('error', error.toString())
   })
 

--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -23,6 +23,7 @@ class Home extends React.Component {
     }
 
     this.changeScreen = this.changeScreen.bind(this)
+    this.onError = this.onError.bind(this)
     this.userFeedback = this.userFeedback.bind(this)
     this.onShowAbout = this.showAbout.bind(this, true)
     this.onShowSettings = this.showSettings.bind(this, true)
@@ -44,9 +45,7 @@ class Home extends React.Component {
 
   componentDidMount () {
     var self = this
-    ipcRenderer.on('error', function (e, text) {
-      self.userFeedback({ type: 'error', text })
-    })
+    ipcRenderer.on('error', this.onError)
     ipcRenderer.on('showAboutDialog', this.onShowAbout)
     ipcRenderer.on('DC_EVENT_IMEX_FILE_WRITTEN', (_event, filename) => {
       self.userFeedback({ type: 'success', text: `${filename} created.` })
@@ -55,6 +54,12 @@ class Home extends React.Component {
 
   componentWillUnmount () {
     ipcRenderer.removeListener('showAboutDialog', this.onShowAbout)
+    ipcRenderer.removeListener('showAboutDialog', this.onError)
+  }
+
+  onError (event, error) {
+    const text = error ? error.toString() : 'Unknown'
+    this.userFeedback({ type: 'error', text })
   }
 
   showAbout (showAbout) {


### PR DESCRIPTION
this handles network errors and shows them raw (as we get them from core) in the user interface. Do we need to do any translation for this? @r10s 

fixes #302 