### PR TITLE
🚧 Fix integration test for loading config

### DIFF
--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -277,17 +277,16 @@ function init (cwd, state, logHandler) {
       Object.keys(savedCredentials).length !== 0) {
     const selectedAccount = state.logins.find(account => account.addr === savedCredentials.addr)
 
-    if (!selectedAccount) {
-      log.error('Previous account not found!')
-      throw new Error('Previous account not found!')
+    if (selectedAccount) {
+      dcController.loginController.login(
+        selectedAccount.path,
+        savedCredentials,
+        sendStateToRenderer,
+        txCoreStrings()
+      )
+    } else {
+      log.error('Previous account not found!', state.saved.credentials)
     }
-
-    dcController.loginController.login(
-      selectedAccount.path,
-      savedCredentials,
-      sendStateToRenderer,
-      txCoreStrings()
-    )
   }
 }
 

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -285,7 +285,7 @@ function init (cwd, state, logHandler) {
         txCoreStrings()
       )
     } else {
-      log.error('Previous account not found!', state.saved.credentials)
+      log.error('Previous account not found!', state.saved.credentials, 'is not in the list of found logins:', state.logins)
     }
   }
 }

--- a/test/integration/fixtures/config.js
+++ b/test/integration/fixtures/config.js
@@ -15,8 +15,7 @@ const getConfig = () => {
     showNotificationContent: true,
     locale: 'en',
     credentials: {
-      addr: process.env.DC_ADDR,
-      mail_pw: process.env.DC_MAIL_PW
+      addr: process.env.DC_ADDR
     },
     bounds: {
       x: 0,

--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -37,6 +37,7 @@ function createApp () {
 function createAppWithConfig (overrideConfig) {
   const TEST_DIR = tempy.directory()
   const defaultConfig = getConfig()
+  // TODO create account folder and acoount database
   if (overrideConfig) {
     const extendedConfig = Object.assign({}, defaultConfig, overrideConfig)
     fs.writeFileSync(path.join(TEST_DIR, 'config.json'), JSON.stringify(extendedConfig))


### PR DESCRIPTION
closes #1299

 - [X]  don't crash when last account isn't found
 - [ ] add debug log of found accounts to logins.js
 - [ ] logic to create account folder and account database (aka. fix the test)

Still needs logic to create account folder and account database, because the logic changed.
@nicodh do you wanna complete this integration test fix? I guess we could use dc node to configure the account folder.