### PR TITLE
Refactor message component and display quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Own Context Menu Implementation that makes development easier
 - Update translations
 - Update deltachat-node to v1.47.0
+- hasLocation indicator on messages is now always shown even when the experimental Location streaming feature is not turned on
 
 ## Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   (this is useful when importing a backup of an account you already have and can't distinguish which is the old account and which is the imported one)
 - Add context menu to gallery
 - Option for packagers to disable asar (`NO_ASAR=true npm run pack:generate_config`).
+- Added context menu for info messages
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Option for packagers to disable asar (`NO_ASAR=true npm run pack:generate_config`).
 - Added context menu for info messages
 - Add simple support for displaying qoutes (no attachment preview nor jump to message yet)
+- Show sending indicator for outgoing info messages #1867
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Add context menu to gallery
 - Option for packagers to disable asar (`NO_ASAR=true npm run pack:generate_config`).
 - Added context menu for info messages
+- Add simple support for displaying qoutes (no attachment preview nor jump to message yet)
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -151,9 +151,9 @@
     }
 
     .qoute {
-      border-left: 4px gray solid;
-      padding: 4px 4px;
-      padding-left: 6px;
+      border-left: 3px gray solid;
+      padding: 0 4px;
+      padding-left: 9px;
       margin: 2px 0 5px 0;
 
       // &.has-message:hover {

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -149,6 +149,38 @@
         }
       }
     }
+
+    .qoute {
+      border-left: 4px gray solid;
+      padding: 4px 4px;
+      margin: 2px 0 5px 0;
+      background: rgba(0, 0, 0, 0.06);
+
+      &.has-message:hover {
+        background: rgba(0, 0, 0, 0.07);
+      }
+
+      .qoute-author {
+        font-size: 13px;
+        line-height: 13px;
+      }
+
+      p {
+        font-size: 12px;
+        line-height: 12px;
+        margin: 0;
+        max-height: 40px;
+        overflow: hidden;
+        line-clamp: 3;
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        // see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+        // and yes using this property is a bit hacky and depends on browser support
+        // but atleast its simpler than estimating size with js
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+    }
   }
 
   .metadata {

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -153,16 +153,18 @@
     .qoute {
       border-left: 4px gray solid;
       padding: 4px 4px;
+      padding-left: 6px;
       margin: 2px 0 5px 0;
-      background: rgba(0, 0, 0, 0.06);
 
-      &.has-message:hover {
-        background: rgba(0, 0, 0, 0.07);
-      }
+      // &.has-message:hover {
+      //   background: rgba(0, 0, 0, 0.07);
+      // }
 
       .qoute-author {
         font-size: 13px;
         line-height: 13px;
+        margin-bottom: 2px;
+        font-weight: 300;
       }
 
       p {
@@ -179,6 +181,7 @@
         // but atleast its simpler than estimating size with js
         -webkit-box-orient: vertical;
         overflow: hidden;
+        color: var(--messageQuotedText);
       }
     }
   }

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -113,7 +113,7 @@
     }
 
     .msg-body {
-      &.msg-body--clickable {
+      &.msg-body--clickable > .text {
         cursor: pointer;
       }
 

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -428,4 +428,8 @@
     white-space: pre-wrap;
     text-align: left;
   }
+
+  .status-icon.sending {
+    background-color: var(--infoMessageBubbleText);
+  }
 }

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -388,11 +388,6 @@
     color: var(--infoMessageBubbleText);
   }
 
-  &[custom-selectable] {
-    user-select: auto;
-    user-select: all;
-  }
-
   &.big > p {
     max-width: 550px;
     font-size: 1rem;

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -169,7 +169,7 @@ export default class DCMessageList extends SplitOut {
   }
 }
 
