### PR TITLE
Improve chatlist scrolling performance

### DIFF
--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -17,6 +17,13 @@ $color-chat-list-item-avatar-text: var(--avatarLabelColor);
   &:hover {
     background-color:#bbb;
   }
+  &.skeleton {
+    background-repeat: no-repeat;
+    background-image: radial-gradient(circle 24px, grey 99%, transparent 0),linear-gradient(grey 40px, transparent 0), linear-gradient(grey 40px, transparent 0), linear-gradient(grey 40px, transparent 0);
+    background-size: 56px 56px, 200px 18px, 300px 16px, 40px 16px;
+    background-position: 6px, 67px 12px, 67px 35px, 96% 12px;
+    opacity: 0.1;
+  }
 }
 
 .chat-list-item--has-unread {
@@ -206,3 +213,4 @@ $color-chat-list-item-avatar-text: var(--avatarLabelColor);
     background-color: #bbb;
   } 
 }
+

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -10,37 +10,5 @@
 }
 
 .chatlist-item-skeleton {
-  opacity: 0.1;
-
-  & .bone {
-    background: grey;
-    border-radius: 3pt;
-    color: grey;
-  }
-
-  .skeleton-avatar {
-    position: relative;
-    height: 48px;
-    width: 48px;
-    margin-top: 8px;
-    margin-bottom: 8px;
-    border-radius: 24px;
-    background-color: grey;
-  }
-
-  animation: breath 2s infinite;
-}
-
-@keyframes breath {
-  0% {
-    opacity: 0.1;
-  }
-
-  50% {
-    opacity: 0.12;
-  }
-
-  100% {
-    opacity: 0.1;
-  }
+  border-bottom: 1px solid #ddd;
 }

--- a/src/main/deltachat/chatlist.js
+++ b/src/main/deltachat/chatlist.js
@@ -31,7 +31,7 @@ module.exports = class DCChatList extends SplitOut {
     this._controller.sendToRenderer('DD_EVENT_CHAT_MODIFIED', { chatId, chat })
   }
 
