### PR TITLE
[wip] Fix export/import keys js error

### DIFF
--- a/src/main/deltachat/settings.ts
+++ b/src/main/deltachat/settings.ts
@@ -76,11 +76,11 @@ export default class DCSettings extends SplitOut {
   }
 
   keysImport(directory: string) {
-    this._dc.importExport(C.DC_IMEX_IMPORT_SELF_KEYS, directory, undefined)
+    this._dc.importExport(C.DC_IMEX_IMPORT_SELF_KEYS, directory, '')
   }
 
   keysExport(directory: string) {
-    this._dc.importExport(C.DC_IMEX_EXPORT_SELF_KEYS, directory, undefined)
+    this._dc.importExport(C.DC_IMEX_EXPORT_SELF_KEYS, directory, '')
   }
 
   /**

--- a/src/renderer/components/dialogs/Settings-ManageKeys.tsx
+++ b/src/renderer/components/dialogs/Settings-ManageKeys.tsx
@@ -10,6 +10,7 @@ const { remote } = window.electron_functions
 
 function onKeysImport() {
   const tx = window.static_translate
+  const userFeedback = window.__userFeedback
 
   const opts: OpenDialogOptions = {
     title: tx('pref_managekeys_import_secret_keys'),
@@ -29,7 +30,7 @@ function onKeysImport() {
       )
       ipcBackend.on('DC_EVENT_IMEX_PROGRESS', (_event, progress) => {
         if (progress !== 1000) return
-        this.props.userFeedback({ type: 'success', text })
+        userFeedback({ type: 'success', text })
       })
       DeltaBackend.call('settings.keysImport', filenames[0])
     })
@@ -40,6 +41,7 @@ function onKeysExport() {
   // TODO: ask for the user's password and check it using
   // var matches = ipcRenderer.sendSync('dispatchSync', 'checkPassword', password)
   const tx = window.static_translate
+  const userFeedback = window.__userFeedback
 
   const opts: OpenDialogOptions = {
     title: tx('pref_managekeys_export_secret_keys'),
@@ -56,7 +58,7 @@ function onKeysExport() {
     confirmationDialog(title, (response: todo) => {
       if (!response || !filenames || !filenames.length) return
       ipcBackend.once('DC_EVENT_IMEX_FILE_WRITTEN', (_event, filename) => {
-        this.props.userFeedback({
+        userFeedback({
           type: 'success',
           text: tx('pref_managekeys_secret_keys_exported_to_x', filename),
         })

--- a/src/renderer/components/dialogs/Settings-ManageKeys.tsx
+++ b/src/renderer/components/dialogs/Settings-ManageKeys.tsx
@@ -57,7 +57,8 @@ function onKeysExport() {
     )
     confirmationDialog(title, (response: todo) => {
       if (!response || !filenames || !filenames.length) return
-      ipcBackend.once('DC_EVENT_IMEX_FILE_WRITTEN', (_event, filename) => {
+      ipcBackend.once('DC_EVENT_IMEX_FILE_WRITTEN', (_event, [_data1, filename]) => {
+        console.log(filename)
         userFeedback({
           type: 'success',
           text: tx('pref_managekeys_secret_keys_exported_to_x', filename),


### PR DESCRIPTION
@hpk42 importing a secret key fails with `set_self_key: rPGP error: no matching packet found`. Should be quite easy to write a rust test for this.