### PR TITLE
Fix "dc_get_msg called with special msg_id=0" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fix drop send multiple files at once ([#1622](https://github.com/deltachat/deltachat-desktop/issues/1622))
 - Fix window bounds are not saved correctly #1705
 - Fix export backup progress bar missing
+- Fix `dc_get_msg called with special msg_id=0` warnings printed to console
 
 ### Changed
 

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -378,10 +378,7 @@ function useLogic(queryStr: string, showArchivedChats: boolean) {
     startIndex,
     stopIndex,
   }) => {
-    const chatIds =
-      startIndex == stopIndex
-        ? [chatListIds[startIndex]]
-        : chatListIds.slice(startIndex, stopIndex + 1)
+    const chatIds = chatListIds.slice(startIndex, stopIndex + 1)
     setChatLoading(state => {
       chatIds.forEach(id => (state[id] = LoadStatus.FETCHING))
       return state
@@ -444,10 +441,7 @@ function useLogic(queryStr: string, showArchivedChats: boolean) {
     startIndex,
     stopIndex,
   }) => {
-    const ids =
-      startIndex == stopIndex
-        ? [contactIds[startIndex]]
-        : contactIds.slice(startIndex, stopIndex + 1)
+    const ids = contactIds.slice(startIndex, stopIndex + 1)
 
     setContactLoading(state => {
       ids.forEach(id => (state[id] = LoadStatus.FETCHING))
@@ -475,10 +469,7 @@ function useLogic(queryStr: string, showArchivedChats: boolean) {
     startIndex,
     stopIndex,
   }) => {
-    const ids =
-      startIndex == stopIndex
-        ? [messageResultIds[startIndex]]
-        : messageResultIds.slice(startIndex, stopIndex + 1)
+    const ids = messageResultIds.slice(startIndex, stopIndex + 1)
 
     setMessageLoading(state => {
       ids.forEach(id => (state[id] = LoadStatus.FETCHING))


### PR DESCRIPTION
When startIndex == stopIndex == 0, ids was equal to [null] and caused
message with msgId = 0 to be loaded. This commit simplifies the logic
and fixes the warning.

<del>stopIndex + 1 is replaced with stopIndex, because stopIndex is limited
by Math.min(messageResultIds.length, 10). When length is less than 10,
it caused slice to try to load more elements that were in the array,
and 11 elements maximum were loaded, which seems to be off-by-one error.</del>