### PR TITLE
adjust labeled link regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix hover color on emoji picker for light theme
 - Fix missing translations in emoji picker
 - Fix broken enlargen group image #1924
+- Fix two issues with the labeled link (see  #1893)
 
 ## [1.13.1] - 2020-10-06
 

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -52,7 +52,7 @@ export const rules: SimpleMarkdown.ParserRules = Object.assign(
     labeled_link: {
       order: 18,
       match: anyScopeRegex(
-        /^\[([^\]]*)\]\((\w+:\/\/[^\s<]+[^<>,;"')\]\s]{3,1000})\)(:?\s|$)/
+        /^\[([^\]]*)\]\((\w+:\/\/[^<>,;"'\[\]\)\s]{3,1000})\)/
       ),
       parse: function(
         capture: RegExpMatchArray,
@@ -67,11 +67,13 @@ export const rules: SimpleMarkdown.ParserRules = Object.assign(
       },
       react: function(node: any, output: any, state: any) {
         return (
-          <LabeledLink
-            key={state.key}
-            target={node.target}
-            label={node.label}
-          />
+          <>
+            <LabeledLink
+              key={state.key}
+              target={node.target}
+              label={node.label}
+            />{' '}
+          </>
         )
       },
     },


### PR DESCRIPTION
to fix the merge of two links after another
and the bug that it ate the linebreak if one followed
fixes #1893