### PR TITLE
Adapt width & height of renderMedia overlay

### DIFF
--- a/src/renderer/components/dialogs/RenderMedia.js
+++ b/src/renderer/components/dialogs/RenderMedia.js
@@ -6,12 +6,15 @@ const RenderMediaWrapper = styled.div`
   display: flex;
   align-items: center;
   flex-direction: column;
+  width: 70%;
+  position:absolute;
 `
 
 const Exit = styled.div`
   float: right;
   position: absolute;
   right: 0;
+  z-index: 2000;
 `
 
 class RenderMedia extends React.Component {
@@ -30,10 +33,10 @@ class RenderMedia extends React.Component {
         elm = <img src={url} />
         break
       case 'audio':
-        elm = <audio src={url} controls='true' />
+        elm = <audio src={url} controls='1' />
         break
       case 'video':
-        elm = <video src={url} controls='true' />
+        elm = <video src={url} controls='1' />
         break
       default:
         elm = null

--- a/static/main.css
+++ b/static/main.css
@@ -52,9 +52,6 @@ input:focus {
 .user-feedback.success {
   background-color: #4caf50;
 }
-img {
-  max-width: 500px;
-}
 
 ul {
   list-style: none;
@@ -84,6 +81,11 @@ ul li button {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.bp3-overlay-content img,
+.bp3-overlay-content video {
+  width: 100%;
 }
 
 .module-conversation-list-item__is-verified {


### PR DESCRIPTION
resolves #470

- add z-index to closing element
- overlay width relative to current window (70%)
- change controls attribute value to 1 to avoid console warning

In my test videos were displayed far too big, so the
cross was not even visible. Now that only happens,
if you have a width/height ratio > 3:2

Not sure if the img {max-width: 500px} is needed
somewhere else...