### PR TITLE
send a suggestion to update after 90 days

### DIFF
--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -21,6 +21,9 @@ import { ExtendedAppMainProcess } from '../types'
 import Extras from './extras'
 import { EventId2EventName as eventStrings } from 'deltachat-node/dist/constants'
 
+import { VERSION, BUILD_TIMESTAMP } from '../../shared/build-info'
+import { Timespans, DAYS_UNTIL_UPDATE_SUGGESTION } from '../../shared/constants'
+
 const app = rawApp as ExtendedAppMainProcess
 const log = getLogger('main/deltachat')
 const logCoreEvent = getLogger('core/event')
@@ -50,6 +53,11 @@ export default class DeltaChatController extends EventEmitter {
   constructor(public cwd: string) {
     super()
     this._resetState()
+    setInterval(
+      // If the dc is allways on
+      this.hintUpdateIfNessesary.bind(this),
+      Timespans.ONE_DAY_IN_SECONDS * 1000
+    )
   }
 
   readonly autocrypt = new DCAutocrypt(this)
@@ -337,6 +345,20 @@ export default class DeltaChatController extends EventEmitter {
 
   getProviderInfo(email: string) {
     return DeltaChatNode.getProviderFromEmail(email)
+  }
+
+  hintUpdateIfNessesary() {
+    if (
+      this._dc &&
+      Date.now() >
+        Timespans.ONE_DAY_IN_SECONDS * DAYS_UNTIL_UPDATE_SUGGESTION * 1000 +
+          BUILD_TIMESTAMP
+    ) {
+      this._dc.addDeviceMessage(
+        `update-suggestion-${VERSION}`,
+        `This build is over ${DAYS_UNTIL_UPDATE_SUGGESTION} days old - There might be a new version availible. -> https://get.delta.chat`
+      )
+    }
   }
 
   /**

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -116,6 +116,7 @@ export default class DCLoginController extends SplitOut {
 
   updateDeviceChats() {
     this._dc.updateDeviceChats()
+    this._controller.hintUpdateIfNessesary()
     this._dc.addDeviceMessage(
       'changelog-version-1.3.0-1',
       `Changes in v1.3.0

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -33,3 +33,5 @@ export const enum AutodeleteDuration {
   FOUR_WEEKS = Timespans.FOUR_WEEKS_IN_SECONDS,
   ONE_YEAR = Timespans.ONE_YEAR_IN_SECONDS,
 }
+
+export const DAYS_UNTIL_UPDATE_SUGGESTION = 90


### PR DESCRIPTION
This reminds people to update without requiring any server contact, it assumes that our release rate is smaller than 90days.

This feature is still being discussed in the forum and the general plan is to eventually implement it in the core instead, because this is useful for all platforms.

Forum Topic: https://support.delta.chat/t/update-availible-message-after-x-day/909