### PR TITLE
loghandler: warn on non-writable stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Try to always focus composer textarea
 - Store relative instead of absolute path to last Account #2028
 - replace parcel bunder with esbuild bundler (faster bundle speed)
+- loghandler: warn on non-writable stream
 
 ### Fixed
 - correctly display RTL text inside of the message input field (see #2036)

--- a/src/main/log-handler.ts
+++ b/src/main/log-handler.ts
@@ -44,7 +44,17 @@ export function createLogHandler() {
       line = line.concat(
         [stacktrace, ...args].map(value => JSON.stringify(value))
       )
-      stream.write(`${line.join('\t')}\n`)
+      if (stream.writable) {
+        stream.write(`${line.join('\t')}\n`)
+      } else {
+        /* ignore-console-log */
+        console.warn('tried to log something after logger shut down', {
+          channel,
+          level,
+          args,
+          stacktrace,
+        })
+      }
     },
     end: () => stream.end(),
     logFilePath: () => fileName,


### PR DESCRIPTION
in essence this prints a warning instead of a huge error stack trace.