### PR TITLE
add primitive & experimental contact import

### DIFF
--- a/src/renderer/experimental.ts
+++ b/src/renderer/experimental.ts
@@ -1,0 +1,35 @@
+import { callDcMethodAsync } from './ipc'
+import { getLogger } from '../shared/logger'
+
+const log = getLogger('renderer/experiments')
+
+class Experimental {
+  help = `
+These functions are highly experimental, use at your own risk.
+- importContacts (contacts:[email,name][]) // for mass importing contacts
+    example: type "exp.importContacts([['email1@example.com', 'Heinz Herlich'],['bea@example.com','Berta Bissig']])"
+    `
+  constructor() {
+    window.exp = this
+  }
+
+  async importContacts(contacts: [string, string][]) {
+    let error_count = 0
+    for (const contact of contacts) {
+      if (
+        await callDcMethodAsync('contacts.createContact', [
+          contact[1],
+          contact[0],
+        ])
+      )
+        log.debug('created contact', contact[1], contact[0])
+      else {
+        log.error('error on creating contact', contact[1], contact[0])
+        error_count++
+      }
+    }
+    log.info(`Imported ${contacts.length - error_count} contacts`)
+  }
+}
+
+export const exp = new Experimental()

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -8,6 +8,7 @@ declare global {
     translate: getMessageFunction
     localeData: LocaleData
     ThemeManager: ThemeManager
+    exp: todo
     electron_functions: {
       // see static/preload.js
       ipcRenderer: import('electron').IpcRenderer

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -3,8 +3,10 @@ const { ipcRenderer, remote } = window.electron_functions
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { ExtendedApp } from '../shared/shared-types'
+import { exp } from './experimental'
 
 function main() {
+  exp.help //make sure experimental.ts is used
   const logger = require('../shared/logger')
   logger.setLogHandler(
     (...args: any[]) => ipcRenderer.send('handleLogMessage', ...args),


### PR DESCRIPTION
(create contacts from json array)
mainly to provide **a** way to import multiple contacts at once into the desktop app. (related to https://support.delta.chat/t/using-importing-contacts-on-desktop-program/368/9)

Better to have the feature this experimental way than not having that possibility at all for the moment.