### PR TITLE
[wip] Change setting for enter key sends or ctrl+enter sends to make it better

### DIFF
--- a/_locales/_experimental_en.json
+++ b/_locales/_experimental_en.json
@@ -82,5 +82,8 @@
   },
   "a11y_message_context_menu_btn_label": {
     "message": "message actions"
+  },
+  "pref_ctrl_enter_sends": {
+    "message": "Ctrl+enter sends"
   }
 }

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -179,14 +179,14 @@ export default class Settings extends React.Component {
    */
   handleDesktopSettingsChange (key, value) {
     ipcRenderer.send('updateDesktopSetting', key, value)
+    this.setState({ ...settings, [key]: value})
   }
 
   /** Saves settings to deltachat core */
   handleDeltaSettingsChange (key, value) {
+    const { settings } = this.state
     ipcRenderer.sendSync('setConfig', key, value)
-    const settings = this.state.settings
-    settings[key] = String(value)
-    this.setState({ settings })
+    this.setState({ ...settings, [key]: String(value)})
   }
 
   onLoginSubmit (config) {
@@ -258,7 +258,13 @@ export default class Settings extends React.Component {
             <H5>{this.translate('pref_chats_and_media')}</H5>
             <Callout>{this.translate('pref_enter_sends_explain')}</Callout>
             <br />
-            { this.renderDTSettingSwitch('enterKeySends', this.translate('pref_enter_sends')) }
+            <RadioGroup
+              onChange={(ev) => {console.log('onChange'); this.handleDesktopSettingsChange('enterKeySends', ev.target.value)}}
+              selectedValue={Boolean(settings['enterKeySends'])}
+            >
+              <Radio label={this.translate('pref_enter_sends')} value={true} />
+              <Radio label={this.translate('pref_ctrl_enter_sends')} value={false} />
+            </RadioGroup>
           </Card>
           <Card elevation={Elevation.ONE}>
             <H5>{this.translate('autocrypt')}</H5>


### PR DESCRIPTION
understandable. Refactor handleXSettingsChange methods

![Screenshot_20190912_130522](https://user-images.githubusercontent.com/34889164/64779390-3e471a00-d55e-11e9-8ea1-f83ac96f5047.png)

- [ ] fix warning of uncontrolled state
- [ ] for whatever reason both radiobutton groups don't rerender on setState

Fixes https://github.com/deltachat/deltachat-desktop/issues/982

BLOCKED on me fixing https://github.com/deltachat/deltachat-core-rust/pull/503
