### PR TITLE
Add runtime.ts and crash screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - add Login migration upgrade info
 - add git rev to the version in the about dialog
 - Oportunistic reminder to update after 90days
+- Add a crash-screen that appears instead of the white-screen on a react crash.
 
 ### Fixed
 
@@ -41,6 +42,7 @@ This section is only relevant to contributors.
 - Refactor Keybindings
 - Split Build script into smaller build scripts.
 - replace `node-sass` with `sass` to remove the native dependency
+- introduce `runtime.ts` as a place to collect electron specific functions (will replace `renderer/ipc.ts`)
 
 ### Updates
 
@@ -382,8 +384,7 @@ This section is only relevant to contributors.
 - [**@adbenitez**](https://github.com/adbenitez) fixed some types
 - Thanks to our translators
 
-
-- Update deltachat-node to 1.0.0-beta.15
+* Update deltachat-node to 1.0.0-beta.15
   - upgrade core [1.0.0-beta.15](https://github.com/deltachat/deltachat-core-rust/blob/master/CHANGELOG.md#100-beta15)
 
 ## [0.840.0] - 2019-11-05
@@ -1038,39 +1039,21 @@ This section is only relevant to contributors.
 - Make sure `Float on Top` menu item stays checked/unchecked when language is changed ([**@ralphtheninja**](https://github.com/ralphtheninja))
 
 [0.999.1]: https://github.com/deltachat/deltachat-desktop/compare/v0.999.0...v0.999.1
-
 [0.999.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.901.0...v0.999.0
-
 [0.901.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.900.0...v0.901.0
-
 [0.900.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.840.0...v0.900.0
-
 [0.840.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.201.0...v0.840.0
-
 [0.201.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.104.0...v0.201.0
-
 [0.200.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.104.0...v0.200.0
-
 [0.104.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.103.0...v0.104.0
-
 [0.103.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.102.0...v0.103.0
-
 [0.102.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.101.0...v0.102.0
-
 [0.101.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.100.0...v0.101.0
-
 [0.100.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.99.0...v0.100.0
-
 [0.99.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.98.2...v0.99.0
-
 [0.98.2]: https://github.com/deltachat/deltachat-desktop/compare/v0.98.1...v0.98.2
-
 [0.98.1]: https://github.com/deltachat/deltachat-desktop/compare/v0.98.0...v0.98.1
-
 [0.98.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.97.0...v0.98.0
-
 [0.97.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.96.0...v0.97.0
-
 [0.96.0]: https://github.com/deltachat/deltachat-desktop/compare/v0.90.1...v0.96.0
-
 [0.90.1]: https://github.com/deltachat/deltachat-desktop/compare/5a94d4e...v0.90.1

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -183,3 +183,18 @@ code {
     background-color: unset;
   }
 }
+
+.crash-screen {
+  padding: 10px;
+
+  h1,
+  h2,
+  code {
+    user-select: text;
+  }
+
+  code {
+    background-color: rgba(177, 10, 10, 0.25);
+    padding: 10px;
+  }
+}

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -189,12 +189,23 @@ code {
 
   h1,
   h2,
-  code {
+  code,
+  pre {
     user-select: text;
   }
 
-  code {
+  p {
+    margin-top: 20px;
+  }
+
+  pre.error-details {
     background-color: rgba(177, 10, 10, 0.25);
     padding: 10px;
+    overflow-x: scroll;
+    font-family: monospace;
+  }
+
+  code {
+    background-color: none;
   }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -289,6 +289,14 @@ export function init(cwd: string, state: AppState, logHandler: LogHandler) {
     await openHelpWindow(locale)
   })
 
+  ipcMain.on('reload-main-window', () => {
+    mainWindow.window.webContents.reload()
+  })
+
+  ipcMain.on('get-log-path', ev => {
+    ev.returnValue = logHandler.logFilePath()
+  })
+
   function sendStateToRenderer() {
     log.debug('RENDER')
     const deltachat = dcController.getState()

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -15,6 +15,7 @@ import { ThemeManager } from './ThemeManager'
 
 const log = getLogger('renderer/App')
 import moment from 'moment'
+import { CrashScreen } from './components/CrashScreen'
 
 addLocaleData(enLocaleData)
 
@@ -98,10 +99,12 @@ export default function App(props: any) {
 
   if (!localeData) return null
   return (
-    <SettingsContext.Provider value={state.saved}>
-      <IntlProvider locale={localeData.locale}>
-        <ScreenController logins={state.logins} deltachat={state.deltachat} />
-      </IntlProvider>
-    </SettingsContext.Provider>
+    <CrashScreen>
+      <SettingsContext.Provider value={state.saved}>
+        <IntlProvider locale={localeData.locale}>
+          <ScreenController logins={state.logins} deltachat={state.deltachat} />
+        </IntlProvider>
+      </SettingsContext.Provider>
+    </CrashScreen>
   )
 }

--- a/src/renderer/components/CrashScreen.tsx
+++ b/src/renderer/components/CrashScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { runtime } from '../runtime'
+import { VERSION, GIT_REF } from '../../shared/build-info'
 export class CrashScreen extends React.Component {
   state = {
     hasError: false,
@@ -54,6 +55,9 @@ export class CrashScreen extends React.Component {
             <a href='#' onClick={_ => runtime.openLogFile()}>
               {runtime.getCurrentLogLocation()}
             </a>
+          </p>
+          <p>
+            DeltaChat Version: {VERSION} (git: {GIT_REF})
           </p>
         </div>
       )

--- a/src/renderer/components/CrashScreen.tsx
+++ b/src/renderer/components/CrashScreen.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+export class CrashScreen extends React.Component {
+  state = {
+    hasError: false,
+    error: null as any,
+  }
+
+  componentDidCatch(error: any) {
+    console.log(error)
+    this.setState({ hasError: true, error })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className='crash-screen'>
+          <h1>Ooops something crashed</h1>
+          <h2>
+            Please restart Deltachat, if this problem persists please notify the
+            developers on github issues
+            (https://github.com/deltachat/deltachat-desktop/issues)
+          </h2>
+          <code>{JSON.stringify(this.state.error)}</code>
+        </div>
+      )
+    } else {
+      return this.props.children
+    }
+  }
+}

--- a/src/renderer/components/CrashScreen.tsx
+++ b/src/renderer/components/CrashScreen.tsx
@@ -1,13 +1,25 @@
 import React from 'react'
+import { runtime } from '../runtime'
 export class CrashScreen extends React.Component {
   state = {
     hasError: false,
-    error: null as any,
+    error: '',
   }
 
   componentDidCatch(error: any) {
-    console.log(error)
-    this.setState({ hasError: true, error })
+    this.setState({
+      hasError: true,
+      error: this.errorToText(error),
+    })
+  }
+
+  errorToText(error: any) {
+    if (error instanceof Error) {
+      // TODO parse the stack and map the sourcemap to provide a usefull stacktrace
+      return error.stack.replace(/file:\/\/\/[\w\W]+?\/html-dist\//g, '')
+    } else {
+      return JSON.stringify(error)
+    }
   }
 
   render() {
@@ -17,10 +29,32 @@ export class CrashScreen extends React.Component {
           <h1>Ooops something crashed</h1>
           <h2>
             Please restart Deltachat, if this problem persists please notify the
-            developers on github issues
-            (https://github.com/deltachat/deltachat-desktop/issues)
+            developers on github issues (
+            <a
+              href='#'
+              onClick={_ =>
+                runtime.openLink(
+                  'https://github.com/deltachat/deltachat-desktop/issues'
+                )
+              }
+            >
+              github.com/deltachat/deltachat-desktop/issues
+            </a>
+            )
           </h2>
-          <code>{JSON.stringify(this.state.error)}</code>
+          <p>
+            <button onClick={_ => runtime.reloadWebContent()}>Reload</button>
+            <button onClick={_ => runtime.openLogFile()}>Open Logfile</button>
+          </p>
+          <p>
+            <pre className='error-details'>{this.state.error}</pre>
+          </p>
+          <p>
+            Full Log under{' '}
+            <a href='#' onClick={_ => runtime.openLogFile()}>
+              {runtime.getCurrentLogLocation()}
+            </a>
+          </p>
         </div>
       )
     } else {

--- a/src/renderer/components/Menu.tsx
+++ b/src/renderer/components/Menu.tsx
@@ -1,6 +1,5 @@
 import { C } from 'deltachat-node/dist/constants'
 import React, { useContext } from 'react'
-import { openHelp } from '../ipc'
 import { DeltaBackend } from '../delta-remote'
 import { ScreenContext } from '../contexts'
 import { useChatStore } from '../stores/chat'
@@ -15,6 +14,7 @@ import {
   unMuteChat,
 } from './helpers/ChatMethods'
 import { FullChat } from '../../shared/shared-types'
+import { runtime } from '../runtime'
 const { ipcRenderer } = window.electron_functions
 
 export function DeltaMenuItem({
@@ -171,7 +171,11 @@ export default function DeltaMenu(props: { selectedChat: FullChat }) {
         text={tx('pref_blocked_contacts')}
         onClick={onUnblockContacts}
       />
-      <DeltaMenuItem key='help' text={tx('menu_help')} onClick={openHelp} />
+      <DeltaMenuItem
+        key='help'
+        text={tx('menu_help')}
+        onClick={_ => runtime.openHelpWindow()}
+      />
       <DeltaMenuItem
         key='logout'
         text={tx('switch_account')}

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -66,9 +66,7 @@ export function _callDcMethodAsync(
   return new Promise((resolve, reject) => callDcMethod(fnName, args, resolve))
 }
 
-export function mainProcessUpdateBadge() {
-  ipcRenderer.send('update-badge')
-}
+// move this part to the deltachat backend / deltachatcontroller
 
 export function saveLastChatId(chatId: number) {
   ipcRenderer.send('saveLastChatId', chatId)
@@ -81,8 +79,4 @@ export function getLastSelectedChatId() {
   return ipcRenderer.sendSync('getLastSelectedChatId')
 }
 
-export function openHelp() {
-  ipcRenderer.send('help', window.localeData.locale)
-}
-
-ipcRenderer.on('showHelpDialog', openHelp)
+// end-move

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,19 +1,14 @@
-const { ipcRenderer, remote } = window.electron_functions
-
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { ExtendedApp } from '../shared/shared-types'
 import { exp } from './experimental'
-import { setLogHandler, printProcessLogLevelInfo } from '../shared/logger'
+import { printProcessLogLevelInfo } from '../shared/logger'
 
 import App from './App'
+import { runtime } from './runtime'
 
 function main() {
   exp.help //make sure experimental.ts is used
-  setLogHandler(
-    (...args: any[]) => ipcRenderer.send('handleLogMessage', ...args),
-    (remote.app as ExtendedApp).rc
-  )
+  runtime.initialize()
   printProcessLogLevelInfo()
 
   ReactDOM.render(<App />, document.querySelector('#root'))

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -1,0 +1,94 @@
+import { ipcBackend } from './ipc'
+import { RC_Config, ExtendedApp } from '../shared/shared-types'
+import { setLogHandler } from '../shared/logger'
+
+const { remote, openExternal, openItem } = window.electron_functions
+
+/**
+ * Offers an abstaction Layer to make it easier to make browser client in the future
+ */
+interface Runtime {
+  /**
+   * initializes runtime stuff
+   * - sets the LogHandler
+   * - event listeners on runtime events
+   */
+  initialize(): void
+  reloadWebContent(): void
+  openLogFile(): void
+  getCurrentLogLocation(): string
+  openHelpWindow(): void
+  updateBadge(): void
+  /**
+   * get the comandline arguments
+   */
+  getRC_Config(): RC_Config
+  /**
+   * Opens a link in a new Window or in the Browser
+   * @param link
+   */
+  openLink(link: string): void
+}
+
+class Browser implements Runtime {
+  openLink(link: string): void {
+    throw new Error('Method not implemented.')
+  }
+  initialize(): void {
+    throw new Error('Method not implemented.')
+  }
+  getRC_Config(): RC_Config {
+    throw new Error('Method not implemented.')
+  }
+  updateBadge(): void {
+    throw new Error('Method not implemented.')
+  }
+  openHelpWindow(): void {
+    throw new Error('Method not implemented.')
+  }
+  openLogFile(): void {
+    throw new Error('Method not implemented.')
+  }
+  getCurrentLogLocation(): string {
+    return 'not implemented.'
+  }
+  reloadWebContent(): void {
+    window.location.reload()
+  }
+}
+
+class Electron implements Runtime {
+  openLink(link: string): void {
+    openExternal(link)
+  }
+  getRC_Config(): RC_Config {
+    return (remote.app as ExtendedApp).rc
+  }
+  initialize() {
+    setLogHandler(
+      (...args: any[]) => ipcBackend.send('handleLogMessage', ...args),
+      this.getRC_Config()
+    )
+    ipcBackend.on('showHelpDialog', this.openHelpWindow)
+  }
+  openHelpWindow(): void {
+    ipcBackend.send('help', window.localeData.locale)
+  }
+  openLogFile(): void {
+    openItem(this.getCurrentLogLocation())
+  }
+  getCurrentLogLocation(): string {
+    return ipcBackend.sendSync('get-log-path')
+  }
+  reloadWebContent(): void {
+    ipcBackend.send('reload-main-window')
+  }
+  updateBadge() {
+    ipcBackend.send('update-badge')
+  }
+}
+
+export const runtime: Runtime = true /* is electron */
+  ? new Electron()
+  : new Browser()
+;(window as any).r = runtime

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -1,7 +1,8 @@
-import { ipcBackend, mainProcessUpdateBadge, saveLastChatId } from '../ipc'
+import { ipcBackend, saveLastChatId } from '../ipc'
 import { Store, useStore, Action } from './store'
 import { JsonContact, FullChat, MessageType } from '../../shared/shared-types'
 import { DeltaBackend } from '../delta-remote'
+import { runtime } from '../runtime'
 
 export const PAGE_SIZE = 10
 
@@ -174,7 +175,7 @@ chatStore.attachEffect(async ({ type, payload }, state) => {
         scrollToBottom: true,
       },
     })
-    mainProcessUpdateBadge()
+    runtime.updateBadge()
     saveLastChatId(chatId)
   } else if (type === 'UI_DELETE_MESSAGE') {
     const msgId = payload


### PR DESCRIPTION
### Introducing Runtime.ts

An interface that abstracts the electron functions.
This way we'll just need to implement one interface for new runtimes such as a Browser runtime.
In the long term this file will replace `src/renderer/ipc.ts`.

https://github.com/deltachat/deltachat-desktop/blob/add_runtime.ts_and_crash_screen/src/renderer/runtime.ts

### Crash screen
Adding a crash screen in the place of the white-screen crash.
![2020-06-04_17-04](https://user-images.githubusercontent.com/18725968/83774862-8ecf4c00-a686-11ea-94e4-627a77f568e5.png)
