### PR TITLE
Remove failed-to-configure accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Fix opening of multiple setting windows via keybinding
 - Fix two issues with the labeled link (see  #1893)
 - Fix refresh of "empty chat" info meassage on chat changes
+- Fix removing incompleted account (see #1952)
 
 ## [1.13.1] - 2020-10-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added context menu for info messages
 - Add simple support for displaying qoutes (no attachment preview nor jump to message yet)
 - Show sending indicator for outgoing info messages #1867
+- Add info log message that lists all unconfigured accounts, so you don't need to find them yourself to delete them.  (see #1952)
 
 ### Changed
 - Change "More info" translation to "Message Details"

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -119,7 +119,10 @@ export default class DCLoginController extends SplitOut {
     try {
       await this.login(newAccountPath, credentials)
     } catch (error) {
-      log.debug("Detected account creation error, deleting unfinished account", newAccountPath)
+      log.debug(
+        'Detected account creation error, deleting unfinished account',
+        newAccountPath
+      )
       await remove(newAccountPath)
       throw error
     }

--- a/src/main/logins.ts
+++ b/src/main/logins.ts
@@ -15,11 +15,11 @@ export async function getLogins(): Promise<DeltaChatAccount[]> {
   var accounts = await readDeltaAccounts(getAccountsPath())
   log.debug('Found following accounts:', accounts)
 
-  const orphantAccounts = await findInvalidDeltaAccounts()
-  if (orphantAccounts.length > 0) {
+  const orphanedAccounts = await findInvalidDeltaAccounts()
+  if (orphanedAccounts.length > 0) {
     log.info(
-      'unconfigured, likely orphant accounts, you may delete them',
-      orphantAccounts
+      'unconfigured, likely orphaned accounts, you may delete them',
+      orphanedAccounts
     )
   }
   return accounts
@@ -56,7 +56,7 @@ export async function getAccountInfo(path: string): Promise<DeltaChatAccount> {
 
     if (!config) {
       throw new Error(
-        'Account is not configured, it is likely an orphant account (artifact of a failed login in older versions)'
+        'Account is not configured, it is likely an orphaned account (artifact of a failed login in older versions)'
       )
     }
 

--- a/src/main/logins.ts
+++ b/src/main/logins.ts
@@ -14,6 +14,14 @@ export async function getLogins(): Promise<DeltaChatAccount[]> {
   // list new accounts
   var accounts = await readDeltaAccounts(getAccountsPath())
   log.debug('Found following accounts:', accounts)
+
+  const orphantAccounts = await findInvalidDeltaAccounts()
+  if (orphantAccounts.length > 0) {
+    log.info(
+      'unconfigured, likely orphant accounts, you may delete them',
+      orphantAccounts
+    )
+  }
   return accounts
 }
 
@@ -45,6 +53,12 @@ export async function getAccountInfo(path: string): Promise<DeltaChatAccount> {
       'profileImage',
       'color',
     ])
+
+    if (!config) {
+      throw new Error(
+        'Account is not configured, it is likely an orphant account (artifact of a failed login in older versions)'
+      )
+    }
 
     if (typeof config.addr !== 'string') {
       // this can be old temp accounts or accounts that somehow lost their addr, what should we do with them?
@@ -82,6 +96,30 @@ async function readDeltaAccounts(accountFolderPath: string) {
   )
 }
 
+async function findInvalidDeltaAccounts() {
+  const paths = (await fs.readdir(getAccountsPath())).map(filename =>
+    join(getAccountsPath(), filename)
+  )
+  const accountFolders = paths.filter(path => {
+    // isDeltaAccountFolder
+    return (
+      fs.existsSync(join(path, 'db.sqlite')) &&
+      !fs.lstatSync(path).isSymbolicLink()
+    )
+  })
+
+  const isConfigured = async (dir: string) => {
+    const dc = new DeltaChat()
+    await dc.open(dir)
+    const isConfigured = dc.isConfigured()
+    return { isConfigured, path: dir }
+  }
+
+  return (await Promise.all(accountFolders.map(isConfigured)))
+    .filter(({ isConfigured }) => !isConfigured)
+    .map(({ path }) => path)
+}
+
 async function getConfig(
   dir: string,
   keys: string[]
@@ -95,14 +133,14 @@ async function getConfig(
     keys.forEach((key: string) => {
       config[key] = dc.getConfig(key)
     })
-  }
-  if (keys.includes('profileImage')) {
-    config['profileImage'] = dc
-      .getContact(C.DC_CONTACT_ID_SELF)
-      .getProfileImage()
-  }
-  if (keys.includes('color')) {
-    config['color'] = dc.getContact(C.DC_CONTACT_ID_SELF).color
+    if (keys.includes('profileImage')) {
+      config['profileImage'] = dc
+        .getContact(C.DC_CONTACT_ID_SELF)
+        .getProfileImage()
+    }
+    if (keys.includes('color')) {
+      config['color'] = dc.getContact(C.DC_CONTACT_ID_SELF).color
+    }
   }
   return config
 }


### PR DESCRIPTION
- fixes deletion of failed-to-configure accounts
- shows a log message with all found previous orphaned/invalid accounts 

closes #1952

such an log message:
```
0.6s [i]main/find_logins: unconfigured, likely orphaned accounts, you may delete them [
  '/home/username/.config/DeltaChat/accounts/ac12',
  '/home/username/.config/DeltaChat/accounts/ac19',
  '/home/username/.config/DeltaChat/accounts/ac20',
  '/home/username/.config/DeltaChat/accounts/ac21',
  '/home/username/.config/DeltaChat/accounts/ac23',
  '/home/username/.config/DeltaChat/accounts/ac24',
  '/home/username/.config/DeltaChat/accounts/ac30',
  '/home/username/.config/DeltaChat/accounts/ac31',
  '/home/username/.config/DeltaChat/accounts/ac32',
  '/home/username/.config/DeltaChat/accounts/ac33',
  '/home/username/.config/DeltaChat/accounts/ac34',
  '/home/username/.config/DeltaChat/accounts/ac36',
  '/home/username/.config/DeltaChat/accounts/ac38',
  '/home/username/.config/DeltaChat/accounts/ac39',
  '/home/username/.config/DeltaChat/accounts/ac40',
  '/home/username/.config/DeltaChat/accounts/ac41',
  '/home/username/.config/DeltaChat/accounts/ac42'
]
```
This log message can be easily copied and either transformed a shell script that removes all them or the json array could be  consumed by an deletion script.