### PR TITLE
Account selection improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Upgrade Emoji Picker(Emoji 12.1) and emojifont(Unicode 13.1) for new emoji support 🦾
 - Add Keyboard navigation between accounts in account selection screen
 - Add the account name to the account deletion-confirmation dialog
+- Add a hover tooltip with account path and size when hovering over the email address of an account
+  (this is useful when importing a backup of an account you already have and can't distinguish which is the old accountand which is the imported one)
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 # Added
 - Upgrade Emoji Picker(Emoji 12.1) and emojifont(Unicode 13.1) for new emoji support 🦾
+- Add Keyboard navigation between accounts in account selection screen
+- Add the account name to the account deletion-confirmation dialog
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Upgrade Emoji Picker(Emoji 12.1) and emojifont(Unicode 13.1) for new emoji support 🦾
 - Add Keyboard navigation between accounts in account selection screen
 - Add the account name to the account deletion-confirmation dialog
-- Add a hover tooltip with account path and size when hovering over the email address of an account
-  (this is useful when importing a backup of an account you already have and can't distinguish which is the old accountand which is the imported one)
+- Add a hover tool-tip with account path and size when hovering over the email address of an account
+  (this is useful when importing a backup of an account you already have and can't distinguish which is the old account and which is the imported one)
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -199,6 +199,6 @@
     "message": "DEPRECATED - PLEASE DELETE THIS STRING"
   },
   "account_info_hover_tooltip_desktop":{
-    "message": "email: %s\nsize: %s\npath: %s"
+    "message": "E-Mail: %s\nSize: %s\nPath: %s"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -197,5 +197,8 @@
   },
   "forget_login_confirmation_desktop": {
     "message": "DEPRECATED - PLEASE DELETE THIS STRING"
+  },
+  "account_info_hover_tooltip_desktop":{
+    "message": "email: %s\nsize: %s\npath: %s"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -188,5 +188,14 @@
   },
   "emoji_flags": {
     "message": "Flags"
+  },
+  "delete_account_confirmation_header_desktop":{
+    "message": "Delete %s?"
+  },
+  "delete_account_confirmation_desktop":{
+    "message": "All account data of \"%s\" on this device will be deleted, including your end-to-end setup, contacts, chats, messages and media. This action cannot be undone."
+  },
+  "forget_login_confirmation_desktop": {
+    "message": "DEPRECATED - PLEASE DELETE THIS STRING"
   }
 }

--- a/scss/contact/_contact-list.scss
+++ b/scss/contact/_contact-list.scss
@@ -3,7 +3,11 @@
   padding-left: 20px;
   padding-right: 20px;
   &:hover {
-    background-color: var(--chatListItemBgHover);
+    background-color: var(--contactListItemBgHover);
+  }
+
+  &:focus {
+    background-color: var(--contactListItemBgFocus);
   }
 
   .chat-list & {

--- a/scss/contact/_contact.scss
+++ b/scss/contact/_contact.scss
@@ -4,7 +4,7 @@ img.verified-icon {
   margin-right: 2px;
 }
 
-div.contact-list-item div.contact {
+.contact-list-item div.contact {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/scss/contact/_contact.scss
+++ b/scss/contact/_contact.scss
@@ -4,41 +4,7 @@ img.verified-icon {
   margin-right: 2px;
 }
 
-div.contact-name {
-  display: inline-block;
-  width: calc(100% - 64px);
-  // height: 54px;
-  margin-left: 10px;
-  .chat-list & {
-    width: calc(100% - 84px);
-  }
-  .display-name {
-    font-weight: bold;
-    margin-bottom: 0px;
-    margin-top: 3px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .email {
-    color: var(--contactEmailColor);
-    margin-bottom: 3px;
-    margin-top: 3px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .pseudo-contact-text {
-    font-weight: bold;
-    margin-bottom: 0px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    font-size: medium;
-  }
-}
-
-div.contact {
+div.contact-list-item div.contact {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -46,5 +12,39 @@ div.contact {
   .chat-list & {
     width: 30vw;
     padding: 0px 10px;
+  }
+
+  div.contact-name {
+    display: inline-block;
+    width: calc(100% - 64px);
+    // height: 54px;
+    margin-left: 10px;
+    .chat-list & {
+      width: calc(100% - 84px);
+    }
+    .display-name {
+      font-weight: bold;
+      margin-bottom: 0px;
+      margin-top: 3px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .email {
+      color: var(--contactEmailColor);
+      margin-bottom: 3px;
+      margin-top: 3px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .pseudo-contact-text {
+      font-weight: bold;
+      margin-bottom: 0px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      font-size: medium;
+    }
   }
 }

--- a/scss/login/_login.scss
+++ b/scss/login/_login.scss
@@ -232,14 +232,6 @@ div.delta-form-group {
 }
 
 .accounts {
-  ul {
-    margin: 0px;
 
-    li {
-      &:hover {
-        cursor: pointer;
-        background-color: var(--chatListItemBgHover);
-      }
-    }
-  }
+  
 }

--- a/scss/login/_login.scss
+++ b/scss/login/_login.scss
@@ -232,6 +232,19 @@ div.delta-form-group {
 }
 
 .accounts {
+  .contact-list-item {
+    .contact {
+      width: 100%;
+    }
 
-  
+    .remove-icon:hover {
+      .bp3-icon {
+        background-color: rgba(125, 125, 125, 0.2);
+        border-radius: 4px;
+        & > svg {
+          fill: #bf0000;
+        }
+      }
+    }
+  }
 }

--- a/src/renderer/components/LoginScreen.tsx
+++ b/src/renderer/components/LoginScreen.tsx
@@ -148,7 +148,7 @@ export default function LoginScreen({
   loadAccount: (account: DeltaChatAccount) => {}
 }) {
   const tx = useTranslationFunction()
-  const { openDialog, changeScreen } = useContext(ScreenContext)
+  const { openDialog } = useContext(ScreenContext)
 
   const [credentials, setCredentials] = useState<Credentials>(
     defaultCredentials()
@@ -275,7 +275,7 @@ function AccountSelection({
   refreshAccounts: () => Promise<void>
   setView: React.Dispatch<React.SetStateAction<string>>
   logins: any
-  loadAccount: (account: DeltaChatAccount) => {}
+  loadAccount: (account: DeltaChatAccount) => void
 }) {
   const tx = useTranslationFunction()
   const { openDialog } = useContext(ScreenContext)
@@ -354,8 +354,8 @@ function AccountItem({
   removeAccount,
 }: {
   login: DeltaChatAccount
-  loadAccount: todo
-  removeAccount: todo
+  loadAccount: (account: DeltaChatAccount) => void
+  removeAccount: (account: DeltaChatAccount) => void
 }) {
   const removeAction = (ev: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     ev?.stopPropagation()

--- a/src/renderer/components/LoginScreen.tsx
+++ b/src/renderer/components/LoginScreen.tsx
@@ -292,8 +292,10 @@ function AccountSelection({
   const { openDialog } = useContext(ScreenContext)
 
   const removeAccount = (login: DeltaChatAccount) => {
-    const message = tx('forget_login_confirmation_desktop')
+    const header = tx("delete_account_confirmation_header_desktop", login.addr)
+    const message = tx('delete_account_confirmation_desktop', login.addr)
     openDialog('ConfirmationDialog', {
+      header,
       message,
       confirmLabel: tx('delete_account'),
       isConfirmDanger: true,
@@ -410,10 +412,7 @@ function AccountItem({
 
 // TODO
 
-// [X] - hover effect for remove icon
 // [] - show properties somewhere (size, path) -> find a good way, I'm not satisfied with the title-hover-popover
-// [X] - keyboard navigation (arrow keys, tab, enter)
-// [] - keyboard navigation for dialog buttons
 // [] - remove not needed imports
 
-// [] - show account name in remove dialog?
+// [X] - show account name in remove dialog?

--- a/src/renderer/components/LoginScreen.tsx
+++ b/src/renderer/components/LoginScreen.tsx
@@ -5,13 +5,7 @@ import LoginForm, {
   defaultCredentials,
   ConfigureProgressDialog,
 } from './LoginForm'
-import {
-  Classes,
-  Elevation,
-  Intent,
-  Card,
-  Icon,
-} from '@blueprintjs/core'
+import { Classes, Elevation, Intent, Card, Icon } from '@blueprintjs/core'
 import { DeltaProgressBar } from './Login-Styles'
 import { getLogger } from '../../shared/logger'
 import { ScreenContext, useTranslationFunction } from '../contexts'
@@ -287,7 +281,7 @@ function AccountSelection({
   const { openDialog } = useContext(ScreenContext)
 
   const removeAccount = (login: DeltaChatAccount) => {
-    const header = tx("delete_account_confirmation_header_desktop", login.addr)
+    const header = tx('delete_account_confirmation_header_desktop', login.addr)
     const message = tx('delete_account_confirmation_desktop', login.addr)
     openDialog('ConfirmationDialog', {
       header,
@@ -368,15 +362,16 @@ function AccountItem({
     removeAccount(login)
   }
 
+  const title = window.static_translate('account_info_hover_tooltip_desktop', [
+    login.addr,
+    filesizeConverter(login.size),
+    'accounts' + login.path.split('accounts')[1],
+  ])
+
   return (
     <div
       role='menu-item'
       className='contact-list-item'
-      title={
-        filesizeConverter(login.size) +
-        '\n' +
-        ('accounts' + login.path.split('accounts')[1])
-      }
       onClick={() => loadAccount(login)}
       tabIndex={0}
     >
@@ -390,7 +385,13 @@ function AccountItem({
         />
         <div className='contact-name'>
           <div className='display-name'>{login.displayname || login.addr}</div>
-          <div className='email'>{login.addr}</div>
+          <div
+            className='email'
+            style={{ display: 'inline-block' }}
+            title={title}
+          >
+            {login.addr}
+          </div>
         </div>
       </div>
       <div
@@ -404,10 +405,3 @@ function AccountItem({
     </div>
   )
 }
-
-// TODO
-
-// [] - show properties somewhere (size, path) -> find a good way, I'm not satisfied with the title-hover-popover
-// [X] - remove not needed imports
-
-// [X] - show account name in remove dialog?

--- a/src/renderer/components/LoginScreen.tsx
+++ b/src/renderer/components/LoginScreen.tsx
@@ -15,6 +15,7 @@ import {
   Navbar,
   NavbarGroup,
   NavbarHeading,
+  Icon,
 } from '@blueprintjs/core'
 import { DeltaProgressBar } from './Login-Styles'
 import { getLogger } from '../../shared/logger'
@@ -35,11 +36,7 @@ import { DeltaBackend } from '../delta-remote'
 import { Screens } from '../ScreenController'
 import { IpcRendererEvent } from 'electron'
 import { Avatar } from './Avatar'
-import {
-  PseudoListItemAddContact,
-  PseudoListItem,
-} from './helpers/PseudoListItem'
-import { ContactListItem } from './contact/ContactListItem'
+import { PseudoContact } from './contact/Contact'
 
 const log = getLogger('renderer/components/LoginScreen')
 
@@ -186,21 +183,6 @@ export default function LoginScreen({
     openDialog(ConfigureProgressDialog, { credentials, onSuccess })
   }
 
-  const removeAccount = (login: DeltaChatAccount) => {
-    const message = tx('forget_login_confirmation_desktop')
-    openDialog('ConfirmationDialog', {
-      message,
-      confirmLabel: tx('delete_account'),
-      isConfirmDanger: true,
-      cb: async (yes: boolean) => {
-        if (yes) {
-          await DeltaBackend.call('login.forgetAccount', login)
-          refreshAccounts()
-        }
-      },
-    })
-  }
-
   if (logins === null) return null
 
   return (
@@ -271,26 +253,9 @@ export default function LoginScreen({
                     />
                     <DeltaDialogBody>
                       <DeltaDialogContent noPadding={true}>
-                        <div className='accounts'>
-                          <ul>
-                            <PseudoListItem
-                              id='action-go-to-login'
-                              cutoff='+'
-                              text={tx('add_account')}
-                              onClick={() => setView('login')}
-                            />
-                            {logins.map(
-                              (login: DeltaChatAccount, index: Number) => (
-                                <AccountItem
-                                  key={`login-${index}`}
-                                  login={login}
-                                  loadAccount={loadAccount}
-                                  removeAccount={removeAccount}
-                                />
-                              )
-                            )}
-                          </ul>
-                        </div>
+                        <AccountSelection
+                          {...{ refreshAccounts, setView, logins, loadAccount }}
+                        />
                       </DeltaDialogContent>
                     </DeltaDialogBody>
                   </>
@@ -312,7 +277,87 @@ export default function LoginScreen({
   )
 }
 
-export function AccountItem({
+function AccountSelection({
+  refreshAccounts,
+  setView,
+  logins,
+  loadAccount,
+}: {
+  refreshAccounts: () => Promise<void>
+  setView: React.Dispatch<React.SetStateAction<string>>
+  logins: any
+  loadAccount: (account: DeltaChatAccount) => {}
+}) {
+  const tx = useTranslationFunction()
+  const { openDialog } = useContext(ScreenContext)
+
+  const removeAccount = (login: DeltaChatAccount) => {
+    const message = tx('forget_login_confirmation_desktop')
+    openDialog('ConfirmationDialog', {
+      message,
+      confirmLabel: tx('delete_account'),
+      isConfirmDanger: true,
+      cb: async (yes: boolean) => {
+        if (yes) {
+          await DeltaBackend.call('login.forgetAccount', login)
+          refreshAccounts()
+        }
+      },
+    })
+  }
+
+  useEffect(() => {
+    const onKeyDown = (ev: KeyboardEvent) => {
+      const parent = document.querySelector<HTMLDivElement>('#accounts')
+      const current = parent?.querySelector(':focus')
+
+      if (ev.key == 'ArrowDown') {
+        if (current && current.nextElementSibling) {
+          ;(current.nextElementSibling as HTMLDivElement)?.focus()
+        } else {
+          ;(parent?.firstElementChild as HTMLDivElement).focus()
+        }
+      } else if (ev.key == 'ArrowUp') {
+        if (current && current.previousElementSibling) {
+          ;(current.previousElementSibling as HTMLDivElement)?.focus()
+        } else {
+          ;(parent?.lastElementChild as HTMLDivElement).focus()
+        }
+      } else if (ev.key == 'Enter') {
+        if (current) {
+          ;(current as HTMLDivElement)?.click()
+        }
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  })
+
+  return (
+    <div className='accounts' id='accounts' role='menu'>
+      <div
+        role='menu-item'
+        id='action-go-to-login'
+        className='contact-list-item'
+        onClick={() => setView('login')}
+        tabIndex={0}
+      >
+        <PseudoContact cutoff='+' text={tx('add_account')}></PseudoContact>
+      </div>
+      {logins.map((login: DeltaChatAccount, index: Number) => (
+        <AccountItem
+          key={`login-${index}`}
+          login={login}
+          loadAccount={loadAccount}
+          removeAccount={removeAccount}
+        />
+      ))}
+    </div>
+  )
+}
+
+function AccountItem({
   login,
   loadAccount,
   removeAccount,
@@ -321,28 +366,54 @@ export function AccountItem({
   loadAccount: todo
   removeAccount: todo
 }) {
-  const contact = {
-    address: login.addr,
-    color: login.color,
-    displayName: login.displayname || login.addr,
-    firstName: '',
-    id: 0,
-    name: login.displayname,
-    profileImage: login.profileImage,
-    nameAndAddr: login.displayname,
-    isBlocked: false,
-    isVerified: false,
+  const removeAction = (ev: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    ev?.stopPropagation()
+    removeAccount(login)
   }
 
   return (
-    <ContactListItem
-      key={login.addr}
-      contact={contact}
+    <div
+      role='menu-item'
+      className='contact-list-item'
+      title={
+        filesizeConverter(login.size) +
+        '\n' +
+        ('accounts' + login.path.split('accounts')[1])
+      }
       onClick={() => loadAccount(login)}
-      showCheckbox={false}
-      checked={false}
-      showRemove={true}
-      onRemoveClick={() => removeAccount(login)}
-    />
+      tabIndex={0}
+    >
+      <div style={{ width: '100%' }}>
+        <div className='contact'>
+          <Avatar
+            {...{
+              avatarPath: login.profileImage,
+              color: login.color,
+              displayName: login.displayname,
+            }}
+          />
+          <div className='contact-name'>
+            <div className='display-name'>
+              {login.displayname || login.addr}
+            </div>
+            <div className='email'>{login.addr}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className='remove-icon' onClick={removeAction}>
+        <Icon icon='cross' />
+      </div>
+    </div>
   )
 }
+
+// TODO
+
+// [] - hover effect for remove icon
+// [] - show properties somewhere (size, path) -> find a good way, I'm not satisfied with the title-hover-popover
+// [X] - keyboard navigation (arrow keys, tab, enter)
+// [] - keyboard navigation for dialog buttons
+// [] - remove not needed imports
+
+// [] - show account name in remove dialog?

--- a/src/renderer/components/LoginScreen.tsx
+++ b/src/renderer/components/LoginScreen.tsx
@@ -383,25 +383,25 @@ function AccountItem({
       onClick={() => loadAccount(login)}
       tabIndex={0}
     >
-      <div style={{ width: '100%' }}>
-        <div className='contact'>
-          <Avatar
-            {...{
-              avatarPath: login.profileImage,
-              color: login.color,
-              displayName: login.displayname,
-            }}
-          />
-          <div className='contact-name'>
-            <div className='display-name'>
-              {login.displayname || login.addr}
-            </div>
-            <div className='email'>{login.addr}</div>
-          </div>
+      <div className='contact'>
+        <Avatar
+          {...{
+            avatarPath: login.profileImage,
+            color: login.color,
+            displayName: login.displayname,
+          }}
+        />
+        <div className='contact-name'>
+          <div className='display-name'>{login.displayname || login.addr}</div>
+          <div className='email'>{login.addr}</div>
         </div>
       </div>
-
-      <div className='remove-icon' onClick={removeAction}>
+      <div
+        role='button'
+        aria-label={window.static_translate('delete_account')}
+        className='remove-icon'
+        onClick={removeAction}
+      >
         <Icon icon='cross' />
       </div>
     </div>
@@ -410,7 +410,7 @@ function AccountItem({
 
 // TODO
 
-// [] - hover effect for remove icon
+// [X] - hover effect for remove icon
 // [] - show properties somewhere (size, path) -> find a good way, I'm not satisfied with the title-hover-popover
 // [X] - keyboard navigation (arrow keys, tab, enter)
 // [] - keyboard navigation for dialog buttons

--- a/src/renderer/components/LoginScreen.tsx
+++ b/src/renderer/components/LoginScreen.tsx
@@ -1,20 +1,15 @@
-import React, { useState, useEffect, Fragment, useContext } from 'react'
-import { sendToBackend, ipcBackend } from '../ipc'
+import React, { useState, useEffect, useContext } from 'react'
+import { ipcBackend } from '../ipc'
 import { Credentials } from '../../shared/shared-types'
 import LoginForm, {
   defaultCredentials,
   ConfigureProgressDialog,
 } from './LoginForm'
 import {
-  Button,
   Classes,
   Elevation,
   Intent,
   Card,
-  Alignment,
-  Navbar,
-  NavbarGroup,
-  NavbarHeading,
   Icon,
 } from '@blueprintjs/core'
 import { DeltaProgressBar } from './Login-Styles'
@@ -413,6 +408,6 @@ function AccountItem({
 // TODO
 
 // [] - show properties somewhere (size, path) -> find a good way, I'm not satisfied with the title-hover-popover
-// [] - remove not needed imports
+// [X] - remove not needed imports
 
 // [X] - show account name in remove dialog?

--- a/src/renderer/components/contact/Contact.tsx
+++ b/src/renderer/components/contact/Contact.tsx
@@ -14,7 +14,7 @@ export function convertContactProps(contact: ContactJSON) {
   }
 }
 
-export const VerifiedIcon = (props: { style?: CSSProperties }) => (
+const VerifiedIcon = (props: { style?: CSSProperties }) => (
   <img
     className='verified-icon'
     src='../images/verified.png'
@@ -22,7 +22,7 @@ export const VerifiedIcon = (props: { style?: CSSProperties }) => (
   />
 )
 
-export function ContactName(
+function ContactName(
   displayName: string,
   address: string,
   isVerified: boolean

--- a/src/renderer/components/dialogs/ConfirmationDialog.tsx
+++ b/src/renderer/components/dialogs/ConfirmationDialog.tsx
@@ -41,6 +41,7 @@ export default function ConfirmationDialog({
   onClose,
   isConfirmDanger = false,
   noMargin = false,
+  header
 }: {
   message: string
   cancelLabel?: string
@@ -49,6 +50,7 @@ export default function ConfirmationDialog({
   onClose: () => {}
   isConfirmDanger?: boolean
   noMargin?: boolean
+  header?:string
 }) {
   const isOpen = !!message
   const tx = useTranslationFunction()
@@ -61,6 +63,17 @@ export default function ConfirmationDialog({
   return (
     <SmallDialog isOpen={isOpen} onClose={onClose}>
       <div className='bp3-dialog-body-with-padding'>
+        {header && (
+          <div
+            style={{
+              fontSize: '1.5em',
+              fontWeight: 'lighter',
+              marginBottom: '6px',
+            }}
+          >
+            {header}
+          </div>
+        )}
         <p>{message}</p>
       </div>
       <DeltaDialogFooter style={{ padding: '0px 20px 10px' }}>

--- a/src/renderer/components/dialogs/ConfirmationDialog.tsx
+++ b/src/renderer/components/dialogs/ConfirmationDialog.tsx
@@ -41,7 +41,7 @@ export default function ConfirmationDialog({
   onClose,
   isConfirmDanger = false,
   noMargin = false,
-  header
+  header,
 }: {
   message: string
   cancelLabel?: string
@@ -50,7 +50,7 @@ export default function ConfirmationDialog({
   onClose: () => {}
   isConfirmDanger?: boolean
   noMargin?: boolean
-  header?:string
+  header?: string
 }) {
   const isOpen = !!message
   const tx = useTranslationFunction()

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -56,6 +56,9 @@ $hover-contrast-change: 2%;
   --cli-search-result-divider: #{changeContrast($bgSecondary, 5%)};
   --cli-search-result-divider-border: #{changeContrast($bgSecondary, 10%)};
   --cli-search-result-divider-border-width: 2px;
+  /* ContactList / AccountList */
+  --contactListItemBgHover: #{changeContrast($bgPrimary, $hover-contrast-change)};
+  --contactListItemBgFocus: #{changeContrast($bgPrimary, 12%)};
   /* Message Bubble */
   --messageText: #{$textPrimary};
   --messageTextLink: #{$textPrimary};
@@ -145,9 +148,7 @@ $hover-contrast-change: 2%;
   --brokenMediaText: #070c14;
   --brokenMediaBg: #ffffff;
   --unreadCountBg: #{$accentColor};
-  --unreadCountLabel: #ffffff; // Manual value: This will not get generated in the future
-  --contactListItemBg: #62656a;
-  --contactListInitalColor: #{$textSecondary};
+  --unreadCountLabel: #ffffff; // Manual value: This will not get generated in the future;
   --contactEmailColor: #{$textSecondary};
   --errorColor: #f44336;
   --globalLinkColor: #2090ea; // Manual value: This will not get generated in the future


### PR DESCRIPTION
- Add Keyboard navigation between accounts in account selection screen (arrow keys or tab)
![Peek 2020-10-06 23-50](https://user-images.githubusercontent.com/18725968/95263804-a97d2180-082e-11eb-8a96-4e3f0aa84cad.gif)

- Add the account name to the account deletion-confirmation dialog (closes #1085)
![2020-10-06_22-41](https://user-images.githubusercontent.com/18725968/95263236-c2d19e00-082d-11eb-943d-ab9f12dc6520.png)

- Add a hover tool-tip with account path and size when hovering over the email address of an account
  (this is useful when importing a backup of an account you already have and can't distinguish which is the old account and which is the imported one)
![Peek 2020-10-06 23-18](https://user-images.githubusercontent.com/18725968/95263268-cfee8d00-082d-11eb-9059-c36d7ad01475.gif)
- add hover effect to remove button (see previous gif)