### PR TITLE
Move/Refactor/abstract all electron imports to src/renderer/ipc

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,7 +4,7 @@ import { SettingsContext } from './contexts'
 import ScreenController from './ScreenController'
 import { addLocaleData, IntlProvider } from 'react-intl'
 import enLocaleData from 'react-intl/locale-data/en'
-import { remote } from 'electron'
+import { appState } from './ipc'
 import { callDcMethod, sendToBackend, sendToBackendSync, ipcBackend, startBackendLogging } from './ipc'
 import attachKeybindingsListener from './keybindings'
 import { ExtendedApp, AppState } from '../shared/shared-types'
@@ -20,7 +20,7 @@ addLocaleData(enLocaleData)
 attachKeybindingsListener()
 
 export default function App (props:any) {
-  const [state, setState] = useState<AppState>((remote.app as ExtendedApp).state)
+  const [state, setState] = useState<AppState>(appState)
   const [localeData, setLocaleData] = useState<LocaleData | null>(null)
 
   useEffect(() => {

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -2,7 +2,8 @@ import { Login, AppState } from "../shared/shared-types"
 
 import React from "react"
 import { Component, createRef } from 'react'
-import { ipcRenderer } from 'electron'
+import { ipcBackend } from './ipc'
+
 
 import { ScreenContext } from './contexts'
 import LoginScreen from'./components/LoginScreen'
@@ -48,15 +49,15 @@ export default class ScreenController extends Component {
   }
 
   componentDidMount () {
-    ipcRenderer.on('error', this.onError)
-    ipcRenderer.on('success', this.onSuccess)
-    ipcRenderer.on('showAboutDialog', this.onShowAbout)
+    ipcBackend.on('error', this.onError)
+    ipcBackend.on('success', this.onSuccess)
+    ipcBackend.on('showAboutDialog', this.onShowAbout)
   }
 
   componentWillUnmount () {
-    ipcRenderer.removeListener('showAboutDialog', this.onShowAbout)
-    ipcRenderer.removeListener('error', this.onError)
-    ipcRenderer.removeListener('success', this.onSuccess)
+    ipcBackend.removeListener('showAboutDialog', this.onShowAbout)
+    ipcBackend.removeListener('error', this.onError)
+    ipcBackend.removeListener('success', this.onSuccess)
   }
 
   onError (_event:any, error:Error) {

--- a/src/renderer/ThemeManager.js
+++ b/src/renderer/ThemeManager.js
@@ -2,7 +2,7 @@ const React = require('react')
 const StyledThemeProvider = require('styled-components').ThemeProvider
 const { EventEmitter } = require('events')
 const { defaultTheme, ThemeDataBuilder: ThemeBuilder, defaultThemeData, ThemeVarOverwrite } = require('./ThemeBackend.js')
-const { ipcRenderer } = require('electron')
+const { ipcBackend } = require('./ipc')
 
 class ThemeManager extends EventEmitter {
   constructor () {
@@ -11,7 +11,7 @@ class ThemeManager extends EventEmitter {
     this.currentTheme = themeJSON !== null ? JSON.parse(themeJSON) : {}
     this.currentThemeData = ThemeBuilder(this.currentTheme)
     window.ThemeManager = this // only for using from the dev console
-    ipcRenderer.on('theme-update', (e, data) => this.setTheme(data))
+    ipcBackend.on('theme-update', (e, data) => this.setTheme(data))
   }
 
   setTheme (theme) {

--- a/src/renderer/components/Login.tsx
+++ b/src/renderer/components/Login.tsx
@@ -2,7 +2,6 @@
 
 import { DeltaChat, C } from 'deltachat-node';
 import React from 'react'
-import { ipcRenderer } from 'electron'
 import update from 'immutability-helper'
 import {
   DeltaInput,
@@ -14,7 +13,7 @@ import {
   Collapse,
   Intent
 } from '@blueprintjs/core'
-import { callDcMethodAsync } from '../ipc'
+import { callDcMethodAsync, ipcBackend } from '../ipc'
 import ClickableLink from './helpers/ClickableLink';
 
 type credentialState = {
@@ -74,11 +73,11 @@ export default class Login extends React.Component<LoginProps, LoginComponentSta
   }
 
   componentDidMount () {
-    ipcRenderer.on('DC_EVENT_CONFIGURE_PROGRESS', this._updateProgress)
+    ipcBackend.on('DC_EVENT_CONFIGURE_PROGRESS', this._updateProgress)
   }
 
   componentWillUnmount () {
-    ipcRenderer.removeListener('DC_EVENT_CONFIGURE_PROGRESS', this._updateProgress)
+    ipcBackend.removeListener('DC_EVENT_CONFIGURE_PROGRESS', this._updateProgress)
   }
 
   _updateProgress (ev:any, [progress, _]:[number, any]) {
@@ -140,8 +139,8 @@ export default class Login extends React.Component<LoginProps, LoginComponentSta
 
   async emailChange (event: React.FormEvent<HTMLElement> & React.ChangeEvent<HTMLInputElement>) {
     this.handleCredentialsChange(event)
-    const result = await callDcMethodAsync('getProviderInfo', [event.target.value])
-    this.setState({ provider_info: result || null })
+    const provider_info = (await callDcMethodAsync('getProviderInfo', [event.target.value]) || null) as ReturnType<typeof DeltaChat.getProviderFromEmail>
+    this.setState({ provider_info })
   }
 
   handleSubmit (event: any) {
@@ -167,7 +166,7 @@ export default class Login extends React.Component<LoginProps, LoginComponentSta
     if (mode === 'update') {
       this.props.onCancel()
     } else {
-      ipcRenderer.send('logout')
+      ipcBackend.send('logout')
     }
   }
 

--- a/src/renderer/components/LoginScreen.js
+++ b/src/renderer/components/LoginScreen.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, Fragment, useContext } from 'react'
-import { remote } from 'electron'
-import { sendToBackend, ipcBackend } from '../ipc'
+import { sendToBackend, ipcBackend, showOpenDialog } from '../ipc'
 import Login from './Login'
 import {
   Button,
@@ -100,7 +99,7 @@ const ImportButton = React.memo(function ImportButton (props) {
       filters: [{ name: 'DeltaChat .bak', extensions: ['bak'] }]
     }
 
-    remote.dialog.showOpenDialog(opts, filenames => {
+    showOpenDialog(opts, filenames => {
       if (!filenames || !filenames.length) return
       sendToBackend('backupImport', filenames[0])
       setShowDialog(true)

--- a/src/renderer/components/Menu.js
+++ b/src/renderer/components/Menu.js
@@ -1,7 +1,6 @@
 import { C } from 'deltachat-node'
 import React, { useContext } from 'react'
-import { callDcMethodAsync, openHelp } from '../ipc'
-import { ipcRenderer } from 'electron'
+import { callDcMethodAsync, openHelp, ipcBackend } from '../ipc'
 import { ScreenContext } from '../contexts'
 import { useChatStore } from '../stores/chat'
 import {
@@ -52,7 +51,7 @@ export default function DeltaMenu (props) {
     if (selectedChat) {
       chatStoreDispatch({ type: 'UI_UNSELECT_CHAT' })
     }
-    ipcRenderer.send('logout')
+    ipcBackend.send('logout')
   }
 
   if (selectedChat && selectedChat.id && !selectedChat.isDeaddrop) {

--- a/src/renderer/components/attachment/Attachment.tsx
+++ b/src/renderer/components/attachment/Attachment.tsx
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron'
+import { ipcBackend } from '../../ipc'
 import mimeTypes from 'mime-types'
 
 /* Section - Data Copied in part from Signal */
@@ -77,6 +77,6 @@ export function getExtension({ fileName, contentType }: attachment) {
 
 export function dragAttachmentOut({ url }: attachment, dragEvent: DragEvent) {
   dragEvent.preventDefault()
-  ipcRenderer.send('ondragstart', url)
+  ipcBackend.send('ondragstart', url)
 }
 

--- a/src/renderer/components/composer/Composer.js
+++ b/src/renderer/components/composer/Composer.js
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react'
 import { Button } from '@blueprintjs/core'
-import { remote } from 'electron'
+import { showOpenDialog } from '../../ipc'
 
 import { SettingsContext } from '../../contexts'
 import ComposerMessageInput from './ComposerMessageInput'
@@ -39,7 +39,7 @@ const Composer = React.forwardRef((props, ref) => {
   }
 
   const addFilename = () => {
-    remote.dialog.showOpenDialog({ properties: ['openFile'] }, filenames => {
+    showOpenDialog({ properties: ['openFile'] }, filenames => {
       if (filenames && filenames[0]) {
         chatStoreDispatch({ type: 'SEND_MESSAGE', payload: [chatId, '', filenames[0]] })
       }

--- a/src/renderer/components/dialogs/About.js
+++ b/src/renderer/components/dialogs/About.js
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react'
-import { remote, clipboard } from 'electron'
-import { callDcMethodAsync } from '../../ipc'
+import { callDcMethodAsync, openExternal, clipboard } from '../../ipc'
 import { Card } from '@blueprintjs/core'
 import reactStringReplace from 'react-string-replace'
 import logger from '../../../shared/logger'
@@ -15,7 +14,7 @@ const log = logger.getLogger('renderer/dialogs/About')
 
 export function ClickableLink (props) {
   const { href, text } = props
-  const onClick = () => { remote.shell.openExternal(href) }
+  const onClick = () => { openExternal(href) }
 
   return <a onClick={onClick} href={href}>{text}</a>
 }

--- a/src/renderer/components/dialogs/ConfirmationDialog.js
+++ b/src/renderer/components/dialogs/ConfirmationDialog.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { remote } from 'electron'
+import { showMessageBox } from '../../ipc'
 import { Classes } from '@blueprintjs/core'
 import SmallDialog, { DeltaButtonPrimary, DeltaButtonDanger } from './SmallDialog'
 
@@ -12,7 +12,7 @@ export function confirmationDialogLegacy (message, opts, cb) {
     message: message,
     buttons: [tx('no'), tx('yes')]
   }
-  remote.dialog.showMessageBox(Object.assign(defaultOpts, opts), response => {
+  showMessageBox(Object.assign(defaultOpts, opts), response => {
     cb(response === 1) // eslint-disable-line
   })
 }

--- a/src/renderer/components/dialogs/CreateChat.js
+++ b/src/renderer/components/dialogs/CreateChat.js
@@ -1,9 +1,8 @@
 import React, { Fragment, useState, useContext } from 'react'
 import { Card, Classes } from '@blueprintjs/core'
-import { remote } from 'electron'
 import { C } from 'deltachat-node'
 
-import { callDcMethodAsync } from '../../ipc'
+import { callDcMethodAsync, showOpenDialog } from '../../ipc'
 import { ScreenContext } from '../../contexts'
 import { selectChat } from '../../stores/chat'
 import { useContacts, ContactList2 } from '../contact/ContactList'
@@ -139,7 +138,7 @@ export function useGroupImage (image) {
   const tx = window.translate
 
   const onSetGroupImage = () => {
-    remote.dialog.showOpenDialog({
+    showOpenDialog({
       title: tx('select_group_image_desktop'),
       filters: [{ name: 'Images', extensions: ['jpg', 'png', 'gif'] }],
       properties: ['openFile']

--- a/src/renderer/components/dialogs/EnterAutocryptSetupMessage.js
+++ b/src/renderer/components/dialogs/EnterAutocryptSetupMessage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ipcRenderer } from 'electron'
+import { ipcBackend } from '../../ipc'
 import { DeltaButtonPrimary } from './SmallDialog'
 import {
   Card,
@@ -79,16 +79,16 @@ export default class EnterAutocryptSetupMessage extends React.Component {
   }
 
   componentDidMount () {
-    ipcRenderer.on('continueKeyTransferResp', this.continueKeyTransferResp)
+    ipcBackend.on('continueKeyTransferResp', this.continueKeyTransferResp)
   }
 
   componentWillUnmount () {
-    ipcRenderer.removeListener('continueKeyTransferResp', this.continueKeyTransferResp)
+    ipcBackend.removeListener('continueKeyTransferResp', this.continueKeyTransferResp)
   }
 
   continueKeyTransfer (key) {
     this.setState({ key, loading: true })
-    ipcRenderer.send('continueKeyTransfer', this.props.message.msg.id, key)
+    ipcBackend.send('continueKeyTransfer', this.props.message.msg.id, key)
   }
 
   render () {

--- a/src/renderer/components/dialogs/ImexProgress.js
+++ b/src/renderer/components/dialogs/ImexProgress.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ipcRenderer } from 'electron'
+import { ipcBackend } from '../../ipc'
 import {
   Intent,
   ProgressBar,
@@ -22,11 +22,11 @@ export default class ImexProgress extends React.Component {
   }
 
   componentDidMount () {
-    ipcRenderer.on('DC_EVENT_IMEX_PROGRESS', this.onDcEventImexProgress)
+    ipcBackend.on('DC_EVENT_IMEX_PROGRESS', this.onDcEventImexProgress)
   }
 
   componentWillUnmount () {
-    ipcRenderer.removeListener('DC_EVENT_IMEX_PROGRESS', this.onDcEventImexProgress)
+    ipcBackend.removeListener('DC_EVENT_IMEX_PROGRESS', this.onDcEventImexProgress)
   }
 
   render () {

--- a/src/renderer/components/dialogs/SendAutocryptSetupMessage.js
+++ b/src/renderer/components/dialogs/SendAutocryptSetupMessage.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ipcRenderer } from 'electron'
+import { ipcBackend } from '../../ipc'
 
 import {
   Card,
@@ -77,11 +77,11 @@ export default class SendAutocryptSetupMessage extends React.Component {
   }
 
   componentDidMount () {
-    ipcRenderer.on('initiateKeyTransferResp', this.initiateKeyTransferResp)
+    ipcBackend.on('initiateKeyTransferResp', this.initiateKeyTransferResp)
   }
 
   componentWillUnmount () {
-    ipcRenderer.removeListener('initiateKeyTransferResp', this.initiateKeyTransferResp)
+    ipcBackend.removeListener('initiateKeyTransferResp', this.initiateKeyTransferResp)
   }
 
   onClose () {
@@ -90,7 +90,7 @@ export default class SendAutocryptSetupMessage extends React.Component {
   }
 
   initiateKeyTransfer () {
-    ipcRenderer.send('initiateKeyTransfer')
+    ipcBackend.send('initiateKeyTransfer')
     this.setState({ loading: true })
   }
 

--- a/src/renderer/components/dialogs/Settings.js
+++ b/src/renderer/components/dialogs/Settings.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import crypto from 'crypto'
-import { callDcMethodAsync, ipcBackend, getPath, showOpenDialog} from '../../ipc'
+import { callDcMethodAsync, ipcBackend, getPath, showOpenDialog } from '../../ipc'
 import { C } from 'deltachat-node'
 import {
   Elevation,
@@ -135,11 +135,11 @@ export default class Settings extends React.Component {
 
     const opts = {
       title: window.translate('pref_managekeys_export_secret_keys'),
-      defaultPath: remote.app.getPath('downloads'),
+      defaultPath: getPath('downloads'),
       properties: ['openDirectory']
     }
 
-    remote.dialog.showOpenDialog(opts, filenames => {
+    showOpenDialog(opts, filenames => {
       if (filenames && filenames.length) {
         confirmationDialog(this.translate('pref_managekeys_export_explain').replace('%1$s', filenames[0]), response => {
           if (!response) return
@@ -163,10 +163,10 @@ export default class Settings extends React.Component {
       if (!response) return
       const opts = {
         title: this.translate('export_backup_desktop'),
-        defaultPath: remote.app.getPath('downloads'),
+        defaultPath: getPath('downloads'),
         properties: ['openDirectory']
       }
-      remote.dialog.showOpenDialog(opts, filenames => {
+      showOpenDialog(opts, filenames => {
         if (!filenames || !filenames.length) {
           return
         }
@@ -500,7 +500,7 @@ function ProfileImageSelector (props) {
   }
 
   const openSelectionDialog = () => {
-    remote.dialog.showOpenDialog({
+    showOpenDialog({
       title: tx('select_profile_image_desktop'),
       filters: [{ name: 'Images', extensions: ['jpg', 'png', 'gif'] }],
       properties: ['openFile']

--- a/src/renderer/components/helpers/ClickableLink.js
+++ b/src/renderer/components/helpers/ClickableLink.js
@@ -1,7 +1,6 @@
 const React = require('react')
 const { openExternal } = require('../../ipc')
 
-
 class ClickableLink extends React.Component {
   constructor (props) {
     super(props)

--- a/src/renderer/components/helpers/ClickableLink.js
+++ b/src/renderer/components/helpers/ClickableLink.js
@@ -1,5 +1,6 @@
 const React = require('react')
-const electron = require('electron')
+const { openExternal } = require('../../ipc')
+
 
 class ClickableLink extends React.Component {
   constructor (props) {
@@ -11,7 +12,7 @@ class ClickableLink extends React.Component {
 
   onClick (event) {
     event.preventDefault()
-    electron.shell.openExternal(this.href)
+    openExternal(this.href)
   }
 
   render () {

--- a/src/renderer/components/message/MessageMarkdown.js
+++ b/src/renderer/components/message/MessageMarkdown.js
@@ -1,6 +1,6 @@
 const React = require('react')
 const { defaultRules, blockRegex, anyScopeRegex } = require('simple-markdown')
-const { remote } = require('electron')
+const { openExternal } = require('../../ipc')
 
 var ignoreCapture = function () { return {} }
 
@@ -54,7 +54,7 @@ const rules = Object.assign({
     react: function (node, output, state) {
       const onClick = (ev) => {
         ev.preventDefault()
-        remote.shell.openExternal(node.content)
+        openExternal(node.content)
       }
       return <a href={node.content} key={state.key} onClick={onClick}>{node.content}</a>
     }

--- a/src/renderer/components/message/messageFunctions.js
+++ b/src/renderer/components/message/messageFunctions.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import { remote, ipcRenderer, shell } from 'electron'
+import { ipcBackend, openItem, showSaveDialog } from '../../ipc'
 
 import { getLogger } from '../../../shared/logger'
 const log = getLogger('render/msgFunctions')
@@ -30,10 +30,8 @@ const log = getLogger('render/msgFunctions')
  */
 export function onDownload (msg) {
   const defaultPath = path.join(remote.app.getPath('downloads'), path.basename(msg.file))
-  remote.dialog.showSaveDialog({
-    defaultPath
-  }, (filename) => {
-    if (filename) ipcRenderer.send('saveFile', msg.file, filename)
+  showSaveDialog({defaultPath}, (filename) => {
+    if (filename) ipcBackend.send('saveFile', msg.file, filename)
   })
 }
 
@@ -41,7 +39,7 @@ export function onDownload (msg) {
  * @param {MsgObject} msg
  */
 export function openAttachmentInShell (msg) {
-  if (!shell.openItem(msg.file)) {
+  if (!openItem(msg.file)) {
     log.info("file couldn't be opened, try saving it in a different place and try to open it from there")
   }
 }

--- a/src/renderer/components/message/messageFunctions.js
+++ b/src/renderer/components/message/messageFunctions.js
@@ -1,5 +1,5 @@
 import path from 'path'
-import { ipcBackend, openItem, showSaveDialog } from '../../ipc'
+import { ipcBackend, openItem, showSaveDialog, getPath } from '../../ipc'
 
 import { getLogger } from '../../../shared/logger'
 const log = getLogger('render/msgFunctions')
@@ -29,8 +29,8 @@ const log = getLogger('render/msgFunctions')
  * @param {MsgObject} msg
  */
 export function onDownload (msg) {
-  const defaultPath = path.join(remote.app.getPath('downloads'), path.basename(msg.file))
-  showSaveDialog({defaultPath}, (filename) => {
+  const defaultPath = path.join(getPath('downloads'), path.basename(msg.file))
+  showSaveDialog({ defaultPath }, (filename) => {
     if (filename) ipcBackend.send('saveFile', msg.file, filename)
   })
 }

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -3,10 +3,29 @@
  * to be able to switch this layer later on...
  */
 
-import { ipcRenderer } from 'electron'
-const log = require('../shared/logger').getLogger('renderer/ipc')
+import { ipcRenderer, remote, clipboard as _clipboard } from 'electron'
+import { ExtendedApp, AppState } from '../shared/shared-types'
+import logger from '../shared/logger'
+
+const log = logger.getLogger('renderer/ipc')    
 
 export const ipcBackend = ipcRenderer
+
+export const appState: AppState = (remote.app as ExtendedApp).state 
+
+export const showOpenDialog = remote.dialog.showOpenDialog  
+
+export const openExternal = remote.shell.openExternal
+
+export const openItem = remote.shell.openItem
+
+export const showSaveDialog = remote.dialog.showSaveDialog
+
+export const showMessageBox = remote.dialog.showMessageBox
+
+export const getPath = remote.app.getPath 
+
+export const clipboard = _clipboard
 
 var backendLoggingStarted = false
 export function startBackendLogging () {
@@ -17,13 +36,13 @@ export function startBackendLogging () {
   ipcBackend.on('error', (e, ...args) => log.error(...args))
 }
 
-export function sendToBackend (event, ...args) {
+export function sendToBackend (event: string, ...args: any[]) {
   log.debug(`sendToBackend: ${event} ${args.join(' ')}`)
   ipcRenderer.send('ALL', event, ...args)
   ipcRenderer.send(event, ...args)
 }
 
-export function sendToBackendSync (event, ...args) {
+export function sendToBackendSync (event: string, ...args: any[]) {
   log.debug(`sendToBackendSync: ${event} ${args.join(' ')}`)
   ipcRenderer.send('ALL', event, ...args)
   return ipcRenderer.sendSync(event, ...args)
@@ -32,7 +51,7 @@ export function sendToBackendSync (event, ...args) {
 // Call a dc method without blocking the renderer process. Return value
 // of the dc method is the first argument to cb
 var callDcMethodIdentifier = 0
-export function callDcMethod (methodName, args, cb) {
+export function callDcMethod (methodName: string, args?: any[], cb?: any) {
   const identifier = callDcMethodIdentifier++
   if (identifier >= Number.MAX_SAFE_INTEGER - 1) callDcMethodIdentifier = 0
   const ignoreReturn = typeof cb !== 'function'
@@ -48,7 +67,7 @@ export function callDcMethod (methodName, args, cb) {
   })
 }
 
-export function callDcMethodAsync (fnName, args) {
+export function callDcMethodAsync (fnName: string, args: any[]) {
   return new Promise((resolve, reject) => callDcMethod(fnName, args, resolve))
 }
 
@@ -56,7 +75,7 @@ export function mainProcessUpdateBadge () {
   ipcRenderer.send('update-badge')
 }
 
-export function saveLastChatId (chatId) {
+export function saveLastChatId (chatId: number) {
   ipcRenderer.send('saveLastChatId', chatId)
 }
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,11 +1,11 @@
-import { ipcRenderer } from 'electron'
+import { ipcBackend } from './ipc'
 
 import React from 'react'
 import ReactDOM from 'react-dom'
 
 function main () {
   const logger = require('../shared/logger')
-  logger.setLogHandler((...args:any[]) => ipcRenderer.send('handleLogMessage', ...args))
+  logger.setLogHandler((...args:any[]) => ipcBackend.send('handleLogMessage', ...args))
   logger.printProcessLogLevelInfo()
 
   const App = require('./App').default

--- a/src/renderer/stores/locations.js
+++ b/src/renderer/stores/locations.js
@@ -60,4 +60,3 @@ locationStore.effects.push((action, state) => {
     getLocations(chatId, state.mapSettings)
   }
 })
-

--- a/src/renderer/stores/locations.js
+++ b/src/renderer/stores/locations.js
@@ -1,6 +1,5 @@
-const { callDcMethod } = require('../ipc')
-const { ipcRenderer } = require('electron')
-const { Store } = require('./store')
+import { callDcMethod, ipcBackend } from '../ipc'
+import { Store } from './store'
 
 const defaultState = {
   selectedChat: null,
@@ -10,7 +9,7 @@ const defaultState = {
   },
   locations: []
 }
-const locationStore = new Store(defaultState)
+export const locationStore = new Store(defaultState)
 
 const getLocations = (chatId, mapSettings) => {
   const { timestampFrom, timestampTo } = mapSettings
@@ -29,7 +28,7 @@ const onLocationChange = (evt, payload) => {
   }
 }
 
-ipcRenderer.on('DC_EVENT_LOCATION_CHANGED', (evt, contactId) => {
+ipcBackend.on('DC_EVENT_LOCATION_CHANGED', (evt, contactId) => {
   const { selectedChat, mapSettings } = locationStore.getState()
   if (contactId === 0) {
     // this means all locations were deleted
@@ -44,8 +43,8 @@ ipcRenderer.on('DC_EVENT_LOCATION_CHANGED', (evt, contactId) => {
 })
 
 // sometimes a MSGS_CHANGED is sent instead of locations changed
-ipcRenderer.on('DC_EVENT_MSGS_CHANGED', onLocationChange)
-ipcRenderer.on('DC_EVENT_INCOMING_MSG', onLocationChange)
+ipcBackend.on('DC_EVENT_MSGS_CHANGED', onLocationChange)
+ipcBackend.on('DC_EVENT_INCOMING_MSG', onLocationChange)
 
 locationStore.reducers.push((action, state) => {
   if (action.type === 'DC_GET_LOCATIONS') {
@@ -62,4 +61,3 @@ locationStore.effects.push((action, state) => {
   }
 })
 
-module.exports = locationStore


### PR DESCRIPTION
This allows us to move all the electron depending methods in src/renderer/ipc to gradually move them to a generic browser solution. This also converts src/renderer/ipc to typescript.

Won't merge this before the 1.0 release