### PR TITLE
debounce composer set size call

### DIFF
--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -9,6 +9,7 @@ import MessageList from './MessageList'
 import { SettingsContext, ScreenContext } from '../../contexts'
 
 import { C } from 'deltachat-node/dist/constants'
+import { debounce } from 'debounce'
 const { DC_CHAT_ID_DEADDROP, DC_CHAT_ID_STARRED } = C
 
 const log = getLogger('renderer/messageListAndComposer')
@@ -21,7 +22,10 @@ export default function MessageListAndComposer({ chat }: { chat: any }) {
   const refComposer = useRef(null)
   const { openDialog } = useContext(ScreenContext)
 
-  const setComposerSize = (size: number) => setState({ composerSize: size })
+  const setComposerSize = debounce(
+    (size: number) => setState({ composerSize: size }),
+    50
+  )
 
   const onDrop = (e: React.DragEvent<any>) => {
     const files = (e.target as any).files || e.dataTransfer.files


### PR DESCRIPTION
 in order to prevent a white-screen crash.
This doesn't fix the issue fully it just turns the crash into some harmless visual glitching.

related issue: https://github.com/deltachat/deltachat-desktop/issues/1526