### PR TITLE
fix: use a friendlier file name for logs on windows (: not appreciated)

### DIFF
--- a/src/main/log-handler.js
+++ b/src/main/log-handler.js
@@ -2,10 +2,31 @@ const { createWriteStream } = require('fs')
 const path = require('path')
 const { getLogsPath } = require('../application-constants')
 
+function logName () {
+  const dir = getLogsPath()
+  const d = new Date()
+  function pad (number) {
+    return number < 10 ? '0' + number : number
+  }
+  const fileName = [
+    `${d.getFullYear()}-`,
+    `${pad(d.getMonth())}-`,
+    `${pad(d.getDay())}-`,
+    `${pad(d.getHours())}-`,
+    `${pad(d.getMinutes())}-`,
+    `${pad(d.getSeconds())}`,
+    '.log'
+  ].join('')
+  return path.join(dir, fileName)
+}
+
 module.exports = () => {
   const dir = getLogsPath()
-  const fileName = path.join(dir, `${(new Date()).toISOString()}.log`)
+  const fileName = logName()
   const stream = createWriteStream(fileName, { flags: 'w' })
+  stream.on('error', err => {
+    throw new Error('log file error ' + err.message)
+  })
   console.log(`Logfile: ${fileName}`)
   return {
     /**


### PR DESCRIPTION
App crashes at startup because we fail to create the log file.