### PR TITLE
Use system language on first launch if available.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Fix offline toast displayed before login #1729
 - Fix "Authentication failed" notification does not disappear even after successfull login #1594
 - Fix login button staying disabled on error #1661
+- Fix use system language until the user chooses their language #1712
 
 ### Changed
 

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -16,7 +16,7 @@ export function getDefaultState(): AppState {
       enterKeySends: false,
       notifications: true,
       showNotificationContent: true,
-      locale: 'en',
+      locale: null, // if this is null, the system chooses the system language electron reports
       credentials: undefined,
       lastAccount: undefined,
       enableOnDemandLocationStreaming: false,


### PR DESCRIPTION
Technically: use system language until the user chooses their language
fixes #1712