### PR TITLE
Avoid react warning

### DIFF
--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -103,7 +103,7 @@ export const RenderMessage = React.memo(
         <div
           className='info-message'
           onContextMenu={onShowDetail}
-          custom-selectable
+          custom-selectable="true"
         >
           <p>{msg.text}</p>
         </div>


### PR DESCRIPTION
The warning says:
react-dom.development.js:530 Warning: Received `true` for a non-boolean attribute `custom-selectable`.

If you want to write it to the DOM, pass a string instead: custom-selectable="true" or custom-selectable={value.toString()}.
...