### PR TITLE
improve logging of core info events

### DIFF
--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -72,11 +72,7 @@ export default class DeltaChatController extends EventEmitter {
 
     if (data1 === 0) data1 = ''
 
-    if (event === 'DC_EVENT_INFO') {
-      logCoreEv.info(event, data1, data2)
-    } else {
-      logCoreEv.debug(event, data1, data2)
-    }
+    logCoreEv.debug(event, data1, data2)
   }
 
   /**
@@ -165,8 +161,8 @@ export default class DeltaChatController extends EventEmitter {
       if (!isNaN(event)) {
         event = eventStrings[event]
       }
-      this.logCoreEvent(event, data1, data2)
       if (!event || event === 'DC_EVENT_INFO') return
+      this.logCoreEvent(event, data1, data2)
       this.sendToRenderer(event, [data1, data2])
     })
 
@@ -204,8 +200,12 @@ export default class DeltaChatController extends EventEmitter {
       this.onChatListItemChanged(chatId)
     })
 
-    dc.on('DC_EVENT_WARNING', (warning: any) => {
+    dc.on('DC_EVENT_WARNING', (warning: string) => {
       log.warn(warning)
+    })
+
+    dc.on('DC_EVENT_INFO', (info: string) => {
+      log.info(info)
     })
 
     const onError = (error: any) => {
@@ -213,7 +213,7 @@ export default class DeltaChatController extends EventEmitter {
       log.error(error)
     }
 
-    dc.on('DC_EVENT_ERROR', (error: any) => {
+    dc.on('DC_EVENT_ERROR', (error: string) => {
       onError(error)
     })
 

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -72,7 +72,11 @@ export default class DeltaChatController extends EventEmitter {
 
     if (data1 === 0) data1 = ''
 
-    logCoreEv.debug(event, data1, data2)
+    if (event === 'DC_EVENT_INFO') {
+      logCoreEv.info(event, data1, data2)
+    } else {
+      logCoreEv.debug(event, data1, data2)
+    }
   }
 
   /**

--- a/src/main/rc.ts
+++ b/src/main/rc.ts
@@ -12,9 +12,9 @@ const defaults: RC_Config = {
   'theme-watch': false,
 }
 
-const config = rc('DeltaChat', defaults) as RC_Config;
+const config = rc('DeltaChat', defaults) as RC_Config
 
-if(config.debug) {
+if (config.debug) {
   config['log-debug'] = true
   config['log-to-console'] = true
 }

--- a/src/main/rc.ts
+++ b/src/main/rc.ts
@@ -12,6 +12,13 @@ const defaults: RC_Config = {
   'theme-watch': false,
 }
 
-const rc_config = Object.freeze(rc('DeltaChat', defaults) as RC_Config)
+const config = rc('DeltaChat', defaults) as RC_Config;
+
+if(config.debug) {
+  config['log-debug'] = true
+  config['log-to-console'] = true
+}
+
+const rc_config = Object.freeze(config)
 
 export default rc_config


### PR DESCRIPTION
This should close #1555

logs always info,warn&error core-events
and logs 'ALL' events only when 'log-debug' is enabled
also --debug enables now --log-debug & --log-to-console