### PR TITLE
Login migration upgrade guides and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased](https://github.com/deltachat/deltachat-desktop/compare/v1.3.2...HEAD)
 
+### Changed
+
+- Account Path: old accounts are now migrated to the new account system.
+
+> If you experience startup problems make sure you don't have two account folders of the same account.\
+> This could happen if you duplicated an account folder for backup purposes, for example.
+> If you did not modify the account folders please open an issue on github.
+
 ## [1.3.2](https://github.com/deltachat/deltachat-desktop/compare/v1.3.1...v1.3.2) - 2020-05-11
 
 ### Fixed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,8 @@
 
 This document describes breaking changes and how to upgrade. For a complete list of changes including minor and patch releases, please refer to the [changelog](CHANGELOG.md).
 
-## v2.0.0
+## v1.4 up
 
-To improve the user experience with `Delta Chat` using multiple devices, we experimentally changed the behaviour of `Delta Chat`. Therefore, beginning with this release, we aren't compatible with the **old android client** which you can currently find in the f-droid store. Please use the **new development** version. You can find it [here](https://github.com/deltachat/deltachat-android/releases).
+If you experience startup problems make sure you don't have two account folders of the same account.\
+This could happen if you duplicated an account folder for backup purposes, for example.
+If you did not modify the account folders please open an issue on github.

--- a/src/main/logins.ts
+++ b/src/main/logins.ts
@@ -38,13 +38,13 @@ async function migrate(dir: string) {
         await fs.move(join(dir, basename(account.path)), join(dir, newFolder))
       } catch (error) {
         log.error(
-          "Moving failed, make sure you don't have multiple account folders for the same account!",
+          "Moving failed, make sure you don't have multiple account folders for the same e-mail address!",
           error
         )
         dialog.showErrorBox(
           'Account migration',
           `Migration of ${account.addr} failed,\n` +
-            "make sure you don't have multiple account folders for the same account!\n" +
+            "Please make sure that you don't have multiple account folders for the same e-mail address!\n" +
             'See the logfile for details'
         )
         continue

--- a/src/main/logins.ts
+++ b/src/main/logins.ts
@@ -5,6 +5,7 @@ import logger from '../shared/logger'
 const log = logger.getLogger('main/find_logins')
 import { getAccountsPath, getConfigPath } from './application-constants'
 import { PromiseType } from '../shared/shared-types'
+import { dialog } from 'electron'
 
 function escapeEmailForAccountFolder(path: string) {
   return encodeURIComponent(path).replace(/%/g, 'P')
@@ -33,8 +34,23 @@ async function migrate(dir: string) {
         'accounts',
         escapeEmailForAccountFolder(account.addr)
       )
-      await fs.move(join(dir, basename(account.path)), join(dir, newFolder))
-      // Backwards compatibility
+      try {
+        await fs.move(join(dir, basename(account.path)), join(dir, newFolder))
+      } catch (error) {
+        log.error(
+          "Moving failed, make sure you don't have multiple account folders for the same account!",
+          error
+        )
+        dialog.showErrorBox(
+          'Account migration',
+          `Migration of ${account.addr} failed,\n` +
+            "make sure you don't have multiple account folders for the same account!\n" +
+            'See the logfile for details'
+        )
+        continue
+      }
+      // Backwards compatibility for versions older than 0.999.0
+      // (doesn't work on windows as symlinks need admin rights there)
       try {
         const compatPath = Buffer.from(account.addr).toString('hex')
         log.info(


### PR DESCRIPTION
- Add information about changed behavior. Also it shouldn't crash anymore if the migration failed, instead it opens an error dialog
- show error dialogs on uncaught errors, in hope to get more less technical people to report crashes