### PR TITLE
Fix importing keys

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -153,7 +153,7 @@ code {
   bottom: 0;
   text-align: center;
   width: 100%;
-  z-index: 10;
+  z-index: 100;
 
   p {
     display: inline-block;

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -129,9 +129,6 @@ function init (cwd, state, logHandler) {
   ipcMain.on('backupImport', (e, fileName) => dcController.backup.import(fileName))
   ipcMain.on('backupExport', (e, dir) => dcController.backup.export(dir))
 
-  ipcMain.on('keysImport', (e, dir) => dcController.settings.keysImport(dir))
-  ipcMain.on('keysExport', (e, dir) => dcController.settings.keysExport(dir))
-
   ipcMain.on('setConfig', (e, key, value) => {
     e.returnValue = dcController.settings.setConfig(key, value)
   })

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -103,7 +103,7 @@ export default class Settings extends React.Component {
     const opts = {
       title: window.translate('pref_managekeys_import_secret_keys'),
       defaultPath: remote.app.getPath('downloads'),
-      properties: ['openFile']
+      properties: ['openDirectory']
     }
     remote.dialog.showOpenDialog(
       opts,
@@ -118,7 +118,7 @@ export default class Settings extends React.Component {
                 this.props.userFeedback({ type: 'success', text: this.translate('pref_managekeys_secret_keys_imported_from_x', filenames[0]) })
               }
             })
-            return ipcRenderer.send('keysImport', filenames[0])
+            callDcMethodAsync('settings.keysImport', [filenames[0]])
           })
         }
       }
@@ -143,7 +143,7 @@ export default class Settings extends React.Component {
             ipcRenderer.once('DC_EVENT_IMEX_FILE_WRITTEN', (_event, filename) => {
               this.props.userFeedback({ type: 'success', text: this.translate('pref_managekeys_secret_keys_exported_to_x', filename) })
             })
-            ipcRenderer.send('keysExport', filenames[0])
+            callDcMethodAsync('settings.keysExport', [filenames[0]])
           }
         })
       }


### PR DESCRIPTION
- Refactor import/export methods into callDcMethodAsync
- Fix user feedback displayed on top of dialog

Fixes https://github.com/deltachat/deltachat-desktop/issues/1226

HINT: There is still a bug in core which doesn't allow importing keys. But it's the same on android. (https://github.com/deltachat/deltachat-core-rust/issues/1104)