### PR TITLE
add chat audit log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - add missing Czech translation #2218
 - add Mailinglist support
 - add support for overwritten sender name (also sometimes referred to as impersonation)
+- add audit log to chats (view where only info/system messages are shown such as member added/removed)
 
 ## Fixed
 - Fix source-mapped stack trace on crash screen in bundled production builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - add missing Czech translation #2218
 - add Mailinglist support
 - add support for overwritten sender name (also sometimes referred to as impersonation)
-- add audit log to chats (view where only info/system messages are shown such as member added/removed)
+- add experimental audit log to chats (view where only info/system messages are shown such as member added/removed)
 
 ## Fixed
 - Fix source-mapped stack trace on crash screen in bundled production builds

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -47,25 +47,25 @@
   "puny_code_warning_header": {
     "message": "Suspicious Link detected"
   },
-  "puny_code_warning_question":{
+  "puny_code_warning_question": {
     "message": "Are you sure you want to visit $$asciiHostname$$?"
   },
   "puny_code_warning_description": {
     "message": "You followed a link which could be misrepresenting characters by using similarly looking ones from different alphabets. Following the link labelled $$originalHostname$$ will lead to $$asciiHostname$$ which is normal for non-Latin characters. If you did not expect such characters this link could be harmful."
   },
-  "menu_learn_spelling":{
+  "menu_learn_spelling": {
     "message": "Learn Spelling"
   },
   "menu_copy_image_to_clipboard": {
     "message": "Copy Image"
   },
-  "no_spellcheck_suggestions_found":{
+  "no_spellcheck_suggestions_found": {
     "message": "No Spelling Suggestions found"
   },
   "forwared_by": {
     "message": "Forwarded by %1$s"
   },
-  "forwarded":{
+  "forwarded": {
     "message": "Forwarded"
   },
   "menu_copy_text_to_clipboard": {
@@ -82,5 +82,20 @@
   },
   "mailing_list_profile_info": {
     "message": "These settings (chat name and image) apply to this device only."
+  },
+  "menu_item_chat_audit_log": {
+    "message": "Chat Audit Log"
+  },
+  "loading": {
+    "message": "Loading"
+  },
+  "chat_audit_log_empty_message": {
+    "message": "System messages of this chat would appear here"
+  },
+  "chat_audit_log_title": {
+    "message": "Audit Log for %1$s"
+  },
+  "chat_audit_log_description": {
+    "message": "This view shows only System- and Info-Messages. Useful for finding the last chat actions without scrolling through many normal messages."
   }
 }

--- a/scss/dialogs/_audit_log.scss
+++ b/scss/dialogs/_audit_log.scss
@@ -63,17 +63,20 @@
         display: inline-block;
         margin-right: 4px;
         font-size: 15px;
-        background-color: var(--infoMessageBubbleBg);
+        background-color: #385e6b;
         border-radius: 10px;
         opacity: 0.76;
         color: var(--infoMessageBubbleText);
         padding: 7px 14px;
       }
-      font-size: 14px;
 
       &:hover {
-        background: rgba($color: grey, $alpha: 0.3);
+        background: rgba($color: grey, $alpha: 0.25);
         border-radius: 10px 0 0 10px;
+        div.timestamp {
+          border-radius: 10px 0 0 10px;
+          transition: ease-in 0.05s;
+        }
       }
     }
   }

