### PR TITLE
fix labeled links dialog issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Fix sluggish ui while typing in email address in login form
+- Fix url parding in labeled link confirmation dialog
 
 
 ## [1.12.0] - 2020-07-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Fixed
 
 - Fix sluggish ui while typing in email address in login form
-- Fix url parding in labeled link confirmation dialog
+- Fix url parsing in labeled link confirmation dialog
 
 
 ## [1.12.0] - 2020-07-31

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "1.10.3",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2430,6 +2430,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
       "integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
+      "dev": true
+    },
+    "@types/url-parse": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==",
       "dev": true
     },
     "@types/yargs": {
@@ -12412,6 +12418,11 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
       "dev": true
     },
+    "querystringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
     "quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
@@ -13444,6 +13455,11 @@
       "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
       "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
       "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
     "resize-observer-polyfill": {
       "version": "1.5.1",
@@ -16488,6 +16504,15 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
           "dev": true
         }
+      }
+    },
+    "url-parse": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
+      "integrity": "sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "sass": "^1.26.5",
     "simple-markdown": "^0.7.1",
     "tempy": "^0.3.0",
+    "url-parse": "^1.4.7",
     "use-debounce": "^3.3.0",
     "wolfy87-eventemitter": "^5.2.9"
   },
@@ -121,6 +122,7 @@
     "@types/react-dom": "^16.9.4",
     "@types/react-virtualized": "^9.21.10",
     "@types/sass": "^1.16.0",
+    "@types/url-parse": "^1.4.3",
     "depcheck": "^0.8.4",
     "electron": "6.1.9",
     "electron-builder": "^22.6.0",

--- a/src/renderer/components/message/LabeledLink.tsx
+++ b/src/renderer/components/message/LabeledLink.tsx
@@ -7,9 +7,10 @@ import {
   DeltaDialogFooterActions,
   DeltaDialogFooter,
 } from '../dialogs/DeltaDialog'
-import { Classes } from '@blueprintjs/core'
 import { DeltaCheckbox } from '../contact/ContactListItem'
 import { getLogger } from '../../../shared/logger'
+
+import UrlParser from 'url-parse'
 
 const log = getLogger('renderer/LabeledLink')
 
@@ -38,31 +39,29 @@ export const LabeledLink = ({
   target: string
 }) => {
   const { openDialog } = useContext(ScreenContext)
-  const splittedTarget = String(target).split('/')
+  
+  const url = UrlParser(target)
   // encode the punycode to make phishing harder
-  const domain = (splittedTarget[2] = splittedTarget[2]
-    .split('.')
-    .map(toASCII)
-    .join('.'))
-  const sanitizedTarget = splittedTarget.join('/')
+  url.set('hostname', url.hostname.split('.').map(toASCII).join('.'));
+
   const onClick = (ev: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     ev.preventDefault()
     ev.stopPropagation()
     //check if domain is trusted
-    if (isDomainTrusted(domain)) {
+    if (isDomainTrusted(url.hostname)) {
       openExternal(target)
       return
     }
     // not trusted - ask for confimation from user
     confirmationDialog(
       openDialog as OpenDialogFunctionType,
-      sanitizedTarget,
-      domain,
+      url.toString(),
+      url.hostname,
       target
     )
   }
   return (
-    <a href={'#' + target} title={sanitizedTarget} onClick={onClick}>
+    <a href={'#' + target} title={url.toString()} onClick={onClick}>
       {String(label)}
     </a>
   )
@@ -71,7 +70,7 @@ export const LabeledLink = ({
 function confirmationDialog(
   openDialog: OpenDialogFunctionType,
   sanitizedTarget: string,
-  domain: string,
+  hostname: string,
   target: string
 ) {
   openDialog(({ isOpen, onClose }) => {
@@ -95,7 +94,7 @@ function confirmationDialog(
             <DeltaCheckbox checked={isChecked} onClick={toggleIsChecked} />
             <div style={{ alignSelf: 'center' }}>
               {tx('open_external_url_trust_domain') + ' '}
-              <i>{domain}</i>
+              <i>{hostname}</i>
             </div>
           </div>
           <DeltaDialogFooter>
@@ -118,7 +117,7 @@ function confirmationDialog(
                   onClose()
                   if (isChecked) {
                     // trust url
-                    trustDomain(domain)
+                    trustDomain(hostname)
                   }
                   openExternal(target)
                 }}

--- a/src/renderer/components/message/LabeledLink.tsx
+++ b/src/renderer/components/message/LabeledLink.tsx
@@ -39,10 +39,16 @@ export const LabeledLink = ({
   target: string
 }) => {
   const { openDialog } = useContext(ScreenContext)
-  
+
   const url = UrlParser(target)
   // encode the punycode to make phishing harder
-  url.set('hostname', url.hostname.split('.').map(toASCII).join('.'));
+  url.set(
+    'hostname',
+    url.hostname
+      .split('.')
+      .map(toASCII)
+      .join('.')
+  )
 
   const onClick = (ev: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     ev.preventDefault()


### PR DESCRIPTION
add a real url parser to handle the domains, this removes the 3 bugs of #1839

**Trust domain contains junk** -> now its only the hostname as it should be
**Punycode encoding should only affect the domain, not the path or the anchor** -> encoding to punycode treatment is only applied to the hostname now.
**Text shouldn't leave the dialog** -> as the remember domain text contains only the hostname it shouldn't be a problem right now (domains aren't too long most of the time, but we could also make the test breaking in the future to fix it the right way)
fix #1839