### PR TITLE
Support builds from tar-ball.

### DIFF
--- a/bin/build-shared-version-info.js
+++ b/bin/build-shared-version-info.js
@@ -4,15 +4,17 @@ const { join } = require('path')
 
 async function gatherBuildInfo() {
   const { status, stdout, stderr } = spawnSync('git', ['describe'])
+  let git_ref = "None"
   if (status !== 0) {
     console.log(stderr)
-    throw new Error('getting git commit failed')
+  } else {
+    git_ref = stdout.toString().replace(/\n/g, '')
   }
   const package = await fs.readJSON(join(__dirname, '../package.json'))
   return {
     VERSION: package.version,
     BUILD_TIMESTAMP: Date.now(),
-    GIT_REF: stdout.toString().replace(/\n/g, ''),
+    GIT_REF: git_ref
   }
 }
 


### PR DESCRIPTION
Set `GIT_REF` to "None" when `git describe` returns with error,
but continue the build.

Closes #1758

-- Not sure if this full fills your style and coding guidelines, feel free to adapt or discard.

`npm test` ran fine. 