### PR TITLE
autocrypt dialog improvements, fixes #282

### DIFF
--- a/_locales/en.json
+++ b/_locales/en.json
@@ -886,6 +886,15 @@
   },
   "loginKnownAccountsTitle": {
     "message": "Known Accounts"
+  },
+  "autocryptIncorrect": {
+    "message": "Incorrect setup code, please try again."
+  },
+  "autocryptCorrect": {
+    "message": "Successfully transferred Autocrypt setup!"
+  },
+  "autocryptEnterMessage": {
+    "message": "Please enter the setup code that is displayed on the other device."
   }
 }
 


### PR DESCRIPTION
* We don't lose the entered transfer verification key if it's incorrect (currently it gets cleared after submit) 
* The autocrypt key is discarded once dialog is exited manually using the X
* Typing 4 figures into one input, automatically focuses the next one so that users don't have to press tab 
* Update and improve visual status messages 
* More accurate base English strings
* Various CSS improvements

