### PR TITLE
Sort chat list on update

### DIFF
--- a/src/main/deltachat/index.js
+++ b/src/main/deltachat/index.js
@@ -37,6 +37,13 @@ class DeltaChatController extends EventEmitter {
     log.debug('Core Event', event)
   }
 
+  /**
+  * TODO: filter by a list of public/allowed methods
+  *
+  * @param evt
+  * @param methodName
+  * @param args
+  */
   handleRendererEvent (evt, methodName, args) {
     if (typeof this[methodName] === 'function') {
       this[methodName](...args)
@@ -93,6 +100,11 @@ class DeltaChatController extends EventEmitter {
     dc.on('DC_EVENT_CONTACTS_CHANGED', (contactId) => {
       this.updateChatList()
       this.updateBlockedContacts()
+    })
+
+    dc.on('DC_EVENT_CHAT_MODIFIED', (chatId) => {
+      log.debug('DC_EVENT_CHAT_MODIFIED: ' + chatId)
+      this.updateChatList()
     })
 
     dc.on('DC_EVENT_MSGS_CHANGED', (chatId, msgId) => {


### PR DESCRIPTION
Update chat list when chat changes
Resolves #831

The chat list gets updated now on every DC_EVENT_CHAT_MODIFIED event.
Maybe we should test and check for more events which might not be handled... 