### PR TITLE
🚧 Offline toast

### DIFF
--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -148,6 +148,7 @@ code {
   text-align: center;
   width: 100%;
   z-index: 100;
+  pointer-events: none;
 
   p {
     display: inline-block;
@@ -160,6 +161,7 @@ code {
     color: white;
     font-size: medium;
     max-width: 90%;
+    pointer-events: all;
   }
   &.error p {
     background-color: #b73a3a;
@@ -179,5 +181,37 @@ code {
   }
   &.bp3-button.bp3-minimal:hover {
     background-color: unset;
+  }
+}
+
+.no-network-toast {
+  position: fixed;
+  bottom: 5px;
+  left: 8px;
+  text-align: center;
+  z-index: 99;
+  background-color: var(--contextMenuBg);
+  border: 1px solid var(--contextMenuBorder);
+  padding: 5px;
+  border-radius: 4px;
+  color: var(--contextMenuText);
+  user-select: none;
+
+  div {
+    display: inline-block;
+    color: var(--colorPrimary);
+    margin-left: 4px;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline solid var(--colorPrimary);
+      opacity: 0.8;
+    }
+
+    &.disabled {
+      text-decoration: none;
+      color: gray;
+      cursor: wait;
+    }
   }
 }

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -164,9 +164,6 @@ export default class DeltaChatController extends EventEmitter {
         logCoreEvent.warn(event, data1, data2)
       } else if (event === 'DC_EVENT_INFO') {
         logCoreEvent.info(event, data1, data2)
-      } else if (_event === C.DC_EVENT_ERROR_NETWORK) {
-        this.networkError = true
-        this.emit('update-network-status')
       } else if (event.startsWith('DC_EVENT_ERROR')) {
         this.emit('error', event, data1, data2)
         logCoreEvent.error(event, data1, data2)
@@ -174,22 +171,6 @@ export default class DeltaChatController extends EventEmitter {
         // in debug mode log all core events
         logCoreEvent.debug(event, data1, data2)
       }
-
-      // ugly hack to find out when the user goes online again:
-      if (
-        this.networkError &&
-        [
-          C.DC_EVENT_SMTP_CONNECTED,
-          C.DC_EVENT_IMAP_CONNECTED,
-          C.DC_EVENT_INCOMING_MSG,
-          C.DC_EVENT_MSG_DELIVERED,
-          C.DC_EVENT_IMAP_MESSAGE_MOVED,
-        ].includes(_event)
-      ) {
-        this.networkError = false
-        this.emit('update-network-status')
-      }
-
       this.sendToRenderer(event, [data1, data2])
     })
 

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -145,6 +145,11 @@ export default class DeltaChatController extends EventEmitter {
   // checkPassword(password: string) {
   //   return password === this.settings.getConfig('mail_pw')
   // }
+  networkError: boolean = false
+
+  getNetworkStatus(): boolean {
+    return !this.networkError
+  }
 
   registerEventHandler(dc: DeltaChat) {
     // in debug mode log all core events
@@ -159,12 +164,30 @@ export default class DeltaChatController extends EventEmitter {
         logCoreEvent.warn(event, data1, data2)
       } else if (event === 'DC_EVENT_INFO') {
         logCoreEvent.info(event, data1, data2)
+      } else if (_event === C.DC_EVENT_ERROR_NETWORK) {
+        this.networkError = true
+        this.emit('update-network-status')
       } else if (event.startsWith('DC_EVENT_ERROR')) {
         this.emit('error', event, data1, data2)
         logCoreEvent.error(event, data1, data2)
       } else if (app.rc['log-debug']) {
         // in debug mode log all core events
         logCoreEvent.debug(event, data1, data2)
+      }
+
+      // ugly hack to find out when the user goes online again:
+      if (
+        this.networkError &&
+        [
+          C.DC_EVENT_SMTP_CONNECTED,
+          C.DC_EVENT_IMAP_CONNECTED,
+          C.DC_EVENT_INCOMING_MSG,
+          C.DC_EVENT_MSG_DELIVERED,
+          C.DC_EVENT_IMAP_MESSAGE_MOVED,
+        ].includes(_event)
+      ) {
+        this.networkError = false
+        this.emit('update-network-status')
       }
 
       this.sendToRenderer(event, [data1, data2])

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -72,10 +72,6 @@ export function init(cwd: string, state: AppState, logHandler: LogHandler) {
 
   dcController.on('error', (error: any) => main.send('error', error))
 
-  dcController.on('update-network-status', () =>
-    main.send('update-network-status')
-  )
-
   dcController.on('DC_EVENT_LOGIN_FAILED', () =>
     main.send('error', 'Login failed!')
   )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -72,6 +72,10 @@ export function init(cwd: string, state: AppState, logHandler: LogHandler) {
 
   dcController.on('error', (error: any) => main.send('error', error))
 
+  dcController.on('update-network-status', () =>
+    main.send('update-network-status')
+  )
+
   dcController.on('DC_EVENT_LOGIN_FAILED', () =>
     main.send('error', 'Login failed!')
   )

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -92,7 +92,6 @@ export default class ScreenController extends Component {
   }
 
   async onNetworkChange(_event?: any) {
-    console.log(await DeltaBackend.call('getNetworkStatus'))
     this.setState({ online: await DeltaBackend.call('getNetworkStatus') })
   }
 

--- a/src/renderer/components/OfflineToast.tsx
+++ b/src/renderer/components/OfflineToast.tsx
@@ -1,0 +1,54 @@
+import React, { Component } from 'react'
+import { DeltaBackend } from '../delta-remote'
+import { ipcBackend } from '../ipc'
+
+export default class OfflineToast extends Component<
+  {},
+  { online: boolean; tryConnectCooldown: boolean }
+> {
+  constructor(props: any) {
+    super(props)
+    this.state = {
+      online: true,
+      tryConnectCooldown: true,
+    }
+
+    this.onNetworkChange = this.onNetworkChange.bind(this)
+    this.onNetworkChange()
+  }
+
+  componentDidMount() {
+    ipcBackend.on('update-network-status', this.onNetworkChange)
+  }
+
+  componentWillUnmount() {
+    ipcBackend.removeListener('update-network-status', this.onNetworkChange)
+  }
+
+  async onNetworkChange(_event?: any) {
+    this.setState({ online: await DeltaBackend.call('getNetworkStatus') })
+  }
+
+  render() {
+    return (
+      !this.state.online && (
+        <div className='no-network-toast'>
+          <b>Offline</b>
+          <div
+            onClick={() => {
+              this.setState({ tryConnectCooldown: false })
+              setTimeout(
+                () => this.setState({ tryConnectCooldown: true }),
+                15000
+              )
+              setTimeout(() => DeltaBackend.call('context.maybeNetwork'), 100)
+            }}
+            className={this.state.tryConnectCooldown ? '' : 'disabled'}
+          >
+            Try to connect now
+          </div>
+        </div>
+      )
+    )
+  }
+}

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -36,6 +36,7 @@ class DeltaRemote {
     timestamp: number
     id: number
   }>
+  call(fnName: 'getNetworkStatus'): Promise<boolean>
   // autocrypt ----------------------------------------------------------
   call(
     fnName: 'autocrypt.initiateKeyTransfer',


### PR DESCRIPTION
Move the network error into a persistent toast message:
![2020-05-14_05-45](https://user-images.githubusercontent.com/18725968/81890943-7ac48d00-95a7-11ea-98ca-2a87c9a8e155.png)

TODO:
- [ ] use language strings instead of hard-coded text
- [ ] move to seperate component  `<OfflineToast />`