### PR TITLE
message input choose text direction (RTL or LTR) based on input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Try to always focus composer textarea
 - Store relative instead of absolute path to last Account #2028
 
+### Fixed
+- correctly display RTL text inside of the message input field (see #2036)
 
 ## [1.14.1] - 2020-12-15
 

--- a/src/renderer/components/composer/ComposerMessageInput.tsx
+++ b/src/renderer/components/composer/ComposerMessageInput.tsx
@@ -213,6 +213,7 @@ export default class ComposerMessageInput extends React.Component<
         onChange={this.onChange}
         placeholder={window.static_translate('write_message_desktop')}
         disabled={this.state.loadingDraft}
+        dir='auto'
       />
     )
   }


### PR DESCRIPTION
(dir=auto)
fix #2036
see https://support.delta.chat/t/problem-with-right-to-left-languages/1312