### PR TITLE
Improvement: change handle position for context menu

### DIFF
--- a/css/conversations/_modules.scss
+++ b/css/conversations/_modules.scss
@@ -51,11 +51,12 @@
 .module-message__buttons {
   position: absolute;
   top: 0;
-  bottom: 0;
+  right: 0;
   display: inline-flex;
   flex-direction: row;
   align-items: center;
   opacity: 0;
+  z-index: 10;
 }
 
 .module-message:hover .module-message__buttons {
@@ -63,11 +64,9 @@
 }
 
 .module-message__buttons--incoming {
-  left: 100%;
+  right: 10px;
 }
-.module-message__buttons--outgoing {
-  right: 100%;
-}
+
 
 .module-message__buttons__download {
   height: 24px;
@@ -469,6 +468,7 @@
   word-wrap: break-word;
   word-break: break-word;
   white-space: pre-wrap;
+  margin-top: 10px;
 
   a {
     text-decoration: underline;


### PR DESCRIPTION
Since deltachat supports custom backgrounds, the handle for context menus (only visible on hover) should not be near the bubble but in the upper right corner. Otherwise it might not have enough contrast.

I added 10px padding-top to the text to enable a proper distance, may be there is a better solution...

<img width="236" alt="context-menu-handle" src="https://user-images.githubusercontent.com/1428457/52258119-29e2d500-291e-11e9-952d-398762c533d8.png">