### PR TITLE
Update deltachat-node to v0.44.0 and fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,49 @@
-sudo: required
 language: node_js
+services:
+  - docker
+sudo: required
 dist: xenial
 
 addons:
-  apt:
+  homebrew:
     packages:
-      - appstream-util
-      - desktop-file-utils
-      - python3-pip
-      - python3-setuptools
-      - libssl-dev
-      - libsqlite3-dev
-      - libbz2-dev
-      - zlib1g-dev
-      - libsasl2-dev
-
-node_js:
-  - 10
-
+      - meson
+      - libetpan
+      - openssl
+      - coreutils
+    update: true
 os:
   - osx
   - linux
 
+node_js:
+  - 10
+
+env:
+  global:
+    - DOCKER_IMAGE=deltachat/travis-dc-node-base:latest
+
+  matrix:
+    - DC_CORE_VERSION="master" SYS_DC_CORE="false"
+    - DC_CORE_VERSION="master" SYS_DC_CORE="true"
+
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
+    - $HOME/.cargo
+    - $TRAVIS_BUILD_DIR/target
+
+before_cache:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cleanup;
+
 before_install:
-  - if [ $(uname) = Linux ]; then
-        wget https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip;
-        unzip ninja-linux.zip;
-        chmod +x ninja;
-        sudo cp ninja /usr/bin;
-    fi
-  - if [ $(uname) = Linux ]; then
-        sudo pip3 install meson;
-    fi
+  - ./ci_scripts/ci-prelude.sh
 
 install:
-  - npm install
+  - ./ci_scripts/ci-build.sh
 
 script:
-  - if [ $(uname) = Linux ]; then
-        desktop-file-validate static/chat.delta.desktop.desktop;
-    fi
-  - if [ $(uname) = Linux ]; then
-        appstream-util validate-relax static/chat.delta.desktop.appdata.xml;
-    fi
-  - npm run build
-  - npm test
-  - if [ $(uname) != Linux ]; then
-        npm run test-integration;
-    fi
-
-# Only deploy for OSX, for linux we only release source.
-deploy:
-  skip_cleanup: true
-  provider: script
-  script: npm run dist-ci
-  on:
-    repo: deltachat/deltachat-desktop
-    os: osx
-    all_branches: true
-
+  - ./ci_scripts/ci-test.sh
 
 notifications:
   email: false

--- a/ci_scripts/build_sasl.sh
+++ b/ci_scripts/build_sasl.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -e -x
+
+SASL_VERSION=2.1.27
+SASL_SHA256=26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5
+
+curl -O https://www.cyrusimap.org/releases/cyrus-sasl-${SASL_VERSION}.tar.gz
+echo "${SASL_SHA256}  cyrus-sasl-${SASL_VERSION}.tar.gz" | shasum -a256 -c -
+tar zxf cyrus-sasl-${SASL_VERSION}.tar.gz
+
+cd cyrus-sasl-${SASL_VERSION}
+
+./configure --enable-shared \
+            --disable-silent-rules \
+            --disable-cmulocal \
+            --disable-sample \
+            --disable-obsolete_cram_attr \
+            --disable-obsolete_digest_attr \
+            --disable-staticdlopen \
+            --disable-java \
+            --disable-alwaystrue \
+            --enable-checkapop \
+            --enable-cram \
+            --enable-digest \
+            --enable-scram \
+            --enable-plain \
+            --enable-anon \
+            --enable-login \
+            --disable-macos-framework \
+            "$@"
+
+make
+make install
+ldconfig || true

--- a/ci_scripts/ci-build.sh
+++ b/ci_scripts/ci-build.sh
@@ -38,9 +38,9 @@ else
 fi
 
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
-$EXEC npm install --dc-system-lib=$SYS_DC_CORE;
-$EXEC npm run build
-$EXEC npm run test
+$EXEC npm install --verbose --dc-system-lib=$SYS_DC_CORE;
+$EXEC npm run build;
+$EXEC npm run test;
 
 if [ $TRAVIS_OS_NAME = linux ]; then
     readelf -d build/Release/deltachat.node

