### PR TITLE
Implement draft message with attachment & reply to message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased][unreleased]
 
-# Added
+### Added
 - Upgrade Emoji Picker(Emoji 12.1) and emojifont(Unicode 13.1) for new emoji support 🦾
 - Add Keyboard navigation between accounts in account selection screen
 - Add the account name to the account deletion-confirmation dialog
@@ -14,6 +14,9 @@
 - Add simple support for displaying qoutes (no attachment preview nor jump to message yet)
 - Show sending indicator for outgoing info messages #1867
 - Add info log message that lists all unconfigured accounts, so you don't need to find them yourself to delete them.  (see #1952)
+- Add draft/staging area
+  - add a description to the files you send
+  - reply to other messages
 
 ### Changed
 - Change "More info" translation to "Message Details"
@@ -27,7 +30,10 @@
 - hasLocation indicator on messages is now always shown even when the experimental Location streaming feature is not turned on
 - localize some unlocalized strings in settings ("select" and "remove" buttons beneath the profile image)
 
-## Fixed
+### Removed
+- removed inline message buttons (3dot menu button and download button)
+
+### Fixed
 
 - Fixed missing application icon for linux
 - Fixed unselecting current chat after deleting another chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Add context menu to gallery
 - Option for packagers to disable asar (`NO_ASAR=true npm run pack:generate_config`).
 - Added context menu for info messages
