### PR TITLE
Move emoji picker left to the send button and improve styling of all

### DIFF
--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -18,7 +18,7 @@ const ChatViewWrapper = styled.div`
   float: right;
 
   #the-conversation {
-    height: calc(100vh - 50px - 43px);
+    height: calc(100vh - 50px - 40px);
     overflow: scroll;
     background-image: url("../images/background_hd.jpg");
     background-size: cover;

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -57,7 +57,7 @@ const EmojiPickerWrapper = styled.div`
   position: absolute;
 
   z-index: 10;
-  width: 30%;
+  width: 350px;
   right: 10px;
   bottom: 50px;
 
@@ -71,8 +71,12 @@ const EmojiPickerWrapper = styled.div`
     }
   }
 
-  @media only screen and (max-width: 1220px) {
-    width: 50%;
+  @media only screen and (max-width: 600px) {
+    width: 300px;
+
+    .emoji-mart-title-label {
+      font-size: 23px;
+    }
   }
 `
 

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -65,6 +65,11 @@ const EmojiPickerWrapper = styled.div`
     font-family: inherit
   }
 
+  .emoji-mart-category .emoji-mart-emoji span {
+    height: auto !important;
+    width: auto !important;
+  }
+
   @media only screen and (max-height: 530px) {
     .emoji-mart-scroll {
       height: 100px;

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -15,9 +15,6 @@ const ComposerWrapper = styled.div`
 
 const AttachmentButtonWrapper = styled.div`
   float: left;
-  button {
-    margin-right: 10px;
-  }
 
   .bp3-button.bp3-minimal {
     width: 40px;
@@ -27,26 +24,32 @@ const AttachmentButtonWrapper = styled.div`
       background: none;
       cursor: pointer;
     }
+    &:focus {
+      outline: none;
+    }
   }
 `
 
 const IconButton = styled.button`
-    margin-right: 10px;
+    height: 40px;
+    width: 40px;
+    margin-right: 0px !important;
+    padding: 0px;
+    border: 0;
     background-size: contain;
     background-repeat: no-repeat;
     background-color: white;
-    height: 40px;
-    margin: 0 auto;
-    width: 40x;
-    margin: 0px;
-    border: 0;
+    &:focus {
+      outline: none;
+    }
 `
 
 const IconButtonSpan = styled.span`
-    background-image: url(../images/emoji.png);
+    display: block
     width: 25px
     height: 25px
-    display: block
+    margin: 0 auto;
+    background-image: url(../images/emoji.png);
     background-size: contain
 `
 
@@ -55,8 +58,8 @@ const EmojiPickerWrapper = styled.div`
 
   z-index: 10;
   width: 30%;
-  left: calc(30vw + 5px);
-  bottom: 45px;
+  right: 10px;
+  bottom: 50px;
 
   .emoji-mart-emoji-native, .emoji-mart {
     font-family: inherit
@@ -75,7 +78,7 @@ const EmojiPickerWrapper = styled.div`
 
 const MessageInput = styled.textarea`
   float: left;
-  width: calc(100% - 140px);
+  width: calc(100% - 120px);
   resize: unset;
   padding: 0px;
   border-color: transparent;
@@ -101,16 +104,15 @@ const SendButtonCircleWrapper = styled.div`
 const SendButton = styled.button`
   height: 24px;
   width: 24px;
-  margin-top: 5px;
-  margin-left: 8px;
+  margin: 4px;
   padding-left: 16px;
+  border: none;
   background-image: url(../images/send-button.png);
   background-color: transparent;
   background-repeat: no-repeat;
-  background-position: 0px 0px;
-  border: none;
-  vertical-align: middle;
+  background-position: 3px 1px;
   background-size: contain;
+  vertical-align: middle;
 `
 
 class Composer extends React.Component {
@@ -242,6 +244,16 @@ class Composer extends React.Component {
         <AttachmentButtonWrapper>
           <Button minimal icon='paperclip' onClick={this.addFilename.bind(this)} />
         </AttachmentButtonWrapper>
+        <MessageInput
+          ref={this.textareaRef}
+          intent={this.state.error ? 'danger' : 'none'}
+          large
+          rows='1'
+          value={this.state.text}
+          onKeyDown={this.onKeyDown.bind(this)}
+          onChange={this.handleChange}
+          placeholder={tx('write_message_desktop')}
+        />
         <AttachmentButtonWrapper ref={this.pickerButtonRef}>
           <IconButton onMouseOver={this.showEmojiPicker.bind(this, true)}>
             <IconButtonSpan />
@@ -259,16 +271,6 @@ class Composer extends React.Component {
             />
           </EmojiPickerWrapper>
         }
-        <MessageInput
-          ref={this.textareaRef}
-          intent={this.state.error ? 'danger' : 'none'}
-          large
-          rows='1'
-          value={this.state.text}
-          onKeyDown={this.onKeyDown.bind(this)}
-          onChange={this.handleChange}
-          placeholder={tx('write_message_desktop')}
-        />
         <SendButtonCircleWrapper onClick={this.sendMessage}>
           <SendButton />
         </SendButtonCircleWrapper>

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -57,7 +57,7 @@ const EmojiPickerWrapper = styled.div`
   position: absolute;
 
   z-index: 10;
-  width: 350px;
+  width: 314px;
   right: 10px;
   bottom: 50px;
 
@@ -77,7 +77,7 @@ const EmojiPickerWrapper = styled.div`
   }
 
   @media only screen and (max-width: 600px) {
-    width: 300px;
+    width: 272px;
 
     .emoji-mart-title-label {
       font-size: 23px;

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -80,7 +80,7 @@ const EmojiPickerWrapper = styled.div`
     width: 272px;
 
     .emoji-mart-title-label {
-      font-size: 23px;
+      font-size: 20px;
     }
   }
 `

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -36,6 +36,7 @@ const NavbarGroupSubtitle = styled.div`
 const BelowNavbar = styled.div`
   height: calc(100vh - 50px);
   margin-top: 50px;
+  overflow: hidden;
 `
 
 class SplittedChatListAndView extends React.Component {


### PR DESCRIPTION
composer elements

Besides general restyling this also adresses all of the things mentioned by @Simon-Laux in the initial pr https://github.com/deltachat/deltachat-desktop/pull/608#issuecomment-456536132. Only thing which is missing is that the emojis might be too big, but i personally like the size.

![screenshot_20190125_014323](https://user-images.githubusercontent.com/34889164/51717876-fb721980-2042-11e9-9717-2131eafb5d11.png)