--- a/ci_scripts/ci-build.sh
+++ b/ci_scripts/ci-build.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# Build deltachat-node itself.
+
+# On linux this uses the latest created docker container, which works
+# fine on the CI build but may be the wrong continer if you are doing
+# things somewhere else.  Set CONTAINER_ID to the correct container to
+# avoid using the latest created container.
+
+set -ex
+
+
+# To facilitate running locally, derive some Travis environment
+# variables.
+if [ -z "$TRAVIS_OS_NAME" ]; then
+    case $(uname) in
+        Darwin)
+            TRAVIS_OS_NAME=osx
+            ;;
+        Linux)
+            TRAVIS_OS_NAME=linux
+            ;;
+        *)
+            echo "TRAVIS_OS_NAME unset and uname=$(uname) is unknown" >&2
+            exit 1
+    esac
+fi
+SYS_DC_CORE=${SYS_DC_CORE:-true}
+
+
+if [ $TRAVIS_OS_NAME = linux ]; then
+    CONTAINER_ID=${CONTAINER_ID:-$(docker ps --latest --format='{{.ID}}')}
+    EXEC="docker exec $CONTAINER_ID";
+    EXEC_ROOT="docker exec -u0:0 -eHOME=/ $CONTAINER_ID";
+else
+    EXEC=
+    EXEC_ROOT=sudo
+fi
+
+export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
+$EXEC npm install --dc-system-lib=$SYS_DC_CORE;
+$EXEC npm run build
+$EXEC npm run test
+
+if [ $TRAVIS_OS_NAME = linux ]; then
+    readelf -d build/Release/deltachat.node
+    ldd build/Release/deltachat.node
+fi
+if [ $TRAVIS_OS_NAME = osx ]; then
+    otool -L build/Release/deltachat.node
+fi

--- a/ci_scripts/ci-build.sh
+++ b/ci_scripts/ci-build.sh
@@ -38,6 +38,5 @@ else
 fi
 
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
-$EXEC npm install --verbose --dc-system-lib=$SYS_DC_CORE;
+$EXEC npm install --dc-system-lib=$SYS_DC_CORE;
 $EXEC npm run build;
-$EXEC npm run test;

--- a/ci_scripts/ci-build.sh
+++ b/ci_scripts/ci-build.sh
@@ -41,11 +41,3 @@ export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
 $EXEC npm install --verbose --dc-system-lib=$SYS_DC_CORE;
 $EXEC npm run build;
 $EXEC npm run test;
-
-if [ $TRAVIS_OS_NAME = linux ]; then
-    readelf -d build/Release/deltachat.node
-    ldd build/Release/deltachat.node
-fi
-if [ $TRAVIS_OS_NAME = osx ]; then
-    otool -L build/Release/deltachat.node
-fi

--- a/ci_scripts/ci-build.sh
+++ b/ci_scripts/ci-build.sh
@@ -38,5 +38,6 @@ else
 fi
 
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
-$EXEC npm install --dc-system-lib=$SYS_DC_CORE;
+$EXEC npm install --dc-system-lib=$SYS_DC_CORE --verbose;
 $EXEC npm run build;
+$EXEC tail -f /dev/null

--- a/ci_scripts/ci-build.sh
+++ b/ci_scripts/ci-build.sh
@@ -40,4 +40,3 @@ fi
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
 $EXEC npm install --dc-system-lib=$SYS_DC_CORE;
 $EXEC npm run build;
-$EXEC tail -f /dev/null

--- a/ci_scripts/ci-build.sh
+++ b/ci_scripts/ci-build.sh
@@ -38,6 +38,6 @@ else
 fi
 
 export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
-$EXEC npm install --dc-system-lib=$SYS_DC_CORE --verbose;
+$EXEC npm install --dc-system-lib=$SYS_DC_CORE;
 $EXEC npm run build;
 $EXEC tail -f /dev/null

