### PR TITLE
Add zoom factor option in order to adjust font size.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Add copy qr code manually
+- Add zoom factor option in order to adjust font size. (It's found under `View`->`Zoom Factor`)
 
 ### Changed
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -82,5 +82,26 @@
   },
   "copy_qr_data_success": {
     "message": "Copied qr code data to clipboard"
+  },
+  "global_menu_view_zoom_factor": {
+    "message": "Zoom Factor"
+  },
+  "global_zoom_factor_custom": {
+    "message": "custom"
+  },
+  "global_zoom_factor_micro": {
+    "message": "micro"
+  },
+  "global_zoom_factor_small": {
+    "message": "small"
+  },
+  "global_zoom_factor_default": {
+    "message": "default"
+  },
+  "global_zoom_factor_large": {
+    "message": "large"
+  },
+  "global_zoom_factor_huge": {
+    "message": "huge"
   }
 }

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -64,6 +64,46 @@ function getAvailableLanguages() {
     })
 }
 
+function getZoomFactors() {
+  // for now this solution is electron specific
+  const zoomFactors = [
+    { scale: 0.6, key: 'micro' },
+    { scale: 0.8, key: 'small' },
+    { scale: 1.0, key: 'default' },
+    { scale: 1.2, key: 'large' },
+    { scale: 1.4, key: 'huge' },
+  ]
+
+  if (
+    zoomFactors
+      .map(({ scale }) => scale)
+      .indexOf(app.state.saved.zoomFactor) === -1
+  )
+    zoomFactors.push({ scale: app.state.saved.zoomFactor, key: 'custom' })
+
+  return zoomFactors.map(({ key, scale }) => {
+    return {
+      label: !(scale === 1 && key === 'custom')
+        ? `${scale}x ${app.translate('global_zoom_factor_' + key)}`
+        : app.translate('global_zoom_factor_custom'),
+      type: 'radio',
+      checked:
+        scale === app.state.saved.zoomFactor &&
+        !(scale === 1 && key === 'custom'),
+      click: () => {
+        if (key !== 'custom') {
+          app.state.saved.zoomFactor = scale
+          windows.main.setZoomFactor(scale)
+          app.saveState()
+        } else {
+          // todo? currently it is a no-op and the 'option' is only shown
+          // when the config value was changed by the user
+        }
+      },
+    }
+  })
+}
+
 function getMenuTemplate(logHandler) {
   return [
     {
@@ -118,6 +158,10 @@ function getMenuTemplate(logHandler) {
           translate: 'global_menu_view_floatontop_desktop',
           type: 'checkbox',
           click: () => windows.main.toggleAlwaysOnTop(),
+        },
+        {
+          translate: 'global_menu_view_zoom_factor',
+          submenu: getZoomFactors(),
         },
         {
           translate: 'pref_language',

--- a/src/main/windows/main.js
+++ b/src/main/windows/main.js
@@ -11,7 +11,9 @@ const main = (module.exports = {
   toggleAlwaysOnTop,
   isAlwaysOnTop,
   toggleDevTools,
+  /** @type {electron.BrowserWindow} */
   win: null,
+  setZoomFactor,
 })
 
 const electron = require('electron')
@@ -94,6 +96,9 @@ function init(app, options) {
     }, 1000)
   )
 
+  win.once('show', e => {
+    win.webContents.setZoomFactor(state.saved.zoomFactor)
+  })
   win.on('close', e => {})
   win.on('blur', e => {
     win.hidden = true
@@ -207,4 +212,10 @@ function toggleDevTools() {
 
 function chooseLanguage(locale) {
   main.win.send('chooseLanguage', locale)
+}
+
+function setZoomFactor(factor) {
+  if (!main.win) return
+  log.info('setZoomFactor', factor)
+  main.win.webContents.setZoomFactor(factor)
 }

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -22,6 +22,7 @@ export interface LocalSettings {
   notifications: boolean
   showNotificationContent: boolean
   lastChats: { [account_addr: string]: number }
+  zoomFactor: number
 }
 
 export interface AppState {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -29,6 +29,7 @@ export function getDefaultState(): AppState {
       enableOnDemandLocationStreaming: false,
       chatViewBgImg: undefined,
       lastChats: {},
+      zoomFactor: 1,
     },
   }
 }


### PR DESCRIPTION
(It's found under `View`->`Zoom Factor`)
![Screenshot from 2020-03-09 14-42-59](https://user-images.githubusercontent.com/18725968/76218335-5ef1e300-6214-11ea-8034-7e5dda258bb4.png)
related to #890

keep in mind that this method is electron specific and not the same as the css zoom property.