### PR TITLE
remove profile picture from nav bar

### DIFF
--- a/src/renderer/components/NavbarWrapper.js
+++ b/src/renderer/components/NavbarWrapper.js
@@ -1,11 +1,6 @@
 const styled = require('styled-components').default
 
 module.exports = styled.div`
-  img {
-    height: 40px;
-    margin-left: 5px;
-  }
-
   .bp3-navbar {
     padding: 0px;
     background-color: ${props => props.theme.navBarBackground};

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -169,7 +169,6 @@ class SplittedChatListAndView extends React.Component {
               />
             </NavbarGroup>
             <NavbarGroup align={Alignment.RIGHT}>
-              {profileImage && <img src={profileImage} />}
               <NavbarHeading>
                 <NavbarGroupName>{selectedChat ? selectedChat.name : ''}</NavbarGroupName>
                 <NavbarGroupSubtitle>{selectedChat ? selectedChat.subtitle : ''}</NavbarGroupSubtitle>

--- a/src/renderer/components/SplittedChatListAndView.js
+++ b/src/renderer/components/SplittedChatListAndView.js
@@ -147,7 +147,6 @@ class SplittedChatListAndView extends React.Component {
     const { selectedChat, filteredChatList, showArchivedChats } = this.state
 
     const tx = window.translate
-    const profileImage = selectedChat && selectedChat.profileImage
 
     const menu = <ScreenContext.Consumer>{(screenContext) =>
       <Menu


### PR DESCRIPTION
Reasons:
- having it only sometimes is distracting because the name moves (currently its in this state)
- displaying it the generated avatar instead looks not too good... IMHO
- It's smaller than the one on the side (in chatList) so the duplication makes not much sense IMHO