--- a/scss/dialogs/_audit_log.scss
+++ b/scss/dialogs/_audit_log.scss
@@ -1,0 +1,80 @@
+.audit-log-dialog {
+  .bp3-dialog-header {
+    padding: 14px 15px 9px 13px;
+  }
+
+  .heading {
+    flex: 1 1 auto;
+    margin: 0;
+    line-height: inherit;
+
+    & > h4 {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      word-wrap: normal;
+      margin: 0;
+      line-height: inherit;
+      font-size: 18px;
+    }
+
+    & > h5 {
+      margin: 0;
+      margin-top: 1px;
+      font-weight: normal;
+      font-size: 14px;
+    }
+  }
+
+  div.no-content {
+    display: flex;
+    flex-direction: column;
+    margin-top: 1.25em;
+    & > div {
+      font-size: 17px;
+      background-color: var(--infoMessageBubbleBg);
+      border-radius: 10px;
+      opacity: 0.76;
+      color: var(--infoMessageBubbleText);
+      padding: 7px 14px;
+      display: inline-block;
+      align-self: center;
+    }
+  }
+
+  ul {
+    list-style: none;
+    padding-left: 12px;
+    li.time {
+      div {
+        text-transform: capitalize;
+        border-bottom: 2px solid var(--globalText);
+        font-size: 15px;
+        font-weight: bold;
+        display: inline-block;
+      }
+      padding-bottom: 11px;
+    }
+
+    li.info {
+      font-size: 14px;
+      div.timestamp {
+        font-weight: bold;
+        display: inline-block;
+        margin-right: 4px;
+        font-size: 15px;
+        background-color: var(--infoMessageBubbleBg);
+        border-radius: 10px;
+        opacity: 0.76;
+        color: var(--infoMessageBubbleText);
+        padding: 7px 14px;
+      }
+      font-size: 14px;
+
+      &:hover {
+        background: rgba($color: grey, $alpha: 0.3);
+        border-radius: 10px 0 0 10px;
+      }
+    }
+  }
+}

--- a/scss/manifest.scss
+++ b/scss/manifest.scss
@@ -33,6 +33,7 @@
 
 // Dialogs
 @import 'dialogs/_about';
+@import 'dialogs/_audit_log';
 @import 'dialogs/_autocrypt_setup.scss';
 @import 'dialogs/_delta-dialog';
 @import 'dialogs/_forward-message';

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -163,12 +163,8 @@ export default class DCMessageList extends SplitOut {
     this._controller.chatList.selectChat(chatId)
   }
 
-  getMessageIds(chatId: number) {
-    const messageIds = this._dc.getChatMessages(
-      chatId,
-      C.DC_GCM_ADDDAYMARKER,
-      0
-    )
+  getMessageIds(chatId: number, flags: number = C.DC_GCM_ADDDAYMARKER) {
+    const messageIds = this._dc.getChatMessages(chatId, flags, 0)
     return messageIds
   }
 

--- a/src/renderer/components/Menu.tsx
+++ b/src/renderer/components/Menu.tsx
@@ -169,13 +169,14 @@ export default function DeltaMenu(props: { selectedChat: FullChat }) {
           onClick={onDisappearingMessages}
         />
       ),
-      !(isSelfTalk || isDeviceChat) && (
-        <DeltaMenuItem
-          key='chat-audit-log'
-          text={tx('menu_item_chat_audit_log')}
-          onClick={openChatAuditLog}
-        />
-      ),
+      !(isSelfTalk || isDeviceChat) &&
+        settingsContext.desktopSettings.enableChatAuditLog && (
+          <DeltaMenuItem
+            key='chat-audit-log'
+            text={tx('menu_item_chat_audit_log')}
+            onClick={openChatAuditLog}
+          />
+        ),
       <Menu.Divider key='divider-2' />,
     ]
   } else {

--- a/src/renderer/components/Menu.tsx
+++ b/src/renderer/components/Menu.tsx
@@ -78,6 +78,8 @@ export default function DeltaMenu(props: { selectedChat: FullChat }) {
       },
     })
   }
