### PR TITLE
hide author name in direct messages again

### DIFF
--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -352,7 +352,7 @@ const Message = (props: {
         )}
         <div
           className={classNames('author-wrapper', {
-            'can-hide': direction === 'outgoing',
+            'can-hide': direction === 'outgoing' || conversationType === 'direct',
           })}
         >
           {Author(message.contact, onContactClick)}


### PR DESCRIPTION
this was accidentally changed by the minimal theme pr,
and because there isn't a version with it we need no changelog entry this time