### PR TITLE
fix linux/debian appIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+## Fixed
+
+- Fixed missing application icon for linux
+
 ## [1.13.1] - 2020-10-06
 
 ### Changed

--- a/build/gen-electron-builder-config.js
+++ b/build/gen-electron-builder-config.js
@@ -138,6 +138,7 @@ build['linux'] = {
     keywords: 'dc;chat;delta;messaging;messenger;email',
   },
   files: [...files, PREBUILD_FILTERS.NOT_MAC, PREBUILD_FILTERS.NOT_WINDOWS],
+  icon: 'build/icon.icns', // electron builder gets the icon out of the mac icon archive
 }
 build['win'] = {
   icon: 'images/deltachat.ico',

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -194,6 +194,7 @@
       '!node_modules/deltachat-node/prebuilds/darwin-x64/${/*}',
       '!node_modules/deltachat-node/prebuilds/win32-x64/${/*}',
     ],
+    icon: 'build/icon.icns',
   },
   win: {
     icon: 'images/deltachat.ico',


### PR DESCRIPTION
fixes #1772

It turned out the icon property was missing for linux. The one for mac is probably still wrong but I'll rather look at it on a actual mac to make sure it wasn't an intentional workaround or sth. (the icon points to a non existent `resource` directory, but the file is in the build directory)