### PR TITLE
Improve logger a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Debug messages are disabled by default, enable them with the `--log-debug` flag.
 | `--log-debug`                   | Log debug messages                           |
 | `--log-to-console`              | Output the log to stout / chrome dev console |
 | `--machine-readable-stacktrace` | Enable JSON stacktrace                       |
+| `--no-color`                    | Disable colors in the output of main process | 
 
 #### Log locations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "0.200.0",
+  "version": "0.201.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2777,10 +2777,9 @@
       }
     },
     "colors": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
     "simple-markdown": "^0.4.4",
     "styled-components": "^4.3.2",
     "tempy": "^0.3.0",
-    "use-debounce": "^3.0.1"
+    "use-debounce": "^3.0.1",
+    "colors": "^1.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.5.5",
@@ -91,7 +92,6 @@
     "@types/mapbox-gl": "^0.54.2",
     "babel-loader": "^8.0.6",
     "chai": "^4.2.0",
-    "colors": "^1.3.3",
     "cp-file": "^7.0.0",
     "depcheck": "^0.8.3",
     "electron": "^4.2.9",

--- a/src/logger.js
+++ b/src/logger.js
@@ -17,7 +17,7 @@ function setLogHandler (LogHandler) {
   handler = LogHandler
 }
 
-function log (channel, level, ...args) {
+function log (channel, level, stacktrace, ...args) {
   const variant = LoggerVariants[level]
   if (!handler) {
     /* ignore-console-log */
@@ -26,9 +26,13 @@ function log (channel, level, ...args) {
     console.log(`Log Message: ${channel} ${level} ${args.join(' ')}`)
     throw Error('Failed to log message - Handler not initilized yet')
   }
-  handler(channel, variant.level, ...args)
+  handler(channel, variant.level, stacktrace, ...args)
   if (rc['log-to-console']) {
-    variant.log(channel, variant.level, ...args)
+    if (stacktrace) {
+      variant.log(channel, variant.level, stacktrace, ...args)
+    } else {
+      variant.log(channel, variant.level, ...args)
+    }
   }
 }
 
@@ -45,11 +49,11 @@ class Logger {
 
   debug (...args) {
     if (!rc['log-debug']) return
-    log(this.channel, 0, [], ...args)
+    log(this.channel, 0, undefined, ...args)
   }
 
   info (...args) {
-    log(this.channel, 1, [], ...args)
+    log(this.channel, 1, undefined, ...args)
   }
 
   warn (...args) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -39,8 +39,10 @@ function log ({ channel, isMainProcess }, level, stacktrace, args) {
         colors.red('[C]')
       ][level]}${colors.grey(channel)}:`
       if (!stacktrace) {
+        /* ignore-console-log */
         console.log(begining, ...args)
       } else {
+        /* ignore-console-log */
         console.log(begining, ...args, colors.red(stacktrace))
       }
     } else {

--- a/src/main/deltachat/backup.js
+++ b/src/main/deltachat/backup.js
@@ -6,7 +6,7 @@ const fs = require('fs-extra')
 const { ipcMain } = require('electron')
 const path = require('path')
 const EventEmitter = require('events').EventEmitter
-const log = require('../../logger').getLogger('main/deltachat/backup')
+const log = require('../../logger').getLogger('main/deltachat/backup', true)
 
 function backupExport (dir) {
   this._dc.importExport(C.DC_IMEX_EXPORT_BACKUP, dir)

--- a/src/main/deltachat/chatlist.js
+++ b/src/main/deltachat/chatlist.js
@@ -1,5 +1,5 @@
 const C = require('deltachat-node/constants')
-const log = require('../../logger').getLogger('main/deltachat/chatlist')
+const log = require('../../logger').getLogger('main/deltachat/chatlist', true)
 const { app } = require('electron')
 
 function selectChat (chatId) {

--- a/src/main/deltachat/chatmethods.js
+++ b/src/main/deltachat/chatmethods.js
@@ -1,6 +1,6 @@
 const DeltaChat = require('deltachat-node')
 const C = require('deltachat-node/constants')
-const log = require('../../logger').getLogger('main/deltachat/chatmethods')
+const log = require('../../logger').getLogger('main/deltachat/chatmethods', true)
 
 function getInfo () {
   if (this.ready === true) {

--- a/src/main/deltachat/index.js
+++ b/src/main/deltachat/index.js
@@ -1,8 +1,8 @@
 const C = require('deltachat-node/constants')
 const eventStrings = require('deltachat-node/events')
 const EventEmitter = require('events').EventEmitter
-const log = require('../../logger').getLogger('main/deltachat')
-const logCoreEv = require('../../logger').getLogger('core/event')
+const log = require('../../logger').getLogger('main/deltachat', true)
+const logCoreEv = require('../../logger').getLogger('core/event', true)
 const windows = require('../windows')
 const { app } = require('electron')
 

--- a/src/main/deltachat/index.js
+++ b/src/main/deltachat/index.js
@@ -2,6 +2,7 @@ const C = require('deltachat-node/constants')
 const eventStrings = require('deltachat-node/events')
 const EventEmitter = require('events').EventEmitter
 const log = require('../../logger').getLogger('main/deltachat')
+const logCoreEv = require('../../logger').getLogger('core/event')
 const windows = require('../windows')
 const { app } = require('electron')
 
@@ -38,7 +39,7 @@ class DeltaChatController extends EventEmitter {
 
     if (data1 === 0) data1 = ''
 
-    log.debug('Core Event', event, data1, data2)
+    logCoreEv.debug(event, data1, data2)
   }
 
   callMethod (evt, methodName, args) {

--- a/src/main/deltachat/login.js
+++ b/src/main/deltachat/login.js
@@ -1,6 +1,6 @@
 const DeltaChat = require('deltachat-node')
 const C = require('deltachat-node/constants')
-const log = require('../../logger').getLogger('main/deltachat/login')
+const log = require('../../logger').getLogger('main/deltachat/login', true)
 const path = require('path')
 
 /**

--- a/src/main/deltachat/settings.js
+++ b/src/main/deltachat/settings.js
@@ -1,5 +1,5 @@
 const C = require('deltachat-node/constants')
-const log = require('../../logger').getLogger('main/deltachat/settings')
+const log = require('../../logger').getLogger('main/deltachat/settings', true)
 
 function setConfig (key, value) {
   log.info(`Setting config ${key}:${value}`)

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -19,7 +19,7 @@ mkdirp.sync(getLogsPath())
 // Setup Logger
 const logHandler = require('./log-handler')()
 const logger = require('../logger')
-const log = logger.getLogger('main/index')
+const log = logger.getLogger('main/index', true)
 logger.setLogHandler(logHandler.log)
 process.on('exit', logHandler.end)
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -11,7 +11,7 @@ const { getConfigPath } = require('../application-constants')
 const localize = require('../localize')
 const menu = require('./menu')
 const windows = require('./windows')
-const log = require('../logger').getLogger('main/ipc')
+const log = require('../logger').getLogger('main/ipc', true)
 const DeltaChat = (() => {
   try {
     return require('./deltachat/index.js')

--- a/src/main/log-handler.js
+++ b/src/main/log-handler.js
@@ -15,7 +15,7 @@ function logName () {
     `${pad(d.getHours())}-`,
     `${pad(d.getMinutes())}-`,
     `${pad(d.getSeconds())}`,
-    '.log'
+    '.log.tsv'
   ].join('')
   return path.join(dir, fileName)
 }

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -1,7 +1,7 @@
 module.exports = { init }
 
 const { app, Menu, shell } = require('electron')
-const log = require('../logger').getLogger('main/menu')
+const log = require('../logger').getLogger('main/menu', true)
 const windows = require('./windows')
 const {
   homePageUrl,

--- a/src/main/state.js
+++ b/src/main/state.js
@@ -1,6 +1,6 @@
 const appConfig = require('../application-config')
 const { EventEmitter } = require('events')
-const log = require('../logger').getLogger('main/state')
+const log = require('../logger').getLogger('main/state', true)
 
 const SAVE_DEBOUNCE_INTERVAL = 1000
 

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -22,7 +22,7 @@ const {
   windowDefaults
 } = require('../../application-constants')
 
-const log = require('../../logger').getLogger('main/mainWindow')
+const log = require('../../logger').getLogger('main/mainWindow', true)
 
 function init (app, options) {
   if (main.win) {


### PR DESCRIPTION
- omit stacktrace for debug and info
- move core event logs to their own log channel (makes event output smaller and less annoying)
- change logile extention to .log.tsv
- add colors, time elapsed and generally rework main process logging a bit:
![2019-09-30_23-17](https://user-images.githubusercontent.com/18725968/65917797-811b4580-e3d8-11e9-98f9-634af1d8dff8.png)
