### PR TITLE
Use electron v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "cp-file": "^6.0.0",
     "depcheck": "^0.6.11",
     "devtron": "^1.4.0",
-    "electron": "^3.0.11",
+    "electron": "^4.0.1",
     "electron-builder": "^20.28.3",
     "glob-watcher": "^5.0.1",
     "hallmark": "^0.1.0",

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -50,7 +50,10 @@ function init (app, options) {
     useContentSize: true, // Specify web page size without OS chrome
     width: initialBounds.width,
     x: initialBounds.x,
-    y: initialBounds.y
+    y: initialBounds.y,
+    webPreferences: {
+      nodeIntegration: true
+    }
   })
 
   win.loadURL(defaults.main)


### PR DESCRIPTION
Just making a PR for it. We don't have to merge this right now. Note that we're now setting `webPreferences: { nodeIntegration: true }` since it will default to `false` in v5.

![screenshot from 2019-01-12 08-22-32](https://user-images.githubusercontent.com/308049/51070576-c11c7b80-1643-11e9-8776-f8fa095e346e.png)

Closes https://github.com/deltachat/deltachat-desktop/issues/473