### PR TITLE
Make sure we have a consistent chatId when DC_EVENT_MSGS_CHANGED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Fix a bug where we render an empty message list
+
 ## [1.13.0] - 2020-10-1
 
 ### Fixed

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -22,6 +22,7 @@ export default function ForwardMessage(props: {
   const { chatListIds, queryStr, setQueryStr } = useChatList(
     C.DC_GCL_FOR_FORWARDING | C.DC_GCL_NO_SPECIALS
   )
+  console.log('test')
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
     chatListIds
   )

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -22,7 +22,6 @@ export default function ForwardMessage(props: {
   const { chatListIds, queryStr, setQueryStr } = useChatList(
     C.DC_GCL_FOR_FORWARDING | C.DC_GCL_NO_SPECIALS
   )
-  console.log('test')
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
     chatListIds
   )

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -321,14 +321,15 @@ ipcBackend.on('DC_EVENT_MSG_READ', (evt, [id, msgId]) => {
 ipcBackend.on('DC_EVENT_MSGS_CHANGED', async (_, [id, messageId]) => {
   log.debug('DC_EVENT_MSGS_CHANGED', id, messageId)
   if (id === 0 && messageId === 0) {
+    const chatId = chatStore.state.id
     const messageIds = await DeltaBackend.call(
       'messageList.getMessageIds',
-      chatStore.state.id
+      chatId
     )
 
     chatStore.dispatch({
       type: 'SET_MESSAGE_IDS',
-      id: chatStore.state.id,
+      id: chatId,
       payload: messageIds,
     })
     return


### PR DESCRIPTION
happens. Otherwise it's possible that we corrupt the chat state.

Fixes https://github.com/deltachat/deltachat-desktop/issues/1900