-function convertMessageStatus(s: number):msgStatus {
+function convertMessageStatus(s: number): msgStatus {
   switch (s) {
     case C.DC_STATE_IN_FRESH:
       return 'sent'

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -12,6 +12,7 @@ import {
   MessageType,
   MessageSearchResult,
   MessageTypeAttachment,
+  msgStatus,
 } from '../../shared/shared-types'
 export default class DCMessageList extends SplitOut {
   sendMessage(
@@ -168,7 +169,7 @@ export default class DCMessageList extends SplitOut {
   }
 }
 
-function convertMessageStatus(s: number) {
+function convertMessageStatus(s: number):msgStatus {
   switch (s) {
     case C.DC_STATE_IN_FRESH:
       return 'sent'

--- a/src/renderer/components/helpers/MapMsgStatus.ts
+++ b/src/renderer/components/helpers/MapMsgStatus.ts
@@ -1,6 +1,7 @@
 import { C } from 'deltachat-node/dist/constants'
+import { msgStatus } from '../../../shared/shared-types'
 
-export function mapCoreMsgStatus2String(state: number) {
+export function mapCoreMsgStatus2String(state: number):msgStatus {
   switch (state) {
     case C.DC_STATE_OUT_FAILED:
       return 'error'

--- a/src/renderer/components/helpers/MapMsgStatus.ts
+++ b/src/renderer/components/helpers/MapMsgStatus.ts
@@ -1,7 +1,7 @@
 import { C } from 'deltachat-node/dist/constants'
 import { msgStatus } from '../../../shared/shared-types'
 
-export function mapCoreMsgStatus2String(state: number):msgStatus {
+export function mapCoreMsgStatus2String(state: number): msgStatus {
   switch (state) {
     case C.DC_STATE_OUT_FAILED:
       return 'error'

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -260,6 +260,15 @@ const Message = (props: {
     })
   }
 
+  // Info Message
+  if (message.isInfo)
+    return (
+      <div className='info-message' onContextMenu={showMenu}>
+        <p>{text}</p>
+      </div>
+    )
+
+  // Normal Message
   const onContactClick = async (contact: DCContact) => {
     openViewProfileDialog(screenContext, contact.id)
   }

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -3,6 +3,7 @@ import {
   openAttachmentInShell,
   forwardMessage,
   deleteMessage,
+  openMessageInfo,
 } from './messageFunctions'
 import React, { useRef, useContext } from 'react'
 
@@ -145,10 +146,9 @@ function buildContextMenu(
     direction,
     status,
     message,
-    text,
     // onReply,
     // onRetrySend,
-    onShowDetail,
+    text,
   }: {
     attachment: MessageTypeAttachment
     direction: 'incoming' | 'outgoing'
@@ -157,7 +157,6 @@ function buildContextMenu(
     text?: string
     // onReply:Function
     // onRetrySend: Function
-    onShowDetail: Function
   },
   link: string,
   chatStoreDispatch: ChatStoreDispatch
@@ -205,7 +204,7 @@ function buildContextMenu(
     },
     {
       label: tx('menu_message_details'),
-      action: onShowDetail,
+      action: openMessageInfo.bind(null, message),
     },
     // showRetry && {
     //   label:tx('retry_send'),
@@ -233,7 +232,6 @@ const Message = (props: {
   onClickMessageBody: (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>
   ) => void
-  onShowDetail: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
   padlock: boolean
   /* onRetrySend */
 }) => {
@@ -248,7 +246,6 @@ const Message = (props: {
     attachment,
     onContactClick,
     onClickMessageBody,
-    onShowDetail,
   } = props
   const tx = useTranslationFunction()
 
@@ -319,7 +316,9 @@ const Message = (props: {
               <MessageBody text={text || ''} />
             )}
           </div>
-          {longMessage && <button onClick={onShowDetail}>...</button>}
+          {longMessage && (
+            <button onClick={openMessageInfo.bind(null, message)}>...</button>
+          )}
           <MessageMetaData {...props} />
         </div>
       </div>
@@ -344,7 +343,6 @@ export const CallMessage = (props: {
   onClickMessageBody: (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>
   ) => void
-  onShowDetail: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
   padlock: boolean
 }) => {
   const {

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -265,7 +265,16 @@ const Message = (props: {
   if (message.isInfo)
     return (
       <div className='info-message' onContextMenu={showMenu}>
-        <p>{text}</p>
+        <p>
+          {text}
+          {direction === 'outgoing' &&
+            (status === 'sending' || status === 'error') && (
+              <div
+                className={classNames('status-icon', status)}
+                aria-label={tx(`a11y_delivery_status_${status}`)}
+              />
+            )}
+        </p>
       </div>
     )
 

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -169,6 +169,9 @@ export const MessageListInner = React.memo(
 
     let specialMessageIdCounter = 0
 
+    const conversationType: 'group' | 'direct' =
+      chat.type === C.DC_CHAT_TYPE_GROUP ? 'group' : 'direct'
+
     return (
       <div id='message-list' ref={messageListRef} onScroll={onScroll}>
         <ul>
@@ -191,7 +194,7 @@ export const MessageListInner = React.memo(
               <MessageWrapper
                 key={messageId}
                 message={message as MessageType}
-                chat={chat}
+                conversationType={conversationType}
               />
             )
           })}

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -146,7 +146,6 @@ export default function MessageList({
       messageListRef={messageListRef}
       locationStreamingEnabled={locationStreamingEnabled}
       chat={chat}
-      chatStoreDispatch={chatStoreDispatch}
     />
   )
 }
@@ -160,7 +159,6 @@ export const MessageListInner = React.memo(
     messageListRef: todo
     locationStreamingEnabled: boolean
     chat: ChatStoreState
-    chatStoreDispatch: ChatStoreDispatch
   }) => {
     const {
       onScroll,
@@ -170,7 +168,6 @@ export const MessageListInner = React.memo(
       messageListRef,
       locationStreamingEnabled,
       chat,
-      chatStoreDispatch,
     } = props
 
     const _messageIdsToShow = messageIdsToShow(
@@ -204,7 +201,6 @@ export const MessageListInner = React.memo(
                 message={message as MessageType}
                 locationStreamingEnabled={locationStreamingEnabled}
                 chat={chat}
-                chatStoreDispatch={chatStoreDispatch}
               />
             )
           })}

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -1,10 +1,6 @@
 import React, { useRef, useEffect } from 'react'
 import { MessageWrapper } from './MessageWrapper'
-import {
-  useChatStore,
-  ChatStoreState,
-  ChatStoreDispatch,
-} from '../../stores/chat'
+import { useChatStore, ChatStoreState } from '../../stores/chat'
 import { useDebouncedCallback } from 'use-debounce'
 import { C } from 'deltachat-node/dist/constants'
 import moment from 'moment'
@@ -29,11 +25,9 @@ const messageIdsToShow = (
 export default function MessageList({
   chat,
   refComposer,
-  locationStreamingEnabled,
 }: {
   chat: ChatStoreState
   refComposer: todo
-  locationStreamingEnabled: boolean
 }) {
   const [
     {
@@ -144,7 +138,6 @@ export default function MessageList({
       messageIds={messageIds}
       messages={messages}
       messageListRef={messageListRef}
-      locationStreamingEnabled={locationStreamingEnabled}
       chat={chat}
     />
   )
@@ -157,7 +150,6 @@ export const MessageListInner = React.memo(
     messageIds: number[]
     messages: ChatStoreState['messages']
     messageListRef: todo
-    locationStreamingEnabled: boolean
     chat: ChatStoreState
   }) => {
     const {
@@ -166,7 +158,7 @@ export const MessageListInner = React.memo(
       messageIds,
       messages,
       messageListRef,
-      locationStreamingEnabled,
+
       chat,
     } = props
 
@@ -199,7 +191,6 @@ export const MessageListInner = React.memo(
               <MessageWrapper
                 key={messageId}
                 message={message as MessageType}
-                locationStreamingEnabled={locationStreamingEnabled}
                 chat={chat}
               />
             )
@@ -213,8 +204,7 @@ export const MessageListInner = React.memo(
       prevProps.messageIds === nextProps.messageIds &&
       prevProps.messages === nextProps.messages &&
       prevProps.oldestFetchedMessageIndex ===
-        nextProps.oldestFetchedMessageIndex &&
-      prevProps.locationStreamingEnabled === nextProps.locationStreamingEnabled
+        nextProps.oldestFetchedMessageIndex
 
     return areEqual
   }

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -131,7 +131,6 @@ export default function MessageListAndComposer({
         <MessageList
           chat={chat}
           refComposer={refComposer}
-          locationStreamingEnabled={settings.enableOnDemandLocationStreaming}
         />
       </div>
       <Composer

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -128,10 +128,7 @@ export default function MessageListAndComposer({
       onDragOver={onDragOver}
     >
       <div className='message-list-and-composer__message-list'>
-        <MessageList
-          chat={chat}
-          refComposer={refComposer}
-        />
+        <MessageList chat={chat} refComposer={refComposer} />
       </div>
       <Composer
         ref={refComposer}

--- a/src/renderer/components/message/MessageMetaData.tsx
+++ b/src/renderer/components/message/MessageMetaData.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames'
 import Timestamp from '../conversations/Timestamp'
 import { isImage, isVideo, hasAttachment } from '../attachment/Attachment'
 import { i18nContext } from '../../contexts'
-import { MessageTypeAttachment } from '../../../shared/shared-types'
+import { MessageTypeAttachment, msgStatus } from '../../../shared/shared-types'
 
 export default class MessageMetaData extends React.Component<{
   padlock: boolean
   username?: string
   attachment?: MessageTypeAttachment
   direction?: 'incoming' | 'outgoing'
-  status: 'error' | 'sending' | 'draft' | 'delivered' | 'read' | ''
+  status: msgStatus
   text?: string
   timestamp: number
   hasLocation?: boolean

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -14,7 +14,6 @@ type RenderMessageProps = {
   message: MessageType
   locationStreamingEnabled: boolean
   chat: ChatStoreState
-  disableMenu?: boolean
 }
 
 export const MessageWrapper = (props: RenderMessageProps) => {
@@ -28,7 +27,6 @@ export const MessageWrapper = (props: RenderMessageProps) => {
 export const RenderMessage = React.memo(
   (props: RenderMessageProps) => {
     const { message, locationStreamingEnabled, chat } = props
-    const { id } = message.msg
     const msg = message.msg
     const screenContext = useContext(ScreenContext)
     const { openDialog } = screenContext
@@ -40,16 +38,9 @@ export const RenderMessage = React.memo(
     }
 
     let new_props = {
-      padlock: msg.showPadlock,
-      id,
       conversationType,
       // onReply: message.onReply,
       onContactClick,
-      status: msg.status,
-      text: msg.text,
-      direction: msg.direction,
-      timestamp: msg.sentAt,
-      viewType: msg.viewType,
       message,
       hasLocation: msg.hasLocation && locationStreamingEnabled,
       attachment: msg.attachment && !msg.isSetupmessage && msg.attachment,

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -12,7 +12,6 @@ const log = getLogger('renderer/messageWrapper')
 
 type RenderMessageProps = {
   message: MessageType
-  locationStreamingEnabled: boolean
   chat: ChatStoreState
 }
 
@@ -26,7 +25,7 @@ export const MessageWrapper = (props: RenderMessageProps) => {
 
 export const RenderMessage = React.memo(
   (props: RenderMessageProps) => {
-    const { message, locationStreamingEnabled, chat } = props
+    const { message, chat } = props
     const msg = message.msg
     const screenContext = useContext(ScreenContext)
     const { openDialog } = screenContext
@@ -42,7 +41,6 @@ export const RenderMessage = React.memo(
       // onReply: message.onReply,
       onContactClick,
       message,
-      hasLocation: msg.hasLocation && locationStreamingEnabled,
       attachment: msg.attachment && !msg.isSetupmessage && msg.attachment,
       onClickMessageBody: null as () => void,
     }

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -6,6 +6,7 @@ import { getLogger } from '../../../shared/logger'
 import { openViewProfileDialog } from '../helpers/ChatMethods'
 import { ChatStoreState } from '../../stores/chat'
 import { MessageType, DCContact } from '../../../shared/shared-types'
+import { openMessageInfo } from './messageFunctions'
 
 const log = getLogger('renderer/messageWrapper')
 
@@ -35,7 +36,6 @@ export const RenderMessage = React.memo(
 
     const conversationType: 'group' | 'direct' =
       chat.type === C.DC_CHAT_TYPE_GROUP ? 'group' : 'direct'
-    const onShowDetail = () => openDialog('MessageDetail', { id: message.id })
     const onContactClick = async (contact: DCContact) => {
       openViewProfileDialog(screenContext, contact.id)
     }
@@ -59,7 +59,6 @@ export const RenderMessage = React.memo(
       id,
       conversationType,
       // onReply: message.onReply,
-      onShowDetail,
       onContactClick,
       contact,
       status: msg.status,
@@ -88,7 +87,7 @@ export const RenderMessage = React.memo(
       return (
         <div
           className='info-message'
-          onContextMenu={onShowDetail}
+          onContextMenu={openMessageInfo.bind(null, message)}
           custom-selectable='true'
         >
           <p>{msg.text}</p>

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -68,7 +68,6 @@ export const RenderMessage = React.memo(
       id,
       conversationType,
       // onReply: message.onReply,
-      onForward: () => openDialog('ForwardMessage', { message }),
       onDelete,
       onShowDetail,
       onContactClick,

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -30,7 +30,6 @@ export const RenderMessage = React.memo(
     const { message, locationStreamingEnabled, chat } = props
     const { fromId, id } = message.msg
     const msg = message.msg
-    const tx = useTranslationFunction()
     const screenContext = useContext(ScreenContext)
     const { openDialog } = screenContext
 
@@ -45,13 +44,6 @@ export const RenderMessage = React.memo(
       onClick: () => {
         log.debug('click contact')
       },
-    }
-
-    if (
-      msg.text ===
-      '[The message was sent with non-verified encryption.. See "Info" for details.]'
-    ) {
-      msg.text = tx('message_not_verified')
     }
 
     let new_props = {

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -4,7 +4,6 @@ import Message, { CallMessage } from './Message'
 import { ScreenContext } from '../../contexts'
 import { getLogger } from '../../../shared/logger'
 import { openViewProfileDialog } from '../helpers/ChatMethods'
-import { ChatStoreState } from '../../stores/chat'
 import { MessageType, DCContact } from '../../../shared/shared-types'
 import { openMessageInfo } from './messageFunctions'
 
@@ -12,7 +11,7 @@ const log = getLogger('renderer/messageWrapper')
 
 type RenderMessageProps = {
   message: MessageType
-  chat: ChatStoreState
+  conversationType: 'group' | 'direct'
 }
 
 export const MessageWrapper = (props: RenderMessageProps) => {
@@ -25,13 +24,11 @@ export const MessageWrapper = (props: RenderMessageProps) => {
 
 export const RenderMessage = React.memo(
   (props: RenderMessageProps) => {
-    const { message, chat } = props
+    const { message, conversationType } = props
     const msg = message.msg
     const screenContext = useContext(ScreenContext)
     const { openDialog } = screenContext
 
-    const conversationType: 'group' | 'direct' =
-      chat.type === C.DC_CHAT_TYPE_GROUP ? 'group' : 'direct'
     const onContactClick = async (contact: DCContact) => {
       openViewProfileDialog(screenContext, contact.id)
     }

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -4,7 +4,7 @@ import Message, { CallMessage } from './Message'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
 import { getLogger } from '../../../shared/logger'
 import { openViewProfileDialog } from '../helpers/ChatMethods'
-import { ChatStoreState, ChatStoreDispatch } from '../../stores/chat'
+import { ChatStoreState } from '../../stores/chat'
 import { MessageType, DCContact } from '../../../shared/shared-types'
 
 const log = getLogger('renderer/messageWrapper')
@@ -13,7 +13,6 @@ type RenderMessageProps = {
   message: MessageType
   locationStreamingEnabled: boolean
   chat: ChatStoreState
-  chatStoreDispatch: ChatStoreDispatch
   disableMenu?: boolean
 }
 
@@ -27,7 +26,7 @@ export const MessageWrapper = (props: RenderMessageProps) => {
 
 export const RenderMessage = React.memo(
   (props: RenderMessageProps) => {
-    const { message, locationStreamingEnabled, chat, chatStoreDispatch } = props
+    const { message, locationStreamingEnabled, chat } = props
     const { fromId, id } = message.msg
     const msg = message.msg
     const tx = useTranslationFunction()
@@ -37,14 +36,6 @@ export const RenderMessage = React.memo(
     const conversationType: 'group' | 'direct' =
       chat.type === C.DC_CHAT_TYPE_GROUP ? 'group' : 'direct'
     const onShowDetail = () => openDialog('MessageDetail', { id: message.id })
-    const onDelete = () =>
-      openDialog('ConfirmationDialog', {
-        message: tx('ask_delete_message_desktop'),
-        confirmLabel: tx('delete'),
-        cb: (yes: boolean) =>
-          yes &&
-          chatStoreDispatch({ type: 'UI_DELETE_MESSAGE', payload: msg.id }),
-      })
     const onContactClick = async (contact: DCContact) => {
       openViewProfileDialog(screenContext, contact.id)
     }
@@ -68,7 +59,6 @@ export const RenderMessage = React.memo(
       id,
       conversationType,
       // onReply: message.onReply,
-      onDelete,
       onShowDetail,
       onContactClick,
       contact,

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import Message from './Message'
 import { getLogger } from '../../../shared/logger'
 import { MessageType } from '../../../shared/shared-types'
-import { openMessageInfo } from './messageFunctions'
 
 const log = getLogger('renderer/messageWrapper')
 
@@ -19,26 +18,7 @@ export const MessageWrapper = (props: RenderMessageProps) => {
   )
 }
 
-export const RenderMessage = React.memo(
-  (props: RenderMessageProps) => {
-    const { message } = props
-    const msg = message.msg
-
-    if (message.isInfo)
-      return (
-        <div
-          className='info-message'
-          onContextMenu={openMessageInfo.bind(null, message)}
-          custom-selectable='true'
-        >
-          <p>{msg.text}</p>
-        </div>
-      )
-
-    return <Message {...props} />
-  },
-  (prevProps, nextProps) => {
-    const areEqual = prevProps.message === nextProps.message
-    return areEqual
-  }
-)
+export const RenderMessage = React.memo(Message, (prevProps, nextProps) => {
+  const areEqual = prevProps.message === nextProps.message
+  return areEqual
+})

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -1,10 +1,7 @@
-import React, { useContext } from 'react'
-import { C } from 'deltachat-node/dist/constants'
-import Message, { CallMessage } from './Message'
-import { ScreenContext } from '../../contexts'
+import React from 'react'
+import Message from './Message'
 import { getLogger } from '../../../shared/logger'
-import { openViewProfileDialog } from '../helpers/ChatMethods'
-import { MessageType, DCContact } from '../../../shared/shared-types'
+import { MessageType } from '../../../shared/shared-types'
 import { openMessageInfo } from './messageFunctions'
 
 const log = getLogger('renderer/messageWrapper')
@@ -26,29 +23,6 @@ export const RenderMessage = React.memo(
   (props: RenderMessageProps) => {
     const { message } = props
     const msg = message.msg
-    const screenContext = useContext(ScreenContext)
-    const { openDialog } = screenContext
-
-    const onContactClick = async (contact: DCContact) => {
-      openViewProfileDialog(screenContext, contact.id)
-    }
-
-    let new_props = {
-      // onReply: message.onReply,
-      onContactClick,
-      onClickMessageBody: null as () => void,
-    }
-
-    const isSetupmessage = message.msg.isSetupmessage
-    const isDeadDrop = message.msg.chatId === C.DC_CHAT_ID_DEADDROP
-    if (isSetupmessage) {
-      new_props.onClickMessageBody = () =>
-        openDialog('EnterAutocryptSetupMessage', { message })
-    } else if (isDeadDrop) {
-      new_props.onClickMessageBody = () => {
-        openDialog('DeadDrop', message)
-      }
-    }
 
     if (message.isInfo)
       return (
@@ -60,10 +34,8 @@ export const RenderMessage = React.memo(
           <p>{msg.text}</p>
         </div>
       )
-    if (message.msg.viewType === C.DC_MSG_VIDEOCHAT_INVITATION)
-      return <CallMessage {...props} {...new_props} />
 
-    return <Message {...props} {...new_props} />
+    return <Message {...props} />
   },
   (prevProps, nextProps) => {
     const areEqual = prevProps.message === nextProps.message

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react'
 import { C } from 'deltachat-node/dist/constants'
 import Message, { CallMessage } from './Message'
-import { ScreenContext, useTranslationFunction } from '../../contexts'
+import { ScreenContext } from '../../contexts'
 import { getLogger } from '../../../shared/logger'
 import { openViewProfileDialog } from '../helpers/ChatMethods'
 import { ChatStoreState } from '../../stores/chat'
@@ -28,7 +28,7 @@ export const MessageWrapper = (props: RenderMessageProps) => {
 export const RenderMessage = React.memo(
   (props: RenderMessageProps) => {
     const { message, locationStreamingEnabled, chat } = props
-    const { fromId, id } = message.msg
+    const { id } = message.msg
     const msg = message.msg
     const screenContext = useContext(ScreenContext)
     const { openDialog } = screenContext
@@ -39,20 +39,12 @@ export const RenderMessage = React.memo(
       openViewProfileDialog(screenContext, contact.id)
     }
 
-    const contact = {
-      onSendMessage: () => log.debug(`send a message to ${fromId}`),
-      onClick: () => {
-        log.debug('click contact')
-      },
-    }
-
     let new_props = {
       padlock: msg.showPadlock,
       id,
       conversationType,
       // onReply: message.onReply,
       onContactClick,
-      contact,
       status: msg.status,
       text: msg.text,
       direction: msg.direction,

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -24,7 +24,7 @@ export const MessageWrapper = (props: RenderMessageProps) => {
 
 export const RenderMessage = React.memo(
   (props: RenderMessageProps) => {
-    const { message, conversationType } = props
+    const { message } = props
     const msg = message.msg
     const screenContext = useContext(ScreenContext)
     const { openDialog } = screenContext
@@ -34,11 +34,8 @@ export const RenderMessage = React.memo(
     }
 
     let new_props = {
-      conversationType,
       // onReply: message.onReply,
       onContactClick,
-      message,
-      attachment: msg.attachment && !msg.isSetupmessage && msg.attachment,
       onClickMessageBody: null as () => void,
     }
 

--- a/src/renderer/components/message/messageFunctions.ts
+++ b/src/renderer/components/message/messageFunctions.ts
@@ -4,6 +4,7 @@ import { getLogger } from '../../../shared/logger'
 const log = getLogger('render/msgFunctions')
 import { Message } from 'deltachat-node'
 import { MessageType } from '../../../shared/shared-types'
+import { ChatStoreDispatch } from '../../stores/chat'
 /**
  * json representation of the message object we get from the backend
  */
@@ -21,6 +22,19 @@ export function openAttachmentInShell(msg: MsgObject) {
   }
 }
 
-export function forwardMessage(message:MessageType){
+export function forwardMessage(message: MessageType) {
   window.__openDialog('ForwardMessage', { message })
+}
+
+export function deleteMessage(
+  msg: MsgObject,
+  chatStoreDispatch: ChatStoreDispatch
+) {
+  const tx = window.static_translate
+  window.__openDialog('ConfirmationDialog', {
+    message: tx('ask_delete_message_desktop'),
+    confirmLabel: tx('delete'),
+    cb: (yes: boolean) =>
+      yes && chatStoreDispatch({ type: 'UI_DELETE_MESSAGE', payload: msg.id }),
+  })
 }

--- a/src/renderer/components/message/messageFunctions.ts
+++ b/src/renderer/components/message/messageFunctions.ts
@@ -38,3 +38,7 @@ export function deleteMessage(
       yes && chatStoreDispatch({ type: 'UI_DELETE_MESSAGE', payload: msg.id }),
   })
 }
+
+export function openMessageInfo(message: MessageType) {
+  window.__openDialog('MessageDetail', { id: message.id })
+}

--- a/src/renderer/components/message/messageFunctions.ts
+++ b/src/renderer/components/message/messageFunctions.ts
@@ -3,6 +3,7 @@ const { openItem } = window.electron_functions
 import { getLogger } from '../../../shared/logger'
 const log = getLogger('render/msgFunctions')
 import { Message } from 'deltachat-node'
+import { MessageType } from '../../../shared/shared-types'
 /**
  * json representation of the message object we get from the backend
  */
@@ -18,4 +19,8 @@ export function openAttachmentInShell(msg: MsgObject) {
       "file couldn't be opened, try saving it in a different place and try to open it from there"
     )
   }
+}
+
+export function forwardMessage(message:MessageType){
+  window.__openDialog('ForwardMessage', { message })
 }

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -154,13 +154,15 @@ export interface MessageTypeAttachment {
   fileSize: string
 }
 
+export type msgStatus = 'error' | 'sending' | 'draft' | 'delivered' | 'read' | ''
+
 export interface MessageType {
   id: number
   msg: JsonMessage & {
     sentAt: number
     receivedAt: number
     direction: 'outgoing' | 'incoming'
-    status: todo
+    status: msgStatus
     attachment?: MessageTypeAttachment
   }
   filemime: string

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -154,7 +154,13 @@ export interface MessageTypeAttachment {
   fileSize: string
 }
 
-export type msgStatus = 'error' | 'sending' | 'draft' | 'delivered' | 'read' | ''
+export type msgStatus =
+  | 'error'
+  | 'sending'
+  | 'draft'
+  | 'delivered'
+  | 'read'
+  | ''
 
 export interface MessageType {
   id: number

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -160,6 +160,7 @@ export type msgStatus =
   | 'draft'
   | 'delivered'
   | 'read'
+  | 'sent'
   | ''
 
 export interface MessageType {

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -62,6 +62,7 @@ $hover-contrast-change: 2%;
   /* Message Bubble */
   --messageText: #{$textPrimary};
   --messageTextLink: #{$textPrimary};
+  --messageQuotedText: #{changeContrast($textPrimary, 45%)};
   /* same as message text */
   --setupMessageText: #ed824e;
   --infoMessageBubbleBg: #0000008c;


### PR DESCRIPTION
- Code cleanup in the message component (remove unused code and some restructuring)
- Display quotes
- Show sending/error state indicator on outgoing info messages:
![2020-11-03_22-01](https://user-images.githubusercontent.com/18725968/98041048-98213800-1e21-11eb-93d2-d80e8c9a650b.png)
(state is only shown if its either pending or error)

for more info see the commit messages.

closes #1921
fixes #1867
fixes #1915
fixes #1866