### PR TITLE
Resize the composer based on the newlines in the text

### DIFF
--- a/src/renderer/components/ChatList.js
+++ b/src/renderer/components/ChatList.js
@@ -7,13 +7,13 @@ const StyleVariables = require('./style-variables')
 
 const ChatListWrapper = styled.div`
   width: 30%;
-  height: 100%;
+  height: calc(100vh - 50px);
   float: left;
   overflow-y: auto;
   border-right: 1px solid #b9b9b9;
   box-shadow: 0 0 4px 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
   user-select: none;
-  margin-top: 54px;
+  margin-top: 50px;
 
   span.module-contact-name {
     font-weight: 200;

--- a/src/renderer/components/ChatList.js
+++ b/src/renderer/components/ChatList.js
@@ -13,6 +13,7 @@ const ChatListWrapper = styled.div`
   border-right: 1px solid #b9b9b9;
   box-shadow: 0 0 4px 1px rgba(16, 22, 26, 0.1), 0 0 0 rgba(16, 22, 26, 0), 0 1px 1px rgba(16, 22, 26, 0.2);
   user-select: none;
+  margin-top: 54px;
 
   span.module-contact-name {
     font-weight: 200;

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -16,9 +16,11 @@ const ChatViewWrapper = styled.div`
   width: 70%;
   background-color: #eeefef;
   float: right;
+  display: grid;
+  grid-template-columns: auto;
+  height: 100vh;
 
   #the-conversation {
-    height: calc(100vh - 50px - 40px);
     overflow: scroll;
     background-image: url("../images/background_hd.jpg");
     background-size: cover;
@@ -78,7 +80,8 @@ class ChatView extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      error: false
+      error: false,
+      composerSize: 40
     }
 
     this.writeMessage = this.writeMessage.bind(this)
@@ -87,7 +90,8 @@ class ChatView extends React.Component {
     this.lastId = this.props.chat.id
     this.previousScrollHeightMinusTop = null
 
-    this.composerRef = React.createRef()
+
+    this.conversationRef = React.createRef()
   }
 
   componentWillUnmount () {
@@ -165,11 +169,17 @@ class ChatView extends React.Component {
     this.props.openDialog('ForwardMessage', { forwardMessage })
   }
 
+  setComposerSize(size) {
+    this.setState({composerSize: size})
+  }
+
   render () {
     const { onDeadDropClick, chat } = this.props
 
     return (
-      <ChatViewWrapper ref={this.ChatViewWrapperRef}>
+      <ChatViewWrapper
+        style= {{gridTemplateRows: `auto ${this.state.composerSize}px`}}
+        ref={this.ChatViewWrapperRef}>
         <div id='the-conversation' ref={this.conversationDiv}>
           <ConversationContext>
             {chat.messages.map(rawMessage => {
@@ -189,7 +199,10 @@ class ChatView extends React.Component {
             })}
           </ConversationContext>
         </div>
-        <Composer ref={this.composerRef} onSubmit={this.writeMessage} />
+        <Composer 
+          onSubmit={this.writeMessage}
+          setComposerSize={this.setComposerSize.bind(this)}
+        />
       </ChatViewWrapper>
     )
   }

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -91,7 +91,6 @@ class ChatView extends React.Component {
     this.lastId = this.props.chat.id
     this.previousScrollHeightMinusTop = null
 
-
     this.conversationRef = React.createRef()
   }
 
@@ -170,8 +169,8 @@ class ChatView extends React.Component {
     this.props.openDialog('ForwardMessage', { forwardMessage })
   }
 
-  setComposerSize(size) {
-    this.setState({composerSize: size})
+  setComposerSize (size) {
+    this.setState({ composerSize: size })
   }
 
   render () {
@@ -179,7 +178,7 @@ class ChatView extends React.Component {
 
     return (
       <ChatViewWrapper
-        style= {{gridTemplateRows: `auto ${this.state.composerSize}px`}}
+        style={{ gridTemplateRows: `auto ${this.state.composerSize}px` }}
         ref={this.ChatViewWrapperRef}>
         <div id='the-conversation' ref={this.conversationDiv}>
           <ConversationContext>
@@ -200,7 +199,7 @@ class ChatView extends React.Component {
             })}
           </ConversationContext>
         </div>
-        <Composer 
+        <Composer
           onSubmit={this.writeMessage}
           setComposerSize={this.setComposerSize.bind(this)}
         />

--- a/src/renderer/components/ChatView.js
+++ b/src/renderer/components/ChatView.js
@@ -18,7 +18,8 @@ const ChatViewWrapper = styled.div`
   float: right;
   display: grid;
   grid-template-columns: auto;
-  height: 100vh;
+  height: calc(100vh - 50px);
+  margin-top: 50px;
 
   #the-conversation {
     overflow: scroll;

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -15,7 +15,7 @@ const ComposerWrapper = styled.div`
 const AttachmentButtonWrapper = styled.div`
   float: left;
 
-  position: absolute;
+  position: fixed;
   bottom: 0;
 
   .bp3-button.bp3-minimal {
@@ -38,30 +38,30 @@ const EmojiButtonWrapper = styled(AttachmentButtonWrapper)`
 `
 
 const IconButton = styled.button`
-    height: 40px;
-    width: 40px;
-    margin-right: 0px !important;
-    padding: 0px;
-    border: 0;
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-color: white;
-    &:focus {
-      outline: none;
-    }
+  height: 40px;
+  width: 40px;
+  margin-right: 0px !important;
+  padding: 0px;
+  border: 0;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-color: white;
+  &:focus {
+    outline: none;
+  }
 `
 
 const IconButtonSpan = styled.span`
-    display: block
-    width: 25px
-    height: 25px
-    margin: 0 auto;
-    background-image: url(../images/emoji.png);
-    background-size: contain
+  display: block
+  width: 25px
+  height: 25px
+  margin: 0 auto;
+  background-image: url(../images/emoji.png);
+  background-size: contain
 `
 
 const EmojiPickerWrapper = styled.div`
-  position: absolute;
+  position: fixed;
 
   z-index: 10;
   width: 314px;
@@ -108,7 +108,7 @@ const MessageInput = styled.textarea`
   }
 `
 const SendButtonCircleWrapper = styled.div`
-  position: absolute;
+  position: fixed;
   bottom: 0;
   right: 0;
   width: 32px;

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -158,7 +158,7 @@ class Composer extends React.Component {
     this.sendMessage = this.sendMessage.bind(this)
     this.onEmojiSelect = this.onEmojiSelect.bind(this)
     this.onMouseMove = this.onMouseMove.bind(this)
-    this.addStringAtCursorPosition = this.addStringAtCursorPosition.bind(this)
+    this.insertStringAtCursorPosition = this.insertStringAtCursorPosition.bind(this)
 
     this.textareaRef = React.createRef()
     this.pickerRef = React.createRef()
@@ -167,7 +167,7 @@ class Composer extends React.Component {
 
   onKeyDown (e) {
     if (e.keyCode === 13 && e.shiftKey) {
-      this.addStringAtCursorPosition('\n')
+      this.insertStringAtCursorPosition('\n')
       e.preventDefault()
       e.stopPropagation()
     } else if (e.keyCode === 13 && !e.shiftKey) {
@@ -255,10 +255,10 @@ class Composer extends React.Component {
 
   onEmojiSelect (emoji) {
     log.debug(`EmojiPicker: Selected ${emoji.id}`)
-    this.addStringAtCursorPosition(emoji.native)
+    this.insertStringAtCursorPosition(emoji.native)
   }
 
-  addStringAtCursorPosition(str) {
+  insertStringAtCursorPosition(str) {
     let textareaElem = this.textareaRef.current
     let {selectionStart, selectionEnd} = textareaElem
     console.log(selectionStart, selectionEnd)
@@ -269,7 +269,7 @@ class Composer extends React.Component {
     
     let updatedText = textBeforeCursor + str + textAfterCursor
 
-    this.setCursorPosition = textareaElem.selectionStart + 1    
+    this.setCursorPosition = textareaElem.selectionStart + str.length    
     this.setState({ text: updatedText })
   }
 

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -8,7 +8,6 @@ const log = require('../../logger').getLogger('renderer/composer')
 const { Picker } = require('emoji-mart')
 
 const ComposerWrapper = styled.div`
-  height: 40px;
   background-color: ${StyleVariables.colors.deltaPrimaryFg};
   border-left: 1px solid rgba(16,22,26,0.1);
 `
@@ -91,8 +90,9 @@ const MessageInput = styled.textarea`
   resize: unset;
   padding: 0px;
   border-color: transparent;
-  height: 40px;
-  line-height: 38px;
+  height: 100%;
+  line-height: 24px;
+  padding-top: 8px;
 
 
   &:focus {
@@ -134,9 +134,13 @@ class Composer extends React.Component {
       showEmojiPicker: false
     }
     this.minimumHeight = 48
+
+    this.setComposerSize = this.props.setComposerSize
+
     this.defaultHeight = 17 + this.minimumHeight
     this.clearInput = this.clearInput.bind(this)
     this.handleChange = this.handleChange.bind(this)
+    this.handleKeyUp = this.handleKeyUp.bind(this)
     this.sendMessage = this.sendMessage.bind(this)
     this.onEmojiSelect = this.onEmojiSelect.bind(this)
     this.onMouseMove = this.onMouseMove.bind(this)
@@ -185,7 +189,28 @@ class Composer extends React.Component {
   }
 
   handleChange (e) {
+    /*
+    console.log(e)
+    console.log(this.textareaRef, this.textareaRef.current.scrollHeight)
+    let size = this.textareaRef.current.scrollHeight
+    let conversationElement = document.getElementById('the-conversation')
+
+    conversationElement.style.height = `calc(100vh - 50px - ${size}px)`
+
+    console.log(this.refs)
+    console.log('as', conversationElement.style.height, this.textareaRef.current.style.height )
+    */
+
+
     this.setState({ text: e.target.value, error: false })
+  }
+
+  handleKeyUp (e) {
+    let value = e.target.value
+    let n = this.findLessThanFourNewLines(value, "\n")
+    console.log('n', n)
+
+    this.setComposerSize(40 + n*40)
   }
 
   focusInputMessage () {
@@ -245,11 +270,23 @@ class Composer extends React.Component {
            mouseY <= boundingRect.y + boundingRect.height + margin
   }
 
+  findLessThanFourNewLines(str, find) {
+    if(!str) return 0
+
+    var count = 0;
+    for (let i = 0; i < str.length && count < 4; ++i) {
+      if (str.substring(i, i + find.length) == find) {
+        count++
+      }
+    }
+    return count;
+  }
+
   render () {
     const tx = window.translate
 
     return (
-      <ComposerWrapper>
+      <ComposerWrapper ref="ComposerWrapper">
         <AttachmentButtonWrapper>
           <Button minimal icon='paperclip' onClick={this.addFilename.bind(this)} />
         </AttachmentButtonWrapper>
@@ -257,10 +294,10 @@ class Composer extends React.Component {
           ref={this.textareaRef}
           intent={this.state.error ? 'danger' : 'none'}
           large
-          rows='1'
           value={this.state.text}
           onKeyDown={this.onKeyDown.bind(this)}
           onChange={this.handleChange}
+          onKeyUp={this.handleKeyUp}
           placeholder={tx('write_message_desktop')}
         />
         <AttachmentButtonWrapper ref={this.pickerButtonRef}>

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -198,7 +198,7 @@ class Composer extends React.Component {
   }
 
   componentDidUpdate () {
-    if(this.setCursorPosition) {
+    if (this.setCursorPosition) {
       this.textareaRef.current.selectionStart = this.setCursorPosition
       this.textareaRef.current.selectionEnd = this.setCursorPosition
       this.setCursorPosition = false
@@ -235,13 +235,13 @@ class Composer extends React.Component {
     }
   }
 
-  resizeComposer(textareaValue) {
-    let n = this.findLessThanFourNewLines(textareaValue, "\n") + 1
-    this.setComposerSize( n * 24 + 16)
-    if(n > 4) {
-      this.textareaRef.current.classList.add('scroll');
+  resizeComposer (textareaValue) {
+    let n = this.findLessThanFourNewLines(textareaValue, '\n') + 1
+    this.setComposerSize(n * 24 + 16)
+    if (n > 4) {
+      this.textareaRef.current.classList.add('scroll')
     } else {
-      this.textareaRef.current.classList.remove('scroll');
+      this.textareaRef.current.classList.remove('scroll')
     }
   }
 
@@ -275,17 +275,17 @@ class Composer extends React.Component {
     this.insertStringAtCursorPosition(emoji.native)
   }
 
-  insertStringAtCursorPosition(str) {
+  insertStringAtCursorPosition (str) {
     let textareaElem = this.textareaRef.current
-    let {selectionStart, selectionEnd} = textareaElem
+    let { selectionStart, selectionEnd } = textareaElem
     let textValue = this.state.text
 
     let textBeforeCursor = textValue.slice(0, selectionStart)
     let textAfterCursor = textValue.slice(selectionEnd)
-    
+
     let updatedText = textBeforeCursor + str + textAfterCursor
 
-    this.setCursorPosition = textareaElem.selectionStart + str.length    
+    this.setCursorPosition = textareaElem.selectionStart + str.length
     this.setState({ text: updatedText })
   }
 
@@ -311,23 +311,23 @@ class Composer extends React.Component {
            mouseY <= boundingRect.y + boundingRect.height + margin
   }
 
-  findLessThanFourNewLines(str, find) {
-    if(!str) return 0
+  findLessThanFourNewLines (str, find) {
+    if (!str) return 0
 
-    var count = 0;
+    var count = 0
     for (let i = 0; i < str.length && count < 4; ++i) {
-      if (str.substring(i, i + find.length) == find) {
+      if (str.substring(i, i + find.length) === find) {
         count++
       }
     }
-    return count;
+    return count
   }
 
   render () {
     const tx = window.translate
 
     return (
-      <ComposerWrapper ref="ComposerWrapper">
+      <ComposerWrapper ref='ComposerWrapper'>
         <AttachmentButtonWrapper>
           <Button minimal icon='paperclip' onClick={this.addFilename.bind(this)} />
         </AttachmentButtonWrapper>

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -144,6 +144,7 @@ class Composer extends React.Component {
     this.sendMessage = this.sendMessage.bind(this)
     this.onEmojiSelect = this.onEmojiSelect.bind(this)
     this.onMouseMove = this.onMouseMove.bind(this)
+    this.addStringAtCursorPosition = this.addStringAtCursorPosition.bind(this)
 
     this.textareaRef = React.createRef()
     this.pickerRef = React.createRef()
@@ -152,7 +153,7 @@ class Composer extends React.Component {
 
   onKeyDown (e) {
     if (e.keyCode === 13 && e.shiftKey) {
-      this.setState({ text: this.state.text + '\n' })
+      this.addStringAtCursorPosition('\n')
       e.preventDefault()
       e.stopPropagation()
     } else if (e.keyCode === 13 && !e.shiftKey) {
@@ -232,11 +233,20 @@ class Composer extends React.Component {
 
   onEmojiSelect (emoji) {
     log.debug(`EmojiPicker: Selected ${emoji.id}`)
+    this.addStringAtCursorPosition(emoji.native)
+  }
+
+  addStringAtCursorPosition(str) {
     let textareaElem = this.textareaRef.current
     let cursorPosition = textareaElem.selectionStart
+    let textValue = this.state.text
 
-    let updatedText = this.state.text.slice(0, cursorPosition) + emoji.native + this.state.text.slice(cursorPosition + 1)
+    let textBeforeCursor = textValue.slice(0, cursorPosition)
+    let textAfterCursor = textValue.slice(cursorPosition)
+    
+    let updatedText = textBeforeCursor + str + textAfterCursor
 
+    
     this.setState({ text: updatedText })
   }
 

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -15,6 +15,9 @@ const ComposerWrapper = styled.div`
 const AttachmentButtonWrapper = styled.div`
   float: left;
 
+  position: absolute;
+  bottom: 0;
+
   .bp3-button.bp3-minimal {
     width: 40px;
     height: 40px;
@@ -27,6 +30,10 @@ const AttachmentButtonWrapper = styled.div`
       outline: none;
     }
   }
+`
+
+const EmojiButtonWrapper = styled(AttachmentButtonWrapper)`
+  right: 40px;
 `
 
 const IconButton = styled.button`
@@ -93,17 +100,21 @@ const MessageInput = styled.textarea`
   height: 100%;
   line-height: 24px;
   padding-top: 8px;
-
+  margin-left: 40px;
 
   &:focus {
     outline: none;
   }
 `
 const SendButtonCircleWrapper = styled.div`
+  position: absolute;
+  bottom: 0;
+  right: 0;
   width: 32px;
   height: 32px;
   float: right;
   margin-top: 4px;
+  margin-bottom: 4px;
   margin-right: 5px;
   background-color: ${StyleVariables.colors.deltaPrimaryBg};
   border-radius: 180px;
@@ -314,11 +325,11 @@ class Composer extends React.Component {
           onKeyUp={this.handleKeyUp}
           placeholder={tx('write_message_desktop')}
         />
-        <AttachmentButtonWrapper ref={this.pickerButtonRef}>
+        <EmojiButtonWrapper ref={this.pickerButtonRef}>
           <IconButton onMouseOver={this.showEmojiPicker.bind(this, true)}>
             <IconButtonSpan />
           </IconButton>
-        </AttachmentButtonWrapper>
+        </EmojiButtonWrapper>
         { this.state.showEmojiPicker &&
           <EmojiPickerWrapper ref={this.pickerRef}>
             <Picker

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -33,6 +33,7 @@ const AttachmentButtonWrapper = styled.div`
 `
 
 const EmojiButtonWrapper = styled(AttachmentButtonWrapper)`
+  height: 40px;
   right: 40px;
 `
 
@@ -215,10 +216,13 @@ class Composer extends React.Component {
 
   handleChange (e) {
     this.setState({ text: e.target.value, error: false })
+    this.resizeComposer(e.target.value)
   }
 
   handleKeyUp (e) {
-    this.resizeComposer(e.target.value)
+    if (e.keyCode === 13 && e.shiftKey) {
+      this.resizeComposer(e.target.value)
+    }
   }
 
   resizeComposer(textareaValue) {
@@ -261,7 +265,6 @@ class Composer extends React.Component {
   insertStringAtCursorPosition(str) {
     let textareaElem = this.textareaRef.current
     let {selectionStart, selectionEnd} = textareaElem
-    console.log(selectionStart, selectionEnd)
     let textValue = this.state.text
 
     let textBeforeCursor = textValue.slice(0, selectionStart)

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -98,14 +98,24 @@ const MessageInput = styled.textarea`
   resize: unset;
   padding: 0px;
   border-color: transparent;
+  border-width: 0px;
   height: 100%;
   line-height: 24px;
-  padding-top: 8px;
+  height: calc(100% - 16px);
+  line-height: 24px;
+  margin-top: 8px;
+  margin-bottom: 8px;
   margin-left: 40px;
+  overflow-y: hidden;
 
   &:focus {
     outline: none;
   }
+
+  &.scroll {
+    overflow-y: scroll;
+  }
+
 `
 const SendButtonCircleWrapper = styled.div`
   position: fixed;
@@ -226,10 +236,13 @@ class Composer extends React.Component {
   }
 
   resizeComposer(textareaValue) {
-    let n = this.findLessThanFourNewLines(textareaValue, "\n")
-    console.log('n', n)
-
-    this.setComposerSize(40 + n*40)
+    let n = this.findLessThanFourNewLines(textareaValue, "\n") + 1
+    this.setComposerSize( n * 24 + 16)
+    if(n > 4) {
+      this.textareaRef.current.classList.add('scroll');
+    } else {
+      this.textareaRef.current.classList.remove('scroll');
+    }
   }
 
   focusInputMessage () {

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -181,33 +181,25 @@ class Composer extends React.Component {
       text: this.state.text
     })
     this.clearInput()
+
     this.focusInputMessage()
   }
 
   clearInput () {
     this.setState({ text: '', filename: null })
+    this.resizeComposer('')
   }
 
   handleChange (e) {
-    /*
-    console.log(e)
-    console.log(this.textareaRef, this.textareaRef.current.scrollHeight)
-    let size = this.textareaRef.current.scrollHeight
-    let conversationElement = document.getElementById('the-conversation')
-
-    conversationElement.style.height = `calc(100vh - 50px - ${size}px)`
-
-    console.log(this.refs)
-    console.log('as', conversationElement.style.height, this.textareaRef.current.style.height )
-    */
-
-
     this.setState({ text: e.target.value, error: false })
   }
 
   handleKeyUp (e) {
-    let value = e.target.value
-    let n = this.findLessThanFourNewLines(value, "\n")
+    this.resizeComposer(e.target.value)
+  }
+
+  resizeComposer(textareaValue) {
+    let n = this.findLessThanFourNewLines(textareaValue, "\n")
     console.log('n', n)
 
     this.setComposerSize(40 + n*40)

--- a/src/renderer/components/Composer.js
+++ b/src/renderer/components/Composer.js
@@ -132,8 +132,11 @@ class Composer extends React.Component {
       text: '',
       error: false,
       showEmojiPicker: false
+
     }
     this.minimumHeight = 48
+
+    this.setCursorPosition = false
 
     this.setComposerSize = this.props.setComposerSize
 
@@ -170,6 +173,14 @@ class Composer extends React.Component {
     // the component changes chat ids, while rendering any cached unsent
     // previous message text (aka "draft" message)
     this.focusInputMessage()
+  }
+
+  componentDidUpdate () {
+    if(this.setCursorPosition) {
+      this.textareaRef.current.selectionStart = this.setCursorPosition
+      this.textareaRef.current.selectionEnd = this.setCursorPosition
+      this.setCursorPosition = false
+    }
   }
 
   handleError () {
@@ -238,15 +249,16 @@ class Composer extends React.Component {
 
   addStringAtCursorPosition(str) {
     let textareaElem = this.textareaRef.current
-    let cursorPosition = textareaElem.selectionStart
+    let {selectionStart, selectionEnd} = textareaElem
+    console.log(selectionStart, selectionEnd)
     let textValue = this.state.text
 
-    let textBeforeCursor = textValue.slice(0, cursorPosition)
-    let textAfterCursor = textValue.slice(cursorPosition)
+    let textBeforeCursor = textValue.slice(0, selectionStart)
+    let textAfterCursor = textValue.slice(selectionEnd)
     
     let updatedText = textBeforeCursor + str + textAfterCursor
 
-    
+    this.setCursorPosition = textareaElem.selectionStart + 1    
     this.setState({ text: updatedText })
   }
 

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -33,10 +33,12 @@ const NavbarGroupSubtitle = styled.div`
   font-weight: 100;
   color: ${StyleVariables.colors.deltaPrimaryFgLight};
 `
-const BelowNavbar = styled.div`
+
+const Welcome = styled.div`
+  width: 70%;
+  float: right;
   height: calc(100vh - 50px);
   margin-top: 50px;
-  overflow: hidden;
 `
 
 class SplittedChatListAndView extends React.Component {
@@ -129,7 +131,7 @@ class SplittedChatListAndView extends React.Component {
             </NavbarGroup>
           </Navbar>
         </NavbarWrapper>
-        <BelowNavbar>
+        <div>
           <ChatList
             chatList={deltachat.chatList}
             onDeadDropClick={this.onDeadDropClick}
@@ -154,17 +156,17 @@ class SplittedChatListAndView extends React.Component {
                   chat={selectedChat}
                   deltachat={this.props.deltachat} />)
               : (
-                <Unselectable>
-                  <Centered>
-                    <div className='window '>
+                <Welcome>
+                  <Unselectable>
+                    <Centered>
                       <h1>{tx('welcome_desktop')}</h1>
                       <p>{tx('no_chat_selected_suggestion_desktop')}</p>
-                    </div>
-                  </Centered>
-                </Unselectable>
+                    </Centered>
+                  </Unselectable>
+                </Welcome>
               )
           }
-        </BelowNavbar>
+        </div>
 
       </div>
     )


### PR DESCRIPTION
![screenshot_20190131_162940](https://user-images.githubusercontent.com/34889164/52064702-6d7fbc80-2575-11e9-8c70-cae0d7511e00.png)

Still missing:
- [x] emoji picker isn't at the right position currently
- [x] resizing isn't on point yet
- [x] we sometimes have scrollbars even if we don't need them
- [x] composer buttons should stick to the bottom (position them absolutely)
- [x] some weird css bugs if we're havent selected a chat yet
- [x] resizing composer is getting called too often