### PR TITLE
Changed default english signature text

### DIFF
--- a/_locales/en.xml
+++ b/_locales/en.xml
@@ -349,7 +349,7 @@
     <!-- Translators: The value entered here is visible only to recipients who DO NOT use Deltachat, so its not a "Status" but the last line in the E-Mail. -->
     <string name="pref_default_status_label">Signature text</string>
     <!-- Translators: The URL should not be localized, it is not clear which language the receiver prefers and the language will be detected on the server -->
-    <string name="pref_default_status_text">Sent with my Delta Chat Messenger: https://delta.chat</string>
+    <string name="pref_default_status_text">Sent via Delta Chat Messenger: https://delta.chat</string>
     <string name="pref_enter_sends">Enter key sends</string>
     <string name="pref_enter_sends_explain">Pressing the Enter key will send text messages</string>
     <string name="pref_outgoing_media_quality">Outgoing media quality</string>


### PR DESCRIPTION
Changed "Sent with my Delta Chat Messenger" to "Sent via Delta Chat Messenger" which sounds more natural.