### PR TITLE
Fix key warnings in message list related components

### DIFF
--- a/src/renderer/components/message/Message.js
+++ b/src/renderer/components/message/Message.js
@@ -2,7 +2,7 @@ const React = require('react')
 const { useRef, useState } = require('react')
 const classNames = require('classnames')
 
-const MessageBody = require('./MessageBody')
+const MessageBody = require('./MessageBody').default
 const MessageMetaData = require('./MessageMetaData')
 
 const ContactName = require('../conversations/ContactName')
@@ -91,7 +91,7 @@ const InlineMenu = (MenuRef, showMenu, triggerId, props) => {
   } = props
   const tx = window.translate
 
-  return [(
+  return (
     <div className='module-message__buttons'>
       {
         attachment && viewType !== 23 && <div
@@ -121,7 +121,7 @@ const InlineMenu = (MenuRef, showMenu, triggerId, props) => {
         />
       </ContextMenuTrigger>
     </div>
-  )]
+  )
 }
 
 const contextMenu = (props, textSelected, triggerId) => {

--- a/src/renderer/components/message/MessageBody.js
+++ b/src/renderer/components/message/MessageBody.js
@@ -1,38 +1,35 @@
-const React = require('react')
-const classNames = require('classnames')
-
-const { getSizeClass, getRegex, replaceColons } = require('../conversations/emoji')
-
-const { previewRules, rules } = require('./MessageMarkdown')
+import React from 'react'
+import classNames from 'classnames'
+import { getSizeClass, getRegex, replaceColons } from '../conversations/emoji'
+import { previewRules, rules } from './MessageMarkdown'
+import SimpleMarkdown from 'simple-markdown'
 
 const emojiRegex = getRegex()
-const SimpleMarkdown = require('simple-markdown')
-
 const previewParser = SimpleMarkdown.parserFor(previewRules, { inline: true })
 const parser = SimpleMarkdown.parserFor(rules)
 const ast2react = SimpleMarkdown.outputFor(rules, 'react')
 
-class MessageBody extends React.Component {
-  render () {
-    const { text, disableJumbomoji, preview } = this.props
-    // if text is only emojis and Jumbomoji is enabled
-    const emojifiedText = text.replace(/:[\w\d_\-+]*:/g, replaceColons)
-    if (
-      emojifiedText.length < 50 &&
-      !disableJumbomoji &&
-      emojifiedText.replace(emojiRegex, '').trim() === ''
-    ) {
-      const sizeClass = disableJumbomoji ? '' : getSizeClass(emojifiedText)
-      return (
-        <span className={classNames('emoji-container', sizeClass)}>
-          {emojifiedText}
-        </span>
-      )
-    }
-    const ast = (preview ? previewParser : parser)(emojifiedText.trim())
-    const res = ast2react(ast)
-    return res
+export default function MessageBody (props) {
+  const { text, disableJumbomoji, preview } = props
+  // if text is only emojis and Jumbomoji is enabled
+  const emojifiedText = text.replace(/:[\w\d_\-+]*:/g, replaceColons)
+  if (
+    emojifiedText.length < 50 &&
+    !disableJumbomoji &&
+    emojifiedText.replace(emojiRegex, '').trim() === ''
+  ) {
+    const sizeClass = disableJumbomoji ? '' : getSizeClass(emojifiedText)
+    return (
+      <span className={classNames('emoji-container', sizeClass)}>
+        {emojifiedText}
+      </span>
+    )
   }
+  const ast = (preview ? previewParser : parser)(emojifiedText.trim())
+  const res = ast2react(ast)
+  return (
+    <>
+      {res.map((element, index) => <div key={index}>{element}</div>)}
+    </>
+  )
 }
-
-module.exports = MessageBody

--- a/src/renderer/components/message/MessageList.js
+++ b/src/renderer/components/message/MessageList.js
@@ -147,6 +147,8 @@ export default function MessageList (props) {
     }
   })(chat)
 
+  let specialMessageIdCounter = 0
+
   return (
     <SettingsContext.Consumer>
       {(settings) => {
@@ -168,17 +170,26 @@ export default function MessageList (props) {
                 <ul>
                   {chat.messages.map(rawMessage => {
                     const message = MessageWrapper.convert(rawMessage)
+
+                    // As messages with a message id below 9 are special messages without a unique id, we need to generate a unique key for them
+                    const key = message.id <= 9
+                      ? 'magic' + message.id + '_' + specialMessageIdCounter++
+                      : message.id
+
                     message.onReply = () => logger.debug('reply to', message)
                     message.onForward = onForward.bind(this, message)
-                    return MessageWrapper.render({
-                      message,
-                      chat,
-                      onClickContactRequest: () => openDialog('DeadDrop', { deaddrop: message }),
-                      onClickSetupMessage: onClickSetupMessage.bind(this, message),
-                      onShowDetail: onShowDetail.bind(this, message),
-                      onDelete: onDelete.bind(this, message),
-                      onClickAttachment: onClickAttachment.bind(this, message)
-                    })
+                    return (
+                      <MessageWrapper.render
+                        key={key}
+                        message={message}
+                        chat={chat}
+                        onClickContactRequest={() => openDialog('DeadDrop', { deaddrop: message })}
+                        onClickSetupMessage={onClickSetupMessage.bind(this, message)}
+                        onShowDetail={onShowDetail.bind(this, message)}
+                        onDelete={onDelete.bind(this, message)}
+                        onClickAttachment={onClickAttachment.bind(this, message)}
+                      />
+                    )
                   })}
                 </ul>
               </div>

--- a/src/renderer/components/message/MessageWrapper.js
+++ b/src/renderer/components/message/MessageWrapper.js
@@ -80,13 +80,12 @@ const MessageWrapper = styled.div`
 function render (props) {
   const { message, onClickSetupMessage, onClickContactRequest } = props
 
-  let key = message.id
   let body
 
   if (message.id === C.DC_MSG_ID_DAYMARKER) {
-    key = message.daymarker.id + message.daymarker.timestamp
+    const key = message.daymarker.id + message.daymarker.timestamp
     body = (
-      <InfoMessage>
+      <InfoMessage key={key}>
         <p>
           {moment.unix(message.daymarker.timestamp).calendar(null, {
             lastDay: '',
@@ -114,7 +113,7 @@ function render (props) {
     body = <RenderMessage {...props} />
   }
 
-  return <li key={key}>{body}</li>
+  return <li>{body}</li>
 }
 
 /**


### PR DESCRIPTION
There is still one more bug, that we have some messageids duplicated. I'm tracking it down, but didn't find it yet.