### PR TITLE
For some reasons emoji-mart doesn't pull in a required dependency, we…

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@blueprintjs/core": "^3.4.0",
     "application-config": "^1.0.1",
     "array-differ": "^2.0.3",
+    "babel-runtime": "^6.26.0",
     "class-autobind": "^0.1.4",
     "debounce": "^1.2.0",
     "deltachat-node": "^0.39.0",


### PR DESCRIPTION
… need to require it manually

Hotfix for https://github.com/deltachat/deltachat-desktop/issues/621 in the long run this should be fixed upstream. Upstream issue: https://github.com/missive/emoji-mart/issues/228