--- a/ci_scripts/ci-prelude.sh
+++ b/ci_scripts/ci-prelude.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script prepares the CI host by installing external dependencies
+# for the deltachat-node bindings.
+
+set -ex
+
+
+# Some default variables, these are normally provided by the CI
+# runtime.
+DOCKER_IMAGE=${DOCKER_IMAGE:-deltachat/travis-dc-node-base:latest}
+DC_CORE_VERSION=${DC_CORE_VERSION:-master}
+
+
+# To facilitate running locally, derive some Travis environment
+# variables.
+if [ -z "$TRAVIS_OS_NAME" ]; then
+    case $(uname) in
+        Darwin)
+            TRAVIS_OS_NAME=osx
+            ;;
+        Linux)
+            TRAVIS_OS_NAME=linux
+            ;;
+        *)
+            echo "TRAVIS_OS_NAME unset and uname=$(uname) is unknown" >&2
+            exit 1
+    esac
+fi
+SYS_DC_CORE=${SYS_DC_CORE:-true}
+
+
+case $TRAVIS_OS_NAME in
+    linux)
+        docker pull $DOCKER_IMAGE
+        CONTAINER_ID=$(docker run -d -v/etc/passwd:/etc/passwd:ro -u$(id -u):$(id -g) -v$(pwd):/work -w/work -eHOME=/work $DOCKER_IMAGE)
+        EXEC="docker exec $CONTAINER_ID";
+        EXEC_ROOT="docker exec -u0:0 -eHOME=/ $CONTAINER_ID";
+        if [ "$SYS_DC_CORE" = "true" ]; then
+            $EXEC git clone --branch=$DC_CORE_VERSION https://github.com/deltachat/deltachat-core deltachat-core-src
+            $EXEC meson -Drpgp=true deltachat-core-build deltachat-core-src
+            $EXEC ninja -v -C deltachat-core-build
+            $EXEC_ROOT ninja -v -C deltachat-core-build install
+            $EXEC_ROOT ldconfig -v
+            $EXEC rm -rf deltachat-core-build deltachat-core-src
+        fi
+        ;;
+    osx)
+        # Install cyrus sasl
+        ./ci_scripts/build_sasl.sh --with-openssl=/usr/local/opt/openssl
+
+        export PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig
+        
+        # Install rust
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+            | sh -s -- --default-toolchain nightly -y
+        . ~/.cargo/env
+
+        # Install rpgp
+        git clone https://github.com/rpgp/rpgp.git
+        pushd rpgp/pgp-ffi
+        make install
+        popd
+
+
+        if [ "$SYS_DC_CORE" = "true" ]; then
+            git clone --branch=$DC_CORE_VERSION https://github.com/deltachat/deltachat-core deltachat-core-src
+            meson -Drpgp=true deltachat-core-build deltachat-core-src
+            ninja -v -C deltachat-core-build
+            sudo ninja -v -C deltachat-core-build install
+        fi
+        rm -rf deltachat-core-build deltachat-core-src cyrus-sasl-*
+        ;;
+    *)
+        echo "Unknown OS: $TRAVIS_OS_NAME" >&2
+        exit 1
+esac

--- a/ci_scripts/ci-test.sh
+++ b/ci_scripts/ci-test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# Build deltachat-node itself.
+
+# On linux this uses the latest created docker container, which works
+# fine on the CI build but may be the wrong continer if you are doing
+# things somewhere else.  Set CONTAINER_ID to the correct container to
+# avoid using the latest created container.
+
+set -ex
+
+
+# To facilitate running locally, derive some Travis environment
+# variables.
+if [ -z "$TRAVIS_OS_NAME" ]; then
+    case $(uname) in
+        Darwin)
+            TRAVIS_OS_NAME=osx
+            ;;
+        Linux)
+            TRAVIS_OS_NAME=linux
+            ;;
+        *)
+            echo "TRAVIS_OS_NAME unset and uname=$(uname) is unknown" >&2
+            exit 1
+    esac
+fi
+
+if [ $TRAVIS_OS_NAME = linux ]; then
+    CONTAINER_ID=${CONTAINER_ID:-$(docker ps --latest --format='{{.ID}}')}
+    EXEC="docker exec -eDC_ADDR=$DC_ADDR -eDC_MAIL_PW=$DC_MAIL_PW $CONTAINER_ID";
+    EXEC_ROOT="docker exec -u0:0 -eHOME=/ $CONTAINER_ID";
+else
+    EXEC=
+    EXEC_ROOT=sudo
+fi
+
+
+$EXEC npm test;
+if [ $TRAVIS_PULL_REQUEST = false ]; then
+    $EXEC npm run test-integration;
+fi
+
+
+# Finally cleanup the running container
+if [ $TRAVIS_OS_NAME = linux ]; then
+    docker kill $CONTAINER_ID;
+fi