-- Add simple support for displaying qoutes (no attachment preview nor jump to message yet)
+- Add simple support for displaying quotes (no attachment preview nor jump to message yet)
 - Show sending indicator for outgoing info messages #1867
 - Add info log message that lists all unconfigured accounts, so you don't need to find them yourself to delete them.  (see #1952)
 - Add draft/staging area

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix two issues with the labeled link (see  #1893)
 - Fix refresh of "empty chat" info meassage on chat changes
 - Fix removing incompleted account (see #1952)
+- Fix that drag n' drop selection message text resulted in an "send following dropped files" dialog
 
 ## [1.13.1] - 2020-10-06
 

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -13,10 +13,13 @@
   }
 
   .upper-bar {
-    display: none;
-    .qoute {
-      // this is just overwrites for the qoute styles defined in _message.scss
-      margin: 4px;
+    &>.quote-section {
+      display: flex;
+
+      &>.qoute {
+        // this is just overwrites for the qoute styles defined in _message.scss
+        margin: 4px;
+      }
     }
   }
 

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -15,10 +15,19 @@
   .upper-bar {
     & > .quote-section {
       display: flex;
+      justify-content: space-between;
 
       & > .qoute {
         // this is just overwrites for the qoute styles defined in _message.scss
         margin: 4px;
+      }
+
+      & > .clear-quote-icon {
+        margin-right: 5px;
+        min-width: 32px;
+        &::before {
+	  color: var(--chat-list-item-summary-text);
+	}
       }
     }
 

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -13,10 +13,10 @@
   }
 
   .upper-bar {
-    &>.quote-section {
+    & > .quote-section {
       display: flex;
 
-      &>.qoute {
+      & > .qoute {
         // this is just overwrites for the qoute styles defined in _message.scss
         margin: 4px;
       }
@@ -32,7 +32,7 @@
       .bp3-button.bp3-minimal {
         width: 40px;
         height: 40px;
-    
+
         &:hover {
           background: none;
           cursor: pointer;
@@ -52,7 +52,7 @@
       &:hover {
         cursor: pointer;
       }
-    
+
       span {
         display: block;
         width: 25px;
@@ -72,11 +72,11 @@
       background-color: var(--composerSendButton);
       border-radius: 180px;
       cursor: pointer;
-    
+
       &:focus {
         outline: none;
       }
-    
+
       button {
         height: 24px;
         width: 24px;
@@ -88,7 +88,7 @@
         background-position: 3px 1px;
         background-size: contain;
         vertical-align: middle;
-    
+
         &:focus {
           outline: none;
         }
@@ -107,24 +107,18 @@
       overflow-y: hidden;
       background-color: var(--composerBg);
       color: var(--composerText);
-    
+
       &::placeholder {
         color: var(--composerPlaceholderText);
       }
-    
+
       &:focus {
         outline: none;
       }
-    
+
       &.scroll {
         overflow-y: scroll;
       }
     }
-    
-
   }
 }
-
-
-
-

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -13,26 +13,36 @@
   }
 
   .upper-bar {
-    & > .quote-section {
+    & > .attachment-quote-section {
       display: flex;
       justify-content: space-between;
 
-      & > .qoute {
-        // this is just overwrites for the qoute styles defined in _message.scss
+      .quote {
+        // this is just overwrites for the quote styles defined in _message.scss
         margin: 4px;
       }
 
-      & > .clear-quote-icon {
+      .message-attachment-media {
+        flex-grow: 1;
+        margin: 4px;
+        border-radius: 0px;
+        cursor: unset;
+        img {
+          cursor: unset;
+        }
+      }
+
+      .message-attachment-generic {
+        margin: 4px;
+      }
+
+      .clear-quote-icon {
         margin-right: 5px;
         min-width: 32px;
         &::before {
-	  color: var(--chat-list-item-summary-text);
-	}
+          color: var(--chat-list-item-summary-text);
+        }
       }
-    }
-
-    & > .attachment-section {
-      display: flex;
     }
   }
 

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -21,6 +21,10 @@
         margin: 4px;
       }
     }
+
+    & > .attachment-section {
+      display: flex;
+    }
   }
 
   .lower-bar {

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -11,117 +11,117 @@
       padding: 0px 3px;
     }
   }
-}
 
-.composer__attachment-button,
-.composer__emoji-button {
-  float: left;
+  .upper-bar {
+    display: none;
+    .qoute {
+      // this is just overwrites for the qoute styles defined in _message.scss
+      margin: 4px;
+    }
+  }
 
-  position: fixed;
-  bottom: 0;
+  .lower-bar {
+    display: flex;
+    align-items: flex-end;
 
-  .bp3-button.bp3-minimal {
-    width: 40px;
-    height: 40px;
+    .attachment-button,
+    .emoji-button {
+      .bp3-button.bp3-minimal {
+        width: 40px;
+        height: 40px;
+    
+        &:hover {
+          background: none;
+          cursor: pointer;
+        }
+        &:focus {
+          outline: none;
+        }
+      }
+    }
 
-    &:hover {
-      background: none;
+    .emoji-button {
+      height: 40px;
+      padding: 0px 3px;
+      &:focus {
+        outline: none;
+      }
+      &:hover {
+        cursor: pointer;
+      }
+    
+      span {
+        display: block;
+        width: 25px;
+        height: 25px;
+        margin-top: calc((40px - 25px) / 2);
+        background-image: url(../images/emoji.png);
+        background-size: contain;
+      }
+    }
+
+    .send-button-wrapper {
+      width: 32px;
+      height: 32px;
+      margin-top: 4px;
+      margin-bottom: 4px;
+      margin-right: 5px;
+      background-color: var(--composerSendButton);
+      border-radius: 180px;
       cursor: pointer;
+    
+      &:focus {
+        outline: none;
+      }
+    
+      button {
+        height: 24px;
+        width: 24px;
+        margin: 4px;
+        border: none;
+        background-image: url(../images/send-button.png);
+        background-color: transparent;
+        background-repeat: no-repeat;
+        background-position: 3px 1px;
+        background-size: contain;
+        vertical-align: middle;
+    
+        &:focus {
+          outline: none;
+        }
+      }
     }
-    &:focus {
-      outline: none;
+
+    textarea.message-input-area {
+      flex-grow: 1;
+      resize: unset;
+      padding: 0px;
+      border: 0;
+      height: auto;
+      line-height: 24px;
+      margin-top: 8px;
+      margin-bottom: 8px;
+      overflow-y: hidden;
+      background-color: var(--composerBg);
+      color: var(--composerText);
+    
+      &::placeholder {
+        color: var(--composerPlaceholderText);
+      }
+    
+      &:focus {
+        outline: none;
+      }
+    
+      &.scroll {
+        overflow-y: scroll;
+      }
     }
+    
+
   }
 }
 
-.composer__emoji-button {
-  height: 40px;
-  right: 45px;
-  margin-right: 0px !important;
-  padding: 0px;
-  border: 0;
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-color: var(--composerBg);
-  &:focus {
-    outline: none;
-  }
-  &:hover {
-    cursor: pointer;
-  }
 
-  span {
-    display: block;
-    width: 25px;
-    height: 25px;
-    margin-top: calc((40px - 25px) / 2);
-    background-image: url(../images/emoji.png);
-    background-size: contain;
-  }
-}
 
-.composer__send-button-wrapper {
-  position: fixed;
-  bottom: 0;
-  right: 0;
-  width: 32px;
-  height: 32px;
-  float: right;
-  margin-top: 4px;
-  margin-bottom: 4px;
-  margin-right: 5px;
-  background-color: var(--composerSendButton);
-  border-radius: 180px;
-  cursor: pointer;
 
-  &:focus {
-    outline: none;
-  }
-
-  button {
-    height: 24px;
-    width: 24px;
-    margin: 4px;
-    padding-left: 16px;
-    border: none;
-    background-image: url(../images/send-button.png);
-    background-color: transparent;
-    background-repeat: no-repeat;
-    background-position: 3px 1px;
-    background-size: contain;
-    vertical-align: middle;
-
-    &:focus {
-      outline: none;
-    }
-  }
-}
-
-textarea.message-input-area {
-  float: left;
-  width: calc(100% - 120px);
-  resize: unset;
-  padding: 0px;
-  border-color: transparent;
-  border-width: 0px;
-  height: auto;
-  line-height: 24px;
-  margin-top: 8px;
-  margin-bottom: 8px;
-  margin-left: 40px;
-  overflow-y: hidden;
-  background-color: var(--composerBg);
-  color: var(--composerText);
-
-  &::placeholder {
-    color: var(--composerPlaceholderText);
-  }
-
-  &:focus {
-    outline: none;
-  }
-
-  &.scroll {
-    overflow-y: scroll;
-  }
-}

--- a/scss/gallery/_attachment-view.scss
+++ b/scss/gallery/_attachment-view.scss
@@ -41,7 +41,10 @@
       width: 32px;
       display: inline-block;
       vertical-align: text-bottom;
-      @include color-svg('../images/download.svg', var(--fullScreenMediaButtons));
+      @include color-svg(
+        '../images/download.svg',
+        var(--fullScreenMediaButtons)
+      );
 
       &:hover {
         background-color: var(--fullScreenMediaButtons);

--- a/scss/gallery/_attachment-view.scss
+++ b/scss/gallery/_attachment-view.scss
@@ -41,10 +41,10 @@
       width: 32px;
       display: inline-block;
       vertical-align: text-bottom;
-      @include color-svg('../images/download.svg', var(--messageButtons));
+      @include color-svg('../images/download.svg', var(--fullScreenMediaButtons));
 
       &:hover {
-        background-color: var(--messageButtons);
+        background-color: var(--fullScreenMediaButtons);
       }
       cursor: pointer;
       margin-right: 5px;

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -1,8 +1,8 @@
 .message-list-and-composer {
   width: 70%;
   float: right;
-  display: grid;
-  grid-template-columns: auto;
+  display: flex;
+  flex-direction: column;
   height: $content-height;
   margin-top: $nav-bar-height;
   background-image: var(--chatViewBgImgPath);
@@ -13,6 +13,7 @@
 
 .message-list-and-composer__message-list {
   position: relative;
+  flex-grow: 1;
 
   #message-list {
     position: absolute;

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -5,8 +5,8 @@
   flex-direction: row;
   align-items: stretch;
 
-  &:hover {
-    .message-buttons {
+  li:hover > & {
+    .reply-button-wrapper {
       opacity: 1;
     }
   }
@@ -46,43 +46,44 @@
     }
   }
 
-  .message-buttons {
-    position: absolute;
-    top: 5px;
-    right: -4px;
-    display: inline-flex;
-    flex-direction: row;
-    align-items: center;
+  .reply-button-wrapper {
     opacity: 0;
-    z-index: 10;
-    user-select: text;
+    position: absolute;
 
-    .msg-button {
-      height: 24px;
-      width: 24px;
-      display: inline-block;
+    display: flex;
+    align-items: center;
+    height: 100%;
+    bottom: 0;
+    z-index: 10;
+
+    &.incoming {
+      right: -52px;
+    }
+
+    &.outgoing {
+      left: -52px;
+      transform: scale(-1, 1);
+    }
+
+    div.reply {
+      padding: 4px;
+      border-radius: 100%;
       cursor: pointer;
+      background-color: var(--messageReplyBtnBg);
 
       &:hover {
-        background-color: var(--messageButtons);
+        background-color: var(--messageReplyBtnBgHover);
+        & > div.reply-icon {
+          background-color: var(--messageReplyBtnHover);
+        }
       }
 
-      &.download {
-        @include color-svg('../images/download.svg', var(--messageButtons));
-      }
-
-      &.reply {
+      div.reply-icon {
+        height: 24px;
+        width: 24px;
+        display: block;
         /* not used currently */
-        @include color-svg('../images/reply.svg', var(--messageButtons));
-        user-select: none;
-      }
-
-      &.menu {
-        @include color-svg-rotated(
-          '../images/ellipsis.svg',
-          var(--messageButtons)
-        );
-        -webkit-mask-position-y: 4px;
+        @include color-svg('../images/reply.svg', var(--messageReplyBtn));
         user-select: none;
       }
     }
@@ -285,17 +286,6 @@
   .status-icon.delivered {
     background-color: white;
   }
-
-  &:hover {
-    .msg-button.menu {
-      background-color: white;
-    }
-
-    .msg-button-wrapper {
-      background-color: #2525258f;
-      border-radius: 4px;
-    }
-  }
 }
 
 .message.error.incoming {
@@ -323,20 +313,6 @@
     .text {
       color: var(--setupMessageText);
     }
-  }
-}
-
-// Media queries (responsiveness)
-// All media query widths have 300px added to account for the left pane
-// And have been tweaked for smoother transitions
-.hide-on-small {
-  display: initial;
-}
-
-@media (max-width: 800px) {
-  // To hide in small breakpoints
-  .hide-on-small {
-    display: none;
   }
 }
 

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -72,7 +72,6 @@
       }
 
       &.reply {
-        display: none;
         /* not used currently */
         @include color-svg('../images/reply.svg', var(--messageButtons));
         user-select: none;

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -377,10 +377,10 @@
   }
 }
 
-// Qoute
+// quote
 
-.message .msg-container .qoute,
-.composer .qoute {
+.message .msg-container .quote,
+.composer .quote {
   border-left: 3px gray solid;
   padding: 0 4px;
   padding-left: 9px;
@@ -390,7 +390,7 @@
   //   background: rgba(0, 0, 0, 0.07);
   // }
 
-  .qoute-author {
+  .quote-author {
     font-size: 13px;
     line-height: 13px;
     margin-bottom: 2px;

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -149,41 +149,6 @@
         }
       }
     }
-
-    .qoute {
-      border-left: 3px gray solid;
-      padding: 0 4px;
-      padding-left: 9px;
-      margin: 2px 0 5px 0;
-
-      // &.has-message:hover {
-      //   background: rgba(0, 0, 0, 0.07);
-      // }
-
-      .qoute-author {
-        font-size: 13px;
-        line-height: 13px;
-        margin-bottom: 2px;
-        font-weight: 300;
-      }
-
-      p {
-        font-size: 12px;
-        line-height: 12px;
-        margin: 0;
-        max-height: 40px;
-        overflow: hidden;
-        line-clamp: 3;
-        display: -webkit-box;
-        -webkit-line-clamp: 3;
-        // see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
-        // and yes using this property is a bit hacky and depends on browser support
-        // but atleast its simpler than estimating size with js
-        -webkit-box-orient: vertical;
-        overflow: hidden;
-        color: var(--messageQuotedText);
-      }
-    }
   }
 
   .metadata {
@@ -434,5 +399,42 @@
 
   .status-icon.sending {
     background-color: var(--infoMessageBubbleText);
+  }
+}
+
+// Qoute
+
+.message .msg-container .qoute, .composer .qoute {
+  border-left: 3px gray solid;
+  padding: 0 4px;
+  padding-left: 9px;
+  margin: 2px 0 5px 0;
+
+  // &.has-message:hover {
+  //   background: rgba(0, 0, 0, 0.07);
+  // }
+
+  .qoute-author {
+    font-size: 13px;
+    line-height: 13px;
+    margin-bottom: 2px;
+    font-weight: 300;
+  }
+
+  p {
+    font-size: 12px;
+    line-height: 12px;
+    margin: 0;
+    max-height: 40px;
+    overflow: hidden;
+    line-clamp: 3;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    // see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp
+    // and yes using this property is a bit hacky and depends on browser support
+    // but atleast its simpler than estimating size with js
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    color: var(--messageQuotedText);
   }
 }

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -404,7 +404,8 @@
 
 // Qoute
 
-.message .msg-container .qoute, .composer .qoute {
+.message .msg-container .qoute,
+.composer .qoute {
   border-left: 3px gray solid;
   padding: 0 4px;
   padding-left: 9px;

--- a/src/main/deltachat/burnerAccounts.ts
+++ b/src/main/deltachat/burnerAccounts.ts
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch'
 // import { getLogger } from '../../shared/logger'
 // const log = getLogger('main/deltachat/burner')
 

--- a/src/main/deltachat/burnerAccounts.ts
+++ b/src/main/deltachat/burnerAccounts.ts
@@ -1,3 +1,4 @@
+import fetch from 'node-fetch'
 // import { getLogger } from '../../shared/logger'
 // const log = getLogger('main/deltachat/burner')
 

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -6,6 +6,7 @@ import {
   JsonChat,
   JsonContact,
   FullChat,
+  JsonMessage,
 } from '../../shared/shared-types'
 import SplitOut from './splitout'
 
@@ -139,9 +140,9 @@ export default class DCChatList extends SplitOut {
     return rawChat.toJson()
   }
 
-  async _getDraft(chatId: number) {
+  async _getDraft(chatId: number):Promise<JsonMessage|null> {
     const draft = this._dc.getDraft(chatId)
-    return draft ? draft.getText() : ''
+    return draft ? draft.toJson() : null
   }
 
   async _getChatContactIds(chatId: number) {

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -140,11 +140,6 @@ export default class DCChatList extends SplitOut {
     return rawChat.toJson()
   }
 
-  async _getDraft(chatId: number):Promise<JsonMessage|null> {
-    const draft = this._dc.getDraft(chatId)
-    return draft ? draft.toJson() : null
-  }
-
   async _getChatContactIds(chatId: number) {
     return this._dc.getChatContacts(chatId)
   }
@@ -176,7 +171,6 @@ export default class DCChatList extends SplitOut {
     const contactIds = await this._getChatContactIds(chatId)
 
     const contacts = await this._getChatContacts(contactIds)
-    const draft = await this._getDraft(chatId)
     const muted = await this.isChatMuted(chatId)
     const ephemeralTimer = this._dc.getChatEphemeralTimer(chatId)
 
@@ -200,7 +194,6 @@ export default class DCChatList extends SplitOut {
       isGroup: isGroup,
       isDeaddrop: chatId === C.DC_CHAT_ID_DEADDROP,
       isDeviceChat: chat.isDeviceTalk,
-      draft,
       selfInGroup: isGroup && contactIds.indexOf(C.DC_CONTACT_ID_SELF) !== -1,
       muted,
       ephemeralTimer,

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -6,7 +6,6 @@ import {
   JsonChat,
   JsonContact,
   FullChat,
-  JsonMessage,
 } from '../../shared/shared-types'
 import SplitOut from './splitout'
 

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -13,7 +13,6 @@ import {
   MessageSearchResult,
   MessageTypeAttachment,
   msgStatus,
-  JsonMessage,
 } from '../../shared/shared-types'
 export default class DCMessageList extends SplitOut {
   sendMessage(

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -69,9 +69,9 @@ export default class DCMessageList extends SplitOut {
     return this._dc.getMessageInfo(msgId)
   }
 
-  async getDraft(chatId: number): Promise<JsonMessage | null> {
+  async getDraft(chatId: number): Promise<MessageType | null> {
     const draft = this._dc.getDraft(chatId)
-    return draft ? draft.toJson() : null
+    return draft ? this._messageToJson(draft) : null
   }
 
   setDraft(

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -22,12 +22,12 @@ export default class DCMessageList extends SplitOut {
       text,
       filename,
       location,
-      qouteMessageId,
+      quoteMessageId,
     }: {
       text?: string
       filename?: string
       location?: { lat: number; lng: number }
-      qouteMessageId?: number
+      quoteMessageId?: number
     }
   ): [number, MessageType | { msg: null }] {
     const viewType = filename ? C.DC_MSG_FILE : C.DC_MSG_TEXT
@@ -36,12 +36,12 @@ export default class DCMessageList extends SplitOut {
     if (text) msg.setText(text)
     if (location) msg.setLocation(location.lat, location.lng)
 
-    if (qouteMessageId) {
-      const qoutedMessage = this._dc.getMessage(qouteMessageId)
-      if (!qoutedMessage) {
-        log.error('sendMessage: Message to qoute not found')
+    if (quoteMessageId) {
+      const quotedMessage = this._dc.getMessage(quoteMessageId)
+      if (!quotedMessage) {
+        log.error('sendMessage: Message to quote not found')
       } else {
-        msg.setQuote(qoutedMessage)
+        msg.setQuote(quotedMessage)
       }
     }
 
@@ -87,11 +87,11 @@ export default class DCMessageList extends SplitOut {
     if (file) draft.setFile(file, undefined)
     if (text) draft.setText(text)
     if (quotedMessageId) {
-      const qoutedMessage = this._dc.getMessage(quotedMessageId)
-      if (!qoutedMessage) {
-        log.error('setDraftQoute: Message to qoute not found')
+      const quotedMessage = this._dc.getMessage(quotedMessageId)
+      if (!quotedMessage) {
+        log.error('setDraftquote: Message to quote not found')
       } else {
-        draft.setQuote(qoutedMessage)
+        draft.setQuote(quotedMessage)
       }
     }
 

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -45,12 +45,6 @@ export default class DCMessageList extends SplitOut {
       }
     }
 
-    console.log('TTTT', {
-      filename,
-      nfilename: msg.getFile(),
-      msg: msg.toJson(),
-    })
-
     const messageId = this._dc.sendMessage(chatId, msg)
     return [messageId, this.getMessage(messageId)]
   }

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -17,15 +17,39 @@ import {
 export default class DCMessageList extends SplitOut {
   sendMessage(
     chatId: number,
-    text: string,
-    filename: string,
-    location: { lat: number; lng: number }
+    {
+      text,
+      filename,
+      location,
+      qouteMessageId,
+    }: {
+      text?: string
+      filename?: string
+      location?: { lat: number; lng: number }
+      qouteMessageId?: number
+    }
   ): [number, MessageType | { msg: null }] {
     const viewType = filename ? C.DC_MSG_FILE : C.DC_MSG_TEXT
     const msg = this._dc.messageNew(viewType)
     if (filename) msg.setFile(filename, undefined)
     if (text) msg.setText(text)
     if (location) msg.setLocation(location.lat, location.lng)
+
+    if (qouteMessageId) {
+      const qoutedMessage = this._dc.getMessage(qouteMessageId)
+      if (!qoutedMessage) {
+        log.error('sendMessage: Message to qoute not found')
+      } else {
+        msg.setQuote(qoutedMessage)
+      }
+    }
+
+    console.log('TTTT', {
+      filename,
+      nfilename: msg.getFile(),
+      msg: msg.toJson(),
+    })
+
     const messageId = this._dc.sendMessage(chatId, msg)
     return [messageId, this.getMessage(messageId)]
   }
@@ -50,11 +74,28 @@ export default class DCMessageList extends SplitOut {
     return this._dc.getMessageInfo(msgId)
   }
 
-  setDraft(chatId: number, msgText: string) {
-    const msg = this._dc.messageNew()
-    msg.setText(msgText)
+  setDraft(
+    chatId: number,
+    {
+      text,
+      filename,
+      qouteMessageId,
+    }: { text?: string; filename?: string; qouteMessageId?: number }
+  ) {
+    const viewType = filename ? C.DC_MSG_FILE : C.DC_MSG_TEXT
+    const draft = this._dc.messageNew(viewType)
+    if (filename) draft.setFile(filename, undefined)
+    if (text) draft.setText(text)
+    if (qouteMessageId) {
+      const qoutedMessage = this._dc.getMessage(qouteMessageId)
+      if (!qoutedMessage) {
+        log.error('setDraftQoute: Message to qoute not found')
+      } else {
+        draft.setQuote(qoutedMessage)
+      }
+    }
 
-    this._dc.setDraft(chatId, msg)
+    this._dc.setDraft(chatId, draft)
   }
 
   messageIdToJson(id: number) {

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -84,16 +84,16 @@ export default class DCMessageList extends SplitOut {
     chatId: number,
     {
       text,
-      filename,
-      qouteMessageId,
-    }: { text?: string; filename?: string; qouteMessageId?: number }
+      file,
+      quotedMessageId,
+    }: { text?: string; file?: string; quotedMessageId?: number }
   ) {
-    const viewType = filename ? C.DC_MSG_FILE : C.DC_MSG_TEXT
+    const viewType = file ? C.DC_MSG_FILE : C.DC_MSG_TEXT
     const draft = this._dc.messageNew(viewType)
-    if (filename) draft.setFile(filename, undefined)
+    if (file) draft.setFile(file, undefined)
     if (text) draft.setText(text)
-    if (qouteMessageId) {
-      const qoutedMessage = this._dc.getMessage(qouteMessageId)
+    if (quotedMessageId) {
+      const qoutedMessage = this._dc.getMessage(quotedMessageId)
       if (!qoutedMessage) {
         log.error('setDraftQoute: Message to qoute not found')
       } else {

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -13,6 +13,7 @@ import {
   MessageSearchResult,
   MessageTypeAttachment,
   msgStatus,
+  JsonMessage,
 } from '../../shared/shared-types'
 export default class DCMessageList extends SplitOut {
   sendMessage(
@@ -72,6 +73,11 @@ export default class DCMessageList extends SplitOut {
 
   getMessageInfo(msgId: number) {
     return this._dc.getMessageInfo(msgId)
+  }
+
+  async getDraft(chatId: number): Promise<JsonMessage | null> {
+    const draft = this._dc.getDraft(chatId)
+    return draft ? draft.toJson() : null
   }
 
   setDraft(

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -155,7 +155,11 @@ export default function Attachment({
   }
 }
 
-export function DraftAttachment({ attachment }: {attachment:MessageTypeAttachment}) {
+export function DraftAttachment({
+  attachment,
+}: {
+  attachment: MessageTypeAttachment
+}) {
   if (!attachment) {
     return null
   }

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -24,7 +24,8 @@ type AttachmentProps = {
   text?: string
   conversationType: 'group' | 'direct'
   direction: MessageType['msg']['direction']
-  message: MessageType
+  message: MessageType,
+  hasQuote: boolean
 }
 
 export default function Attachment({
@@ -33,6 +34,7 @@ export default function Attachment({
   conversationType,
   direction,
   message,
+  hasQuote
 }: AttachmentProps) {
   const tx = useTranslationFunction()
   if (!attachment) {
@@ -52,8 +54,7 @@ export default function Attachment({
   const withCaption = Boolean(text)
   // For attachments which aren't full-frame
   const withContentBelow = withCaption
-  const withContentAbove =
-    conversationType === 'group' && direction === 'incoming'
+  const withContentAbove = hasQuote || (conversationType === 'group' && direction === 'incoming')
   // const dimensions = message.msg.dimensions || {}
   // Calculating height to prevent reflow when image loads
   // const height = Math.max(MINIMUM_IMG_HEIGHT, (dimensions as any).height || 0)

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -24,7 +24,7 @@ type AttachmentProps = {
   text?: string
   conversationType: 'group' | 'direct'
   direction: MessageType['msg']['direction']
-  message: MessageType,
+  message: MessageType
   hasQuote: boolean
 }
 
@@ -34,7 +34,7 @@ export default function Attachment({
   conversationType,
   direction,
   message,
-  hasQuote
+  hasQuote,
 }: AttachmentProps) {
   const tx = useTranslationFunction()
   if (!attachment) {
@@ -54,7 +54,8 @@ export default function Attachment({
   const withCaption = Boolean(text)
   // For attachments which aren't full-frame
   const withContentBelow = withCaption
-  const withContentAbove = hasQuote || (conversationType === 'group' && direction === 'incoming')
+  const withContentAbove =
+    hasQuote || (conversationType === 'group' && direction === 'incoming')
   // const dimensions = message.msg.dimensions || {}
   // Calculating height to prevent reflow when image loads
   // const height = Math.max(MINIMUM_IMG_HEIGHT, (dimensions as any).height || 0)

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -154,3 +154,51 @@ export default function Attachment({
     )
   }
 }
+
+export function DraftAttachment({ attachment }: {attachment:MessageTypeAttachment}) {
+  if (!attachment) {
+    return null
+  }
+  if (isImage(attachment)) {
+    return (
+      <div className={classNames('message-attachment-media')}>
+        <img className='attachment-content' src={attachment.url} />
+      </div>
+    )
+  } else if (isVideo(attachment)) {
+    return (
+      <div className={classNames('message-attachment-media')}>
+        <video className='attachment-content' src={attachment.url} controls />
+      </div>
+    )
+  } else if (isAudio(attachment)) {
+    return (
+      <audio controls className={classNames('message-attachment-audio')}>
+        <source src={attachment.url} />
+      </audio>
+    )
+  } else {
+    const { fileName, fileSize, contentType } = attachment
+    const extension = getExtension(attachment)
+    return (
+      <div className={classNames('message-attachment-generic')}>
+        <div
+          className='file-icon'
+          draggable='true'
+          onDragStart={dragAttachmentOut.bind(null, attachment)}
+          title={contentType}
+        >
+          {extension ? (
+            <div className='file-extension'>
+              {contentType === 'application/octet-stream' ? '' : extension}
+            </div>
+          ) : null}
+        </div>
+        <div className='text-part'>
+          <div className='name'>{fileName}</div>
+          <div className='size'>{fileSize}</div>
+        </div>
+      </div>
+    )
+  }
+}

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -12,6 +12,7 @@ import { JsonMessage, MessageType } from '../../../shared/shared-types'
 import { Qoute } from '../message/Message'
 import { DeltaBackend, sendMessageParams } from '../../delta-remote'
 import { DraftAttachment } from '../attachment/messageAttachment'
+import { C } from 'deltachat-node'
 const { remote } = window.electron_functions
 
 const log = getLogger('renderer/composer')
@@ -156,6 +157,7 @@ const Composer = forwardRef<
             </div>
           )}
           {draftState.file && (
+            <div>
             <div className='attachment-section'>
               {/* TODO make this pretty: draft image/video/attachment */}
               {/* <p>file: {draftState.file}</p> */}
@@ -163,6 +165,8 @@ const Composer = forwardRef<
                 <DraftAttachment attachment={draftState.attachment} />
               </div>
               <button onClick={removeFile}>X</button>
+            </div>
+            <div>{`draftState.viewType ->${draftState.viewType}`}</div>
             </div>
           )}
         </div>
@@ -218,7 +222,7 @@ type draftObject = { chatId: number } & Pick<
   JsonMessage,
   'text' | 'file' | 'quotedMessageId' | 'quotedText'
 > &
-  Pick<MessageType['msg'], 'attachment'>
+  Pick<MessageType['msg'], 'attachment'|'viewType'>
 
 function useDraft(
   chatId: number,
@@ -229,6 +233,7 @@ function useDraft(
     text: '',
     file: null,
     attachment: null,
+    viewType: null,
     quotedMessageId: 0,
     quotedText: null,
   })
@@ -249,6 +254,7 @@ function useDraft(
           text: newDraft.msg.text,
           file: newDraft.msg.file,
           attachment: newDraft.msg.attachment,
+          viewType: newDraft.msg.viewType,
           quotedMessageId: newDraft.msg.quotedMessageId,
           quotedText: newDraft.msg.quotedText,
         }))
@@ -276,6 +282,7 @@ function useDraft(
         ...old,
         file: newDraft.msg.file,
         attachment: newDraft.msg.attachment,
+        viewType: newDraft.msg.viewType,
         quotedMessageId: newDraft.msg.quotedMessageId,
         quotedText: newDraft.msg.quotedText,
       }))
@@ -314,6 +321,8 @@ function useDraft(
       chatId,
       text: '',
       file: null,
+      attachment: null,
+      viewType: null,
       quotedMessageId: 0,
       quotedText: null,
     }))

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -31,12 +31,12 @@ const insideBoundingRect = (
   )
 }
 
-const QuoteOrDraftRemoveButton = ({onClick} : {onClick: () => void}) => {
+const QuoteOrDraftRemoveButton = ({ onClick }: { onClick: () => void }) => {
   return (
     <button
       onClick={onClick}
-      aria-label="Clear"
-       className="clear-quote-icon bp3-dialog-close-button bp3-button bp3-minimal bp3-icon-large bp3-icon-cross clear-button"
+      aria-label='Clear'
+      className='clear-quote-icon bp3-dialog-close-button bp3-button bp3-minimal bp3-icon-large bp3-icon-cross clear-button'
     />
   )
 }
@@ -57,25 +57,23 @@ const Composer = forwardRef<
     clearDraft: () => void
   }
 >((props, ref) => {
-  const { 
+  const {
     isDisabled,
     disabledReason,
     chatId,
     messageInputRef,
-    draftState, 
+    draftState,
     removeQuote,
     updateDraftText,
     addFileToDraft,
     removeFile,
-    clearDraft
+    clearDraft,
   } = props
   const chatStoreDispatch = useChatStore()[1]
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
 
-  
   const emojiAndStickerRef = useRef<HTMLDivElement>()
   const pickerButtonRef = useRef()
-
 
   const sendMessage = () => {
     const message = messageInputRef.current.getText()

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -12,7 +12,6 @@ import { JsonMessage, MessageType } from '../../../shared/shared-types'
 import { Quote } from '../message/Message'
 import { DeltaBackend, sendMessageParams } from '../../delta-remote'
 import { DraftAttachment } from '../attachment/messageAttachment'
-import { C } from 'deltachat-node'
 const { remote } = window.electron_functions
 
 const log = getLogger('renderer/composer')
@@ -47,7 +46,6 @@ const Composer = forwardRef<
     isDisabled: boolean
     disabledReason: string
     chatId: number
-    setComposerSize: (size: number) => void
     messageInputRef: React.MutableRefObject<ComposerMessageInput>
     draftState: draftObject
     removeQuote: () => void
@@ -195,10 +193,10 @@ const Composer = forwardRef<
           <SettingsContext.Consumer>
             {({ desktopSettings }) => (
               <ComposerMessageInput
+
                 ref={messageInputRef}
                 enterKeySends={desktopSettings.enterKeySends}
                 sendMessage={sendMessage}
-                setComposerSize={props.setComposerSize}
                 chatId={chatId}
                 updateDraftText={updateDraftText}
               />

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -265,6 +265,8 @@ function useDraft(
         quotedText: newDraft.quotedText,
       }))
       // don't load text to prevent bugging back
+    } else {
+      clearDraft()
     }
   }
 

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -158,15 +158,15 @@ const Composer = forwardRef<
           )}
           {draftState.file && (
             <div>
-            <div className='attachment-section'>
-              {/* TODO make this pretty: draft image/video/attachment */}
-              {/* <p>file: {draftState.file}</p> */}
-              <div style={{ flexGrow: 1 }}>
-                <DraftAttachment attachment={draftState.attachment} />
+              <div className='attachment-section'>
+                {/* TODO make this pretty: draft image/video/attachment */}
+                {/* <p>file: {draftState.file}</p> */}
+                <div style={{ flexGrow: 1 }}>
+                  <DraftAttachment attachment={draftState.attachment} />
+                </div>
+                <button onClick={removeFile}>X</button>
               </div>
-              <button onClick={removeFile}>X</button>
-            </div>
-            <div>{`draftState.viewType ->${draftState.viewType}`}</div>
+              <div>{`draftState.viewType ->${draftState.viewType}`}</div>
             </div>
           )}
         </div>
@@ -222,7 +222,7 @@ type draftObject = { chatId: number } & Pick<
   JsonMessage,
   'text' | 'file' | 'quotedMessageId' | 'quotedText'
 > &
-  Pick<MessageType['msg'], 'attachment'|'viewType'>
+  Pick<MessageType['msg'], 'attachment' | 'viewType'>
 
 function useDraft(
   chatId: number,

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -76,6 +76,13 @@ const Composer = forwardRef<
 
     messageInputRef.current.clearText()
     messageInputRef.current.focus()
+    /* clear it here to make sure the draft is cleared */
+    DeltaBackend.call('messageList.setDraft', chatId, {
+      text: '',
+      file: null,
+      quotedMessageId: null,
+    })
+    /* update the state to reflect the removed draft */
     clearDraft()
   }
 

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -8,6 +8,7 @@ import { EmojiAndStickerPicker } from './EmojiAndStickerPicker'
 import { useChatStore } from '../../stores/chat'
 import { EmojiData, BaseEmoji } from 'emoji-mart'
 import { replaceColonsSafe } from '../conversations/emoji'
+import { JsonMessage } from '../../../shared/shared-types'
 const { remote } = window.electron_functions
 
 const log = getLogger('renderer/composer')
@@ -32,7 +33,7 @@ const Composer = forwardRef<
     isDisabled: boolean
     disabledReason: string
     chatId: number
-    draft: string
+    draft: JsonMessage | null
     setComposerSize: (size: number) => void
   }
 >((props, ref) => {
@@ -125,24 +126,12 @@ const Composer = forwardRef<
       <div className='composer' ref={ref}>
         <div className='upper-bar'>
           <div className='quote-section'>
-            <div
-              className='qoute has-message'
-              style={{ borderLeftColor: 'rgb(96, 200, 77)' }}
-            >
-              <div
-                className='qoute-author'
-                style={{ color: 'rgb(96, 200, 77)' }}
-              >
-                holger
-              </div>
-              <p>
-                Curabitur et erat leo. Cras a elit suscipit, dictum ligula non,
-                accumsan purus. Ut eu diam velit. Nullam convallis interdum
-                pellentesque. Suspendisse vitae odio mollis, convallis ex ut,
-                efficitur nisl. In porttitor dui eget justo finibus, ut
-                malesuada odio gravida. Integer nisi felis, fermentum id est in,
-              </p>
-            </div>
+            {hasQoute && (
+              <Qoute
+                quotedText={message.msg.quotedText}
+                quotedMessageId={message.msg.quotedMessageId}
+              />
+            )}
             <button>X</button>
           </div>
           {/* TODO draft image/video/attachment */}
@@ -164,7 +153,7 @@ const Composer = forwardRef<
                 sendMessage={sendMessage}
                 setComposerSize={props.setComposerSize}
                 chatId={chatId}
-                draft={draft}
+                draft={draft?.text || ''}
               />
             )}
           </SettingsContext.Consumer>

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -123,45 +123,50 @@ const Composer = forwardRef<
   } else {
     return (
       <div className='composer' ref={ref}>
-        <div className='composer__attachment-button'>
-          <Button
-            minimal
-            icon='paperclip'
-            onClick={addFilename.bind(this)}
-            aria-label={tx('attachment')}
-          />
+        <div className='upper-bar'>
+          
         </div>
-        <SettingsContext.Consumer>
-          {({ desktopSettings }) => (
-            <ComposerMessageInput
-              ref={messageInputRef}
-              enterKeySends={desktopSettings.enterKeySends}
-              sendMessage={sendMessage}
-              setComposerSize={props.setComposerSize}
-              chatId={chatId}
-              draft={draft}
+        <div className='lower-bar'>
+          <div className='attachment-button'>
+            <Button
+              minimal
+              icon='paperclip'
+              onClick={addFilename.bind(this)}
+              aria-label={tx('attachment')}
             />
-          )}
-        </SettingsContext.Consumer>
-        <div
-          className='composer__emoji-button'
-          ref={pickerButtonRef}
-          onClick={onEmojiIconClick}
-          aria-label={tx('emoji')}
-        >
-          <span />
+          </div>
+          <SettingsContext.Consumer>
+            {({ desktopSettings }) => (
+              <ComposerMessageInput
+                ref={messageInputRef}
+                enterKeySends={desktopSettings.enterKeySends}
+                sendMessage={sendMessage}
+                setComposerSize={props.setComposerSize}
+                chatId={chatId}
+                draft={draft}
+              />
+            )}
+          </SettingsContext.Consumer>
+          <div
+            className='emoji-button'
+            ref={pickerButtonRef}
+            onClick={onEmojiIconClick}
+            aria-label={tx('emoji')}
+          >
+            <span />
+          </div>
+          <div className='send-button-wrapper' onClick={sendMessage}>
+            <button aria-label={tx('menu_send')} />
+          </div>
         </div>
         {showEmojiPicker && (
-          <EmojiAndStickerPicker
-            chatId={chatId}
-            ref={emojiAndStickerRef}
-            onEmojiSelect={onEmojiSelect}
-            setShowEmojiPicker={setShowEmojiPicker}
-          />
-        )}
-        <div className='composer__send-button-wrapper' onClick={sendMessage}>
-          <button aria-label={tx('menu_send')} />
-        </div>
+            <EmojiAndStickerPicker
+              chatId={chatId}
+              ref={emojiAndStickerRef}
+              onEmojiSelect={onEmojiSelect}
+              setShowEmojiPicker={setShowEmojiPicker}
+            />
+          )}
       </div>
     )
   }

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -46,7 +46,10 @@ const Composer = forwardRef<
   const emojiAndStickerRef = useRef<HTMLDivElement>()
   const pickerButtonRef = useRef()
 
-  const { draftState, updateDraftText } = useDraft(chatId, messageInputRef)
+  const { draftState, updateDraftText, removeQuote } = useDraft(
+    chatId,
+    messageInputRef
+  )
 
   const sendMessage = () => {
     const message = messageInputRef.current.getText()
@@ -126,15 +129,15 @@ const Composer = forwardRef<
     return (
       <div className='composer' ref={ref}>
         <div className='upper-bar'>
-          <div className='quote-section'>
-            {draftState.quotedText !== null && (
+          {draftState.quotedText !== null && (
+            <div className='quote-section'>
               <Qoute
                 quotedText={draftState.quotedText}
                 quotedMessageId={draftState.quotedMessageId}
               />
-            )}
-            <button>X</button>
-          </div>
+              <button onClick={removeQuote}>X</button>
+            </div>
+          )}
           {/* TODO draft image/video/attachment */}
         </div>
         <div className='lower-bar'>
@@ -194,7 +197,6 @@ function useDraft(
   chatId: number,
   inputRef: React.MutableRefObject<ComposerMessageInput>
 ) {
-  const [startingText, setStartingText] = useState('')
   const [draftState, setDraft] = useState<draftObject>({
     chatId,
     text: '',
@@ -267,5 +269,10 @@ function useDraft(
     }
   }
 
-  return { draftState, startingText, updateDraftText }
+  const removeQuote = () => {
+    setDraft(state => ({ ...state, quotedMessageId: null }))
+    saveDraft()
+  }
+
+  return { draftState, removeQuote, updateDraftText }
 }

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -124,7 +124,28 @@ const Composer = forwardRef<
     return (
       <div className='composer' ref={ref}>
         <div className='upper-bar'>
-          
+          <div className='quote-section'>
+            <div
+              className='qoute has-message'
+              style={{ borderLeftColor: 'rgb(96, 200, 77)' }}
+            >
+              <div
+                className='qoute-author'
+                style={{ color: 'rgb(96, 200, 77)' }}
+              >
+                holger
+              </div>
+              <p>
+                Curabitur et erat leo. Cras a elit suscipit, dictum ligula non,
+                accumsan purus. Ut eu diam velit. Nullam convallis interdum
+                pellentesque. Suspendisse vitae odio mollis, convallis ex ut,
+                efficitur nisl. In porttitor dui eget justo finibus, ut
+                malesuada odio gravida. Integer nisi felis, fermentum id est in,
+              </p>
+            </div>
+            <button>X</button>
+          </div>
+          {/* TODO draft image/video/attachment */}
         </div>
         <div className='lower-bar'>
           <div className='attachment-button'>

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -248,8 +248,8 @@ function useDraft(
     const oldChatId = chatId
     await DeltaBackend.call('messageList.setDraft', chatId, {
       text: draft.text,
-      filename: draft.file,
-      qouteMessageId: draft.quotedMessageId,
+      file: draft.file,
+      quotedMessageId: draft.quotedMessageId,
     })
 
     if (oldChatId !== chatId) {
@@ -272,14 +272,14 @@ function useDraft(
     if (chatId !== InputChatId) {
       log.warn("chat Id and InputChatId don't match, do nothing")
     } else {
-      draftRef.current.text = text
-      // setDraft(state => ({ ...state, text }))
+      draftRef.current.text = text // don't need to rerender on text change
       saveDraft()
     }
   }
 
   const removeQuote = () => {
     draftRef.current.quotedMessageId = null
+    // not sure why the state change does not work...
     // setDraft(state => ({ ...state, quotedMessageId: null }))
     saveDraft()
   }
@@ -305,6 +305,17 @@ function useDraft(
       quotedText: null,
     }))
   }
+
+  useEffect(() => {
+    window.__setQuoteInDraft = (messageId: number) => {
+      draftRef.current.quotedMessageId = messageId
+      //setDraft(state => ({ ...state, quotedMessageId: messageId }))
+      saveDraft()
+    }
+    return () => {
+      window.__setQuoteInDraft = null
+    }
+  })
 
   return {
     draftState,

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -212,7 +212,7 @@ function useDraft(
   chatId: number,
   inputRef: React.MutableRefObject<ComposerMessageInput>
 ) {
-  const [draftState, setDraft] = useState<draftObject>({
+  const [draftState, _setDraft] = useState<draftObject>({
     chatId,
     text: '',
     file: null,
@@ -231,7 +231,7 @@ function useDraft(
         clearDraft()
         inputRef.current?.setText('')
       } else {
-        setDraft(old => ({
+        _setDraft(old => ({
           ...old,
           text: newDraft.text,
           file: newDraft.file,
@@ -258,7 +258,7 @@ function useDraft(
     }
     const newDraft = await DeltaBackend.call('messageList.getDraft', chatId)
     if (newDraft) {
-      setDraft(old => ({
+      _setDraft(old => ({
         ...old,
         file: newDraft.file,
         quotedMessageId: newDraft.quotedMessageId,
@@ -281,25 +281,21 @@ function useDraft(
 
   const removeQuote = () => {
     draftRef.current.quotedMessageId = null
-    // not sure why the state change does not work...
-    // setDraft(state => ({ ...state, quotedMessageId: null }))
     saveDraft()
   }
 
   const removeFile = () => {
     draftRef.current.file = null
-    // not sure why the state change does not work...
-    // setDraft(state => ({ ...state, file: null }))
     saveDraft()
   }
 
   const addFileToDraft = (file: string) => {
-    setDraft(state => ({ ...state, file }))
+    draftRef.current.file = file
     saveDraft()
   }
 
   const clearDraft = () => {
-    setDraft(_ => ({
+    _setDraft(_ => ({
       chatId,
       text: '',
       file: null,
@@ -311,7 +307,6 @@ function useDraft(
   useEffect(() => {
     window.__setQuoteInDraft = (messageId: number) => {
       draftRef.current.quotedMessageId = messageId
-      //setDraft(state => ({ ...state, quotedMessageId: messageId }))
       saveDraft()
     }
     return () => {

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -160,13 +160,13 @@ const Composer = forwardRef<
           </div>
         </div>
         {showEmojiPicker && (
-            <EmojiAndStickerPicker
-              chatId={chatId}
-              ref={emojiAndStickerRef}
-              onEmojiSelect={onEmojiSelect}
-              setShowEmojiPicker={setShowEmojiPicker}
-            />
-          )}
+          <EmojiAndStickerPicker
+            chatId={chatId}
+            ref={emojiAndStickerRef}
+            onEmojiSelect={onEmojiSelect}
+            setShowEmojiPicker={setShowEmojiPicker}
+          />
+        )}
       </div>
     )
   }

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -193,7 +193,6 @@ const Composer = forwardRef<
           <SettingsContext.Consumer>
             {({ desktopSettings }) => (
               <ComposerMessageInput
-
                 ref={messageInputRef}
                 enterKeySends={desktopSettings.enterKeySends}
                 sendMessage={sendMessage}

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -153,7 +153,7 @@ const Composer = forwardRef<
                 quotedText={draftState.quotedText}
                 quotedMessageId={draftState.quotedMessageId}
               />
-              <button onClick={removeQuote}>X</button>
+	      <button onClick={removeQuote} aria-label="Clear" className="clear-quote-icon bp3-dialog-close-button bp3-button bp3-minimal bp3-icon-large bp3-icon-cross clear-button"/>
             </div>
           )}
           {draftState.file && (

--- a/src/renderer/components/composer/ComposerMessageInput.tsx
+++ b/src/renderer/components/composer/ComposerMessageInput.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import { DeltaBackend } from '../../delta-remote'
 import debounce from 'debounce'
 import { ActionEmitter, KeybindAction } from '../../keybindings'
 
 type ComposerMessageInputProps = {
   chatId: number
-  setComposerSize: (size: number) => void
   sendMessage: () => void
   enterKeySends: boolean
   updateDraftText: (text: string, InputChatId: number) => void
@@ -77,7 +75,6 @@ export default class ComposerMessageInput extends React.Component<
 
   setComposerSize(size: number) {
     this.composerSize = size
-    this.props.setComposerSize(size)
   }
 
   focus() {

--- a/src/renderer/components/composer/ComposerMessageInput.tsx
+++ b/src/renderer/components/composer/ComposerMessageInput.tsx
@@ -43,7 +43,7 @@ export default class ComposerMessageInput extends React.Component<
 
     this.saveDraft = debounce(() => {
       const { text, chatId } = this.state
-      DeltaBackend.call('messageList.setDraft', chatId, text)
+      DeltaBackend.call('messageList.setDraft', chatId, {text})
     }, 500)
 
     this.textareaRef = React.createRef()

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -428,7 +428,10 @@ export default class MapComponent extends React.Component<
     const latLng = Object.assign({}, this.poiLocation)
     chatStore.dispatch({
       type: 'SEND_MESSAGE',
-      payload: [selectedChat.id, { text: message, location: latLng } as sendMessageParams],
+      payload: [
+        selectedChat.id,
+        { text: message, location: latLng } as sendMessageParams,
+      ],
     })
 
     if (this.contextMenuPopup) {

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -1,4 +1,4 @@
-import { DeltaBackend } from '../../delta-remote'
+import { DeltaBackend, sendMessageParams } from '../../delta-remote'
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import ReactDOM from 'react-dom'
@@ -428,7 +428,7 @@ export default class MapComponent extends React.Component<
     const latLng = Object.assign({}, this.poiLocation)
     chatStore.dispatch({
       type: 'SEND_MESSAGE',
-      payload: [selectedChat.id, message, null, latLng],
+      payload: [selectedChat.id, { text: message, location: latLng } as sendMessageParams],
     })
 
     if (this.contextMenuPopup) {

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -132,8 +132,8 @@ function buildContextMenu(
     message,
     text,
     conversationType,
-    // onRetrySend,
-  }: {
+  }: // onRetrySend,
+  {
     attachment: MessageTypeAttachment
     direction: 'incoming' | 'outgoing'
     status: msgStatus

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -401,7 +401,7 @@ const Message = (props: {
 
 export default Message
 
-const Qoute = ({
+export const Qoute = ({
   quotedText,
   quotedMessageId,
 }: {

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -103,27 +103,6 @@ const Author = (
   )
 }
 
-const FloatingReplyButton = (
-  message: MessageType | { msg: null },
-  direction: MessageType['msg']['direction']
-) => {
-  if (!message.msg) {
-    return
-  }
-
-  return (
-    <div className={`reply-button-wrapper ${direction}`}>
-      <div
-        onClick={setQuoteInDraft.bind(null, message.msg.id)}
-        role='button'
-        className='reply'
-      >
-        <div className='reply-icon' />
-      </div>
-    </div>
-  )
-}
-
 function buildContextMenu(
   {
     attachment,
@@ -325,6 +304,12 @@ const Message = (props: {
 
   const hasQuote = message.msg.quotedText !== null
 
+  const onMessageDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
+    event.preventDefault()
+    setQuoteInDraft(message.msg.id)
+    window.getSelection().empty()
+  }
+
   return (
     <div
       onContextMenu={showMenu}
@@ -335,11 +320,11 @@ const Message = (props: {
         { error: status === 'error' },
         { forwarded: message.msg.isForwarded }
       )}
+      onDoubleClick={onMessageDoubleClick}
     >
       {conversationType === 'group' &&
         direction === 'incoming' &&
         Avatar(message.contact, onContactClick)}
-      {FloatingReplyButton(message, direction)}
       <div onContextMenu={showMenu} className='msg-container'>
         {message.msg.isForwarded && (
           <div className='forwarded-indicator'>{tx('forwarded_message')}</div>

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -367,7 +367,7 @@ const Message = (props: {
                 conversationType,
                 direction,
                 message,
-                hasQuote
+                hasQuote,
               }}
             />
           )}

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -323,7 +323,7 @@ const Message = (props: {
   // TODO another check - don't check it only over string
   const longMessage = /\[.{3}\]$/.test(text)
 
-  const hasQoute = message.msg.quotedText !== null
+  const hasquote = message.msg.quotedText !== null
 
   return (
     <div
@@ -353,8 +353,8 @@ const Message = (props: {
           })}
           onClick={onClickMessageBody}
         >
-          {hasQoute && (
-            <Qoute
+          {hasquote && (
+            <Quote
               quotedText={message.msg.quotedText}
               quotedMessageId={message.msg.quotedMessageId}
             />
@@ -391,7 +391,7 @@ const Message = (props: {
 
 export default Message
 
-export const Qoute = ({
+export const Quote = ({
   quotedText,
   quotedMessageId,
 }: {
@@ -413,10 +413,10 @@ export const Qoute = ({
   if (quotedMessageId !== 0 && message) {
     return (
       <div
-        className='qoute has-message'
+        className='quote has-message'
         style={{ borderLeftColor: message.contact.color }}
       >
-        <div className='qoute-author' style={{ color: message.contact.color }}>
+        <div className='quote-author' style={{ color: message.contact.color }}>
           {message.contact.displayName}
         </div>
         <p>{quotedText}</p>
@@ -424,7 +424,7 @@ export const Qoute = ({
     )
   } else {
     return (
-      <div className='qoute'>
+      <div className='quote'>
         <p>{quotedText}</p>
       </div>
     )

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -102,41 +102,22 @@ const Author = (
   )
 }
 
-const InlineMenu = (
-  showMenu: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void,
-  attachment: MessageTypeAttachment,
+const FloatingReplyButton = (
   message: MessageType | { msg: null },
-  // onReply
-  viewType: number
+  direction: MessageType['msg']['direction']
 ) => {
-  const tx = useTranslationFunction()
-
   if (!message.msg) {
     return
   }
 
   return (
-    <div className='message-buttons'>
-      {attachment && viewType !== 23 && !message.msg.isSetupmessage && (
-        <div
-          onClick={onDownload.bind(null, message.msg)}
-          role='button'
-          className='msg-button download hide-on-small'
-          aria-label={tx('save')}
-        />
-      )}
+    <div className={`reply-button-wrapper ${direction}`}>
       <div
         onClick={setQuoteInDraft.bind(null, message.msg.id)}
         role='button'
-        className='msg-button reply hide-on-small'
-      />
-      <div className='msg-button-wrapper'>
-        <div
-          role='button'
-          onClick={showMenu}
-          className='msg-button menu'
-          aria-label={tx('a11y_message_context_menu_btn_label')}
-        />
+        className='reply'
+      >
+        <div className='reply-icon' />
       </div>
     </div>
   )
@@ -298,8 +279,6 @@ const Message = (props: {
     }
   }
 
-  const menu = InlineMenu(showMenu, attachment, message, viewType)
-
   let content
   if (message.msg.viewType === C.DC_MSG_VIDEOCHAT_INVITATION) {
     content = (
@@ -350,7 +329,7 @@ const Message = (props: {
       {conversationType === 'group' &&
         direction === 'incoming' &&
         Avatar(message.contact, onContactClick)}
-      {menu}
+      {FloatingReplyButton(message, direction)}
       <div onContextMenu={showMenu} className='msg-container'>
         {message.msg.isForwarded && (
           <div className='forwarded-indicator'>{tx('forwarded_message')}</div>

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -323,7 +323,7 @@ const Message = (props: {
   // TODO another check - don't check it only over string
   const longMessage = /\[.{3}\]$/.test(text)
 
-  const hasquote = message.msg.quotedText !== null
+  const hasQuote = message.msg.quotedText !== null
 
   return (
     <div
@@ -353,7 +353,7 @@ const Message = (props: {
           })}
           onClick={onClickMessageBody}
         >
-          {hasquote && (
+          {hasQuote && (
             <Quote
               quotedText={message.msg.quotedText}
               quotedMessageId={message.msg.quotedMessageId}
@@ -367,6 +367,7 @@ const Message = (props: {
                 conversationType,
                 direction,
                 message,
+                hasQuote
               }}
             />
           )}

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -4,6 +4,7 @@ import {
   forwardMessage,
   deleteMessage,
   openMessageInfo,
+  setQuoteInDraft,
 } from './messageFunctions'
 import React, { useContext, useState, useEffect } from 'react'
 
@@ -110,23 +111,25 @@ const InlineMenu = (
 ) => {
   const tx = useTranslationFunction()
 
+  if (!message.msg) {
+    return
+  }
+
   return (
     <div className='message-buttons'>
-      {attachment &&
-        viewType !== C.DC_MSG_STICKER &&
-        !message.msg.isSetupmessage && (
-          <div
-            onClick={onDownload.bind(null, message.msg)}
-            role='button'
-            className='msg-button download hide-on-small'
-            aria-label={tx('save')}
-          />
-        )}
-      {/* <div
-        onClick={onReply}
+      {attachment && viewType !== 23 && !message.msg.isSetupmessage && (
+        <div
+          onClick={onDownload.bind(null, message.msg)}
+          role='button'
+          className='msg-button download hide-on-small'
+          aria-label={tx('save')}
+        />
+      )}
+      <div
+        onClick={setQuoteInDraft.bind(null, message.msg.id)}
         role='button'
         className='msg-button reply hide-on-small'
-      /> */}
+      />
       <div className='msg-button-wrapper'>
         <div
           role='button'
@@ -145,7 +148,6 @@ function buildContextMenu(
     direction,
     status,
     message,
-    // onReply,
     // onRetrySend,
     text,
   }: {
@@ -154,7 +156,6 @@ function buildContextMenu(
     status: msgStatus
     message: MessageType | { msg: null }
     text?: string
-    // onReply:Function
     // onRetrySend: Function
   },
   link: string,
@@ -195,10 +196,10 @@ function buildContextMenu(
       label: tx('download_attachment_desktop'),
       action: onDownload.bind(null, message.msg),
     },
-    // {
-    //   label: tx('reply_to_message_desktop'),
-    //   action: onReply
-    // },
+    {
+      label: tx('reply_to_message_desktop'),
+      action: setQuoteInDraft.bind(null, message.msg.id),
+    },
     {
       label: tx('menu_forward'),
       action: forwardMessage.bind(null, message),

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -5,6 +5,7 @@ import {
   deleteMessage,
   openMessageInfo,
   setQuoteInDraft,
+  privateReply,
 } from './messageFunctions'
 import React, { useContext, useState, useEffect } from 'react'
 
@@ -129,14 +130,16 @@ function buildContextMenu(
     direction,
     status,
     message,
-    // onRetrySend,
     text,
+    conversationType,
+    // onRetrySend,
   }: {
     attachment: MessageTypeAttachment
     direction: 'incoming' | 'outgoing'
     status: msgStatus
     message: MessageType | { msg: null }
     text?: string
+    conversationType: 'group' | 'direct'
     // onRetrySend: Function
   },
   link: string,
@@ -181,6 +184,12 @@ function buildContextMenu(
       label: tx('reply_to_message_desktop'),
       action: setQuoteInDraft.bind(null, message.msg.id),
     },
+    // privateReply -> only show in groups, don't show on info messages or outgoing messages
+    conversationType === 'group' &&
+      message.msg.fromId > C.DC_CONTACT_ID_LAST_SPECIAL && {
+        label: tx('reply_privately'),
+        action: privateReply.bind(null, message.msg),
+      },
     {
       label: tx('menu_forward'),
       action: forwardMessage.bind(null, message),
@@ -233,6 +242,7 @@ const Message = (props: {
         status,
         message,
         text,
+        conversationType,
       },
       link,
       chatStoreDispatch

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -76,7 +76,9 @@ export default function MessageListAndComposer({
       cb: (yes: boolean) =>
         yes &&
         sanitizedFileList.forEach(({ path }) =>
-          DeltaBackend.call('messageList.sendMessage', chat.id, {filename: path})
+          DeltaBackend.call('messageList.sendMessage', chat.id, {
+            filename: path,
+          })
         ),
     })
   }
@@ -132,7 +134,6 @@ export default function MessageListAndComposer({
       <Composer
         ref={refComposer}
         chatId={chat.id}
-        draft={chat.draft}
         setComposerSize={setComposerSize.bind(this)}
         isDisabled={disabled}
         disabledReason={disabledReason}

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -1,11 +1,10 @@
-import React, { useRef, useState, useContext } from 'react'
+import React, { useRef, useContext } from 'react'
 import { DeltaBackend } from '../../delta-remote'
 import Composer, { useDraft } from '../composer/Composer'
 import { getLogger } from '../../../shared/logger'
 import MessageList from './MessageList'
 import { SettingsContext, ScreenContext } from '../../contexts'
 import { C } from 'deltachat-node/dist/constants'
-import { useDebouncedCallback } from 'use-debounce'
 import { ChatStoreState } from '../../stores/chat'
 import ComposerMessageInput from '../composer/ComposerMessageInput'
 
@@ -18,18 +17,9 @@ export default function MessageListAndComposer({
 }: {
   chat: ChatStoreState
 }) {
-  const [state, setState] = useState({
-    //error: false,
-    composerSize: 40,
-  })
   const conversationRef = useRef(null)
   const refComposer = useRef(null)
   const { openDialog } = useContext(ScreenContext)
-
-  const [setComposerSize] = useDebouncedCallback(
-    (size: number) => setState({ composerSize: size }),
-    25
-  )
 
   const messageInputRef = useRef<ComposerMessageInput>()
   const {
@@ -153,7 +143,6 @@ export default function MessageListAndComposer({
       <Composer
         ref={refComposer}
         chatId={chat.id}
-        setComposerSize={setComposerSize.bind(this)}
         isDisabled={disabled}
         disabledReason={disabledReason}
         messageInputRef={messageInputRef}

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -105,7 +105,6 @@ export default function MessageListAndComposer({
   const settings = useContext(SettingsContext).desktopSettings
   const style: React.CSSProperties = {
     backgroundSize: 'cover',
-    gridTemplateRows: `auto ${state.composerSize}px`,
   }
   if (settings['chatViewBgImg']) {
     if (

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -76,7 +76,7 @@ export default function MessageListAndComposer({
       cb: (yes: boolean) =>
         yes &&
         sanitizedFileList.forEach(({ path }) =>
-          DeltaBackend.call('messageList.sendMessage', chat.id, null, path)
+          DeltaBackend.call('messageList.sendMessage', chat.id, {filename: path})
         ),
     })
   }

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -1,12 +1,13 @@
 import React, { useRef, useState, useContext } from 'react'
 import { DeltaBackend } from '../../delta-remote'
-import Composer from '../composer/Composer'
+import Composer, { useDraft } from '../composer/Composer'
 import { getLogger } from '../../../shared/logger'
 import MessageList from './MessageList'
 import { SettingsContext, ScreenContext } from '../../contexts'
 import { C } from 'deltachat-node/dist/constants'
 import { useDebouncedCallback } from 'use-debounce'
 import { ChatStoreState } from '../../stores/chat'
+import ComposerMessageInput from '../composer/ComposerMessageInput'
 
 const { DC_CHAT_ID_DEADDROP } = C
 
@@ -29,6 +30,17 @@ export default function MessageListAndComposer({
     (size: number) => setState({ composerSize: size }),
     25
   )
+
+
+  const messageInputRef = useRef<ComposerMessageInput>()
+  const {
+    draftState,
+    updateDraftText,
+    removeQuote,
+    addFileToDraft,
+    removeFile,
+    clearDraft,
+  } = useDraft(chat.id, messageInputRef)
 
   const onDrop = (e: React.DragEvent<any>) => {
     e.preventDefault()
@@ -58,6 +70,11 @@ export default function MessageListAndComposer({
     if (fileCount === 0) {
       return
     }
+    if (fileCount === 1) {
+      addFileToDraft(sanitizedFileList[0].path)
+      return
+    }
+    // This is a desktop specific "hack" to support sending multiple attachments at once.
     openDialog('ConfirmationDialog', {
       message: (
         <>
@@ -140,6 +157,13 @@ export default function MessageListAndComposer({
         setComposerSize={setComposerSize.bind(this)}
         isDisabled={disabled}
         disabledReason={disabledReason}
+        messageInputRef={messageInputRef}
+        draftState={draftState}
+        updateDraftText={updateDraftText}
+        removeQuote={removeQuote}
+        addFileToDraft={addFileToDraft}
+        removeFile={removeFile}
+        clearDraft={clearDraft}
       />
     </div>
   )

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -31,7 +31,6 @@ export default function MessageListAndComposer({
     25
   )
 
-
   const messageInputRef = useRef<ComposerMessageInput>()
   const {
     draftState,

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -55,6 +55,9 @@ export default function MessageListAndComposer({
     }
     const tx = window.static_translate
     const fileCount = sanitizedFileList.length
+    if(fileCount === 0){
+      return
+    }
     openDialog('ConfirmationDialog', {
       message: (
         <>

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -55,7 +55,7 @@ export default function MessageListAndComposer({
     }
     const tx = window.static_translate
     const fileCount = sanitizedFileList.length
-    if(fileCount === 0){
+    if (fileCount === 0) {
       return
     }
     openDialog('ConfirmationDialog', {

--- a/src/renderer/components/message/messageFunctions.ts
+++ b/src/renderer/components/message/messageFunctions.ts
@@ -42,3 +42,11 @@ export function deleteMessage(
 export function openMessageInfo(message: MessageType) {
   window.__openDialog('MessageDetail', { id: message.id })
 }
+
+export function setQuoteInDraft(messageId: number) {
+  if (window.__setQuoteInDraft) {
+    window.__setQuoteInDraft(messageId)
+  } else {
+    throw new Error('window.__setQuoteInDraft undefined')
+  }
+}

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -17,6 +17,16 @@ import {
 import { MuteDuration } from '../shared/constants'
 import { LocaleData } from '../shared/localize'
 
+export type sendMessageParams = {
+  text?: string | null
+  filename?: string
+  location?: {
+    lat: number
+    lng: number
+  }
+  qouteMessageId?: number
+}
+
 class DeltaRemote {
   // root ---------------------------------------------------------------
   call(fnName: 'updateBlockedContacts'): Promise<void>
@@ -207,15 +217,7 @@ class DeltaRemote {
   call(
     fnName: 'messageList.sendMessage',
     chatId: number,
-    params: {
-      text?: string | null
-      filename?: string
-      location?: {
-        lat: number
-        lng: number
-      }
-      qouteMessageId?: number
-    }
+    params: sendMessageParams
   ): Promise<
     [
       number,

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -206,11 +206,14 @@ class DeltaRemote {
   call(
     fnName: 'messageList.sendMessage',
     chatId: number,
-    text: string | null,
-    filename?: string,
-    location?: {
-      lat: number
-      lng: number
+    params: {
+      text?: string | null
+      filename?: string
+      location?: {
+        lat: number
+        lng: number
+      }
+      qouteMessageId?: number
     }
   ): Promise<
     [
@@ -241,7 +244,11 @@ class DeltaRemote {
   call(
     fnName: 'messageList.setDraft',
     chatId: number,
-    msgText: string
+    {
+      text,
+      filename,
+      qouteMessageId,
+    }: { text?: string; filename?: string; qouteMessageId?: number }
   ): Promise<void>
   call(
     fnName: 'messageList.messageIdToJson',

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -24,7 +24,7 @@ export type sendMessageParams = {
     lat: number
     lng: number
   }
-  qouteMessageId?: number
+  quoteMessageId?: number
 }
 
 class DeltaRemote {

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -12,6 +12,7 @@ import {
   DeltaChatAccount,
   DesktopSettings,
   QrCodeResponse,
+  JsonMessage,
 } from '../shared/shared-types'
 import { MuteDuration } from '../shared/constants'
 import { LocaleData } from '../shared/localize'
@@ -241,6 +242,10 @@ class DeltaRemote {
     messageIds: number[]
   ): Promise<{ [key: number]: MessageType | { msg: null } }>
   call(fnName: 'messageList.getMessageInfo', msgId: number): Promise<string>
+  call(
+    fnName: 'messageList.getDraft',
+    chatId: number
+  ): Promise<JsonMessage | null>
   call(
     fnName: 'messageList.setDraft',
     chatId: number,

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -247,7 +247,7 @@ class DeltaRemote {
   call(
     fnName: 'messageList.getDraft',
     chatId: number
-  ): Promise<JsonMessage | null>
+  ): Promise<MessageType | null>
   call(
     fnName: 'messageList.setDraft',
     chatId: number,

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -253,9 +253,9 @@ class DeltaRemote {
     chatId: number,
     {
       text,
-      filename,
-      qouteMessageId,
-    }: { text?: string; filename?: string; qouteMessageId?: number }
+      file,
+      quotedMessageId,
+    }: { text?: string; file?: string; quotedMessageId?: number }
   ): Promise<void>
   call(
     fnName: 'messageList.messageIdToJson',

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -12,7 +12,6 @@ import {
   DeltaChatAccount,
   DesktopSettings,
   QrCodeResponse,
-  JsonMessage,
 } from '../shared/shared-types'
 import { MuteDuration } from '../shared/constants'
 import { LocaleData } from '../shared/localize'

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -33,5 +33,6 @@ declare global {
     __screen: Screens
     __contextMenuActive: boolean
     __settingsOpened: boolean
+    __setQuoteInDraft: (msgId: number) => void | null
   }
 }

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -238,11 +238,7 @@ chatStore.attachEffect(async ({ type, payload }, state) => {
     const messageObj = await DeltaBackend.call(
       'messageList.sendMessage',
       payload[0],
-      {
-        text: payload[1],
-        filename: payload[2],
-        location: payload[3],
-      }
+      payload[1]
     )
     chatStore.dispatch({
       type: 'MESSAGE_SENT',

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -1,10 +1,9 @@
 import { ipcBackend, saveLastChatId } from '../ipc'
-import { Store, useStore, Action } from './store'
+import { Store, useStore } from './store'
 import {
   JsonContact,
   FullChat,
   MessageType,
-  JsonMessage,
 } from '../../shared/shared-types'
 import { DeltaBackend } from '../delta-remote'
 import { runtime } from '../runtime'

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -1,10 +1,6 @@
 import { ipcBackend, saveLastChatId } from '../ipc'
 import { Store, useStore } from './store'
-import {
-  JsonContact,
-  FullChat,
-  MessageType,
-} from '../../shared/shared-types'
+import { JsonContact, FullChat, MessageType } from '../../shared/shared-types'
 import { DeltaBackend } from '../delta-remote'
 import { runtime } from '../runtime'
 

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -1,6 +1,6 @@
 import { ipcBackend, saveLastChatId } from '../ipc'
-import { Store, useStore } from './store'
-import { JsonContact, FullChat, MessageType } from '../../shared/shared-types'
+import { Store, useStore, Action } from './store'
+import { JsonContact, FullChat, MessageType, JsonMessage } from '../../shared/shared-types'
 import { DeltaBackend } from '../delta-remote'
 import { runtime } from '../runtime'
 
@@ -27,7 +27,7 @@ class state implements FullChat {
   freshMessageCounter = 0
   isGroup = false
   isDeaddrop = false
-  draft: string | null = null
+  draft: JsonMessage | null = null
 
   messageIds: number[] = []
   messages: { [key: number]: MessageType | { msg: null } } = {}
@@ -233,12 +233,12 @@ chatStore.attachEffect(async ({ type, payload }, state) => {
     if (payload[0] !== chatStore.state.id) return
     const messageObj = await DeltaBackend.call(
       'messageList.sendMessage',
-      ...(payload as [
-        number,
-        string,
-        string,
-        any
-      ]) /* [chatId, text, filename, location]*/
+      payload[0],
+      {
+        text: payload[1],
+        filename:payload[2],
+        location: payload[3]
+      }
     )
     chatStore.dispatch({
       type: 'MESSAGE_SENT',

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -1,6 +1,11 @@
 import { ipcBackend, saveLastChatId } from '../ipc'
 import { Store, useStore, Action } from './store'
-import { JsonContact, FullChat, MessageType, JsonMessage } from '../../shared/shared-types'
+import {
+  JsonContact,
+  FullChat,
+  MessageType,
+  JsonMessage,
+} from '../../shared/shared-types'
 import { DeltaBackend } from '../delta-remote'
 import { runtime } from '../runtime'
 
@@ -27,7 +32,6 @@ class state implements FullChat {
   freshMessageCounter = 0
   isGroup = false
   isDeaddrop = false
-  draft: JsonMessage | null = null
 
   messageIds: number[] = []
   messages: { [key: number]: MessageType | { msg: null } } = {}
@@ -236,8 +240,8 @@ chatStore.attachEffect(async ({ type, payload }, state) => {
       payload[0],
       {
         text: payload[1],
-        filename:payload[2],
-        location: payload[3]
+        filename: payload[2],
+        location: payload[3],
       }
     )
     chatStore.dispatch({

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -139,7 +139,7 @@ export interface FullChat {
   isGroup: boolean
   isDeaddrop: boolean
   isDeviceChat: boolean
-  draft: string
+  draft: JsonMessage | null
   selfInGroup: boolean
   muted: boolean
   ephemeralTimer: number

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -139,7 +139,6 @@ export interface FullChat {
   isGroup: boolean
   isDeaddrop: boolean
   isDeviceChat: boolean
-  draft: JsonMessage | null
   selfInGroup: boolean
   muted: boolean
   ephemeralTimer: number

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -71,8 +71,6 @@ $hover-contrast-change: 2%;
   --messageIncommingDate: #{$textPrimary};
   --messageOutgoingBg: #{$bgMessageBubbleOutgoing};
   --messageOutgoingStatusColor: #4caf50; // Message Bubble - Buttons
-  --messageButtons: #8b8e91;
-  --messageButtonsHover: #070c14;
   /* Message Bubble - Metadata */
   --messageStatusIcon: #4caf50;
   --messageStatusIconSending: #62656a;
@@ -81,6 +79,10 @@ $hover-contrast-change: 2%;
   --messageMetadataDate: #62656a;
   --messageMetadataIncomming: rgba(#ffffff, 0.7);
   --messageAuthor: #ffffff;
+  --messageReplyBtn: whitesmoke;
+  --messageReplyBtnHover: white;
+  --messageReplyBtnBg: rgba(0, 0, 0, 0.23);
+  --messageReplyBtnBgHover: rgba(0, 0, 0, 0.33);
   /* Message Bubble - Attachments */
   --messageAttachmentIconExtentionColor: #070c14;
   /* Manual value: This will not get generated in the future */
@@ -160,15 +162,18 @@ $hover-contrast-change: 2%;
   --videoPlayBtnBg: #ffffff; // Manual value: This will not get generated in the future
   --videoPlayBtnBorder: #eaeaea;
   --videoPlayBtnBgHover: #eeeeee;
+  --fullScreenMediaButtons: #8b8e91;
 
   @if lightness($bgPrimary) < 50 {
+    // dark theme
     --scrollbarThumb: #{rgba(white, $scrollbarTransparency)};
-  } @else {
-    --scrollbarThumb: #{rgba(grey, $scrollbarTransparency)};
-  }
-  @if lightness($bgPrimary) < 50 {
     --scrollbarThumbHover: #{rgba(white, $scrollbarTransparency + 0.14)};
+
+    --messageReplyBtnBg: rgba(255, 255, 255, 0.13);
+    --messageReplyBtnBgHover: rgba(255, 255, 255, 0.23);
   } @else {
+    // light theme
+    --scrollbarThumb: #{rgba(grey, $scrollbarTransparency)};
     --scrollbarThumbHover: #{rgba(grey, $scrollbarTransparency + 0.14)};
   }
 }


### PR DESCRIPTION
Add a draft area:
- Add possibility to add an description to an attachment
- Add quoting / reply to message

- Also removed the inline message buttons - the context menu is enough, we don't need them and they overlap sometimes with the text or the author name.

![Peek 2020-11-06 21-14](https://user-images.githubusercontent.com/18725968/98410368-d498a200-2074-11eb-87ad-f33569d85802.gif)

## Todo

- [x] Make it prettier -> especially attachments in the staging area like images, videos and audio files don't look good.
- [x] Private reply, not too useful without the functionality of jumping to message but still we could already implement it. (make sure that it only sets the quoted message of the draft and don't change anything else if there is already a draft in that chat) 

closes  #1680