### PR TITLE
Avoid reload of settings dialog

### DIFF
--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -478,7 +478,7 @@ function ProfileImageSelector (props) {
   useEffect(_ => {
     callDcMethodAsync('getProfilePicture').then(setProfileImagePreview)
     // return nothing because reacts wants it like that
-  })
+  }, [profileImagePreview])
 
   const changeProfilePicture = async (picture) => {
     await callDcMethodAsync('setProfilePicture', [picture])

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -1,4 +1,4 @@
-import React, { useState, useLayoutEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import crypto from 'crypto'
 import { ipcRenderer, remote } from 'electron'
 import { callDcMethodAsync } from '../../ipc'
@@ -475,7 +475,7 @@ function ProfileImageSelector (props) {
   const { displayName, color } = props
   const tx = window.translate
   const [profileImagePreview, setProfileImagePreview] = useState('')
-  useLayoutEffect(_ => {
+  useEffect(_ => {
     callDcMethodAsync('getProfilePicture').then(setProfileImagePreview)
     // return nothing because reacts wants it like that
   })


### PR DESCRIPTION
Since useLayoutEffect is called after complete rendering the dialog is visibly reloaded 