### PR TITLE
some Attachment improvments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 - Change "More info" translation to "Message Details"
+- gallery media display type is chosen via viewType now and if the mime type is not displayable by the browser an error is shown
+- minor gallery style adjustments 
 
 ## Fixed
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -149,5 +149,11 @@
   },
   "a11y_disappearing_messages_activated": {
     "message": "Disapearing messages are active for this chat"
+  },
+  "can_not_display_unsuported_file_type":{
+    "message": "Can not display this file type: %s"
+  },
+  "attachment_failed_to_load":{
+    "message": "attachment failed to load"
   }
 }

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -31,7 +31,7 @@
     border: 2px solid var(--videoPlayBtnBorder);
     border-radius: 24px;
 
-    &:hover{
+    &:hover {
       background-color: var(--videoPlayBtnBgHover);
     }
 

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -43,15 +43,12 @@
   }
 }
 
-.media-attachment-broken-media {
-  font-size: 11px;
-  line-height: 16px;
-  letter-spacing: 0.3px;
-
+.media-attachment-media.broken > .attachment-content {
+  font-size: 22px;
   padding: 10px;
-  text-align: center;
-  text-transform: uppercase;
-  color: var(--brokenMediaBg);
+  color: var(--colorDanger);
+  background-color: lightgrey;
+  margin-bottom: 0;
 }
 
 .media-attachment-audio {

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -28,7 +28,12 @@
     width: 48px;
     height: 48px;
     background-color: var(--videoPlayBtnBg);
+    border: 2px solid var(--videoPlayBtnBorder);
     border-radius: 24px;
+
+    &:hover{
+      background-color: var(--videoPlayBtnBgHover);
+    }
 
     & > .video-play-btn-icon {
       position: absolute;
@@ -71,7 +76,7 @@
 .media-attachment-generic {
   display: flex;
   flex-direction: row;
-  width: 400px;
+  width: 300px;
   margin: 5px 3px;
 
   & > .file-icon {

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -78,7 +78,7 @@ export default class DCMessageList extends SplitOut {
 
     const jsonMSG = msg.toJson()
 
-    let attachment:MessageTypeAttachment = jsonMSG.file && {
+    let attachment: MessageTypeAttachment = jsonMSG.file && {
       url: jsonMSG.file,
       contentType: convertContentType({
         filemime,

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -9,9 +9,9 @@ import mime from 'mime-types'
 import SplitOut from './splitout'
 import { Message } from 'deltachat-node'
 import {
-  JsonMessage,
   MessageType,
   MessageSearchResult,
+  MessageTypeAttachment,
 } from '../../shared/shared-types'
 export default class DCMessageList extends SplitOut {
   sendMessage(
@@ -78,7 +78,7 @@ export default class DCMessageList extends SplitOut {
 
     const jsonMSG = msg.toJson()
 
-    let attachment = jsonMSG.file && {
+    let attachment:MessageTypeAttachment = jsonMSG.file && {
       url: jsonMSG.file,
       contentType: convertContentType({
         filemime,

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -98,16 +98,10 @@ export default class Gallery extends Component<
                 .sort(
                   ({ msg: a }, { msg: b }) => b.sortTimestamp - a.sortTimestamp
                 )
-                .map((message) => {
-                  var msg = message.msg
+                .map(message => {
                   return (
-                    <div className='item' key={msg.id}>
-                      <MediaAttachment
-                        {...{
-                          attachment: msg.attachment,
-                          message
-                        }}
-                      />
+                    <div className='item' key={message.msg.id}>
+                      <MediaAttachment message={message} />
                     </div>
                   )
                 })}

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -29,7 +29,7 @@ const MediaTabs: Readonly<
 
 type mediaProps = { chat: any }
 
-export default class Media extends Component<
+export default class Gallery extends Component<
   mediaProps,
   { id: MediaTabKey; msgTypes: number[]; medias: MessageType[] }
 > {
@@ -98,17 +98,14 @@ export default class Media extends Component<
                 .sort(
                   ({ msg: a }, { msg: b }) => b.sortTimestamp - a.sortTimestamp
                 )
-                .map((message, index) => {
+                .map((message) => {
                   var msg = message.msg
                   return (
                     <div className='item' key={msg.id}>
                       <MediaAttachment
                         {...{
-                          direction: msg.direction,
                           attachment: msg.attachment,
-                          conversationType: 'direct',
-                          message,
-                          isInMediaView: true,
+                          message
                         }}
                       />
                     </div>
@@ -122,4 +119,4 @@ export default class Media extends Component<
   }
 }
 
-Media.contextType = ScreenContext
+Gallery.contextType = ScreenContext

--- a/src/renderer/components/MainScreen.tsx
+++ b/src/renderer/components/MainScreen.tsx
@@ -5,7 +5,7 @@ import {
   useTranslationFunction,
 } from '../contexts'
 
-import Media from './Media'
+import Gallery from './Gallery'
 import Menu from './Menu'
 import ChatList from './chat/ChatList'
 import MessageListAndComposer from './message/MessageListAndComposer'
@@ -74,7 +74,7 @@ export default function MainScreen() {
   const menu = <Menu selectedChat={selectedChat} />
   const MessageListView = selectedChat.id ? (
     media ? (
-      <Media chat={selectedChat} />
+      <Gallery chat={selectedChat} />
     ) : (
       <MessageListAndComposer chat={selectedChat} />
     )

--- a/src/renderer/components/attachment/Attachment.tsx
+++ b/src/renderer/components/attachment/Attachment.tsx
@@ -1,5 +1,6 @@
 const { ipcRenderer } = window.electron_functions
 import mimeTypes from 'mime-types'
+import { MessageTypeAttachment } from '../../../shared/shared-types'
 
 /* Section - Data Copied in part from Signal */
 // Supported media types in google chrome
@@ -31,14 +32,8 @@ const SUPPORTED_VIDEO_MIME_TYPES = Object.freeze([
 
 // TODO define this correctly
 // (maybe inside shared module??, but that depends on wether its also used in the backend or just exists in the frontend)
-export type attachment = {
-  [key: string]: todo
-  contentType: string
-  fileName: string
-  url: any
-}
 
-export function isImage(attachment: attachment) {
+export function isImage(attachment: MessageTypeAttachment) {
   return (
     attachment &&
     attachment.contentType &&
@@ -46,11 +41,11 @@ export function isImage(attachment: attachment) {
   )
 }
 
-export function hasImage(attachment: attachment) {
+export function hasImage(attachment: MessageTypeAttachment) {
   return attachment && attachment.url
 }
 
-export function isVideo(attachment: attachment) {
+export function isVideo(attachment: MessageTypeAttachment) {
   return (
     attachment &&
     attachment.contentType &&
@@ -58,11 +53,7 @@ export function isVideo(attachment: attachment) {
   )
 }
 
-export function hasVideoScreenshot(attachment: attachment) {
-  return attachment && attachment.screenshot && attachment.screenshot.url
-}
-
-export function isAudio(attachment: attachment) {
+export function isAudio(attachment: MessageTypeAttachment) {
   return (
     attachment &&
     attachment.contentType &&
@@ -70,11 +61,13 @@ export function isAudio(attachment: attachment) {
   )
 }
 
-export function isDisplayableByFullscreenMedia(attachment: attachment) {
+export function isDisplayableByFullscreenMedia(
+  attachment: MessageTypeAttachment
+) {
   return isImage(attachment) || isAudio(attachment) || isVideo(attachment)
 }
 
-export function getExtension({ fileName, contentType }: attachment) {
+export function getExtension({ fileName, contentType }: MessageTypeAttachment) {
   if (fileName && fileName.indexOf('.') >= 0) {
     const lastPeriod = fileName.lastIndexOf('.')
     const extension = fileName.slice(lastPeriod + 1)
@@ -86,11 +79,14 @@ export function getExtension({ fileName, contentType }: attachment) {
   return mimeTypes.extension(contentType) || null
 }
 
-export function dragAttachmentOut({ url }: attachment, dragEvent: DragEvent) {
+export function dragAttachmentOut(
+  { url }: MessageTypeAttachment,
+  dragEvent: DragEvent
+) {
   dragEvent.preventDefault()
   ipcRenderer.send('ondragstart', url)
 }
 
-export function isGenericAttachment(attachment: attachment) {
+export function isGenericAttachment(attachment: MessageTypeAttachment) {
   return !(isImage(attachment) || isVideo(attachment) || isAudio(attachment))
 }

--- a/src/renderer/components/attachment/Attachment.tsx
+++ b/src/renderer/components/attachment/Attachment.tsx
@@ -41,7 +41,7 @@ export function isImage(attachment: MessageTypeAttachment) {
   )
 }
 
-export function hasImage(attachment: MessageTypeAttachment) {
+export function hasAttachment(attachment: MessageTypeAttachment) {
   return attachment && attachment.url
 }
 

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react'
-import classNames from 'classnames'
 import { openAttachmentInShell, onDownload } from '../message/messageFunctions'
-import { ScreenContext, useTranslationFunction } from '../../contexts'
+import { ScreenContext } from '../../contexts'
 import {
   isDisplayableByFullscreenMedia,
   isImage,
@@ -9,120 +8,176 @@ import {
   isAudio,
   getExtension,
   dragAttachmentOut,
-  attachment,
 } from './Attachment'
 import Timestamp from '../conversations/Timestamp'
-import { MessageType } from '../../../shared/shared-types'
-
-type AttachmentProps = {
-  attachment: attachment
-  message: MessageType
-}
+import { MessageType, MessageTypeAttachment } from '../../../shared/shared-types'
 
 export default function MediaAttachment({
   attachment,
   message,
-}: AttachmentProps) {
-  const tx = useTranslationFunction()
+}: {
+  attachment: MessageTypeAttachment
+  message: MessageType
+}) {
   if (!attachment) {
     return null
   }
   const { openDialog } = useContext(ScreenContext)
-  const msg = message.msg
-  const onClickAttachment = (ev: any) => {
+
+  const onClickAttachment = (
+    ev: React.MouseEvent<HTMLDivElement, MouseEvent>
+  ) => {
     ev.stopPropagation()
-    if (isDisplayableByFullscreenMedia(message.msg.attachment)) {
+    const { msg } = message
+    if (isDisplayableByFullscreenMedia(msg.attachment)) {
       openDialog('FullscreenMedia', { msg })
     } else {
       openAttachmentInShell(msg)
     }
   }
   if (isImage(attachment)) {
-    if (!attachment.url) {
-      return (
-        <div className='media-attachment-broken-media'>
-          {tx('imageFailedToLoad')}
-        </div>
-      )
-    }
     return (
-      <div
-        onClick={onClickAttachment}
-        role='button'
-        className='media-attachment-media'
-      >
-        <img className='attachment-content' src={attachment.url} />
-      </div>
+      <ImageAttachment
+        attachment={attachment}
+        onClickAttachment={onClickAttachment}
+      />
     )
   } else if (isVideo(attachment)) {
-    if (!attachment.url) {
-      return (
-        <div role='button' className='media-attachment-broken-media'>
-          {tx('videoScreenshotFailedToLoad')}
-        </div>
-      )
-    }
     return (
-      <div
-        onClick={onClickAttachment}
-        role='button'
-        className='media-attachment-media'
-      >
-        <video
-          className='attachment-content'
-          src={attachment.url}
-          controls={false}
-        />
-        <div className='video-play-btn'>
-          <div className='video-play-btn-icon' />
-        </div>
-      </div>
+      <VideoAttachment
+        attachment={attachment}
+        onClickAttachment={onClickAttachment}
+      />
     )
   } else if (isAudio(attachment)) {
-    return (
-      <div className='media-attachment-audio'>
-        <div className='heading'>
-          <div className='name'>{message?.contact.displayName}</div>
-          <Timestamp
-            timestamp={message?.msg.timestamp * 1000}
-            extended
-            module='date'
-          />
-        </div>
-        <audio controls>
-          <source src={attachment.url} />
-        </audio>
-      </div>
-    )
+    return <AudioAttachment attachment={attachment} message={message} />
   } else {
-    const { fileName, fileSize, contentType } = attachment
-    const extension = getExtension(attachment)
+    return <FileAttachment attachment={attachment} message={message} />
+  }
+}
+
+type onClickFunction = (
+  ev: React.MouseEvent<HTMLDivElement, MouseEvent>
+) => void
+
+function ImageAttachment({
+  attachment,
+  onClickAttachment,
+}: {
+  attachment: MessageTypeAttachment
+  onClickAttachment: onClickFunction
+}) {
+  if (!attachment.url) {
     return (
-      <div
-        className='media-attachment-generic'
-        role='button'
-        onClick={ev => {
-          onDownload(message.msg)
-        }}
-      >
-        <div
-          className='file-icon'
-          draggable='true'
-          onClick={onClickAttachment}
-          onDragStart={dragAttachmentOut.bind(null, attachment)}
-          title={contentType}
-        >
-          {extension ? (
-            <div className='file-extension'>
-              {contentType === 'application/octet-stream' ? '' : extension}
-            </div>
-          ) : null}
-        </div>
-        <div className='text-part'>
-          <div className='name'>{fileName}</div>
-          <div className='size'>{fileSize}</div>
-        </div>
+      <div className='media-attachment-broken-media'>
+        {window.static_translate('imageFailedToLoad')}
       </div>
     )
   }
+  return (
+    <div
+      onClick={onClickAttachment}
+      role='button'
+      className='media-attachment-media'
+    >
+      <img className='attachment-content' src={attachment.url} />
+    </div>
+  )
+}
+
+function VideoAttachment({
+  attachment,
+  onClickAttachment,
+}: {
+  attachment: MessageTypeAttachment
+  onClickAttachment: onClickFunction
+}) {
+  if (!attachment.url) {
+    return (
+      <div role='button' className='media-attachment-broken-media'>
+        {window.static_translate('videoScreenshotFailedToLoad')}
+      </div>
+    )
+  }
+  return (
+    <div
+      onClick={onClickAttachment}
+      role='button'
+      className='media-attachment-media'
+    >
+      <video
+        className='attachment-content'
+        src={attachment.url}
+        controls={false}
+      />
+      <div className='video-play-btn'>
+        <div className='video-play-btn-icon' />
+      </div>
+    </div>
+  )
+}
+
+function AudioAttachment({
+  attachment,
+  message,
+}: {
+  attachment: MessageTypeAttachment
+  message: MessageType
+}) {
+  return (
+    <div className='media-attachment-audio'>
+      <div className='heading'>
+        <div className='name'>{message?.contact.displayName}</div>
+        <Timestamp
+          timestamp={message?.msg.timestamp * 1000}
+          extended
+          module='date'
+        />
+      </div>
+      <audio controls>
+        <source src={attachment.url} />
+      </audio>
+    </div>
+  )
+}
+
+function FileAttachment({
+  attachment,
+  message,
+}: {
+  attachment: MessageTypeAttachment
+  message: MessageType
+}) {
+  const { fileName, fileSize, contentType } = attachment
+  const extension = getExtension(attachment)
+  return (
+    <div
+      className='media-attachment-generic'
+      role='button'
+      onClick={ev => {
+        onDownload(message.msg)
+      }}
+    >
+      <div
+        className='file-icon'
+        draggable='true'
+        onClick={ev => {
+          ev.stopPropagation()
+          openAttachmentInShell(message.msg)
+        }}
+        onDragStart={dragAttachmentOut.bind(null, attachment)}
+        title={contentType}
+      >
+        {extension ? (
+          <div className='file-extension'>
+            {contentType === 'application/octet-stream' ? '' : extension}
+          </div>
+        ) : null}
+      </div>
+      <div className='text-part'>
+        <div className='name'>{fileName}</div>
+        <div className='size'>{fileSize}</div>
+      </div>
+    </div>
+  )
 }

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react'
 import { openAttachmentInShell, onDownload } from '../message/messageFunctions'
 import { ScreenContext } from '../../contexts'
 import {
-  isDisplayableByFullscreenMedia,
   isImage,
   isVideo,
   isAudio,
@@ -10,71 +9,38 @@ import {
   dragAttachmentOut,
 } from './Attachment'
 import Timestamp from '../conversations/Timestamp'
-import {
-  MessageType,
-  MessageTypeAttachment,
-} from '../../../shared/shared-types'
+import { MessageType } from '../../../shared/shared-types'
 import { C } from 'deltachat-node/dist/constants'
 
 export default function MediaAttachment({ message }: { message: MessageType }) {
-  const attachment = message.msg.attachment
-  if (!attachment) {
+  if (!message.msg.attachment) {
     return null
   }
-  const { openDialog } = useContext(ScreenContext)
-
-  const onClickAttachment = (
-    ev: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => {
-    ev.stopPropagation()
-    const { msg } = message
-    if (isDisplayableByFullscreenMedia(msg.attachment)) {
-      openDialog('FullscreenMedia', { msg })
-    } else {
-      openAttachmentInShell(msg)
-    }
-  }
-
   switch (message.msg.viewType) {
     case C.DC_MSG_GIF:
     case C.DC_MSG_IMAGE:
-      return (
-        <ImageAttachment
-          attachment={attachment}
-          onClickAttachment={onClickAttachment}
-        />
-      )
+      return <ImageAttachment message={message} />
     case C.DC_MSG_VIDEO:
-      return (
-        <VideoAttachment
-          attachment={attachment}
-          onClickAttachment={onClickAttachment}
-        />
-      )
+      return <VideoAttachment message={message} />
     case C.DC_MSG_AUDIO:
     case C.DC_MSG_VOICE:
-      return <AudioAttachment attachment={attachment} message={message} />
+      return <AudioAttachment message={message} />
     case C.DC_MSG_FILE:
     default:
-      return <FileAttachment attachment={attachment} message={message} />
+      return <FileAttachment message={message} />
   }
 }
 
-type onClickFunction = (
-  ev: React.MouseEvent<HTMLDivElement, MouseEvent>
-) => void
-
-function ImageAttachment({
-  attachment,
-  onClickAttachment,
-}: {
-  attachment: MessageTypeAttachment
-  onClickAttachment: onClickFunction
-}) {
+function ImageAttachment({ message }: { message: MessageType }) {
+  const { openDialog } = useContext(ScreenContext)
+  const { attachment } = message.msg
   const hasSupportedFormat = isImage(attachment)
   if (!attachment.url || !hasSupportedFormat) {
     return (
-      <div className='media-attachment-media broken'>
+      <div
+        className='media-attachment-media broken'
+        onClick={() => openAttachmentInShell(message.msg)}
+      >
         <div className='attachment-content'>
           {hasSupportedFormat
             ? window.static_translate('attachment_failed_to_load')
@@ -88,7 +54,7 @@ function ImageAttachment({
   }
   return (
     <div
-      onClick={onClickAttachment}
+      onClick={() => openDialog('FullscreenMedia', { msg: message.msg })}
       role='button'
       className='media-attachment-media'
     >
@@ -97,17 +63,16 @@ function ImageAttachment({
   )
 }
 
-function VideoAttachment({
-  attachment,
-  onClickAttachment,
-}: {
-  attachment: MessageTypeAttachment
-  onClickAttachment: onClickFunction
-}) {
+function VideoAttachment({ message }: { message: MessageType }) {
+  const { openDialog } = useContext(ScreenContext)
+  const { attachment } = message.msg
   const hasSupportedFormat = isVideo(attachment)
   if (!attachment.url || !hasSupportedFormat) {
     return (
-      <div className='media-attachment-media broken'>
+      <div
+        className='media-attachment-media broken'
+        onClick={() => openAttachmentInShell(message.msg)}
+      >
         <div className='attachment-content'>
           {hasSupportedFormat
             ? window.static_translate('attachment_failed_to_load')
@@ -121,7 +86,7 @@ function VideoAttachment({
   }
   return (
     <div
-      onClick={onClickAttachment}
+      onClick={() => openDialog('FullscreenMedia', { msg: message.msg })}
       role='button'
       className='media-attachment-media'
     >
@@ -137,13 +102,8 @@ function VideoAttachment({
   )
 }
 
-function AudioAttachment({
-  attachment,
-  message,
-}: {
-  attachment: MessageTypeAttachment
-  message: MessageType
-}) {
+function AudioAttachment({ message }: { message: MessageType }) {
+  const { attachment } = message.msg
   const hasSupportedFormat = isAudio(attachment)
   return (
     <div className='media-attachment-audio'>
@@ -171,13 +131,8 @@ function AudioAttachment({
   )
 }
 
-function FileAttachment({
-  attachment,
-  message,
-}: {
-  attachment: MessageTypeAttachment
-  message: MessageType
-}) {
+function FileAttachment({ message }: { message: MessageType }) {
+  const { attachment } = message.msg
   const { fileName, fileSize, contentType } = attachment
   const extension = getExtension(attachment)
   return (

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -11,7 +11,10 @@ import {
   getExtension,
   dragAttachmentOut,
 } from './Attachment'
-import { MessageType, MessageTypeAttachment } from '../../../shared/shared-types'
+import {
+  MessageType,
+  MessageTypeAttachment,
+} from '../../../shared/shared-types'
 
 const MINIMUM_IMG_HEIGHT = 150
 const MAXIMUM_IMG_HEIGHT = 300
@@ -61,7 +64,7 @@ export default function Attachment({
         <div
           className={classNames('message-attachment-broken-media', direction)}
         >
-          {tx('imageFailedToLoad')}
+          {tx('attachment_failed_to_load')}
         </div>
       )
     }
@@ -87,7 +90,7 @@ export default function Attachment({
           style={{ cursor: 'pointer' }}
           className={classNames('message-attachment-broken-media', direction)}
         >
-          {tx('videoScreenshotFailedToLoad')}
+          {tx('attachment_failed_to_load')}
         </div>
       )
     }

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -10,15 +10,14 @@ import {
   isAudio,
   getExtension,
   dragAttachmentOut,
-  attachment,
 } from './Attachment'
-import { MessageType } from '../../../shared/shared-types'
+import { MessageType, MessageTypeAttachment } from '../../../shared/shared-types'
 
 const MINIMUM_IMG_HEIGHT = 150
 const MAXIMUM_IMG_HEIGHT = 300
 
 type AttachmentProps = {
-  attachment: attachment
+  attachment: MessageTypeAttachment
   text?: string
   conversationType: 'group' | 'direct'
   direction: MessageType['msg']['direction']

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -7,7 +7,11 @@ import MessageMetaData from './MessageMetaData'
 
 import { ContextMenu, ContextMenuTrigger, MenuItem } from 'react-contextmenu'
 import Attachment from '../attachment/messageAttachment'
-import { MessageType, DCContact, MessageTypeAttachment } from '../../../shared/shared-types'
+import {
+  MessageType,
+  DCContact,
+  MessageTypeAttachment,
+} from '../../../shared/shared-types'
 import { isGenericAttachment } from '../attachment/Attachment'
 import { useTranslationFunction, ScreenContext } from '../../contexts'
 import { joinCall } from '../helpers/ChatMethods'

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -7,8 +7,8 @@ import MessageMetaData from './MessageMetaData'
 
 import { ContextMenu, ContextMenuTrigger, MenuItem } from 'react-contextmenu'
 import Attachment from '../attachment/messageAttachment'
-import { MessageType, DCContact } from '../../../shared/shared-types'
-import { attachment, isGenericAttachment } from '../attachment/Attachment'
+import { MessageType, DCContact, MessageTypeAttachment } from '../../../shared/shared-types'
+import { isGenericAttachment } from '../attachment/Attachment'
 import { useTranslationFunction, ScreenContext } from '../../contexts'
 import { joinCall } from '../helpers/ChatMethods'
 import { C } from 'deltachat-node/dist/constants'
@@ -98,7 +98,7 @@ const InlineMenu = (
   showMenu: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void,
   triggerId: string,
   props: {
-    attachment: attachment
+    attachment: MessageTypeAttachment
     message: MessageType | { msg: null }
     // onReply
     viewType: number
@@ -136,7 +136,7 @@ const InlineMenu = (
 
 const contextMenu = (
   props: {
-    attachment: attachment
+    attachment: MessageTypeAttachment
     direction: 'incoming' | 'outgoing'
     status: msgStatus
     onDelete: Function
@@ -226,7 +226,7 @@ const Message = (props: {
   text?: string
   disableMenu?: boolean
   status: msgStatus
-  attachment: attachment
+  attachment: MessageTypeAttachment
   onContactClick: (contact: DCContact) => void
   onClickMessageBody: (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>
@@ -351,7 +351,7 @@ export const CallMessage = (props: {
   text?: string
   disableMenu?: boolean
   status: msgStatus
-  attachment: attachment
+  attachment: MessageTypeAttachment
   onContactClick: (contact: DCContact) => void
   onClickMessageBody: (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>

--- a/src/renderer/components/message/MessageMetaData.tsx
+++ b/src/renderer/components/message/MessageMetaData.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import Timestamp from '../conversations/Timestamp'
-import { isImage, isVideo, hasImage } from '../attachment/Attachment'
+import { isImage, isVideo, hasAttachment } from '../attachment/Attachment'
 import { i18nContext } from '../../contexts'
 import { MessageTypeAttachment } from '../../../shared/shared-types'
 
@@ -29,7 +29,8 @@ export default class MessageMetaData extends React.Component<{
 
     const withImageNoCaption = Boolean(
       !text &&
-        ((isImage(attachment) && hasImage(attachment)) || isVideo(attachment))
+        ((isImage(attachment) && hasAttachment(attachment)) ||
+          isVideo(attachment))
     )
     const showError = status === 'error' && direction === 'outgoing'
 

--- a/src/renderer/components/message/MessageMetaData.tsx
+++ b/src/renderer/components/message/MessageMetaData.tsx
@@ -1,19 +1,14 @@
 import React from 'react'
 import classNames from 'classnames'
 import Timestamp from '../conversations/Timestamp'
-import {
-  isImage,
-  isVideo,
-  hasVideoScreenshot,
-  hasImage,
-  attachment,
-} from '../attachment/Attachment'
+import { isImage, isVideo, hasImage } from '../attachment/Attachment'
 import { i18nContext } from '../../contexts'
+import { MessageTypeAttachment } from '../../../shared/shared-types'
 
 export default class MessageMetaData extends React.Component<{
   padlock: boolean
   username?: string
-  attachment?: attachment
+  attachment?: MessageTypeAttachment
   direction?: 'incoming' | 'outgoing'
   status: 'error' | 'sending' | 'draft' | 'delivered' | 'read' | ''
   text?: string
@@ -34,8 +29,7 @@ export default class MessageMetaData extends React.Component<{
 
     const withImageNoCaption = Boolean(
       !text &&
-        ((isImage(attachment) && hasImage(attachment)) ||
-          (isVideo(attachment) && hasVideoScreenshot(attachment)))
+        ((isImage(attachment) && hasImage(attachment)) || isVideo(attachment))
     )
     const showError = status === 'error' && direction === 'outgoing'
 

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -146,6 +146,14 @@ export interface FullChat {
 }
 
 type todo = any
+
+export interface MessageTypeAttachment {
+  url: string
+  contentType: string
+  fileName: string
+  fileSize: string
+}
+
 export interface MessageType {
   id: number
   msg: JsonMessage & {
@@ -153,12 +161,7 @@ export interface MessageType {
     receivedAt: number
     direction: 'outgoing' | 'incoming'
     status: todo
-    attachment?: {
-      url: string
-      contentType: string
-      fileName: string
-      fileSize: string
-    }
+    attachment?: MessageTypeAttachment
   }
   filemime: string
   filename: string

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -156,6 +156,8 @@ $hover-contrast-change: 2%;
   --mapOverlayBg: #{$bgPrimary};
   --videoPlayBtnIcon: #{$accentColor};
   --videoPlayBtnBg: #ffffff; // Manual value: This will not get generated in the future
+  --videoPlayBtnBorder: #eaeaea;
+  --videoPlayBtnBgHover: #eeeeee;
 
   @if lightness($bgPrimary) < 50 {
     --scrollbarThumb: #{rgba(white, $scrollbarTransparency)};


### PR DESCRIPTION
- restructure GalleryMediaAttachment code
- use real attachment type
- rename Gallery file from Media.tsx to Gallery.tsx
- display type is chosen via viewType now and if the mime type is not displayable by the browser an error is shown (fixes #1394)

adjust gallery styles:
- shorten width of files a bit so two rows can be displayed at once on half fullhd screen
- adjust play button in videos in gallery to make it clearer its a button.
