### PR TITLE
Move download btn to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Tweak Login styling
 - move qr code description up
 - Tweak: Less cursor type switching
+- Improve styling of Fullscreen-Attachment buttons
 
 ### Technical
 

--- a/scss/gallery/_attachment-view.scss
+++ b/scss/gallery/_attachment-view.scss
@@ -29,18 +29,29 @@
     float: right;
     position: absolute;
     z-index: 10;
-    cursor: pointer;
-  }
+    background-color: rgba(0, 0, 0, 0.75);
+    border-radius: 3px;
 
-  .download-btn {
-    height: 32px;
-    width: 32px;
-    display: inline-block;
-    vertical-align: text-bottom;
-    @include color-svg('../images/download.svg', var(--messageButtons));
+    right: 8px;
+    top: 6px;
+    padding: 5px;
 
-    &:hover {
-      background-color: var(--messageButtons);
+    .download-btn {
+      height: 32px;
+      width: 32px;
+      display: inline-block;
+      vertical-align: text-bottom;
+      @include color-svg('../images/download.svg', var(--messageButtons));
+
+      &:hover {
+        background-color: var(--messageButtons);
+      }
+      cursor: pointer;
+      margin-right: 5px;
+    }
+
+    .bp3-icon-cross {
+      cursor: pointer;
     }
   }
 }

--- a/scss/gallery/_attachment-view.scss
+++ b/scss/gallery/_attachment-view.scss
@@ -33,9 +33,10 @@
   }
 
   .download-btn {
-    height: 36px;
-    width: 36px;
+    height: 32px;
+    width: 32px;
     display: inline-block;
+    vertical-align: text-bottom;
     @include color-svg('../images/download.svg', var(--messageButtons));
 
     &:hover {

--- a/src/renderer/components/dialogs/FullscreenMedia.tsx
+++ b/src/renderer/components/dialogs/FullscreenMedia.tsx
@@ -42,6 +42,12 @@ export default function FullscreenMedia(props: {
       <div className='render-media-wrapper'>
         {elm && (
           <div className='btn-wrapper' style={{ right: '5px' }}>
+            <div
+              role='button'
+              onClick={onDownload.bind(null, msg)}
+              className='download-btn'
+              aria-label={tx('save')}
+            />
             <Icon
               onClick={onClose}
               icon='cross'
@@ -52,14 +58,6 @@ export default function FullscreenMedia(props: {
           </div>
         )}
         <div className='attachment-view'>{elm}</div>
-        <div className='btn-wrapper' style={{ right: 0, bottom: 0 }}>
-          <div
-            role='button'
-            onClick={onDownload.bind(null, msg)}
-            className='download-btn'
-            aria-label={tx('save')}
-          />
-        </div>
       </div>
     </Overlay>
   )

--- a/src/renderer/components/dialogs/FullscreenMedia.tsx
+++ b/src/renderer/components/dialogs/FullscreenMedia.tsx
@@ -41,7 +41,7 @@ export default function FullscreenMedia(props: {
     >
       <div className='render-media-wrapper'>
         {elm && (
-          <div className='btn-wrapper' style={{ right: '5px' }}>
+          <div className='btn-wrapper'>
             <div
               role='button'
               onClick={onDownload.bind(null, msg)}

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -113,7 +113,7 @@ export default function ViewProfile(props: {
                   },
                 })
               }}
-              style={{ cursor: 'pointer' }}
+              style={{ cursor: contact.profileImage ? 'pointer' : 'default' }}
             >
               <ProfileInfoAvatar contact={contact} />
             </div>


### PR DESCRIPTION
move download button in fullscreen media view to top and improve its styling a bit.
![2020-06-05_14-10](https://user-images.githubusercontent.com/18725968/83877076-322d6900-a73a-11ea-8e74-eddd3286eef8.png)
