### PR TITLE
Delete old logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2151,6 +2151,15 @@
       "resolved": "https://registry.npmjs.org/@types/domhandler/-/domhandler-2.4.1.tgz",
       "integrity": "sha512-cfBw6q6tT5sa1gSPFSRKzF/xxYrrmeiut7E0TxNBObiLSBTuFEHibcfEe3waQPEDbqBsq+ql/TOniw65EyDFMA=="
     },
+    "@types/fs-extra": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-8.0.1.tgz",
+      "integrity": "sha512-J00cVDALmi/hJOYsunyT52Hva5TnJeKP5yd1r+mH/ZU0mbYZflR0Z5kw5kITtKTRYMhm1JMClOFYdHnQszEvqw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/geojson": {
       "version": "7946.0.7",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@babel/preset-env": "^7.7.7",
     "@babel/preset-react": "^7.7.4",
     "@types/css": "0.0.31",
+    "@types/fs-extra": "^8.0.1",
     "@types/mapbox-gl": "^0.54.5",
     "@types/node": "^13.1.6",
     "@types/prop-types": "^15.7.3",

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -18,7 +18,7 @@ ensureDirSync(getLogsPath())
 ensureDirSync(getAccountsPath())
 
 // Setup Logger
-const logHandler = require('./log-handler')()
+const logHandler = require('./log-handler').createLogHandler()
 const logger = require('../shared/logger')
 const log = logger.getLogger('main/index')
 logger.setLogHandler(logHandler.log)

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -18,6 +18,7 @@ ensureDirSync(getLogsPath())
 ensureDirSync(getAccountsPath())
 
 // Setup Logger
+const { cleanupLogFolder } = require('./log-handler')
 const logHandler = require('./log-handler').createLogHandler()
 const logger = require('../shared/logger')
 const log = logger.getLogger('main/index')
@@ -112,6 +113,8 @@ function onReady ([logins, _appReady, loadedState]) {
       log.error("theme: couldn't find file")
     }
   }
+
+  cleanupLogFolder().catch(err => log.error('Cleanup of old logfiles failed: ', err))
 }
 
 app.once('ipcReady', () => {

--- a/src/main/log-handler.ts
+++ b/src/main/log-handler.ts
@@ -1,11 +1,11 @@
-const { createWriteStream } = require('fs')
-const path = require('path')
-const { getLogsPath } = require('./application-constants')
+import { createWriteStream } from 'fs'
+import { join } from 'path'
+import { getLogsPath } from './application-constants'
 
 function logName () {
   const dir = getLogsPath()
   const d = new Date()
-  function pad (number) {
+  function pad (number:number) {
     return number < 10 ? '0' + number : number
   }
   const fileName = [
@@ -17,10 +17,10 @@ function logName () {
     `${pad(d.getSeconds())}`,
     '.log.tsv'
   ].join('')
-  return path.join(dir, fileName)
+  return join(dir, fileName)
 }
 
-module.exports = () => {
+export function createLogHandler () {
   const fileName = logName()
   const stream = createWriteStream(fileName, { flags: 'w' })
   /* ignore-console-log */
@@ -28,17 +28,17 @@ module.exports = () => {
   return {
     /**
      * Internal log handler. Do not call directly!
-     * @param {string} channel The part/module where the message was logged from, e.g. 'main/deltachat'
-     * @param {string} level DEBUG, INFO, WARNING, ERROR or CRITICAL
-     * @param {array} stacktrace Stack trace if WARNING, ERROR or CRITICAL
-     * @param {string} ...args Variadic parameters. Stringified before logged to file
+     * @param channel The part/module where the message was logged from, e.g. 'main/deltachat'
+     * @param level DEBUG, INFO, WARNING, ERROR or CRITICAL
+     * @param stacktrace Stack trace if WARNING, ERROR or CRITICAL
+     * @param ...args Variadic parameters. Stringified before logged to file
      */
-    log: (channel, level, stacktrace, ...args) => {
+    log: (channel:string, level:string, stacktrace:any[], ...args:any[]) => {
       const timestamp = new Date().toISOString()
       let line = [timestamp, channel, level]
       line = line
         .concat([stacktrace, ...args])
-        .map(JSON.stringify)
+        .map(value => JSON.stringify(value))
       stream.write(`${line.join('\t')}\n`)
     },
     end: () => stream.end(),


### PR DESCRIPTION
transform log-handler file to typescript.
keep only the last 10 log files in order to save disk-space.
closes #1321