### PR TITLE
Ensure that the QR-data string prefix is upper-case.

### DIFF
--- a/src/renderer/components/dialogs/ImportQrCode.tsx
+++ b/src/renderer/components/dialogs/ImportQrCode.tsx
@@ -44,6 +44,10 @@ export function DeltaDialogImportQrInner({
   const [secureJoinOngoing, setSecureJoinOngoing] = useState(false)
 
   const handleResponse = async (scannedQrCode: string) => {
+    // Work around: Some browsers lower-case the prefix when using "Copy Link
+    // Location", but the core only accepts the string if the prefix is
+    // upper-case.
+    scannedQrCode = scannedQrCode.replace('openpgp4fpr', 'OPENPGP4FPR')
     setQrCode(scannedQrCode)
     const tx = window.translate
     let error = false


### PR DESCRIPTION
This works around the behaviour of some browsers, that lower-case the
prefix when using "Copy Link Location". The core only accepts the string
if the prefix is upper-case, though.

This occurs when trying to use the discourse login bot and copying the "Manual link" via "Copy Link Location". We could work around this problem in the login bot, too. But this might not be the only situation in which the prefix get's lower-cased, I'd suppose. And it doesn't hurt much to work around it in DC Desktop.