### PR TITLE
Make hovering over a selected chatlist item almost unnoticeable

### DIFF
--- a/src/renderer/ThemeBackend.ts
+++ b/src/renderer/ThemeBackend.ts
@@ -131,7 +131,7 @@ export function ThemeDataBuilder(theme: { [key: string]: string }) {
     chatListItemSelectedBg: '#4c6e7d',
     chatListItemSelectedBgHover: undefinedGuard(true, _ =>
       Color('#4c6e7d')
-        .lighten(0.24)
+        .lighten(0.02)
         .hex()
     ),
     chatListItemSelectedText: theme.bgPrimary,


### PR DESCRIPTION
# After
![deltachat-hover-selected-chat-list-item-after](https://user-images.githubusercontent.com/34889164/80127841-312ee680-8595-11ea-8ce5-5b77c5e65147.gif)


# Before

![deltachat-hover-selected-chat-list-item-before](https://user-images.githubusercontent.com/34889164/80127819-2a07d880-8595-11ea-8eff-9a4ad7f0ad3c.gif)


In my opinion it should be almost unnoticable and stay in the back. The element is already selected and flashing background colors is just to busy.