### PR TITLE
package: linux add mode for just directory creation when building the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "pack:generate_config": "node ./build/gen-electron-builder-config.js && prettier --write ./electron-builder.json5 --loglevel silent",
     "pack:win": "electron-builder --config ./electron-builder.json5 --win nsis portable",
     "pack:mac": "electron-builder --config ./electron-builder.json5 --mac dmg mas",
+    "pack:linux:dir": "electron-builder --config ./electron-builder.json5 --linux --dir",
     "pack:linux": "electron-builder --config ./electron-builder.json5 --linux AppImage deb",
     "pack:all": "electron-builder --config ./electron-builder.json5 --mac dmg --win nsis portable --linux AppImage deb"
   },


### PR DESCRIPTION
The flatpak build does not require appimage or anything else.
Just the app in a directory. The change in behaviour was changed with
ff0d88bfce175ea9b182d095b6555d1e94dfb105.

This change makes the flatpak version build again.