### PR TITLE
move error toast to top...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Try to always focus composer textarea
 - Store relative instead of absolute path to last Account #2028
 - replace parcel bunder with esbuild bundler (faster bundle speed)
+- move error toast to top in order to free the view onto the message input field.
 
 ### Fixed
 - correctly display RTL text inside of the message input field (see #2036)

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -145,7 +145,7 @@ code {
 
 .user-feedback {
   position: fixed;
-  bottom: 0;
+  top: 60px;
   text-align: center;
   width: 100%;
   z-index: 100;


### PR DESCRIPTION
...because it blocks view on the message input field.

until we find a real solution for it (by removing it?)

