### PR TITLE
refresh "empty chat" info meassage on chat changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Fix broken enlargen group image #1924
 - Fix opening of multiple setting windows via keybinding
 - Fix two issues with the labeled link (see  #1893)
+- Fix refresh of "empty chat" info meassage on chat changes
 
 ## [1.13.1] - 2020-10-06
 
@@ -39,6 +40,7 @@
 
 - Fix a bug where we render an empty message list
 - Hide invalid options in menu (example: send video invitation in device chat)
+
 
 ## [1.13.0] - 2020-10-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 - Fix a bug where we render an empty message list
 - Hide invalid options in menu (example: send video invitation in device chat)
 
-
 ## [1.13.0] - 2020-10-01
 
 ### Fixed

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useLayoutEffect } from 'react'
+import React, { useRef, useEffect, useState } from 'react'
 import { MessageWrapper } from './MessageWrapper'
 import {
   useChatStore,
@@ -10,9 +10,11 @@ import { C } from 'deltachat-node/dist/constants'
 import moment from 'moment'
 
 import { getLogger } from '../../../shared/logger'
-import { MessageType } from '../../../shared/shared-types'
+import { MessageType, FullChat } from '../../../shared/shared-types'
 import { useTranslationFunction } from '../../contexts'
 import { useDCConfigOnce } from '../helpers/useDCConfigOnce'
+import { ipcBackend } from '../../ipc'
+import { DeltaBackend } from '../../delta-remote'
 const log = getLogger('render/msgList')
 
 const messageIdsToShow = (
@@ -177,39 +179,13 @@ export const MessageListInner = React.memo(
       oldestFetchedMessageIndex,
       messageIds
     )
-    const tx = useTranslationFunction()
 
     let specialMessageIdCounter = 0
-
-    let emptyChatMessage = tx('chat_no_messages_hint', [chat.name, chat.name])
-
-    const showAllEmail = useDCConfigOnce('show_emails')
-
-    if (chat.isGroup && !chat.isDeaddrop) {
-      emptyChatMessage = chat.isUnpromoted
-        ? tx('chat_new_group_hint')
-        : tx('chat_no_messages')
-    } else if (chat.isSelfTalk) {
-      emptyChatMessage = tx('saved_messages_explain')
-    } else if (chat.isDeviceChat) {
-      emptyChatMessage = tx('device_talk_explain')
-    } else if (chat.isDeaddrop) {
-      emptyChatMessage =
-        Number(showAllEmail) !== C.DC_SHOW_EMAILS_ALL
-          ? tx('chat_no_contact_requests')
-          : tx('chat_no_messages')
-    }
 
     return (
       <div id='message-list' ref={messageListRef} onScroll={onScroll}>
         <ul>
-          {messageIds.length === 0 && (
-            <li>
-              <div className='info-message big'>
-                <p>{emptyChatMessage}</p>
-              </div>
-            </li>
-          )}
+          {messageIds.length === 0 && <EmptyChatMessage chat={chat} />}
           {_messageIdsToShow.map((messageId, i) => {
             if (messageId === C.DC_MSG_ID_DAYMARKER) {
               const key = 'magic' + messageId + '_' + specialMessageIdCounter++
@@ -249,6 +225,52 @@ export const MessageListInner = React.memo(
     return areEqual
   }
 )
+
+function EmptyChatMessage({ chat: chatStoreState }: { chat: ChatStoreState }) {
+  const tx = useTranslationFunction()
+  
+  const [chat, setChat] = useState<FullChat>(chatStoreState)
+  useEffect(() => {
+    const refresh = (_ev: any, chatId: number) => {
+      if (chatId == chat.id) {
+        DeltaBackend.call('chatList.getFullChatById', chat.id).then(
+          fullChat => {
+            setChat(fullChat)
+          }
+        )
+      }
+    }
+    ipcBackend.on('DC_EVENT_CHAT_MODIFIED', refresh)
+    return () => ipcBackend.removeListener('DC_EVENT_CHAT_MODIFIED', refresh)
+  })
+
+  let emptyChatMessage = tx('chat_no_messages_hint', [chat.name, chat.name])
+
+  const showAllEmail = useDCConfigOnce('show_emails')
+
+  if (chat.isGroup && !chat.isDeaddrop) {
+    emptyChatMessage = chat.isUnpromoted
+      ? tx('chat_new_group_hint')
+      : tx('chat_no_messages')
+  } else if (chat.isSelfTalk) {
+    emptyChatMessage = tx('saved_messages_explain')
+  } else if (chat.isDeviceChat) {
+    emptyChatMessage = tx('device_talk_explain')
+  } else if (chat.isDeaddrop) {
+    emptyChatMessage =
+      Number(showAllEmail) !== C.DC_SHOW_EMAILS_ALL
+        ? tx('chat_no_contact_requests')
+        : tx('chat_no_messages')
+  }
+
+  return (
+    <li>
+      <div className='info-message big'>
+        <p>{emptyChatMessage}</p>
+      </div>
+    </li>
+  )
+}
 
 export function DayMarker(props: { timestamp: number }) {
   const { timestamp } = props

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -228,7 +228,7 @@ export const MessageListInner = React.memo(
 
 function EmptyChatMessage({ chat: chatStoreState }: { chat: ChatStoreState }) {
   const tx = useTranslationFunction()
-  
+
   const [chat, setChat] = useState<FullChat>(chatStoreState)
   useEffect(() => {
     const refresh = (_ev: any, chatId: number) => {

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -185,7 +185,7 @@ export const MessageListInner = React.memo(
     return (
       <div id='message-list' ref={messageListRef} onScroll={onScroll}>
         <ul>
-          {messageIds.length === 0 && <EmptyChatMessage chat={chat} />}
+          {messageIds.length === 0 && <EmptyChatMessage />}
           {_messageIdsToShow.map((messageId, i) => {
             if (messageId === C.DC_MSG_ID_DAYMARKER) {
               const key = 'magic' + messageId + '_' + specialMessageIdCounter++
@@ -226,23 +226,9 @@ export const MessageListInner = React.memo(
   }
 )
 
-function EmptyChatMessage({ chat: chatStoreState }: { chat: ChatStoreState }) {
+function EmptyChatMessage() {
   const tx = useTranslationFunction()
-
-  const [chat, setChat] = useState<FullChat>(chatStoreState)
-  useEffect(() => {
-    const refresh = (_ev: any, chatId: number) => {
-      if (chatId == chat.id) {
-        DeltaBackend.call('chatList.getFullChatById', chat.id).then(
-          fullChat => {
-            setChat(fullChat)
-          }
-        )
-      }
-    }
-    ipcBackend.on('DC_EVENT_CHAT_MODIFIED', refresh)
-    return () => ipcBackend.removeListener('DC_EVENT_CHAT_MODIFIED', refresh)
-  })
+  const [chat] = useChatStore()
 
   let emptyChatMessage = tx('chat_no_messages_hint', [chat.name, chat.name])
 

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useState } from 'react'
+import React, { useRef, useEffect } from 'react'
 import { MessageWrapper } from './MessageWrapper'
 import {
   useChatStore,
@@ -10,11 +10,9 @@ import { C } from 'deltachat-node/dist/constants'
 import moment from 'moment'
 
 import { getLogger } from '../../../shared/logger'
-import { MessageType, FullChat } from '../../../shared/shared-types'
+import { MessageType } from '../../../shared/shared-types'
 import { useTranslationFunction } from '../../contexts'
 import { useDCConfigOnce } from '../helpers/useDCConfigOnce'
-import { ipcBackend } from '../../ipc'
-import { DeltaBackend } from '../../delta-remote'
 const log = getLogger('render/msgList')
 
 const messageIdsToShow = (


### PR DESCRIPTION
should work, haven't tested it yet because it needs a new core(1.47) (https://github.com/deltachat/deltachat-core-rust/pull/1936) which isn't out yet

fixes #1850