### PR TITLE
Fixes #1083 - Add confirm delete message dialog.

### DIFF
--- a/src/renderer/components/message/MessageList.js
+++ b/src/renderer/components/message/MessageList.js
@@ -11,6 +11,7 @@ import { isDisplayableByRenderMedia } from './Attachment'
 import SettingsContext from '../../contexts/SettingsContext'
 
 import { DC_CHAT_ID_DEADDROP, DC_CHAT_ID_STARRED } from 'deltachat-node/constants'
+import chatStore from '../../stores/chat'
 
 const MutationObserver = window.MutationObserver
 
@@ -76,6 +77,10 @@ export default function MessageList (props) {
 
   const onClickSetupMessage = setupMessage => openDialog('EnterAutocryptSetupMessage', { setupMessage })
   const onShowDetail = message => openDialog('MessageDetail', { message, chat })
+  const onDelete = message => openDialog('ConfirmationDialog', {
+    message: 'Are you sure you want to delete message',
+    cb: yes => yes && chatStore.dispatch({ type: 'UI_DELETE_MESSAGE', payload: { msgId: message.id } })
+  })
   const onForward = forwardMessage => openDialog('ForwardMessage', { forwardMessage })
   const setComposerSize = size => setState({ composerSize: size })
 
@@ -170,6 +175,7 @@ export default function MessageList (props) {
                       onClickContactRequest: () => openDialog('DeadDrop', { deaddrop: message }),
                       onClickSetupMessage: onClickSetupMessage.bind(this, message),
                       onShowDetail: onShowDetail.bind(this, message),
+                      onDelete: onDelete.bind(this, message),
                       onClickAttachment: onClickAttachment.bind(this, message)
                     })
                   })}

--- a/src/renderer/components/message/MessageWrapper.js
+++ b/src/renderer/components/message/MessageWrapper.js
@@ -8,7 +8,6 @@ const moment = require('moment')
 const mime = require('mime-types')
 const filesizeConverter = require('filesize')
 const log = require('../../../logger').getLogger('renderer/messageWrapper')
-const chatStore = require('../../stores/chat')
 
 const GROUP_TYPES = [
   C.DC_CHAT_TYPE_GROUP,
@@ -142,7 +141,7 @@ class RenderMessage extends React.Component {
   }
 
   render () {
-    const { onShowDetail, onClickAttachment, chat, message } = this.props
+    const { onDelete, onShowDetail, onClickAttachment, chat, message } = this.props
     const { fromId, id } = message
     const msg = message.msg
     const conversationType = convertChatType(chat.type)
@@ -163,7 +162,7 @@ class RenderMessage extends React.Component {
       onDownload: message.onDownload,
       onReply: message.onReply,
       onForward: message.onForward,
-      onDelete: message.onDelete,
+      onDelete,
       onShowDetail,
       contact,
       onClickAttachment,
@@ -192,8 +191,6 @@ function convert (message) {
       if (filename) ipcRenderer.send('saveFile', message.msg.file, filename)
     })
   }
-
-  message.onDelete = () => chatStore.dispatch({ type: 'UI_DELETE_MESSAGE', payload: { msgId: message.id } })
 
   const msg = message.msg
 


### PR DESCRIPTION
### What changes are being made? (feature/bug)
Adds a confirm delete message dialog that is shown to the user before deleting any messages.

### Why are these changes necessary? Link any related issues
As outlined in issue #1083, it is very easy for the user to press the delete message option without having the chance to undo such an operation. The confirm delete message dialog will prompt the user to confirm the delete operation or cancel it.

### Unit Test
[![](https://imgur.com/uVJf25I.gif)](https://imgur.com/uVJf25I.gif)