+  const openChatAuditLog = () =>
+    screenContext.openDialog('ChatAuditLogDialog', { selectedChat })
   const logout = () => {
     if (selectedChat) {
       chatStoreDispatch({ type: 'UI_UNSELECT_CHAT' })
@@ -165,6 +167,13 @@ export default function DeltaMenu(props: { selectedChat: FullChat }) {
           key='disappearing'
           text={tx('ephemeral_messages')}
           onClick={onDisappearingMessages}
+        />
+      ),
+      !(isSelfTalk || isDeviceChat) && (
+        <DeltaMenuItem
+          key='chat-audit-log'
+          text={tx('menu_item_chat_audit_log')}
+          onClick={openChatAuditLog}
         />
       ),
       <Menu.Divider key='divider-2' />,

--- a/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
+++ b/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
@@ -1,0 +1,137 @@
+import React, { useState, useEffect, useRef } from 'react'
+import { DeltaDialogBase, DeltaDialogCloseButton } from './DeltaDialog'
+import { DialogProps } from './DialogController'
+import type { FullChat, MessageType } from '../../../shared/shared-types'
+import { DeltaBackend } from '../../delta-remote'
+import { C } from 'deltachat-node/dist/constants'
+import { getLogger } from '../../../shared/logger'
+import { useTranslationFunction } from '../../contexts'
+import moment from 'moment'
+
+const log = getLogger('render/ChatAuditLog')
+
+export default function ChatAuditLogDialog(props: {
+  selectedChat: FullChat
+  onClose: DialogProps['onClose']
+}) {
+  const { selectedChat, onClose } = props
+  const isOpen = !!selectedChat
+
+  const [loading, setLoading] = useState(true)
+  const [msgIds, setMsgIds] = useState<number[]>([])
+  const [messages, setMessages] = useState<{
+    [key: number]:
+      | MessageType
+      | {
+          msg: null
+        }
+  }>({})
+
+  const listView = useRef<HTMLDivElement>()
+
+  async function refresh() {
+    setLoading(true)
+    const msgIds = await DeltaBackend.call(
+      'messageList.getMessageIds',
+      selectedChat.id,
+      C.DC_GCM_ADDDAYMARKER | C.DC_GCM_SYSTEM_ONLY
+    )
+    const messages = await DeltaBackend.call('messageList.getMessages', msgIds)
+    console.log({ msgIds, messages })
+    setMsgIds(msgIds)
+    setMessages(messages)
+    setLoading(false)
+
+    setTimeout(() => {
+      listView.current.scrollTop = listView.current?.scrollHeight
+    }, 0)
+  }
+
+  useEffect(() => {
+    refresh()
+  }, [selectedChat.id])
+
+  let specialMessageIdCounter = 0
+
+  const tx = useTranslationFunction()
+
+  return (
+    <DeltaDialogBase
+      isOpen={isOpen}
+      onClose={onClose}
+      fixed
+      className={'audit-log-dialog'}
+      style={{ width: 'calc(100vw - 50px)', maxWidth: '733px' }}
+      isCloseButtonShown={true}
+    >
+      <div className='bp3-dialog-header bp3-dialog-header-border-bottom'>
+        <div className='heading'>
+          <h4>{tx('chat_audit_log_title', selectedChat.name)}</h4>
+          <h5>{tx('chat_audit_log_description')}</h5>
+        </div>
+        <DeltaDialogCloseButton onClick={onClose} />
+      </div>
+
+      {loading ? (
+        <div>{tx('loading')}</div>
+      ) : (
+        <div style={{ overflowY: 'scroll' }} ref={listView}>
+          {msgIds.length === 0 && (
+            <div className='no-content' key='no-content-msg'>
+              <div>{tx('chat_audit_log_empty_message')}</div>
+            </div>
+          )}
+          <ul key='info-message-list'>
+            {msgIds.map((id, index) => {
+              if (id === C.DC_MSG_ID_DAYMARKER) {
+                const key = 'magic' + id + '_' + specialMessageIdCounter++
+                const nextMessage = messages[msgIds[index + 1]]
+                if (!nextMessage) return null
+                return (
+                  <li key={key} className='time'>
+                    <div>
+                      {moment.unix(nextMessage.msg.timestamp).calendar(null, {
+                        sameDay: `[${tx('today')}]`,
+                        lastDay: `[${tx('yesterday')}]`,
+                        lastWeek: 'LL',
+                        sameElse: 'LL',
+                      })}
+                    </div>
+                  </li>
+                )
+              }
+              const message = messages[id]
+              if (!message || message.msg == null) {
+                log.debug(`Missing message with id ${id}`)
+                return
+              }
+              const {
+                text,
+                direction,
+                status,
+                timestamp,
+              } = (message as MessageType).msg
+              return (
+                <li key={id} className='info' onContextMenu={() => {}}>
+                  <p>
+                    <div className='timestamp'>
+                      {moment.unix(timestamp).format('LT')}
+                    </div>
+                    {text}
+                    {direction === 'outgoing' &&
+                      (status === 'sending' || status === 'error') && (
+                        <div
+                          className={`status-icon ${status}`}
+                          aria-label={tx(`a11y_delivery_status_${status}`)}
+                        />
+                      )}
+                  </p>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      )}
+    </DeltaDialogBase>
+  )
+}

--- a/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
+++ b/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
@@ -93,7 +93,7 @@ export default function ChatAuditLogDialog(props: {
     const msgIds = await DeltaBackend.call(
       'messageList.getMessageIds',
       selectedChat.id,
-      C.DC_GCM_ADDDAYMARKER | C.DC_GCM_SYSTEM_ONLY
+      C.DC_GCM_ADDDAYMARKER | C.DC_GCM_INFO_ONLY
     )
     const messages = await DeltaBackend.call('messageList.getMessages', msgIds)
     console.log({ msgIds, messages })

--- a/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
+++ b/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
@@ -96,7 +96,6 @@ export default function ChatAuditLogDialog(props: {
       C.DC_GCM_ADDDAYMARKER | C.DC_GCM_INFO_ONLY
     )
     const messages = await DeltaBackend.call('messageList.getMessages', msgIds)
-    console.log({ msgIds, messages })
     setMsgIds(msgIds)
     setMessages(messages)
     setLoading(false)

--- a/src/renderer/components/dialogs/DeltaDialog.tsx
+++ b/src/renderer/components/dialogs/DeltaDialog.tsx
@@ -37,7 +37,7 @@ export const DeltaDialogBase = React.memo<
   )
 })
 
-function DeltaDialogCloseButton(
+export function DeltaDialogCloseButton(
   props: React.ButtonHTMLAttributes<HTMLButtonElement>
 ) {
   return (

--- a/src/renderer/components/dialogs/DialogController.tsx
+++ b/src/renderer/components/dialogs/DialogController.tsx
@@ -17,6 +17,7 @@ import UnblockContacts from './UnblockContacts'
 import MuteChat from './MuteChat'
 import QrCode from './QrCode'
 import DisappearingMessages from './DisappearingMessages'
+import ChatAuditLogDialog from './ChatAuditLogDialog'
 import { DeltaChatAccount } from '../../../shared/shared-types'
 import { getLogger } from '../../../shared/logger'
 
@@ -38,6 +39,7 @@ export const allDialogs: { [key: string]: any } = {
   UnblockContacts,
   MuteChat,
   DisappearingMessages,
+  ChatAuditLogDialog,
   QrCode,
 }
 

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -292,6 +292,10 @@ export default function Settings(props: DialogProps) {
                 'minimizeToTray',
                 tx('pref_show_tray_icon')
               )}
+              {renderDTSettingSwitch(
+                'enableChatAuditLog',
+                tx('menu_item_chat_audit_log')
+              )}
               {renderDTSettingSwitch('enableAVCalls', tx('videochat'))}
               {desktopSettings['enableAVCalls'] === true && (
                 <>

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -257,7 +257,11 @@ class DeltaRemote {
     fnName: 'messageList.messageIdToJson',
     id: number
   ): Promise<{ msg: null } | MessageType>
-  call(fnName: 'messageList.getMessageIds', chatid: number): Promise<number[]>
+  call(
+    fnName: 'messageList.getMessageIds',
+    chatid: number,
+    flags?: number
+  ): Promise<number[]>
   call(
     fnName: 'messageList.forwardMessage',
     msgId: number,

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -32,6 +32,7 @@ export interface DesktopSettings {
   /** path to last used/selected Account */
   lastAccount: string
   enableAVCalls: boolean
+  enableChatAuditLog: boolean
   enableOnDemandLocationStreaming: boolean
   enterKeySends: boolean
   locale: string | null

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -14,6 +14,7 @@ export function getDefaultState(): AppState {
       credentials: undefined,
       lastAccount: undefined,
       enableAVCalls: false,
+      enableChatAuditLog: false,
       enableOnDemandLocationStreaming: false,
       chatViewBgImg: undefined,
       lastChats: {},


### PR DESCRIPTION
## Add a dialog that only shows info/system messages
### TODO
- [x] needs to reference a core that has https://github.com/deltachat/deltachat-core-rust/pull/2132 merged 
- [ ] optional: virtual lazyloaded list (like chatlist)
    - [ ] reload list/items when state changes (pending/sending system messages)
- [x] changelog entry: "added chat audit log view"
### Pictures
![2021-01-11_15-09](https://user-images.githubusercontent.com/18725968/104192945-cf165a00-541f-11eb-9f0c-ac036df72a06.png)

### See also
Core PR: https://github.com/deltachat/deltachat-core-rust/pull/2132
Forum Feature Proposal: https://support.delta.chat/t/show-audit-log-of-group/512