### PR TITLE
Performance improvements for messagelist

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "0.901.0",
+  "version": "0.999.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -186,7 +186,7 @@ function init (cwd, state, logHandler) {
   ipcMain.on('saveLastChatId', (e, chatId) => {
     const { lastChats } = app.state.saved
     lastChats[dcController.credentials.addr] = chatId
-    sendStateToRenderer()
+    //sendStateToRenderer()
     // don't save to disk, because this is already done on close and it might block
     // we can ignore the crash case, because a crash isn't supposed to happen
     // and it's not important data

--- a/src/main/ipc.js
+++ b/src/main/ipc.js
@@ -186,7 +186,6 @@ function init (cwd, state, logHandler) {
   ipcMain.on('saveLastChatId', (e, chatId) => {
     const { lastChats } = app.state.saved
     lastChats[dcController.credentials.addr] = chatId
-    //sendStateToRenderer()
     // don't save to disk, because this is already done on close and it might block
     // we can ignore the crash case, because a crash isn't supposed to happen
     // and it's not important data

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -10,6 +10,9 @@ import attachKeybindingsListener from './keybindings'
 import { ExtendedApp, AppState } from '../shared/shared-types'
 
 import { translate, LocaleData } from '../shared/localize'
+import logger from '../shared/logger'
+
+const log = logger.getLogger('renderer/App')
 const moment = require('moment')
 
 addLocaleData(enLocaleData)
@@ -51,7 +54,10 @@ export default function App (props:any) {
     startBackendLogging()
     setupLocaleData(state.saved.locale)
   }, [])
-  const onRender = (e:any, state:AppState) => setState(state)
+  const onRender = (e:any, state:AppState) => {
+    log.debug('onRenderer')
+    setState(state)
+  }
   useEffect(() => {
     ipcBackend.on('render', onRender)
     return () => {

--- a/src/renderer/components/message/MessageList.js
+++ b/src/renderer/components/message/MessageList.js
@@ -31,7 +31,7 @@ export default function MessageList ({ chat, refComposer, locationStreamingEnabl
 
   useEffect(() => {
     if (scrollToBottom === false) return
-    
+
     log.debug('scrollToBottom', messageListRef.current.scrollTop, messageListRef.current.scrollHeight)
     messageListRef.current.scrollTop = messageListRef.current.scrollHeight
     chatStoreDispatch({ type: 'FINISHED_SCROLL', payload: 'SCROLLED_TO_BOTTOM' })
@@ -61,11 +61,10 @@ export default function MessageList ({ chat, refComposer, locationStreamingEnabl
       log.debug('Scrolled to top, fetching more messsages!')
       fetchMore()
     }
-    Event.preventDefault();
-    Event.stopPropagation();
-    return false;
+    Event.preventDefault()
+    Event.stopPropagation()
+    return false
   }
-
 
   return <MessageListInner
     onScroll={onScroll}
@@ -87,12 +86,12 @@ export const MessageListInner = React.memo((props) => {
     messages,
     messageListRef,
     locationStreamingEnabled,
-    chat, 
+    chat,
     chatStoreDispatch
   } = props
-  
+
   const _messageIdsToShow = messageIdsToShow(oldestFetchedMessageIndex, messageIds)
-  
+
   let specialMessageIdCounter = 0
   return (
     <div id='message-list' ref={messageListRef} onScroll={onScroll}>
@@ -124,7 +123,6 @@ export const MessageListInner = React.memo((props) => {
     prevProps.oldestFetchedMessageIndex === nextProps.oldestFetchedMessageIndex &&
     prevProps.locationStreamingEnabled === nextProps.locationStreamingEnabled
 
-  console.log('MessageListInner componentDidUpdate', areEqual, prevProps.oldestFetchedMessageIndex, nextProps.oldestFetchedMessageIndex, prevProps.locationStreamingEnabled, nextProps.locationStreamingEnabled)
   return areEqual
 })
 

--- a/src/renderer/components/message/MessageList.js
+++ b/src/renderer/components/message/MessageList.js
@@ -26,22 +26,21 @@ export default function MessageList ({ chat, refComposer, locationStreamingEnabl
     scrollHeight
   }, chatStoreDispatch] = useChatStore()
   const messageListRef = useRef(null)
-  const lastKnownScrollPosition = useRef([null, null])
+  const lastKnownScrollHeight = useRef([null, null])
   const isFetching = useRef(false)
 
   useEffect(() => {
     if (scrollToBottom === false) return
+    
+    log.debug('scrollToBottom', messageListRef.current.scrollTop, messageListRef.current.scrollHeight)
     messageListRef.current.scrollTop = messageListRef.current.scrollHeight
-    setTimeout(() => {
-      messageListRef.current.scrollTop = messageListRef.current.scrollHeight
-    }, 30)
     chatStoreDispatch({ type: 'FINISHED_SCROLL', payload: 'SCROLLED_TO_BOTTOM' })
   }, [scrollToBottom])
 
   useEffect(() => {
     if (scrollToLastPage === false) return
     // restore old scroll position after new messages are rendered
-    messageListRef.current.scrollTop = messageListRef.current.scrollHeight - lastKnownScrollPosition.current
+    messageListRef.current.scrollTop = messageListRef.current.scrollHeight - lastKnownScrollHeight.current
     chatStoreDispatch({ type: 'FINISHED_SCROLL', payload: 'SCROLLED_TO_LAST_PAGE' })
     isFetching.current = false
   }, [scrollToLastPage, scrollHeight])
@@ -55,12 +54,16 @@ export default function MessageList ({ chat, refComposer, locationStreamingEnabl
   }, 30, { leading: true })
 
   const onScroll = Event => {
-    if (messageListRef.current.scrollTop === 0 && isFetching.current === false) {
-      lastKnownScrollPosition.current = messageListRef.current.scrollHeight
+    if (messageListRef.current.scrollTop !== 0) return
+    if (isFetching.current === false) {
+      lastKnownScrollHeight.current = messageListRef.current.scrollHeight
       isFetching.current = true
       log.debug('Scrolled to top, fetching more messsages!')
       fetchMore()
     }
+    Event.preventDefault();
+    Event.stopPropagation();
+    return false;
   }
 
 

--- a/src/renderer/components/message/MessageList.js
+++ b/src/renderer/components/message/MessageList.js
@@ -82,8 +82,9 @@ export default function MessageList ({ chat, refComposer, locationStreamingEnabl
             <MessageWrapper.render
               key={messageId}
               message={message}
-              chat={chat}
               locationStreamingEnabled={locationStreamingEnabled}
+              chat={chat}
+              chatStoreDispatch={chatStoreDispatch}
             />
           )
         })}

--- a/src/renderer/components/message/MessageList.js
+++ b/src/renderer/components/message/MessageList.js
@@ -63,8 +63,33 @@ export default function MessageList ({ chat, refComposer, locationStreamingEnabl
     }
   }
 
-  const _messageIdsToShow = messageIdsToShow(oldestFetchedMessageIndex, messageIds)
 
+  return <MessageListInner
+    onScroll={onScroll}
+    oldestFetchedMessageIndex={oldestFetchedMessageIndex}
+    messageIds={messageIds}
+    messages={messages}
+    messageListRef={messageListRef}
+    locationStreamingEnabled={locationStreamingEnabled}
+    chat={chat}
+    chatStoreDispatch={chatStoreDispatch}
+  />
+}
+
+export const MessageListInner = React.memo((props) => {
+  const {
+    onScroll,
+    oldestFetchedMessageIndex,
+    messageIds,
+    messages,
+    messageListRef,
+    locationStreamingEnabled,
+    chat, 
+    chatStoreDispatch
+  } = props
+  
+  const _messageIdsToShow = messageIdsToShow(oldestFetchedMessageIndex, messageIds)
+  
   let specialMessageIdCounter = 0
   return (
     <div id='message-list' ref={messageListRef} onScroll={onScroll}>
@@ -91,7 +116,14 @@ export default function MessageList ({ chat, refComposer, locationStreamingEnabl
       </ul>
     </div>
   )
-}
+}, (prevProps, nextProps) => {
+  const areEqual = prevProps.messageIds === nextProps.messageIds &&
+    prevProps.oldestFetchedMessageIndex === nextProps.oldestFetchedMessageIndex &&
+    prevProps.locationStreamingEnabled === nextProps.locationStreamingEnabled
+
+  console.log('MessageListInner componentDidUpdate', areEqual, prevProps.oldestFetchedMessageIndex, nextProps.oldestFetchedMessageIndex, prevProps.locationStreamingEnabled, nextProps.locationStreamingEnabled)
+  return areEqual
+})
 
 export function DayMarker (props) {
   const { timestamp } = props

--- a/src/renderer/components/message/MessageWrapper.js
+++ b/src/renderer/components/message/MessageWrapper.js
@@ -110,7 +110,7 @@ export const RenderMessage = React.memo((props) => {
   if (message.isInfo) return <InfoMessage onContextMenu={onShowDetail}><p>{msg.text}</p></InfoMessage>
 
   return <Message {...props} />
-}, (prevProps, nextProps) => {
+}, (prevProps, nextProps) => {  
   const areEqual = prevProps.message === nextProps.message
   console.log('MessageWrapper.render componentDidUpdate', areEqual)
   return areEqual

--- a/src/renderer/components/message/MessageWrapper.js
+++ b/src/renderer/components/message/MessageWrapper.js
@@ -4,7 +4,6 @@ import styled from 'styled-components'
 import Message from './Message'
 import { ScreenContext } from '../../contexts'
 import logger from '../../../shared/logger'
-import { useChatStore } from '../../stores/chat'
 import { openViewProfileDialog } from '../helpers/ChatMethods'
 
 const log = logger.getLogger('renderer/messageWrapper')
@@ -31,17 +30,6 @@ export const InfoMessage = styled.div`
     color: ${props => props.theme.infoMessageBubbleText};
   }
 `
-
-function diff(o1, o2) {
-  let diff = Object.keys(o2).reduce((diff, key) => {
-    if (o1[key] === o2[key]) return diff
-    return {
-      ...diff,
-      [key]: o2[key]
-    }
-  }, {})
-  return diff  
-}
 
 export const render = (props) => {
   return <li><RenderMessage {...props} /></li>
@@ -110,9 +98,8 @@ export const RenderMessage = React.memo((props) => {
   if (message.isInfo) return <InfoMessage onContextMenu={onShowDetail}><p>{msg.text}</p></InfoMessage>
 
   return <Message {...props} />
-}, (prevProps, nextProps) => {  
+}, (prevProps, nextProps) => {
   const areEqual = prevProps.message === nextProps.message
-  console.log('MessageWrapper.render componentDidUpdate', areEqual)
   return areEqual
 })
 const MessageWrapper = { render }

--- a/src/renderer/components/message/MessageWrapper.js
+++ b/src/renderer/components/message/MessageWrapper.js
@@ -32,13 +32,23 @@ export const InfoMessage = styled.div`
   }
 `
 
-export const render = React.memo((props) => {
-  return <li><RenderMessage {...props} /></li>
-})
+function diff(o1, o2) {
+  let diff = Object.keys(o2).reduce((diff, key) => {
+    if (o1[key] === o2[key]) return diff
+    return {
+      ...diff,
+      [key]: o2[key]
+    }
+  }, {})
+  return diff  
+}
 
-export function RenderMessage (props) {
-  const [chat, chatStoreDispatch] = useChatStore()
-  const { message, locationStreamingEnabled } = props
+export const render = (props) => {
+  return <li><RenderMessage {...props} /></li>
+}
+
+export const RenderMessage = React.memo((props) => {
+  const { message, locationStreamingEnabled, chat, chatStoreDispatch } = props
   const { fromId, id } = message.msg
   const msg = message.msg
   const tx = window.translate
@@ -100,6 +110,10 @@ export function RenderMessage (props) {
   if (message.isInfo) return <InfoMessage onContextMenu={onShowDetail}><p>{msg.text}</p></InfoMessage>
 
   return <Message {...props} />
-}
+}, (prevProps, nextProps) => {
+  const areEqual = prevProps.message === nextProps.message
+  console.log('MessageWrapper.render componentDidUpdate', areEqual)
+  return areEqual
+})
 const MessageWrapper = { render }
 export default MessageWrapper


### PR DESCRIPTION
On each update a functional component will "rerender", or at least build the virtual dom stuff and compare it with what is there. To avoid this the 2nd memo parameter allows us to check if we actually need to do anything. I added this to the new MessageListInner component which checks if the messages to show changed (if we need to show new messages) and we also check this for each Message component if the message object changed it's identity and only if so we rerender. Besides this i moved the useStore call out of MessageWrapper as a useState change always triggers a rerender, causing us to rerender all Messages no matter what changed in the chat store.