### PR TITLE
🚧 Add preference to trust all labeled links 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add the account name to the account deletion-confirmation dialog
 - Add a hover tool-tip with account path and size when hovering over the email address of an account
   (this is useful when importing a backup of an account you already have and can't distinguish which is the old account and which is the imported one)
+- add preference to trust all labeled links (don't show the confirmation dialog, just open them)
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - gallery media display type is chosen via viewType now and if the mime type is not displayable by the browser an error is shown
 - minor gallery style adjustments 
 - Own Context Menu Implementation that makes development easier
+- Adjust order of buttons at labeled link dialog
 
 ## Fixed
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -200,5 +200,8 @@
   },
   "account_info_hover_tooltip_desktop":{
     "message": "E-Mail: %s\nSize: %s\nPath: %s"
+  },
+  "pref_trust_all_labeled_links":{
+    "message": "Trust all Labeled Links"
   }
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -122,7 +122,7 @@ export default function App(props: any) {
     </CrashScreen>
   )
 }
-export function SettingsContextWrapper({
+function SettingsContextWrapper({
   account,
   children,
 }: {

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -281,6 +281,10 @@ export default function Settings(props: DialogProps) {
             <Card elevation={Elevation.ONE}>
               <H5>{tx('pref_experimental_features')}</H5>
               {renderDTSettingSwitch(
+                'trustAllLabeledLinks',
+                tx('pref_trust_all_labeled_links')
+              )}
+              {renderDTSettingSwitch(
                 'enableOnDemandLocationStreaming',
                 tx('pref_on_demand_location_streaming')
               )}

--- a/src/renderer/components/message/LabeledLink.tsx
+++ b/src/renderer/components/message/LabeledLink.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from 'react'
-import { ScreenContext } from '../../contexts'
+import { ScreenContext, SettingsContext } from '../../contexts'
 import { toASCII } from 'punycode'
 import { OpenDialogFunctionType } from '../dialogs/DialogController'
 import {
@@ -39,6 +39,7 @@ export const LabeledLink = ({
   target: string
 }) => {
   const { openDialog } = useContext(ScreenContext)
+  const { desktopSettings } = useContext(SettingsContext)
 
   const url = UrlParser(target)
   // encode the punycode to make phishing harder
@@ -54,7 +55,10 @@ export const LabeledLink = ({
     ev.preventDefault()
     ev.stopPropagation()
     //check if domain is trusted
-    if (isDomainTrusted(url.hostname)) {
+    if (
+      isDomainTrusted(url.hostname) ||
+      desktopSettings['trustAllLabeledLinks']
+    ) {
       openExternal(target)
       return
     }
@@ -111,7 +115,7 @@ function confirmationDialog(
                   onClose()
                   navigator.clipboard.writeText(target)
                 }}
-                style={{marginRight:'auto'}}
+                style={{ marginRight: 'auto' }}
               >
                 {tx('menu_copy_link_to_clipboard')}
               </p>

--- a/src/renderer/components/message/LabeledLink.tsx
+++ b/src/renderer/components/message/LabeledLink.tsx
@@ -105,17 +105,18 @@ function confirmationDialog(
           </div>
           <DeltaDialogFooter>
             <DeltaDialogFooterActions>
-              <p className={`delta-button bold primary`} onClick={onClose}>
-                {tx('no')}
-              </p>
               <p
                 className={`delta-button bold primary`}
                 onClick={() => {
                   onClose()
                   navigator.clipboard.writeText(target)
                 }}
+                style={{marginRight:'auto'}}
               >
                 {tx('menu_copy_link_to_clipboard')}
+              </p>
+              <p className={`delta-button bold primary`} onClick={onClose}>
+                {tx('cancel')}
               </p>
               <p
                 className={`delta-button bold primary`}

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -41,6 +41,7 @@ export interface DesktopSettings {
   zoomFactor: number
   /** adress to the active theme file scheme: "custom:name" or "dc:name" */
   activeTheme: string
+  trustAllLabeledLinks: boolean
 }
 
 export interface AppState {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -19,6 +19,7 @@ export function getDefaultState(): AppState {
       lastChats: {},
       zoomFactor: 1,
       activeTheme: 'system',
+      trustAllLabeledLinks: false,
     },
     logins: [],
   }


### PR DESCRIPTION
- Adjust order of buttons at labeled link dialog
![2020-10-14_00-19](https://user-images.githubusercontent.com/18725968/95928369-7a802600-0dc1-11eb-8af5-53964137aa9b.png)

- Add preference to trust all labeled links 
![2020-10-14_01-20](https://user-images.githubusercontent.com/18725968/95928380-81a73400-0dc1-11eb-87dc-947774c6d720.png)

Fixes #1894