-  async __chatListGetChatId (list, index) {
+  async _chatListGetChatId (list, index) {
     return list.getChatId(index)
   }
 
@@ -39,22 +39,22 @@ module.exports = class DCChatList extends SplitOut {
     const chatList = this._dc.getChatList(listFlags, queryStr, queryContactId)
     const chatListIds = []
     for (let counter = 0; counter < chatList.getCount(); counter++) {
-      const chatId = await this.__chatListGetChatId(chatList, counter)
+      const chatId = await this._chatListGetChatId(chatList, counter)
       chatListIds.push(chatId)
     }
     return chatListIds
   }
 
-  async __getChatList (listflags, queryStr, queryContactId) {
+  async _getChatList (listflags, queryStr, queryContactId) {
     return this._dc.getChatList(listflags, queryStr, queryContactId)
   }
 
   async getListAndIndexForChatId (chatId) {
-    let list = await this.__getChatList(0, '', 0)
+    let list = await this._getChatList(0, '', 0)
     let i = await findIndexOfChatIdInChatList(list, chatId)
 
     if (i === -1) {
-      list = await this.__getChatList(1, '', 0)
+      list = await this._getChatList(1, '', 0)
       i = await findIndexOfChatIdInChatList(list, chatId)
     }
     return [list, i]
@@ -85,7 +85,7 @@ module.exports = class DCChatList extends SplitOut {
   }
 
   async getChatListItemById (chatId, list, i) {
-    const chat = await this.__getChatById(chatId)
+    const chat = await this._getChatById(chatId)
     if (chat === null) return null
 
     if (!list) [list, i] = await this.getListAndIndexForChatId(chatId)
@@ -104,7 +104,7 @@ module.exports = class DCChatList extends SplitOut {
       summary.text2 = this._controller.translate('message_not_verified')
     }
     const isGroup = isGroupChat(chat)
-    const contactIds = await this.__getChatContactIds(chatId)
+    const contactIds = await this._getChatContactIds(chatId)
     // This is NOT the Chat Oject, it's a smaller version for use as ChatListItem in the ChatList
     const chatListItem = {
       id: chat.id,
@@ -131,44 +131,44 @@ module.exports = class DCChatList extends SplitOut {
     return chatListItem
   }
 
-  async __getChatById (chatId) {
+  async _getChatById (chatId) {
     if (!chatId) return null
     const rawChat = this._dc.getChat(chatId)
     if (!rawChat) return null
     return rawChat.toJson()
   }
 
-  async __getDraft (chatId) {
+  async _getDraft (chatId) {
     const draft = this._dc.getDraft(chatId)
     return draft ? draft.getText() : ''
   }
 
-  async __getChatContactIds (chatId) {
+  async _getChatContactIds (chatId) {
     return this._dc.getChatContacts(chatId)
   }
 
-  async __getChatContact (contactId) {
+  async _getChatContact (contactId) {
     return this._dc.getContact(contactId).toJson()
   }
 
-  async __getChatContacts (contactIds) {
+  async _getChatContacts (contactIds) {
     const contacts = []
     for (let i = 0; i < contactIds.length; i++) {
-      const contact = await this.__getChatContact(contactIds[i])
+      const contact = await this._getChatContact(contactIds[i])
       contacts.push(contact)
     }
     return contacts
   }
 
   async getFullChatById (chatId) {
-    const chat = await this.__getChatById(chatId)
+    const chat = await this._getChatById(chatId)
     if (chat === null) return null
     this._controller._pages = 0
 
     const isGroup = isGroupChat(chat)
-    const contactIds = await this.__getChatContactIds(chatId)
+    const contactIds = await this._getChatContactIds(chatId)
 
-    const contacts = await this.__getChatContacts(contactIds)
+    const contacts = await this._getChatContacts(contactIds)
 
     // This object is NOT created with object assign to promote consistency and to be easier to understand
     return {
@@ -178,7 +178,7 @@ module.exports = class DCChatList extends SplitOut {
       profileImage: chat.profileImage,
 
       archived: chat.archived,
-      subtitle: await this.__chatSubtitle(chat, contacts),
+      subtitle: await this._chatSubtitle(chat, contacts),
       type: chat.type,
       isUnpromoted: chat.isUnpromoted, // new chat but no initial message sent
       isSelfTalk: chat.isSelfTalk,
@@ -191,12 +191,12 @@ module.exports = class DCChatList extends SplitOut {
       isGroup: isGroup,
       isDeaddrop: chatId === C.DC_CHAT_ID_DEADDROP,
       isDeviceChat: chat.isDeviceTalk,
-      draft: this.__getDraft(chatId),
+      draft: this._getDraft(chatId),
       selfInGroup: isGroup && contactIds.indexOf(C.DC_CONTACT_ID_SELF) !== -1
     }
   }
 
-  __chatSubtitle (chat, contacts) {
+  _chatSubtitle (chat, contacts) {
     const tx = this._controller.translate
     if (chat.id > C.DC_CHAT_ID_LAST_SPECIAL) {
       if (isGroupChat(chat)) {
@@ -224,18 +224,18 @@ module.exports = class DCChatList extends SplitOut {
     return this._dc.getFreshMessages().length
   }
 
-  async __getMessage (id) {
+  async _getMessage (id) {
     return this._dc.getMessage(id)
   }
 
   async _deadDropMessage (id) {
-    const msg = await this.__getMessage(id)
+    const msg = await this._getMessage(id)
     const fromId = msg && msg.getFromId()
     if (!fromId) {
       log.warn('Ignoring DEADDROP due to missing fromId')
       return
     }
-    const contact = await this.__getChatContact(fromId)
+    const contact = await this._getChatContact(fromId)
     return { id, contact }
   }
 

--- a/src/main/deltachat/chatlist.js
+++ b/src/main/deltachat/chatlist.js
@@ -61,18 +61,22 @@ module.exports = class DCChatList extends SplitOut {
   }
 
   async getChatListItemsByIds (chatIds) {
+    const label = '[BENCH] getChatListItemByIds'
+    console.time(label)
     const chats = {}
-    let list, i
+    let list
+    let i = 0
     for (const chatId of chatIds) {
       if (!list) {
         [list, i] = await this.getListAndIndexForChatId(chatIds[0])
       } else {
-        i = await findIndexOfChatIdInChatList(list, chatId)
+        i = await findIndexOfChatIdInChatList(list, chatId, i)
       }
 
       const chat = await this.getChatListItemById(chatId, list, i)
       chats[chatId] = chat
     }
+    console.timeEnd(label)
     return chats
   }
 
@@ -241,9 +245,11 @@ module.exports = class DCChatList extends SplitOut {
   }
 }
 // section: Internal functions
-async function findIndexOfChatIdInChatList (list, chatId) {
+async function findIndexOfChatIdInChatList (list, chatId, startI = 0) {
   let i = -1
-  for (let counter = 0; counter < list.getCount(); counter++) {
+  const listCount = list.getCount()
+  for (let counter = startI; counter < listCount; counter++) {
+    counter = counter % listCount
     const currentChatId = await chatListGetChatId(list, counter)
     if (currentChatId === chatId) {
       i = counter

--- a/src/main/deltachat/chatlist.js
+++ b/src/main/deltachat/chatlist.js
@@ -225,7 +225,7 @@ module.exports = class DCChatList extends SplitOut {
   }
 
   async __getMessage (id) {
-    return this._dc_getMessage(id)
+    return this._dc.getMessage(id)
   }
 
   async _deadDropMessage (id) {

--- a/src/renderer/components/Menu.js
+++ b/src/renderer/components/Menu.js
@@ -38,7 +38,12 @@ export default function DeltaMenu (props) {
   const onDeleteChat = () => openDeleteChatDialog(screenContext, selectedChat)
   const onUnblockContacts = () => screenContext.openDialog('UnblockContacts', {})
   const onContactRequests = () => chatStoreDispatch({ type: 'SELECT_CHAT', payload: C.DC_CHAT_ID_DEADDROP })
-  const logout = () => ipcRenderer.send('logout')
+  const logout = () => {
+    if (selectedChat) {
+      chatStoreDispatch({ type: 'UI_UNSELECT_CHAT' })
+    }
+    ipcRenderer.send('logout')
+  }
   const onEncrInfo = () => openEncryptionInfoDialog(screenContext, selectedChat)
 
   if (selectedChat && selectedChat.id && !selectedChat.isDeaddrop) {

--- a/src/renderer/components/chat/ChatListHelpers.js
+++ b/src/renderer/components/chat/ChatListHelpers.js
@@ -146,7 +146,7 @@ export const useLazyChatListItems = chatListIds => {
   }
 
   const [onChatListScroll] = useDebouncedCallback(() => {
-    fetchChatsInView(20)
+    fetchChatsInView(0)
   }, 50)
 
   const onChatListItemChanged = (event, { chatId }) => {
@@ -157,7 +157,7 @@ export const useLazyChatListItems = chatListIds => {
     }
   }
 
-  const onResize = () => fetchChatsInView(10)
+  const onResize = () => fetchChatsInView(0)
 
   useLayoutEffect(() => {
     window.addEventListener('resize', onResize)
@@ -166,7 +166,7 @@ export const useLazyChatListItems = chatListIds => {
 
   useEffect(() => {
     log.debug('useLazyChatListItems: chatListIds changed, updating chats in view')
-    fetchChatsInView(10)
+    fetchChatsInView(0)
     ipcBackend.on('DD_EVENT_CHATLIST_ITEM_CHANGED', onChatListItemChanged)
     return () => {
       ipcBackend.removeListener('DD_EVENT_CHATLIST_ITEM_CHANGED', onChatListItemChanged)

--- a/src/renderer/components/chat/ChatListHelpers.js
+++ b/src/renderer/components/chat/ChatListHelpers.js
@@ -146,8 +146,8 @@ export const useLazyChatListItems = chatListIds => {
   }
 
   const [onChatListScroll] = useDebouncedCallback(() => {
-    fetchChatsInView(0)
-  }, 50)
+    fetchChatsInView(20)
+  }, 30)
 
   const onChatListItemChanged = (event, { chatId }) => {
     if (chatId === 0) {
@@ -157,7 +157,7 @@ export const useLazyChatListItems = chatListIds => {
     }
   }
 
-  const onResize = () => fetchChatsInView(0)
+  const onResize = () => fetchChatsInView(10)
 
   useLayoutEffect(() => {
     window.addEventListener('resize', onResize)
@@ -166,7 +166,7 @@ export const useLazyChatListItems = chatListIds => {
 
   useEffect(() => {
     log.debug('useLazyChatListItems: chatListIds changed, updating chats in view')
-    fetchChatsInView(0)
+    fetchChatsInView(10)
     ipcBackend.on('DD_EVENT_CHATLIST_ITEM_CHANGED', onChatListItemChanged)
     return () => {
       ipcBackend.removeListener('DD_EVENT_CHATLIST_ITEM_CHANGED', onChatListItemChanged)
@@ -176,7 +176,7 @@ export const useLazyChatListItems = chatListIds => {
   useEffect(() => {
     if (Object.keys(chatItems).length > 0) return
     if (!scrollRef.current) return
-    fetchChatsInView(scrollRef)
+    fetchChatsInView(10)
   }, [chatListIds, chatItems, scrollRef])
   return { chatItems, onChatListScroll, scrollRef }
 }

--- a/src/renderer/components/chat/ChatListItem.js
+++ b/src/renderer/components/chat/ChatListItem.js
@@ -76,27 +76,7 @@ export const PlaceholderChatListItem = React.memo((props) => {
       props.className,
       'chatlist-item-skeleton'
     )}
-  >
-    <div className='skeleton-avatar' />
-    <div className='chat-list-item__content'>
-      <div className='chat-list-item__header'>
-        <div className={'chat-list-item__header__name'}>
-          <span className={classNames('chat-list-item__name', 'bone')}>
-            Chat name
-          </span>
-        </div>
-        <div className={'chat-list-item__header__date'}>
-          <div className={classNames('chat-list-item__header__timestamp', 'bone')}>Jan 1, 1970</div>
-        </div>
-      </div>
-      <div className='chat-list-item__message'>
-        <div className={classNames('chat-list-item__message__text', 'bone')}>
-          test: message
-        </div>
-        <div className={classNames('status-icon', 'delivered')} />
-      </div>
-    </div>
-  </div>
+  />
 })
 
 const ChatListItemArchiveLink = React.memo(props => {

--- a/src/renderer/components/chat/ChatListItem.js
+++ b/src/renderer/components/chat/ChatListItem.js
@@ -74,7 +74,7 @@ export const PlaceholderChatListItem = React.memo((props) => {
     className={classNames(
       'chat-list-item',
       props.className,
-      'chatlist-item-skeleton'
+      'skeleton'
     )}
   />
 })

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -22,7 +22,7 @@ test('Bad mail address results in error message', async (t) => {
       .setValue('#mail_pw', 'bar')
       .click('button[type=\'submit\']')
 
-    await setup.wait(500)
+    await setup.wait(1500)
     const text = await app.client.getText('.user-feedback')
     t.equal(text, 'Bad email address.', 'Mail validation error is shown')
     setup.endTest(app, t)

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -22,7 +22,7 @@ test('Bad mail address results in error message', async (t) => {
       .setValue('#mail_pw', 'bar')
       .click('button[type=\'submit\']')
 
-    await setup.wait(1500)
+    await setup.wait(1000)
     const text = await app.client.getText('.user-feedback')
     t.equal(text, 'Bad email address.', 'Mail validation error is shown')
     setup.endTest(app, t)


### PR DESCRIPTION
This improves the chatlist scrolling performance by splitting some heavy backend methods into some async callback "chunks" which blocks the event loop only for the time each chunk takes and allows other things to happen in between instead of blocking for the whole time. This is important for any ipc events getting queued up in between and unblocking the renderer process. This is still not perfect but feels snappier and smoother as before. Besides this, this also tries to fetch the deltachat-core chatList datastructure only once.

# Benchmarks

### improved
```
[BENCH] getChatListItemByIds 26: 132.433ms
[BENCH] getChatListItemByIds 56: 253.712ms
[BENCH] getChatListItemByIds 16: 83.381ms
[BENCH] getChatListItemByIds 1: 18.506ms
[BENCH] getChatListItemByIds 5: 36.413ms
[BENCH] getChatListItemByIds 8: 49.686ms
[BENCH] getChatListItemByIds 8: 49.323ms
[BENCH] getChatListItemByIds 1: 16.919ms
[BENCH] getChatListItemByIds 1: 16.367ms
[BENCH] getChatListItemByIds 34: 161.838ms
[BENCH] getChatListItemByIds 6: 39.748ms
```

Average: 858,326ms/162=5,26ms

### old
```
[BENCH] getChatListItemByIds 26: 395.527ms
[BENCH] getChatListItemByIds 34: 492.897ms
[BENCH] getChatListItemByIds 24: 346.927ms
[BENCH] getChatListItemByIds 12: 179.940ms
[BENCH] getChatListItemByIds 33: 476.247ms
[BENCH] getChatListItemByIds 22: 325.160ms
[BENCH] getChatListItemByIds 10: 147.971ms
[BENCH] getChatListItemByIds 20: 297.857ms
[BENCH] getChatListItemByIds 10: 147.255ms
```

Average: 12809,78ms/191=14,710895288ms