### PR TITLE
WIP: Detect mime type for files

### DIFF
--- a/src/main/deltachat/messagelist.js
+++ b/src/main/deltachat/messagelist.js
@@ -2,13 +2,17 @@ const C = require('deltachat-node/constants')
 const log = require('../../logger').getLogger('main/deltachat/messagelist')
 const { integerToHexColor } = require('./util')
 const CHATVIEW_PAGE_SIZE = 20
+const mime = require('mime-types')
 
 const SplitOut = require('./splitout')
 module.exports = class DCMessageList extends SplitOut {
   sendMessage (chatId, text, filename, location) {
     const viewType = filename ? C.DC_MSG_FILE : C.DC_MSG_TEXT
     const msg = this._dc.messageNew(viewType)
-    if (filename) msg.setFile(filename)
+    if (filename) {
+      const mimeType = mime.lookup(filename)
+      msg.setFile(filename, mimeType)
+    }
     if (text) msg.setText(text)
     if (location) msg.setLocation(location.lat, location.lng)
     this._dc.sendMessage(chatId, msg)

--- a/src/renderer/components/composer/Composer.js
+++ b/src/renderer/components/composer/Composer.js
@@ -29,7 +29,7 @@ const Composer = React.forwardRef((props, ref) => {
 
   const sendMessage = () => {
     const message = messageInputRef.current.getText()
-    if (message.match(/^\s*$/)) {
+    if (message.match(/^\s*$/) && !filename) {
       log.debug(`Empty message: don't send it...`)
       return
     }


### PR DESCRIPTION
related #469

I added the mime type as second parameter, but it does not help for webm files. I see the correct mime type in the msgs database table: 
c=1
f=$BLOBDIR/BBH_gravitational_lensing.webm
m=video/webm
but the file is not listed in the video group.
So maybe it's a core bug?