### PR TITLE
Call setCoreStrings after opening the context

### DIFF
--- a/src/main/deltachat/login.js
+++ b/src/main/deltachat/login.js
@@ -32,8 +32,6 @@ module.exports = class DCLoginController extends SplitOut {
     this._controller.credentials = credentials
     this._controller._render = render
 
-    this.setCoreStrings(coreStrings)
-
     if (!DeltaChat.maybeValidAddr(credentials.addr)) {
       this._controller.emit('error', this._controller.translate('bad_email_address'))
       return
@@ -41,6 +39,7 @@ module.exports = class DCLoginController extends SplitOut {
 
     this._dc.open(this._controller.fullCwd, err => {
       if (err) throw err
+      this.setCoreStrings(coreStrings)
       const onReady = () => {
         log.info('Ready')
         this._controller.ready = true


### PR DESCRIPTION
setCoreStrings calls setStockTranslation since 05f7de61b59c3fe587932d6d886c5cc12dbdf8a7

It requires the context to be open.

Fixes #1093