### PR TITLE
Show title, not search field when showing archived chats.

### DIFF
--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -70,4 +70,12 @@
     .bp3-popover-target {
         margin-right: 6px;
     }
+
+    .archived-chats-title {
+      flex: 1 1 auto;
+      overflow-x: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-size: 18px;
+    }
 }

--- a/src/renderer/components/MainScreen.js
+++ b/src/renderer/components/MainScreen.js
@@ -85,7 +85,7 @@ export default function MainScreen () {
           <NavbarGroup align={Alignment.LEFT}>
             { showArchivedChats && (
               <>
-                <div class='archived-chats-title'>{tx('chat_archived_chats_title')}</div>
+                <div className='archived-chats-title'>{tx('chat_archived_chats_title')}</div>
                 <Button
                   className={[Classes.MINIMAL, 'icon-rotated', 'archived-chats-return-button']}
                   icon='undo' onClick={() => setShowArchivedChats(false)}

--- a/src/renderer/components/MainScreen.js
+++ b/src/renderer/components/MainScreen.js
@@ -76,22 +76,29 @@ export default function MainScreen () {
       </div>
     )
 
+  // StandardJS won't let me use '&& { } || { }', so the following code
+  // compares with showArchivedChats twice.
   return (
     <div className='main-screen'>
       <div className='navbar-wrapper'>
         <Navbar fixedToTop>
           <NavbarGroup align={Alignment.LEFT}>
-            <SearchInput
-              id='chat-list-search'
-              onChange={handleSearchChange}
-              value={queryStr}
-              className='icon-rotated'
-            />
             { showArchivedChats && (
-              <Button
-                className={[Classes.MINIMAL, 'icon-rotated']}
-                icon='undo' onClick={() => setShowArchivedChats(false)}
-                aria-label={tx('back')} />
+              <>
+                <div class='archived-chats-title'>{tx('chat_archived_chats_title')}</div>
+                <Button
+                  className={[Classes.MINIMAL, 'icon-rotated', 'archived-chats-return-button']}
+                  icon='undo' onClick={() => setShowArchivedChats(false)}
+                  aria-label={tx('back')} />
+              </>
+            ) }
+            { showArchivedChats || (
+              <SearchInput
+                id='chat-list-search'
+                onChange={handleSearchChange}
+                value={queryStr}
+                className='icon-rotated'
+              />
             ) }
           </NavbarGroup>
           <NavbarGroup align={Alignment.RIGHT}>


### PR DESCRIPTION
The search wasn't functional. This change is preliminary until someone
builds a change that fixes the search and jumps out of the archive-view
(the search is global, not restricted to the archives).

Screenshot:
![2020-01-23-141354_408x165_scrot](https://user-images.githubusercontent.com/57864086/72987782-5de32e80-3deb-11ea-86b8-ef46cfbd499a.png)

Closes #1366 