### PR TITLE
this.chatView.current is not set from the start

### DIFF
--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -68,7 +68,9 @@ class SplittedChatListAndView extends React.Component {
   onChatClick (chatId) {
     ipcRenderer.send('dispatch', 'selectChat', chatId)
     try {
-      this.chatView.current.composerRef.current.focusInputMessage()
+      if (this.chatView.current) {
+        this.chatView.current.composerRef.current.focusInputMessage()
+      }
     } catch (error) {
       console.debug(error)
     }


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/584

Happens because the ref `this.chatView` is only passed to the `ChatView` component if there's a chat selected. From the start no chat is selected so when we click a chat the first time `this.chatView.current` is `null` (because it has never been rendered).