### PR TITLE
Overhaul the whole reconnecting logic, making it more fault tolerant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix state update on unmounted components in Timestamp and LoginScreen
 - Fix non emojis getting displayed big (see #1989)
 - Fix selecting a chat focus composer input (see #1986)
+- Fix reconnecting logic on suspend/resume or disconnecting/connecting to a network
 
 ## [1.14.0] - 2020-11-24
 

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -159,16 +159,6 @@ export default class DeltaChatController extends EventEmitter {
     return (app as any).translate(...args)
   }
 
-  // checkPassword(password: string) {
-  //   return password === this.settings.getConfig('mail_pw')
-  // }
-  networkStatus = false
-  networkStatusMessage = ''
-
-  getNetworkStatus(): [boolean, string] {
-    return [this.networkStatus, this.networkStatusMessage]
-  }
-
   onAll(_event: any, data1: any, data2: any) {
     const event: string = !isNaN(_event) ? eventStrings[_event] : String(_event)
 
@@ -181,30 +171,6 @@ export default class DeltaChatController extends EventEmitter {
     } else if (app.rc['log-debug']) {
       // in debug mode log all core events
       logCoreEvent.debug(event, data1, data2)
-    }
-
-    // Network Status
-    if (this.networkStatus !== false && event === 'DC_EVENT_ERROR_NETWORK') {
-      this.networkStatus = false
-      this.networkStatusMessage = data1 + data2
-      this.sendToRenderer('NETWORK_STATUS', [
-        this.networkStatus,
-        this.networkStatusMessage,
-      ])
-    } else if (
-      this.networkStatus === false &&
-      (event === 'DC_EVENT_SMTP_CONNECTED' ||
-        event === 'DC_EVENT_IMAP_CONNECTED' ||
-        event === 'DC_EVENT_INCOMING_MSG' ||
-        event === 'DC_EVENT_MSG_DELIVERED' ||
-        event === 'DC_EVENT_IMAP_MESSAGE_MOVED')
-    ) {
-      this.networkStatus = true
-      this.networkStatusMessage = ''
-      this.sendToRenderer('NETWORK_STATUS', [
-        this.networkStatus,
-        this.networkStatusMessage,
-      ])
     }
 
     this.sendToRenderer(event, [data1, data2])

--- a/src/renderer/components/OfflineToast.tsx
+++ b/src/renderer/components/OfflineToast.tsx
@@ -1,52 +1,97 @@
 import React, { useEffect, useState } from 'react'
 import { DeltaBackend } from '../delta-remote'
-import { ipcBackend } from '../ipc'
+import { ipcBackend, onDCEvent } from '../ipc'
 
 import { getLogger } from '../../shared/logger'
 import { useTranslationFunction } from '../contexts'
+import { bool } from 'prop-types'
+import { SetStateAction } from 'react'
+import { Dispatch } from 'react'
 
 const log = getLogger('renderer/components/OfflineToast')
 
+// Array holding all events on which we know that we have some online connectivity
+const DC_NETWORK_SUCCESS_EVENTS = [
+  'DC_EVENT_SMTP_CONNECTED',
+  'DC_EVENT_IMAP_CONNECTED',
+  'DC_EVENT_INCOMING_MSG',
+  'DC_EVENT_MSG_DELIVERED',
+  'DC_EVENT_IMAP_MESSAGE_MOVED',
+  'DC_EVENT_IMAP_MESSAGE_DELETED',
+]
+
 export default function OfflineToast() {
-  const [networkStatusMessage, setNetworkStatusMessage] = useState('')
-  const [networkStatus, setNetworkStatus] = useState(true)
+  const [networkState, setNetworkState]: [[boolean, string], todo] = useState([
+    true,
+    '',
+  ])
   const [tryConnectCooldown, setTryConnectCooldown] = useState(true)
 
-  const onNetworkStatus = (
-    _: any,
-    [networkStatus, networkStatusMessage]: [boolean, string]
-  ) => {
-    log.debug(
-      `network status changed, we're ${
-        networkStatus ? 'online' : 'offline'
-      }. The message is "${networkStatusMessage}"`
-    )
-    setNetworkStatus(networkStatus)
-    setNetworkStatusMessage(networkStatusMessage)
-  }
   const onBrowserOffline = () => {
-    log.debug("Browser thinks we're offline, telling rust core")
-    DeltaBackend.call('context.maybeNetwork')
+    log.debug("Browser knows we're offline")
+    setNetworkState(() => [false, "Browser knows we're offline"])
+  }
+
+  const tryMaybeNetworkIfOfflineAfterXms = (ms: number) => {
+    setTimeout(() => {
+      // This is a hack to get the current network state by abusing the setNetworkState function.
+      // Not pretty but works.
+      setNetworkState(([online, error]: [boolean, string]) => {
+        if (!online) {
+          log.debug(
+            `We are still not online after ${ms}  milli seconds, try maybeNetwork again`
+          )
+          DeltaBackend.call('context.maybeNetwork')
+        } else if (ms < 30000) {
+          tryMaybeNetworkIfOfflineAfterXms(2 * ms)
+        } else {
+          log.debug(
+            `We tried reconnecting with waiting for more then 30 seconds, now stop`
+          )
+        }
+
+        // Keep state unchanged
+        return [online, error]
+      })
+    }, ms)
   }
 
   const onBrowserOnline = () => {
     log.debug("Browser thinks we're back online, telling rust core")
+    setNetworkState(() => [true, "Browser thinks we're online"])
     DeltaBackend.call('context.maybeNetwork')
+
+    tryMaybeNetworkIfOfflineAfterXms(150)
+  }
+
+  const onDeltaNetworkError = (data1: string, data2: string) => {
+    setNetworkState(() => [false, data1 + data2])
+  }
+
+  const onDeltaNetworkSuccess = (data1: string, data2: string) => {
+    setNetworkState(() => [true, ''])
   }
 
   useEffect(() => {
-    ;(async () => {
-      const networkStatusReturn = await DeltaBackend.call('getNetworkStatus')
-      onNetworkStatus(null, networkStatusReturn)
-    })()
-    window.addEventListener('online', onBrowserOffline)
-    window.addEventListener('offline', onBrowserOnline)
-    ipcBackend.on('NETWORK_STATUS', onNetworkStatus)
+    if (navigator.onLine === false) onBrowserOffline()
+
+    window.addEventListener('online', onBrowserOnline)
+    window.addEventListener('offline', onBrowserOffline)
+    const removeEventListenerDCNetworkError = onDCEvent(
+      'DC_EVENT_ERROR_NETWORK',
+      onDeltaNetworkError
+    )
+    const removeEventListenerDCNetworkSuccess = onDCEvent(
+      DC_NETWORK_SUCCESS_EVENTS,
+      onDeltaNetworkSuccess
+    )
 
     return () => {
       window.removeEventListener('online', onBrowserOffline)
       window.removeEventListener('offline', onBrowserOnline)
-      ipcBackend.removeListener('NETWORK_STATUS', onNetworkStatus)
+
+      removeEventListenerDCNetworkError()
+      removeEventListenerDCNetworkSuccess()
     }
   }, [])
 
@@ -59,9 +104,9 @@ export default function OfflineToast() {
   const tx = useTranslationFunction()
 
   return (
-    networkStatus === false && (
+    networkState[0] === false && (
       <div className='OfflineToast'>
-        <a title={networkStatusMessage}>{tx('offline')}</a>
+        <a title={networkState[1]}>{tx('offline')}</a>
         <div
           className={tryConnectCooldown ? '' : 'disabled'}
           onClick={onTryReconnectClick}

--- a/src/renderer/components/OfflineToast.tsx
+++ b/src/renderer/components/OfflineToast.tsx
@@ -1,12 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import { DeltaBackend } from '../delta-remote'
-import { ipcBackend, onDCEvent } from '../ipc'
+import { onDCEvent } from '../ipc'
 
 import { getLogger } from '../../shared/logger'
 import { useTranslationFunction } from '../contexts'
-import { bool } from 'prop-types'
-import { SetStateAction } from 'react'
-import { Dispatch } from 'react'
 
 const log = getLogger('renderer/components/OfflineToast')
 
@@ -68,7 +65,7 @@ export default function OfflineToast() {
     setNetworkState(() => [false, data1 + data2])
   }
 
-  const onDeltaNetworkSuccess = (data1: string, data2: string) => {
+  const onDeltaNetworkSuccess = () => {
     setNetworkState(() => [true, ''])
   }
 

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -43,7 +43,6 @@ class DeltaRemote {
   call(fnName: 'joinSecurejoin', qrCode: string): Promise<number>
   call(fnName: 'stopOngoingProcess'): Promise<number>
   call(fnName: 'checkQrCode', qrCode: string): Promise<QrCodeResponse>
-  call(fnName: 'getNetworkStatus'): Promise<[boolean, string]>
   // autocrypt ----------------------------------------------------------
   call(fnName: 'autocrypt.initiateKeyTransfer'): Promise<string>
   call(

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -11,7 +11,6 @@ const log = getLogger('renderer/ipc')
 
 export const ipcBackend = ipcRenderer
 
-
 // Listen to DC/Backend events in a conventient way. Returns a callback to remove the
 // event listener. You can bind the same event listener to multiple events by passing them
 // as an array of strings.

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -1,3 +1,4 @@
+import { array } from 'prop-types'
 import { getLogger } from '../shared/logger'
 
 /**
@@ -9,6 +10,22 @@ const { ipcRenderer } = window.electron_functions
 const log = getLogger('renderer/ipc')
 
 export const ipcBackend = ipcRenderer
+
+export function onDCEvent(
+  event: string | string[],
+  cb: (data1: string, data2: string) => void
+) {
+  const wrapperCb = (_: any, [data1, data2]: [string, string]) => {
+    cb(data1, data2)
+  }
+  if (Array.isArray(event)) {
+    event.forEach(e => ipcBackend.on(e, wrapperCb))
+    return () => event.forEach(e => ipcBackend.removeListener(e, wrapperCb))
+  } else {
+    ipcBackend.on(event, wrapperCb)
+    return () => ipcBackend.removeListener(event, wrapperCb)
+  }
+}
 
 let backendLoggingStarted = false
 export function startBackendLogging() {

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -11,6 +11,10 @@ const log = getLogger('renderer/ipc')
 
 export const ipcBackend = ipcRenderer
 
+
+// Listen to DC/Backend events in a conventient way. Returns a callback to remove the
+// event listener. You can bind the same event listener to multiple events by passing them
+// as an array of strings.
 export function onDCEvent(
   event: string | string[],
   cb: (data1: string, data2: string) => void

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -1,4 +1,3 @@
-import { array } from 'prop-types'
 import { getLogger } from '../shared/logger'
 
 /**


### PR DESCRIPTION
- Move the networkstatus state into the frontend
- introduce ipc.onDCEvent method as alternative for
ipc.ipcBackend.on(...)

Supersedes https://github.com/deltachat/deltachat-desktop/pull/2001
Fixes https://github.com/deltachat/deltachat-desktop/issues/1842