### PR TITLE
Properly center the autocrypt input form

### DIFF
--- a/src/renderer/components/helpers/AutocryptSetupMessage.js
+++ b/src/renderer/components/helpers/AutocryptSetupMessage.js
@@ -6,7 +6,8 @@ export const InputTransferKeyWrapper = styled.div`
   display: grid;
   grid-template-columns: auto auto auto;
   grid-gap: 10px;
-  padding: 20px 10px 20px 30px;
+  padding: 20px 0px 20px 0px;
+  margin-right: -55px;
 `
 
 export const SetupMessagePartialInputWrapper = styled.div`


### PR DESCRIPTION
![Screenshot_20190824_194324](https://user-images.githubusercontent.com/34889164/63641000-7833a780-c6a7-11e9-8e5a-15219fb1c23c.png)