--- a/ci_scripts/ci-test.sh
+++ b/ci_scripts/ci-test.sh
@@ -37,9 +37,9 @@ fi
 
 
 $EXEC npm test;
-if [ $TRAVIS_PULL_REQUEST = false ]; then
-    $EXEC npm run test-integration;
-fi
+#if [ $TRAVIS_PULL_REQUEST = false ]; then
+#    $EXEC npm run test-integration;
+#fi
 
 
 # Finally cleanup the running container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,115 @@
+FROM debian:stretch
+
+# Update apt repositories
+RUN apt-get update && \
+    apt-get upgrade -y \
+    && apt-get install -y zip \
+                          curl \
+                          python \
+                          python3-pip \
+                          build-essential \
+                          git \
+                          pkg-config \
+                          autoconf \
+                          libtool \
+                          zlib1g-dev \
+                          libbz2-dev \
+                          libsqlite3-dev \
+                          libssl-dev
+
+# Install meson and ninja
+ENV NINJA_VERSION v1.9.0
+ENV NINJA_SHA256 1b1235f2b0b4df55ac6d80bbe681ea3639c9d2c505c7ff2159a3daf63d196305
+RUN curl -L -o ninja-linux-${NINJA_VERSION}.zip https://github.com/ninja-build/ninja/releases/download/${NINJA_VERSION}/ninja-linux.zip
+RUN echo "${NINJA_SHA256}  ninja-linux-${NINJA_VERSION}.zip" | sha256sum -c -
+RUN unzip ninja-linux-${NINJA_VERSION}.zip
+RUN mv ninja /usr/bin/ninja
+RUN chmod +x /usr/bin/ninja
+RUN pip3 install meson
+
+# Need a new zlib because node does not get on with the one shipped in
+# debian stretch
+ENV ZLIB_VERSION 1.2.11
+ENV ZLIB_SHA256 c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+RUN curl -O https://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz
+RUN echo "${ZLIB_SHA256}  zlib-${ZLIB_VERSION}.tar.gz" | sha256sum -c -
+RUN tar -xzf zlib-${ZLIB_VERSION}.tar.gz
+RUN cd zlib-${ZLIB_VERSION} && ./configure
+RUN cd zlib-${ZLIB_VERSION} && make
+RUN cd zlib-${ZLIB_VERSION} && make install
+RUN ldconfig -v
+
+# Install node.js using shared zlib and libssl.  This is important
+# because these libraries are a shared dependency between libssl and
+# libdeltchat and they all end up in the same address space.
+ENV NODEJS_VERSION v10.15.3
+ENV NODEJS_SHA256 db460a63d057ac015b75bb6a879fcbe2fefaaf22afa4b6f6445b9db61ce2270d
+RUN curl -L -O https://nodejs.org/dist/v10.15.3/node-${NODEJS_VERSION}.tar.gz
+RUN tar -xzf node-${NODEJS_VERSION}.tar.gz
+RUN cd node-${NODEJS_VERSION} && \
+    ./configure --shared-openssl \
+                --shared-zlib
+RUN cd node-${NODEJS_VERSION} && make -j $(nproc)
+RUN cd node-${NODEJS_VERSION} && make install
+RUN ldconfig -v
+
+# Install cyrus-sasl
+ENV SASL_VERSION 2.1.27
+ENV SASL_SHA256 26866b1549b00ffd020f188a43c258017fa1c382b3ddadd8201536f72efb05d5
+RUN curl -O https://www.cyrusimap.org/releases/cyrus-sasl-${SASL_VERSION}.tar.gz
+RUN echo "${SASL_SHA256}  cyrus-sasl-${SASL_VERSION}.tar.gz" | sha256sum -c -
+RUN tar zxf cyrus-sasl-${SASL_VERSION}.tar.gz
+RUN cd cyrus-sasl-${SASL_VERSION} && \
+    ./configure --enable-shared \
+                --disable-cmulocal \
+                --disable-sample \
+                --disable-obsolete_cram_attr \
+                --disable-obsolete_digest_attr \
+                --disable-alwaystrue \
+                --enable-checkapop \
+                --enable-cram \
+                --enable-digest \
+                --enable-scram \
+                --enable-plain \
+                --enable-anon \
+                --enable-login
+RUN cd cyrus-sasl-${SASL_VERSION} && make -j $(nproc)
+RUN cd cyrus-sasl-${SASL_VERSION} && make install
+RUN ldconfig -v
+
+# Install libetpan
+ENV ETPAN_VERSION 1.9.1
+ENV ETPAN_SHA256 f5e354ccf1014c6ee313ade1009b8a82f28043d2504655e388bb4c1328700fcd
+RUN curl -L -o libetpan-${ETPAN_VERSION}.tar.gz \
+    https://github.com/dinhviethoa/libetpan/archive/${ETPAN_VERSION}.tar.gz
+RUN echo "${ETPAN_SHA256}  libetpan-${ETPAN_VERSION}.tar.gz" | sha256sum -c -
+RUN tar xzf libetpan-${ETPAN_VERSION}.tar.gz
+RUN cd libetpan-${ETPAN_VERSION} && \
+    ./autogen.sh && \
+    ./configure --disable-silent-rules \
+                --enable-ipv6 \
+                --enable-iconv \
+                --disable-db \
+                --with-openssl \
+                --with-sasl \
+                --with-zlib \
+                --without-curl \
+                --without-expat
+RUN cd libetpan-${ETPAN_VERSION} && make -j $(nproc)
+RUN cd libetpan-${ETPAN_VERSION} && make install
+RUN ldconfig -v
+
+# Configure ld.so to look in /usr/local/lib/x86_64-linux-gnu/
+RUN echo /usr/local/lib/x86_64-linux-gnu/ > /etc/ld.so.conf.d/local.conf
+
+# Install rust for rpgp
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- --default-toolchain nightly -y
+ENV PATH=/root/.cargo/bin:$PATH
+
+# Install rpgp
+RUN git clone https://github.com/rpgp/rpgp.git
+RUN cd rpgp/pgp-ffi && make install
+RUN ldconfig -v
+
+CMD /usr/bin/tail -f /dev/null

