### PR TITLE
theming fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- show right default background for theme in background preview in settings
+- handle invalid theme metadata better (don't display no themes anymore when one has invalid metadata)
+
 ### Added
 - open message info when clicking on the error status icon of a message
 - add deltachat desktop version & build info to the logfiles
@@ -13,6 +17,7 @@
 - Try to always focus composer textarea
 - Store relative instead of absolute path to last Account #2028
 - replace parcel bunder with esbuild bundler (faster bundle speed)
+- turn "theme not found" error from the `--theme` cli option from process exit into normal init fail with a user readable error message in an dialog.
 
 ### Fixed
 - correctly display RTL text inside of the message input field (see #2036)

--- a/docs/THEMES.md
+++ b/docs/THEMES.md
@@ -48,11 +48,46 @@ npm run start -- --theme dc:dark --theme-watch
 
 We use scss to create themes, because it allows us to save work by using its color transformation functions (such as `lighten` or `darken`)
 
+### **Method A** - When you have a deltachat desktop checkout
+
+0. make sure deltachat desktop is up to date and checked out to the version you want to make your theme for, normaly checking out master is suffientent for making themes for the newest version.
+
+1. copy the light or dark theme and save it to your user deltachat folder `DeltaChat/custom-themes/my_theme.scss`
+
+2. run `npm i`
+
+3. compile the theme to css in watchmode
+
+```sh
+npx sass --watch path/to/Deltachat/config/folder/custom-themes/my_theme.scss path/to/Deltachat/config/folder/custom-themes/my_theme.css -I themes/ --no-source-map
+# for linux
+npx sass --watch ~/.config/DeltaChat/custom-themes/my_theme.scss ~/.config/DeltaChat/custom-themes/my_theme.css -I themes/ --no-source-map
+```
+
+> Note: you have to set `-I` to the theme folder in an deltachat-desktop git checkout, otherwise you'll get an error!
+
+4. open a new terminal window/tab
+
+5. start deltachat from your terminal with your theme selected in watch mode:
+
+```sh
+deltachat --theme custom:my_theme --theme-watch
+```
+
+6. Open your theme file in your favorite code/text editor and edit it,
+   when you save it your changes should be applied 1-2 seconds later.
+
+Read the comments in the theme files for additional information.
+
+### **Method B** - Without cloning the whole deltachat desktop
+
 0. install the sass compiler via `npm i -g node-sass` (if it says that npm was not found, then you need to install nodejs first)
 
-1. copy the light or dark theme and save it to your user deltachat folder DeltaChat/custom-themes/my_theme.scss
+1. Download all files starting with `_` from https://github.com/deltachat/deltachat-desktop/tree/master/themes and put them in a `./themes/` folder in your working directory (or alternativly download the folder to your working directory).
 
-1. compile the theme to css in watchmode
+2. copy the light or dark theme and save it to your user deltachat folder `DeltaChat/custom-themes/my_theme.scss`
+
+3. compile the theme to css in watchmode
 
 ```sh
 node-sass -w path/to/Deltachat/config/folder/custom-themes/my_theme.scss path/to/Deltachat/config/folder/custom-themes/my_theme.css --include-path path/to/deltachat-desktop-git-folder/themes/
@@ -60,17 +95,17 @@ node-sass -w path/to/Deltachat/config/folder/custom-themes/my_theme.scss path/to
 node-sass -w ~/.config/DeltaChat/custom-themes/my_theme.scss ~/.config/DeltaChat/custom-themes/my_theme.css --include-path themes/
 ```
 
-> Note: you have to set --include-path to the theme folder in an deltachat-desktop git checkout, otherwise you'll get an error!
+> Note: you have to set `--include-path` to the theme folder you created or downloaded earlier in step 1.
 
-3. open a new terminal window/tab
+4. open a new terminal window/tab
 
-4. start deltachat from your terminal with your theme selected in watch mode:
+5. start deltachat from your terminal with your theme selected in watch mode:
 
 ```sh
 deltachat --theme custom:my_theme --theme-watch
 ```
 
-5. Open your theme file in your favorite code/text editor and edit it,
+6. Open your theme file in your favorite code/text editor and edit it,
    when you save it your changes should be applied 1-2 seconds later.
 
 Read the comments in the theme files for additional information.

--- a/scss/dialogs/_settings.scss
+++ b/scss/dialogs/_settings.scss
@@ -9,7 +9,7 @@
   width: 45%;
   height: 142px;
   border-radius: 5pt;
-  background-image: url(../images/background_light.svg);
+  background-image: var(--chatViewBgImgPath);
   background-color: var(--chatViewBg);
   background-size: cover;
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -88,6 +88,9 @@ function onReady([logins, _appReady, loadedState]: [
   any,
   AppState
 ]) {
+  // can fail due to user error so running it first is better (cli argument)
+  acceptThemeCLI()
+
   const state = (app.state = loadedState)
   state.logins = logins
 
@@ -113,7 +116,6 @@ function onReady([logins, _appReady, loadedState]: [
       }
     })
   }
-  acceptThemeCLI()
 
   cleanupLogFolder().catch(err =>
     log.error('Cleanup of old logfiles failed: ', err)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -88,13 +88,13 @@ function onReady([logins, _appReady, loadedState]: [
   any,
   AppState
 ]) {
-  // can fail due to user error so running it first is better (cli argument)
-  acceptThemeCLI()
-
   const state = (app.state = loadedState)
   state.logins = logins
 
   app.saveState = () => State.save({ saved: state.saved })
+
+  // can fail due to user error so running it first is better (cli argument)
+  acceptThemeCLI()
 
   setLanguage(state.saved.locale || app.getLocale())
 

--- a/src/main/themes.ts
+++ b/src/main/themes.ts
@@ -138,7 +138,15 @@ export function acceptThemeCLI() {
       resolveThemeAddress(app.rc['theme'])
     } catch (error) {
       log.error('THEME NOT FOUND', { error, path: app.rc['theme'] })
-      process.exit(1) // user specied a theme via cli argument so we should fail if this fails
+      throw new Error(
+        `THEME "${app.rc['theme']}" NOT FOUND,
+this is fatal because the user specified it via cli argument.
+If you did not specify this, ask the person which installed deltachat for you to remove the cli argument again.
+
+If they are not available find the shortcut/.desktop file yourself and edit it to not contain the "--theme" argument.
+Using --theme is for developers and theme creators ONLY and should not be used by normal users
+If you have question or need help, feel free to ask in our forum https://support.delta.chat.`
+      )
     }
     app.state.saved.activeTheme = app.rc['theme']
     log.info(`set theme`)


### PR DESCRIPTION
- ignore css sourcemaps in theme folder (it was detecting them as themes)
- show right default background for theme in preview
- handle invalid theme metadata better


- turn cli '--theme' not found into normal init fail
and write an error message that explains it,
so normal user have a chance to understand the reason for the error:

![2021-01-12_11-17](https://user-images.githubusercontent.com/18725968/104303605-92ec0380-54ca-11eb-9890-2f97edd1b490.png)

- update guide to creating custom themes