### PR TITLE
fix sending spinner not clearly visible on sending an image..

### DIFF
--- a/scss/message/_metadata.scss
+++ b/scss/message/_metadata.scss
@@ -24,6 +24,10 @@
         &>.padlock-icon {
             @include color-svg('../images/padlock.svg', white, 125%);
         }
+
+        .status-icon.sending {
+            background-color: white;
+        }
     }
 
     &>.status-icon {


### PR DESCRIPTION
..with no caption.

I just came across this and fixed it - it was grey on semi-transparent black now its white on semi-transparent black .