### PR TITLE
Improve usability of dark theme

### DIFF
--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -28,5 +28,11 @@ When using generic classnames like `date`, `avatar`, `username`, `error` make su
 
 ```
 
-This document is not final, feel free to ask questions and discuss this with us.
+## How do we do colors and theming
 
+We use css variables for theming, we use scss to generate them from a small set of base colors, see [THEMES.md](./THEMES.md) for more general information about theming.
+
+The scss vars should be named in snake-case (we still use camelCase for some variabels, but we decided to switch to snake-case, because electron/chromium doens't support css var autocompletion for camelCase)
+
+<br>
+This document is not final, feel free to ask questions and discuss this with us.

--- a/docs/STYLES.md
+++ b/docs/STYLES.md
@@ -13,19 +13,17 @@ Also make sure that global module-classes don't have a class name that is allrea
 When using generic classnames like `date`, `avatar`, `username`, `error` make sure to scope them in an component scss class.
 
 ```scss
-
 .metadata {
-    .date {
-        color: green;
-    }
-    .avatar {
-        background: url('profile.png');
-    }
-    .error {
-        color: red;
-    }
+  .date {
+    color: green;
+  }
+  .avatar {
+    background: url('profile.png');
+  }
+  .error {
+    color: red;
+  }
 }
-
 ```
 
 ## How do we do colors and theming

--- a/scss/_offline-toast.scss
+++ b/scss/_offline-toast.scss
@@ -13,7 +13,7 @@
 
   a {
     font-weight: bold;
-    color: black;
+    color: var(--globalText);
     &:hover {
       cursor: unset;
       text-decoration: unset;

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -80,8 +80,8 @@
       }
 
       .archived-label {
-        border: 1px solid #a5a5a5;
-        color: #3a3a3a;
+        border: 1px solid var(--chat-list-item-archived-label-border);
+        color: var(--chat-list-item-archived-label);
         border-radius: 2px;
         font-size: 11px;
         padding: 1px 4px;

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -68,7 +68,7 @@
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
-        color: #565656;
+        color: var(--chat-list-item-summary-text);
 
         & > .summary {
           float: left;
@@ -192,7 +192,7 @@
   width: 100%;
   font-weight: 200;
   text-align: center;
-  color: #565656;
+  color: var(--chat-list-item-summary-text);
 }
 
 .chat-list-item.is-deaddrop {

--- a/scss/dialogs/_about.scss
+++ b/scss/dialogs/_about.scss
@@ -18,6 +18,6 @@
   }
 
   tr:nth-child(odd) {
-    background-color: #ececec;
+    background-color: var(--bp3DialogBgSecondary);
   }
 }

--- a/scss/dialogs/_autocrypt_setup.scss
+++ b/scss/dialogs/_autocrypt_setup.scss
@@ -10,10 +10,19 @@
     .bp3-input {
       width: 66%;
       float: left;
+      border: 1px solid var(--globalText);
+      box-shadow: none;
+    }
+
+    .bp3-input:focus {
+      border-color: var(--bp3-input-focused);
     }
 
     .bp3-input:disabled {
       cursor: text;
+      color: inherit;
+      background: inherit;
+      border: none;
     }
 
     & > .seperator {

--- a/scss/dialogs/_delta-dialog.scss
+++ b/scss/dialogs/_delta-dialog.scss
@@ -26,19 +26,17 @@
       padding-left: 15px;
       /* text-align: center; */
       font-weight: 200;
-      color: #56565682;
-      background: var(--bp3DialogBgSecondary);
-      box-shadow: inset 0px 2px 0 0px rgba(24, 33, 39, 0.14),
-        0px 1px 0 0px rgba(24, 33, 39, 0.18);
+      color: var(--delta-dialog-seperator-text);
+      background: var(--delta-dialog-seperator);
       margin-bottom: 1px;
     }
 
-    .delta-dialog-content-seperator {
-      height: 10px;
-      background: var(--bp3DialogBgSecondary);
-      box-shadow: inset 0px 2px 0 0px rgba(24, 33, 39, 0.14),
-        0px 1px 0 0px rgba(24, 33, 39, 0.18);
-    }
+    // .delta-dialog-content-seperator {
+    //   height: 10px;
+    //   background: var(--delta-dialog-seperator);
+    //   box-shadow: inset 0px 2px 0 0px rgba(24, 33, 39, 0.14),
+    //     0px 1px 0 0px rgba(24, 33, 39, 0.18);
+    // }
 
     .delta-dialog-button {
       color: var(--colorPrimary);

--- a/scss/dialogs/_settings.scss
+++ b/scss/dialogs/_settings.scss
@@ -117,6 +117,7 @@
 
     text-align: center;
     line-height: 40px;
+    color: var(--globalText);
   }
 }
 
@@ -142,6 +143,7 @@
 
     text-align: center;
     line-height: 40px;
+    color: var(--globalText);
   }
 
   .CurrentValue {

--- a/scss/overwrites/_bp3-overwrites.scss
+++ b/scss/overwrites/_bp3-overwrites.scss
@@ -150,12 +150,7 @@ $bp3-dialog-radius: 2px;
 
 .bp3-control .bp3-control-indicator,
 .bp3-control:hover .bp3-control-indicator {
-  background-color: transparent;
-  background-image: linear-gradient(
-    to bottom,
-    var(--bp3SelectorTop),
-    var(--bp3SelectorBottom)
-  );
+  background: var(--bp3-control-indicator-color);
 }
 
 .bp3-control input:checked ~ .bp3-control-indicator,

--- a/src/renderer/components/dialogs/DeltaDialog.tsx
+++ b/src/renderer/components/dialogs/DeltaDialog.tsx
@@ -241,11 +241,12 @@ export function DeltaDialogContentTextSeperator(props: { text: string }) {
   return <div className='delta-dialog-content-text-seperator'>{props.text}</div>
 }
 
-export function DeltaDialogContentSeperator(props: {
-  style?: React.CSSProperties
-}) {
-  return <div style={props.style} className='delta-dialog-content-seperator' />
-}
+// unused - info: scss class is also comented out
+// export function DeltaDialogContentSeperator(props: {
+//   style?: React.CSSProperties
+// }) {
+//   return <div style={props.style} className='delta-dialog-content-seperator' />
+// }
 
 export function DeltaDialogButton(
   props: React.PropsWithChildren<{ onClick: () => void }>

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -102,6 +102,7 @@ $hover-contrast-change: 2%;
   --bp3InputText: #{$textPrimary};
   --bp3InputBg: #{$bgPrimary};
   --bp3InputPlaceholder: lightgray;
+  --bp3-input-focused: #{$colorPrimary};
   --bp3MenuText: #{$textPrimary};
   --bp3MenuBg: #{$bgPrimary};
   --bp3Switch: #7a8084;

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -118,6 +118,8 @@ $hover-contrast-change: 2%;
   --bp3SelectorBottom: rgba(255, 255, 255, 0);
   --outlineProperties: 1px solid transparent;
   --outlineColor: #{$outlineColor};
+  --delta-dialog-seperator: #{$bgSecondary};
+  --delta-dialog-seperator-text: #{changeContrast($bgSecondary, 24%)};
   /* EmojiMart overwrites */
   --emojiMartText: #{$textPrimary};
   --emojiMartBorder: #{$outlineColor};

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -50,6 +50,8 @@ $hover-contrast-change: 2%;
       15% + $hover-contrast-change
     )};
   --chat-list-item-summary-text: #{changeContrast($textPrimary, 33%)};
+  --chat-list-item-archived-label: #{changeContrast($textPrimary, 20%)};
+  --chat-list-item-archived-label-border: #{changeContrast($textPrimary, 33%)};
   /* Message Bubble */
   --messageText: #{$textPrimary};
   --messageTextLink: #{$textPrimary};

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -117,6 +117,7 @@ $hover-contrast-change: 2%;
   --bp3SpinnerHead: #42a5f5;
   --bp3SelectorTop: rgba(255, 255, 255, 0.8);
   --bp3SelectorBottom: rgba(255, 255, 255, 0);
+  --bp3-control-indicator-color: #{rgba($textPrimary, 0.08)};
   --outlineProperties: 1px solid transparent;
   --outlineColor: #{$outlineColor};
   --delta-dialog-seperator: #{$bgSecondary};

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -8,7 +8,6 @@ $hover-contrast-change: 2%;
   }
 }
 
-// generated
 :root {
   --colorPrimary: #{$colorPrimary};
   --colorDanger: #{$colorDanger};

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -49,6 +49,7 @@ $hover-contrast-change: 2%;
       $bgPrimary,
       15% + $hover-contrast-change
     )};
+  --chat-list-item-summary-text: #{changeContrast($textPrimary, 33%)};
   /* Message Bubble */
   --messageText: #{$textPrimary};
   --messageTextLink: #{$textPrimary};

--- a/themes/dark.scss
+++ b/themes/dark.scss
@@ -4,7 +4,7 @@
 }
 
 /* Set theme variables used for theme Generation */
-$outlineColor: #b9b9b9;
+$outlineColor: #505050;
 $accentColor: #2090ea;
 $bgChatView: #19232b;
 $bgImage: url('../images/background_dark.svg');
@@ -29,7 +29,6 @@ $scrollbarTransparency: 0.34;
 
 /* overwrite themedata */
 :root {
-  --chatListItemBgPinned: #272727;
 }
 
 /* overwrite css */

--- a/themes/dark_amoled.scss
+++ b/themes/dark_amoled.scss
@@ -15,7 +15,7 @@ $bgSecondary: #222;
 $colorDanger: #f96856;
 $colorNone: #a0a0a0;
 $colorPrimary: #42a5f5;
-$outlineColor: #b9b9b9;
+$outlineColor: #272727;
 $ovalButtonBg: darkgreen;
 $ovalButtonText: #fff;
 $scrollbarTransparency: 0.45;
@@ -30,9 +30,6 @@ $textSecondary: #ddd;
 :root {
   --bp3SelectorBottom: rgba(80, 80, 80, 0.6);
   --bp3SelectorTop: rgba(80, 80, 80, 0.8);
-  --chatListItemBgPinned: #222222;
-  --outlineColor: #505050;
-  --outlineProperties: 1px solid #202020;
 }
 
 /* overwrite css */

--- a/themes/darkpurple.scss
+++ b/themes/darkpurple.scss
@@ -15,7 +15,7 @@ $bgSecondary: #333444;
 $colorDanger: #f96856;
 $colorNone: #a0a0a0;
 $colorPrimary: #42a5f5;
-$outlineColor: #b9b9b9;
+$outlineColor: #505050;
 $ovalButtonBg: darkgreen;
 $ovalButtonText: #fff;
 $scrollbarTransparency: 0.34;

--- a/themes/light.scss
+++ b/themes/light.scss
@@ -33,7 +33,6 @@ $scrollbarTransparency: 0.5;
   --scrollbarThumbHover: #606060;
   --bp3DialogBgSecondary: #ececec;
   --chatListItemBgHover: rgb(242, 242, 242);
-  //--chatListItemBgPinned: #eeeeee;
 }
 
 /* overwrite css */


### PR DESCRIPTION
tweaks theming with an strong focus on making the dark theme usable (avoid black text on dark background for example)

also adds information about css var naming to the docs (prefer snake-case from now on, because electron will give auto completion for css-vars with snake-case which makes it more fun to play with in the dev-console)