### PR TITLE
Fix sort errors

### DIFF
--- a/src/renderer/stores/chatList.js
+++ b/src/renderer/stores/chatList.js
@@ -12,11 +12,11 @@ const chatListStore = new Store(defaultState)
 const DC_TEXT1_DRAFT = 1
 
 function sortChatList (first, second) {
-  if (first.deaddrop) {
-    return -1
+  if (first.deaddrop || second.deaddrop) {
+    return first.deaddrop ? -1 : 1
   }
-  if (first.isArchiveLink) {
-    return 1
+  if (first.isArchiveLink || second.isArchiveLink) {
+    return first.isArchiveLink ? 1 : -1
   }
   return first.summary.timestamp > second.summary.timestamp ? -1 : 1
 }


### PR DESCRIPTION
Archived chats link should always be at the last position

resolves #859