### PR TITLE
Save log to file containing correct day and month.

### DIFF
--- a/src/main/log-handler.js
+++ b/src/main/log-handler.js
@@ -10,8 +10,8 @@ function logName () {
   }
   const fileName = [
     `${d.getFullYear()}-`,
-    `${pad(d.getMonth())}-`,
-    `${pad(d.getDay())}-`,
+    `${pad(d.getMonth() + 1)}-`,
+    `${pad(d.getDate())}-`,
     `${pad(d.getHours())}-`,
     `${pad(d.getMinutes())}-`,
     `${pad(d.getSeconds())}`,


### PR DESCRIPTION
`getMonth()` starts at 0, and `getDay()` returns the day of the week.