### PR TITLE
Restyle buttons in create chat

### DIFF
--- a/src/renderer/components/SearchInput.js
+++ b/src/renderer/components/SearchInput.js
@@ -1,13 +1,37 @@
 const React = require('react')
 const { InputGroup } = require('@blueprintjs/core')
+const styled = require('styled-components').default
 
-module.exports = function (props) {
-  const tx = window.translate
-  return <InputGroup
-    type='search'
-    large
-    placeholder={tx('search')}
-    leftIcon='search'
-    {...props}
-  />
+
+
+const SearchInputWrapper = styled.div`
+  width: 100%
+  .bp3-input-group {
+    width: 100%
+  }
+
+  input[type="search"]::-webkit-search-cancel-button {
+    /* Remove default */
+    -webkit-appearance: none;
+  }
+`
+
+class SearchInput extends React.Component {
+  render() {
+
+    const tx = window.translate
+    return (
+      <SearchInputWrapper>
+        <InputGroup
+          type='search'   
+          large
+          placeholder={tx('search')}
+          leftIcon='search'
+          {...this.props}
+        />
+      </SearchInputWrapper>
+    )
+  }
 }
+
+module.exports = SearchInput

--- a/src/renderer/components/SearchInput.js
+++ b/src/renderer/components/SearchInput.js
@@ -9,11 +9,6 @@ const SearchInputWrapper = styled.div`
   .bp3-input-group {
     width: 100%
   }
-
-  input[type="search"]::-webkit-search-cancel-button {
-    /* Remove default */
-    -webkit-appearance: none;
-  }
 `
 
 class SearchInput extends React.Component {

--- a/src/renderer/components/SearchInput.js
+++ b/src/renderer/components/SearchInput.js
@@ -2,8 +2,6 @@ const React = require('react')
 const { InputGroup } = require('@blueprintjs/core')
 const styled = require('styled-components').default
 
-
-
 const SearchInputWrapper = styled.div`
   width: 100%
   .bp3-input-group {
@@ -12,13 +10,12 @@ const SearchInputWrapper = styled.div`
 `
 
 class SearchInput extends React.Component {
-  render() {
-
+  render () {
     const tx = window.translate
     return (
       <SearchInputWrapper>
         <InputGroup
-          type='search'   
+          type='search'
           large
           placeholder={tx('search')}
           leftIcon='search'


### PR DESCRIPTION
for search input. This currently removes the possibility to clear the search input which is a regression, but maybe only a small one. Putting in a js version of this should be doable.