### PR TITLE
fix incomming image metadata unreadable

### DIFF
--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -157,7 +157,7 @@
     margin-left: 0;
     margin-right: 32px;
 
-    .metadata {
+    .metadata:not(.with-image-no-caption) {
         &>.padlock-icon {
             @include color-svg('../images/padlock.svg', var(--messagePadlockIncomming), 125%);
         }

--- a/scss/message/_metadata.scss
+++ b/scss/message/_metadata.scss
@@ -18,7 +18,11 @@
         font-weight: bold;
 
         &>.date {
-            color: var(--messageMetadataImageNoCaption);
+            color: white;
+        }
+
+        &>.padlock-icon {
+            @include color-svg('../images/padlock.svg', white, 125%);
         }
     }
 

--- a/src/renderer/ThemeBackend.js
+++ b/src/renderer/ThemeBackend.js
@@ -113,7 +113,6 @@ export function ThemeDataBuilder (theme) {
     messageStatusIconSending: '#62656a',
     messagePadlockOutgoing: '#4caf50',
     messagePadlockIncomming: '#a4a6a9',
-    messageMetadataImageNoCaption: '#ffffff',
     messageMetadataDate: '#62656a',
     messageMetadataIncomming: 'rgba(#ffffff, 0.7)',
     messageAuthor: '#ffffff',


### PR DESCRIPTION
in light theme.
before it was grey on black, now its always white on black, except for the outgoing messages, which text color is green, which is still readable on black.