--- a/package-lock.json
+++ b/package-lock.json
@@ -3195,9 +3195,8 @@
       "dev": true
     },
     "deltachat-node": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/deltachat-node/-/deltachat-node-0.44.0.tgz",
-      "integrity": "sha512-QJIjb9ZtckQWThosodHKMyoJt3eFos1TdCEAbTos0zkJOFtIjRdBvpvFDup4ma2mN4H3mE6QPGgAHi+di9gi0w==",
+      "version": "git+https://github.com/deltachat/deltachat-node.git#8f3310fdf9255487009339a7010a650eab7cb9b6",
+      "from": "git+https://github.com/deltachat/deltachat-node.git#v0.44.1",
       "requires": {
         "bindings": "^1.5.0",
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "0.102.0",
+  "version": "0.102.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -473,7 +473,8 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
     },
     "acorn": {
       "version": "6.1.1",
@@ -515,6 +516,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
       "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -591,7 +593,8 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -677,7 +680,8 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "dev": true
     },
     "archiver": {
       "version": "2.1.1",
@@ -713,6 +717,7 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "dev": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -799,6 +804,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -843,7 +849,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -907,7 +914,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -918,18 +926,19 @@
     "author-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
-      "integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=",
-      "dev": true
+      "integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA="
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1825,6 +1834,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -1841,6 +1851,14 @@
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
@@ -1855,6 +1873,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "dev": true,
       "requires": {
         "inherits": "~2.0.0"
       }
@@ -2348,7 +2367,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "ccount": {
       "version": "1.0.3",
@@ -2598,7 +2618,8 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collapse-white-space": {
       "version": "1.0.4",
@@ -2635,6 +2656,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
       "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2720,7 +2742,8 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -2994,6 +3017,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -3161,25 +3185,26 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "deltachat-node": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/deltachat-node/-/deltachat-node-0.43.0.tgz",
-      "integrity": "sha512-nXbrpS/IiMfvNNXrJsaz0PQt2L2Jqy7FQSTx+MHEtfj5TfKZQmhjpQh7wzNqNzXmJBmujUxbcYwlm9f3h+NAEA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/deltachat-node/-/deltachat-node-0.44.0.tgz",
+      "integrity": "sha512-QJIjb9ZtckQWThosodHKMyoJt3eFos1TdCEAbTos0zkJOFtIjRdBvpvFDup4ma2mN4H3mE6QPGgAHi+di9gi0w==",
       "requires": {
+        "bindings": "^1.5.0",
         "debug": "^4.1.1",
         "got": "^9.6.0",
         "lodash.pick": "^4.4.0",
         "mkdirp": "^0.5.1",
         "napi-macros": "^1.7.0",
-        "node-gyp": "^3.8.0",
-        "node-gyp-build": "^3.8.0",
         "rimraf": "^2.6.3"
       }
     },
@@ -3372,6 +3397,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -4460,7 +4486,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4591,17 +4618,20 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -4665,6 +4695,11 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filesize": {
       "version": "3.6.1",
@@ -4798,12 +4833,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -4933,12 +4970,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4953,17 +4992,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5080,7 +5122,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5092,6 +5135,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5106,6 +5150,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5113,12 +5158,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5137,6 +5184,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5217,7 +5265,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5229,6 +5278,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5350,6 +5400,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5425,6 +5476,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -5448,6 +5500,7 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "dev": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -5517,6 +5570,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -5686,7 +5740,8 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -5754,12 +5809,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
       "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
       "requires": {
         "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
@@ -5812,7 +5869,8 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -5916,6 +5974,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -6397,6 +6456,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -6622,12 +6682,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
-    "is-url": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
     "is-utf8": {
@@ -6668,7 +6723,8 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "3.0.1",
@@ -6688,7 +6744,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "isurl": {
       "version": "1.0.0",
@@ -6732,7 +6789,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsesc": {
       "version": "1.3.0",
@@ -6754,12 +6812,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -6770,7 +6830,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -6791,6 +6852,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -7182,8 +7244,7 @@
     "mdast-util-to-string": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-1.0.5.tgz",
-      "integrity": "sha512-2qLt/DEOo5F6nc2VFScQiHPzQ0XXcabquRJxKMhKte8nt42o08HUxNDPk7tt0YPxnWjAT11I1SYi0X0iPnfI5A==",
-      "dev": true
+      "integrity": "sha512-2qLt/DEOo5F6nc2VFScQiHPzQ0XXcabquRJxKMhKte8nt42o08HUxNDPk7tt0YPxnWjAT11I1SYi0X0iPnfI5A=="
     },
     "mdast-util-toc": {
       "version": "3.1.0",
@@ -7601,6 +7662,7 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
       "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
+      "dev": true,
       "requires": {
         "fstream": "^1.0.0",
         "glob": "^7.0.3",
@@ -7620,6 +7682,7 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
           "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "dev": true,
           "requires": {
             "block-stream": "*",
             "fstream": "^1.0.2",
@@ -7627,11 +7690,6 @@
           }
         }
       }
-    },
-    "node-gyp-build": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.9.0.tgz",
-      "integrity": "sha512-zLcTg6P4AbcHPq465ZMFNXx7XpKKJh+7kkN699NiQWisR2uWYOWNWqRHAmbnmKiL4e9aLSlmy5U7rEMUXV59+A=="
     },
     "node-libs-browser": {
       "version": "2.2.0",
@@ -7730,6 +7788,7 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
       "requires": {
         "abbrev": "1"
       }
@@ -7795,6 +7854,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -7837,12 +7897,14 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -7988,7 +8050,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-locale": {
       "version": "2.1.0",
@@ -8004,12 +8067,14 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -8215,7 +8280,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
       "integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
-      "dev": true,
       "requires": {
         "author-regex": "^1.0.0"
       }
@@ -8384,7 +8448,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -8643,7 +8708,8 @@
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw=="
+      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -8809,7 +8875,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "2.0.3",
@@ -8830,7 +8897,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "query-string": {
       "version": "5.1.1",
@@ -9180,16 +9248,6 @@
         "mdast-util-to-string": "^1.0.2"
       }
     },
-    "remark-contributors": {
-      "version": "github:hughsk/remark-contributors#b1703ce019560906e3f0b7af40b43c620b6e1786",
-      "from": "github:hughsk/remark-contributors#b1703ce",
-      "dev": true,
-      "requires": {
-        "is-url": "^1.2.2",
-        "mdast-util-to-string": "^1.0.0",
-        "parse-author": "^2.0.0"
-      }
-    },
     "remark-git-contributors": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/remark-git-contributors/-/remark-git-contributors-0.3.0.tgz",
@@ -9199,11 +9257,19 @@
         "git-contributors": "~0.2.3",
         "mdast-util-heading-range": "~2.1.0",
         "parse-author": "~2.0.0",
-        "remark-contributors": "github:hughsk/remark-contributors#b1703ce019560906e3f0b7af40b43c620b6e1786",
         "resolve": "~1.8.1",
         "unist-util-visit": "~1.4.0"
       },
       "dependencies": {
+        "remark-contributors": {
+          "version": "github:hughsk/remark-contributors#b1703ce019560906e3f0b7af40b43c620b6e1786",
+          "from": "github:hughsk/remark-contributors#b1703ce019560906e3f0b7af40b43c620b6e1786",
+          "requires": {
+            "is-url": "^1.2.2",
+            "mdast-util-to-string": "^1.0.0",
+            "parse-author": "^2.0.0"
+          }
+        },
         "resolve": {
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -9646,6 +9712,7 @@
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -10102,7 +10169,8 @@
     "semver": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
@@ -10122,7 +10190,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-value": {
       "version": "2.0.0",
@@ -10203,7 +10272,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "single-line-log": {
       "version": "1.1.2",
@@ -10518,6 +10588,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -10700,6 +10771,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -10741,6 +10813,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -11329,6 +11402,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -11337,7 +11411,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },
@@ -11409,6 +11484,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -11416,7 +11492,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -11821,6 +11898,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -11909,7 +11987,8 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.0.2",
@@ -11931,6 +12010,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -12467,6 +12547,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -12481,6 +12562,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "0.102.0",
+  "version": "0.102.1",
   "description": "Desktop Application for delta.chat",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "array-differ": "^2.0.3",
     "class-autobind": "^0.1.4",
     "debounce": "^1.2.0",
-    "deltachat-node": "^0.44.0",
+    "deltachat-node": "git+https://github.com/deltachat/deltachat-node.git#v0.44.1",
     "emoji-js-clean": "^4.0.0",
     "emoji-mart": "^2.10.0",
     "error-stack-parser": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "array-differ": "^2.0.3",
     "class-autobind": "^0.1.4",
     "debounce": "^1.2.0",
-    "deltachat-node": "^0.43.0",
+    "deltachat-node": "^0.44.0",
     "emoji-js-clean": "^4.0.0",
     "emoji-mart": "^2.10.0",
     "error-stack-parser": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "0.102.1",
+  "version": "0.102.0",
   "description": "Desktop Application for delta.chat",
   "main": "index.js",
   "scripts": {
@@ -48,7 +48,7 @@
     "array-differ": "^2.0.3",
     "class-autobind": "^0.1.4",
     "debounce": "^1.2.0",
-    "deltachat-node": "git+https://github.com/deltachat/deltachat-node.git#v0.44.1",
+    "deltachat-node": "^0.44.1",
     "emoji-js-clean": "^4.0.0",
     "emoji-mart": "^2.10.0",
     "error-stack-parser": "^2.0.2",


### PR DESCRIPTION
Fixes https://github.com/deltachat/deltachat-desktop/issues/792 because -node v0.44.x is compatible with newer node versions.
Fixes https://github.com/deltachat/deltachat-desktop/issues/659 because we can bundle
Fixes https://github.com/deltachat/deltachat-desktop/issues/722 because ci is fixed
Fixes https://github.com/deltachat/deltachat-desktop/issues/708 because we bundle openssl