### PR TITLE
When clicking on advanced, the top of the login form was hidden below

### DIFF
--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -177,13 +177,14 @@ const LoginWrapper = styled.div`
   height: calc(100vh);
 
   .bp3-card {
+    width: 400px;
     margin-top: 20px;
   }
 
-  .window {
-    max-width: 400px;
-    height: auto;
+  .window { 
+    padding-left: calc((100vw - 400px) / 2)
   }
+
 `
 
 const LoginItem = styled.li`


### PR DESCRIPTION
the navbar