### PR TITLE
Change accounts folder structure again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 - move qr code description up
 - Tweak: Less cursor type switching
 - Improve styling of Fullscreen-Attachment buttons
+- now it is possible to have multiple accounts with the same email address (you can import a backup next to the active account)
+- change account path again - now the account folder name isn't tied to the email address anymore.
 
 ### Technical
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,9 +1,3 @@
 # Upgrade Guide
 
 This document describes breaking changes and how to upgrade. For a complete list of changes including minor and patch releases, please refer to the [changelog](CHANGELOG.md).
-
-## v1.4 up
-
-If you experience startup problems make sure you don't have two account folders of the same account.\
-This could happen if you duplicated an account folder for backup purposes, for example.
-If you did not modify the account folders please open an issue on github.

--- a/src/main/deltachat/backup.ts
+++ b/src/main/deltachat/backup.ts
@@ -80,7 +80,7 @@ export default class DCBackup extends SplitOut {
 
         sendToRenderer('DD_EVENT_IMPORT_PROGRESS', 600)
 
-        const newPath = getNewAccountPath(addr)
+        const newPath = getNewAccountPath()
         const configFolderExists = await fs.pathExists(newPath)
 
         if (configFolderExists) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -57,7 +57,7 @@ import { init as initMenu } from './menu'
 import State from './state'
 import * as mainWindow from './windows/main'
 import * as devTools from './devtools'
-import { AppState } from '../shared/shared-types'
+import { AppState, DeltaChatAccount } from '../shared/shared-types'
 import { ExtendedAppMainProcess } from './types'
 import { resolveThemeAddress, acceptThemeCLI } from './themes'
 
@@ -77,10 +77,7 @@ Promise.all([
   })
 
 function onReady([logins, _appReady, loadedState]: [
-  {
-    path: string
-    addr: string
-  }[],
+  DeltaChatAccount[],
   any,
   AppState
 ]) {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -124,7 +124,7 @@ export function init(cwd: string, state: AppState, logHandler: LogHandler) {
   ipcMain.on('login', (_e: any, credentials) => {
     CatchError2Event(() =>
       dcController.loginController.login(
-        getNewAccountPath(credentials.addr),
+        getNewAccountPath(),
         credentials,
         sendStateToRenderer,
         txCoreStrings()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3,17 +3,17 @@ import { app as rawApp, dialog, ipcMain, shell } from 'electron'
 import { copy, copyFile, emptyDir, ensureDir, pathExists } from 'fs-extra'
 import { extname, join, relative } from 'path'
 import { getLogger } from '../shared/logger'
-import { AppState, Credentials, LocalSettings } from '../shared/shared-types'
+import {
+  AppState,
+  Credentials,
+  LocalSettings,
+  DeltaChatAccount,
+} from '../shared/shared-types'
 import { getConfigPath, getLogsPath } from './application-constants'
 import { credential_config } from './deltachat/login'
 import loadTranslations from './load-translations'
 import { LogHandler } from './log-handler'
-import {
-  DeltaChatAccount,
-  getLogins,
-  getNewAccountPath,
-  removeAccount,
-} from './logins'
+import { getLogins, getNewAccountPath, removeAccount } from './logins'
 import { init as refreshMenu } from './menu'
 import { ExtendedAppMainProcess } from './types'
 import * as mainWindow from './windows/main'

--- a/src/main/logins.ts
+++ b/src/main/logins.ts
@@ -5,7 +5,7 @@ import * as binding from 'deltachat-node/binding'
 import { getLogger } from '../shared/logger'
 const log = getLogger('main/find_logins')
 import { getAccountsPath, getConfigPath } from './application-constants'
-import { PromiseType } from '../shared/shared-types'
+import { DeltaChatAccount } from '../shared/shared-types'
 
 export async function getLogins() {
   // search for old accounts and convert them
@@ -37,7 +37,7 @@ async function migrate(dir: string) {
   }
 }
 
-async function getAccountInfo(path: string) {
+async function getAccountInfo(path: string): Promise<DeltaChatAccount> {
   try {
     const config = await getConfig(path, ['addr', 'displayname'])
     if (typeof config.addr !== 'string') {
@@ -56,8 +56,6 @@ async function getAccountInfo(path: string) {
     return null
   }
 }
-
-export type DeltaChatAccount = PromiseType<ReturnType<typeof getAccountInfo>>
 
 async function readDeltaAccounts(accountFolderPath: string) {
   const paths = (await fs.readdir(accountFolderPath)).map(filename =>
@@ -85,8 +83,6 @@ function getConfig(
     const db = dir.endsWith('db.sqlite') ? dir : join(dir, 'db.sqlite')
 
     binding.dcn_open(dcn_context, db, '', (err: any) => {
-      console.log('opened')
-
       if (err) {
         console.log(err)
         binding.dcn_close(dcn_context, () => {})
@@ -100,7 +96,6 @@ function getConfig(
           result[key] = binding.dcn_get_config(dcn_context, key)
         })
       }
-      console.log('result', result, dcn_context)
       binding.dcn_close(dcn_context, () => {})
       resolve(result)
     })
@@ -139,7 +134,6 @@ export function getNewAccountPath() {
     join(getAccountsPath(), 'ac' + String(num))
 
   while (fs.pathExistsSync(constructName(init_count))) {
-    console.log(init_count)
     init_count++
   }
 

--- a/src/main/logins.ts
+++ b/src/main/logins.ts
@@ -84,7 +84,7 @@ function getConfig(
 
     binding.dcn_open(dcn_context, db, '', (err: any) => {
       if (err) {
-        console.log(err)
+        log.error('getConfig', err)
         binding.dcn_close(dcn_context, () => {})
         reject(err)
       }

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -1,4 +1,4 @@
-import { Login, AppState } from '../shared/shared-types'
+import { AppState, DeltaChatAccount } from '../shared/shared-types'
 
 import React from 'react'
 import { Component, createRef } from 'react'
@@ -31,7 +31,10 @@ export default class ScreenController extends Component {
   onShowAbout: any
 
   constructor(
-    public props: { logins: Login[]; deltachat: AppState['deltachat'] }
+    public props: {
+      logins: DeltaChatAccount[]
+      deltachat: AppState['deltachat']
+    }
   ) {
     super(props)
     this.state = {

--- a/src/renderer/components/LoginScreen.tsx
+++ b/src/renderer/components/LoginScreen.tsx
@@ -16,14 +16,11 @@ import { DeltaProgressBar } from './Login-Styles'
 import { getLogger } from '../../shared/logger'
 import { ScreenContext } from '../contexts'
 import DeltaDialog from './dialogs/DeltaDialog'
+import { DeltaChatAccount } from '../../shared/shared-types'
 const { remote } = window.electron_functions
+import filesizeConverter from 'filesize'
 
 const log = getLogger('renderer/components/LoginScreen')
-
-type DeltaChatAccount = {
-  path: string
-  addr: string
-}
 
 const ImportDialogContent = React.memo(function ImportDialogContent(props: {
   onClose: (ev: React.SyntheticEvent) => void
@@ -200,7 +197,8 @@ export default function LoginScreen(props: {
                     onClick={() => onClickLoadAccount(login)}
                     title={login.path}
                   >
-                    {login.addr}
+                    {login.displayname} {login.addr} [
+                    {filesizeConverter(login.size)}]
                   </Button>
                   <Button
                     intent={Intent.DANGER}

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -1,10 +1,5 @@
 type PromiseType<T> = T extends Promise<infer U> ? U : any
 
-export interface Login {
-  addr: string
-  path: string
-}
-
 export interface Credentials {
   addr: string
 }
@@ -35,7 +30,7 @@ export interface AppState {
     credentials: Credentials
     ready: boolean
   }
-  logins: Array<Login>
+  logins: DeltaChatAccount[]
   saved: LocalSettings
 }
 
@@ -176,4 +171,11 @@ export type MessageSearchResult = {
   chat_name: null | string
   message: string
   timestamp: number
+}
+
+export type DeltaChatAccount = {
+  path: string
+  displayname: string
+  addr: string
+  size: number
 }


### PR DESCRIPTION
- You can have multiple accounts with the same email address (for example different backups you can distinguish them via the new size property on the known accounts section)
- Account folder name isn't tied to email address anymore, you can rename account folders as you like. New account folders have the format `acc[number]`. This mimics the behavior of dc iOS and dc android which could help with burner qr code reading (allows having the context before knowing the email address).