### PR TITLE
Fix script shebangs.

### DIFF
--- a/ci_scripts/pkg-build.sh
+++ b/ci_scripts/pkg-build.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 DIR=${1:?specify directory of ubuntu docker dir}
 export BUILDER_NAME=$(basename $DIR)

--- a/ci_scripts/shared-build-context/deltachat-desktop
+++ b/ci_scripts/shared-build-context/deltachat-desktop
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 # Currently we rely on a wrapper script to preload bundled
 # libdeltachat because of rpgp.

--- a/ci_scripts/shared-prelude-context/build-install-rpgp.sh
+++ b/ci_scripts/shared-prelude-context/build-install-rpgp.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 set -xe
 
 _gittag="v0.2.0-alpha"

--- a/ci_scripts/shared-prelude-context/install-nvm-node.sh
+++ b/ci_scripts/shared-prelude-context/install-nvm-node.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 set -xe
 
 wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.4/install.sh | bash

--- a/ci_scripts/shared-prelude-context/install-rust.sh
+++ b/ci_scripts/shared-prelude-context/install-rust.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 set -xe
 RUST_VERSION='nightly-2019-03-23'
 

--- a/ci_scripts/shared-prelude-context/nvm-use.sh
+++ b/ci_scripts/shared-prelude-context/nvm-use.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 set -xe
 
 NODE_VERSION='v10'


### PR DESCRIPTION
Some scripts have an erroneous shebang, for example `/opt/DeltaChat/deltachat-desktop` in the Ubuntu package, so the program cannot be started.

This patch corrects the issue.