### PR TITLE
show timestamp and padlock even on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Added
 - Add Press F5 to call dcMaybeNetwork
+- open message info when clicking on the error status icon of a message
 
 ## Changed
 - Show linebreaks in quotes
@@ -17,6 +18,7 @@
 - Switch to archived/normal view accordingly when selecting an archived/unarchived chat
 - Update Translations
 - call maybe_network on window focus
+- always show timestamp and padlock/nopadlock on messages (previously padlock and timestamp were hidden on error)
 
 ## Fixed
 - Fix "copy link" context menu option for labeled links

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -385,6 +385,7 @@ const Message = (props: {
             hasLocation={hasLocation}
             timestamp={message.msg.sentAt}
             padlock={message.msg.showPadlock}
+            onClickError={openMessageInfo.bind(null, message)}
           />
         </div>
       </div>

--- a/src/renderer/components/message/MessageMetaData.tsx
+++ b/src/renderer/components/message/MessageMetaData.tsx
@@ -14,6 +14,7 @@ export default class MessageMetaData extends React.Component<{
   text?: string
   timestamp: number
   hasLocation?: boolean
+  onClickError?: () => void
 }> {
   render() {
     const {
@@ -25,6 +26,7 @@ export default class MessageMetaData extends React.Component<{
       text,
       timestamp,
       hasLocation,
+      onClickError,
     } = this.props
 
     const withImageNoCaption = Boolean(
@@ -32,7 +34,6 @@ export default class MessageMetaData extends React.Component<{
         ((isImage(attachment) && hasAttachment(attachment)) ||
           isVideo(attachment))
     )
-    const showError = status === 'error' && direction === 'outgoing'
 
     return (
       <i18nContext.Consumer>
@@ -45,30 +46,25 @@ export default class MessageMetaData extends React.Component<{
             {username !== undefined ? (
               <div className='username'>{username}</div>
             ) : null}
-            {padlock === true && status !== 'error' ? (
+            {padlock === true ? (
               <div
                 aria-label={tx('a11y_encryption_padlock')}
                 className={'padlock-icon'}
               />
             ) : null}
             {hasLocation ? <span className={'location-icon'} /> : null}
-            {showError ? (
-              <span className='date' style={{ color: 'red' }}>
-                {tx('send_failed')}
-              </span>
-            ) : (
-              <Timestamp
-                timestamp={timestamp}
-                extended
-                direction={direction}
-                module='date'
-              />
-            )}
+            <Timestamp
+              timestamp={timestamp}
+              extended
+              direction={direction}
+              module='date'
+            />
             <span className='spacer' />
             {direction === 'outgoing' ? (
               <div
                 className={classNames('status-icon', status)}
                 aria-label={tx(`a11y_delivery_status_${status}`)}
+                onClick={status === 'error' && onClickError}
               />
             ) : null}
           </div>


### PR DESCRIPTION
- show timestamp and padlock even on error
- open message info when clicking on the error status icon.

Fixes #2020 