### PR TITLE
fix first message missing in messagelist

### DIFF
--- a/src/main/deltachat/messagelist.js
+++ b/src/main/deltachat/messagelist.js
@@ -74,8 +74,6 @@ module.exports = class DCMessageList extends SplitOut {
         messages.push(json)
       }
     }
-    // remove the additional message again
-    messages.shift()
     return messages
   }
 


### PR DESCRIPTION
For an off by one issue, we didn't display the first message in chats.