### PR TITLE
Labeled link tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Adjust order of buttons at labeled link dialog
 
 ## Fixed
+- Fix "copy link" context menu option for labeled links
 - Fix exception when opening second instance of deltachat and tray icon is disabled
 - Fix showing/focusing deltachat on second instance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Changed
 - trust all labeled links from device chat
+- Adjust order of buttons at labeled link dialog
 
 ## Fixed
 - Fix exception when opening second instance of deltachat and tray icon is disabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+## Changed
+- trust all labeled links from device chat
+
 ## Fixed
 - Fix exception when opening second instance of deltachat and tray icon is disabled
 - Fix showing/focusing deltachat on second instance

--- a/src/renderer/components/message/LabeledLink.tsx
+++ b/src/renderer/components/message/LabeledLink.tsx
@@ -69,7 +69,12 @@ export const LabeledLink = ({
     )
   }
   return (
-    <a href={'#' + target} title={url.toString()} onClick={onClick}>
+    <a
+      href={'#' + target}
+      x-custom-url={target}
+      title={url.toString()}
+      onClick={onClick}
+    >
       {String(label)}
     </a>
   )

--- a/src/renderer/components/message/LabeledLink.tsx
+++ b/src/renderer/components/message/LabeledLink.tsx
@@ -11,6 +11,7 @@ import { DeltaCheckbox } from '../contact/ContactListItem'
 import { getLogger } from '../../../shared/logger'
 
 import UrlParser from 'url-parse'
+import chatStore from '../../stores/chat'
 
 const log = getLogger('renderer/LabeledLink')
 
@@ -53,8 +54,9 @@ export const LabeledLink = ({
   const onClick = (ev: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     ev.preventDefault()
     ev.stopPropagation()
+    const { isDeviceChat } = chatStore.getState()
     //check if domain is trusted
-    if (isDomainTrusted(url.hostname)) {
+    if (isDeviceChat || isDomainTrusted(url.hostname)) {
       openExternal(target)
       return
     }

--- a/src/renderer/components/message/LabeledLink.tsx
+++ b/src/renderer/components/message/LabeledLink.tsx
@@ -107,17 +107,18 @@ function confirmationDialog(
           </div>
           <DeltaDialogFooter>
             <DeltaDialogFooterActions>
-              <p className={`delta-button bold primary`} onClick={onClose}>
-                {tx('no')}
-              </p>
               <p
                 className={`delta-button bold primary`}
                 onClick={() => {
                   onClose()
                   navigator.clipboard.writeText(target)
                 }}
+                style={{ marginRight: 'auto' }}
               >
-                {tx('menu_copy_link_to_clipboard')}
+                {tx('copy')}
+              </p>
+              <p className={`delta-button bold primary`} onClick={onClose}>
+                {tx('cancel')}
               </p>
               <p
                 className={`delta-button bold primary`}

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -213,7 +213,9 @@ const Message = (props: {
   const showMenu: (
     event: React.MouseEvent<HTMLDivElement | HTMLAnchorElement, MouseEvent>
   ) => void = event => {
-    const link: string = (event.target as any).href || ''
+    const target = event.target as HTMLAnchorElement
+    const link: string =
+      target?.getAttribute('x-custom-url') || target?.href || ''
     const items = buildContextMenu(
       {
         attachment,


### PR DESCRIPTION
![2020-11-26_19-54](https://user-images.githubusercontent.com/18725968/100385527-2785c980-3023-11eb-8d64-ef79ae412a0a.png)

- trust all labeled links from device chat
- Adjust order of buttons at labeled link dialog
- Fix "copy link" context menu option for labeled links

Closes #1894
Successor of #1932