### PR TITLE
disable keycombination for Scroll active chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Removed
+- disable keycombination for Scroll active chat (`alt + left arrow` because this keyboard shortcut is already used by mac to move over words in input fields)
+
 ## [1.10.0] - 2020-07-16
 
 ## Added

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -2,7 +2,7 @@
 
 Switch between chats: `alt + arrow down`, `alt + arrow up`
 
-Scroll active chat into view ~~`alt + arrow left`~~ *(disabled until we find a better key combo, because this one collides with to mac system shortcut to move a word (see [#1796](https://github.com/deltachat/deltachat-desktop/issues/1796)))*
+Scroll active chat into view ~~`alt + arrow left`~~ _(disabled until we find a better key combo, because this one collides with to mac system shortcut to move a word (see [#1796](https://github.com/deltachat/deltachat-desktop/issues/1796)))_
 
 Search contact list: `ctrl + k`
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -2,7 +2,7 @@
 
 Switch between chats: `alt + arrow down`, `alt + arrow up`
 
-Scroll active chat into view `alt + arrow left`
+Scroll active chat into view ~~`alt + arrow left`~~ *(disabled until we find a better key combo, because this one collides with to mac system shortcut to move a word (see [#1796](https://github.com/deltachat/deltachat-desktop/issues/1796)))*
 
 Search contact list: `ctrl + k`
 

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -67,9 +67,9 @@ function keyDownEvent2Action(ev: KeyboardEvent): KeybindAction {
       return KeybindAction.ChatList_SelectNextChat
     } else if (ev.altKey && ev.key === 'ArrowUp') {
       return KeybindAction.ChatList_SelectPreviousChat
-    // } else if (ev.altKey && ev.key === 'ArrowLeft') {
-    // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
-    //   return KeybindAction.ChatList_ScrollToSelectedChat
+      // } else if (ev.altKey && ev.key === 'ArrowLeft') {
+      // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
+      //   return KeybindAction.ChatList_ScrollToSelectedChat
     } else if (ev.ctrlKey && ev.key === 'k') {
       return KeybindAction.ChatList_FocusAndClearSearchInput
     } else if (ev.ctrlKey && ev.key === 'n') {

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -67,8 +67,9 @@ function keyDownEvent2Action(ev: KeyboardEvent): KeybindAction {
       return KeybindAction.ChatList_SelectNextChat
     } else if (ev.altKey && ev.key === 'ArrowUp') {
       return KeybindAction.ChatList_SelectPreviousChat
-    } else if (ev.altKey && ev.key === 'ArrowLeft') {
-      return KeybindAction.ChatList_ScrollToSelectedChat
+    // } else if (ev.altKey && ev.key === 'ArrowLeft') {
+    // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
+    //   return KeybindAction.ChatList_ScrollToSelectedChat
     } else if (ev.ctrlKey && ev.key === 'k') {
       return KeybindAction.ChatList_FocusAndClearSearchInput
     } else if (ev.ctrlKey && ev.key === 'n') {


### PR DESCRIPTION
in order to provide a quick fix #1796
because `alt + left arrow` is Option + `left arrow` on mac which means move over a word like `ctrl + left arrow` on linux or windows.