### PR TITLE
Hide error message when attempting to login

### DIFF
--- a/src/renderer/ScreenController.js
+++ b/src/renderer/ScreenController.js
@@ -42,6 +42,7 @@ class ScreenController extends React.Component {
     this.openDialog = this.openDialog.bind(this)
     this.closeDialog = this.closeDialog.bind(this)
     this.onShowAbout = this.showAbout.bind(this, true)
+    this.handleLogin = this.handleLogin.bind(this)
     this.dialogs = React.createRef()
   }
 
@@ -70,6 +71,7 @@ class ScreenController extends React.Component {
   }
 
   handleLogin (credentials) {
+    this.userFeedback(false)
     ipcRenderer.send('login', credentials)
   }
 


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/624

Does this a bit differently. Instead of hiding the error message at successful login, we always hide the error message before trying to login. if the login is successful, the error message is gone and if login fails again, the error is shown again.