### PR TITLE
localize some unlocalized strings in settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Update deltachat-node to v1.49.0
 - Update inAppHelp
 - hasLocation indicator on messages is now always shown even when the experimental Location streaming feature is not turned on
+- localize some unlocalized strings in settings ("select" and "remove" buttons beneath the profile image)
 
 ## Fixed
 

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -380,7 +380,7 @@ function ProfileImageSelector(props: any) {
     remote.dialog.showOpenDialog(
       {
         title: tx('select_your_new_profile_image'),
-        filters: [{ name: 'Images', extensions: ['jpg', 'png', 'gif'] }],
+        filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif'] }],
         properties: ['openFile'],
       },
       async (files: string[]) => {
@@ -411,7 +411,7 @@ function ProfileImageSelector(props: any) {
           onClick={openSelectionDialog}
           className={'bp3-button'}
         >
-          Select
+          {tx('select')}
         </button>
         {profileImagePreview && (
           <button
@@ -419,7 +419,7 @@ function ProfileImageSelector(props: any) {
             onClick={changeProfilePicture.bind(null, '')}
             className={'bp3-button'}
           >
-            Remove
+            {tx('remove_desktop')}
           </button>
         )}
       </div>


### PR DESCRIPTION
("select" and "remove" buttons beneath the profile image)
fixes #1800 