### PR TITLE
🚧 WIP: Show all chat members, not only those present in searchContacts.

### DIFF
--- a/src/renderer/components/dialogs/EditGroup.js
+++ b/src/renderer/components/dialogs/EditGroup.js
@@ -123,7 +123,7 @@ export function EditGroupInner (props) {
               <GroupMemberSearchInput onChange={onSearchChange} value={queryStr} placeholder={tx('search')} />
               {renderAddMemberIfNeeded()}
               <ContactList2
-                contacts={searchContacts.filter(({ id }) => groupMembers.indexOf(id) !== -1)}
+                contacts={chat.contacts}
                 onClick={removeGroupMember}
                 showCheckbox
                 isChecked={() => true}


### PR DESCRIPTION
searchContacts are those contacts that the core returns as "known
contacts". This excludes e.g. contacts which haven't ever been included
in a message from a known sender. Those contacts can still be a group
member already.

Closes #1244