### PR TITLE
[Feature] mailing list support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - allow starting a video chat in groups
 - add local help for zh_CN and fr
 - add missing Czech translation #2218
+- add Mailinglist support
+- add support for overwritten sender name (also sometimes referred to as impersonation)
 
 ## Fixed
 - Fix source-mapped stack trace on crash screen in bundled production builds

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -81,6 +81,6 @@
     "message": "Sending Messages in Mailinglists is not supported yet"
   },
   "mailing_list_profile_info": {
-    "message": "The name change and list-avatar change is only local and not synced when using multi device"
+    "message": "These settings (chat name and image) apply to this device only and are not applied to other devices."
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -76,5 +76,8 @@
   },
   "show_full_message_in_browser": {
     "message": "Show full message in browser…"
+  },
+  "mailing_list_diabled_composer": {
+    "message": "Sending Messages in Mailinglists is not supported yet"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -79,5 +79,8 @@
   },
   "mailing_list_diabled_composer": {
     "message": "Sending Messages in Mailinglists is not supported yet"
+  },
+  "mailing_list_profile_info": {
+    "message": "The name change and list-avatar change is only local and not synced when using multi device"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -81,6 +81,6 @@
     "message": "Sending Messages in Mailinglists is not supported yet"
   },
   "mailing_list_profile_info": {
-    "message": "These settings (chat name and image) apply to this device only and are not applied to other devices."
+    "message": "These settings (chat name and image) apply to this device only."
   }
 }

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -391,7 +391,8 @@
   //   background: rgba(0, 0, 0, 0.07);
   // }
 
-  .quote-author {
+  .author {
+    display: block;
     height: 13px;
     font-size: 13px;
     line-height: 13px;

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -203,7 +203,9 @@ export default class DCChatList extends SplitOut {
         return tx('n_members', [String(contacts.length)], {
           quantity: contacts.length,
         })
-      } else if (contacts.length >= 1) {
+      } else if (chat.type === C.DC_CHAT_TYPE_MAILINGLIST) {
+        return tx('mailing_list')
+      }else if (contacts.length >= 1) {
         if (chat.isSelfTalk) {
           return tx('chat_self_talk_subtitle')
         } else if (chat.isDeviceTalk) {

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -205,7 +205,7 @@ export default class DCChatList extends SplitOut {
         })
       } else if (chat.type === C.DC_CHAT_TYPE_MAILINGLIST) {
         return tx('mailing_list')
-      }else if (contacts.length >= 1) {
+      } else if (contacts.length >= 1) {
         if (chat.isSelfTalk) {
           return tx('chat_self_talk_subtitle')
         } else if (chat.isDeviceTalk) {

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -167,7 +167,6 @@ export default class DCChatList extends SplitOut {
     const contactIds = await this._getChatContactIds(chatId)
 
     const contacts = await this._getChatContacts(contactIds)
-    const muted = await this.isChatMuted(chatId)
     const ephemeralTimer = this._dc.getChatEphemeralTimer(chatId)
 
     // This object is NOT created with object assign to promote consistency and to be easier to understand
@@ -191,7 +190,7 @@ export default class DCChatList extends SplitOut {
       isDeaddrop: chatId === C.DC_CHAT_ID_DEADDROP,
       isDeviceChat: chat.isDeviceTalk,
       selfInGroup: isGroup && contactIds.indexOf(C.DC_CONTACT_ID_SELF) !== -1,
-      muted,
+      muted: chat.muted,
       ephemeralTimer,
     }
   }

--- a/src/renderer/components/MainScreen.tsx
+++ b/src/renderer/components/MainScreen.tsx
@@ -32,6 +32,7 @@ import { Avatar } from './Avatar'
 import OfflineToast from './OfflineToast'
 import { C } from 'deltachat-node/dist/constants'
 import MapComponent from './map/MapComponent'
+import MessageListProfile from './dialogs/MessageListProfile'
 
 enum View {
   MessageList,
@@ -70,7 +71,9 @@ export default function MainScreen() {
     if (!selectedChat) return
 
     if (selectedChat.type === C.DC_CHAT_TYPE_MAILINGLIST) {
-      return
+      screenContext.openDialog(MessageListProfile, {
+        chat: selectedChat,
+      })
     } else if (selectedChat.isGroup) {
       openEditGroupDialog(screenContext, selectedChat)
     } else {

--- a/src/renderer/components/MainScreen.tsx
+++ b/src/renderer/components/MainScreen.tsx
@@ -69,7 +69,9 @@ export default function MainScreen() {
   const onTitleClick = () => {
     if (!selectedChat) return
 
-    if (selectedChat.isGroup) {
+    if (selectedChat.type === C.DC_CHAT_TYPE_MAILINGLIST) {
+      return
+    } else if (selectedChat.isGroup) {
       openEditGroupDialog(screenContext, selectedChat)
     } else {
       openViewProfileDialog(screenContext, selectedChat.contacts[0].id)

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -16,6 +16,7 @@ import {
   MessageTypeAttachment,
 } from '../../../shared/shared-types'
 import { runtime } from '../../runtime'
+import { ConversationType } from '../message/MessageList'
 
 // const MINIMUM_IMG_HEIGHT = 150
 // const MAXIMUM_IMG_HEIGHT = 300
@@ -23,7 +24,7 @@ import { runtime } from '../../runtime'
 type AttachmentProps = {
   attachment: MessageTypeAttachment
   text?: string
-  conversationType: 'group' | 'direct'
+  conversationType: ConversationType
   direction: MessageType['msg']['direction']
   message: MessageType
   hasQuote: boolean
@@ -56,7 +57,8 @@ export default function Attachment({
   // For attachments which aren't full-frame
   const withContentBelow = withCaption
   const withContentAbove =
-    hasQuote || (conversationType === 'group' && direction === 'incoming')
+    hasQuote ||
+    (conversationType.hasMultipleParticipants && direction === 'incoming')
   // const dimensions = message.msg.dimensions || {}
   // Calculating height to prevent reflow when image loads
   // const height = Math.max(MINIMUM_IMG_HEIGHT, (dimensions as any).height || 0)

--- a/src/renderer/components/chat/ChatListContextMenu.tsx
+++ b/src/renderer/components/chat/ChatListContextMenu.tsx
@@ -16,6 +16,7 @@ import { ChatListItemType } from '../../../shared/shared-types'
 import { C } from 'deltachat-node/dist/constants'
 import { DeltaBackend } from '../../delta-remote'
 import { ContextMenuItem } from '../ContextMenu'
+import MessageListProfile from '../dialogs/MessageListProfile'
 
 // const log = getLogger('renderer/ChatListContextMenu')
 
@@ -84,7 +85,13 @@ export function useChatListContextMenu() {
         'chatList.getFullChatById',
         chatListItem.id
       )
-      openViewProfileDialog(screenContext, fullChat.contacts[0].id)
+      if (fullChat.type !== C.DC_CHAT_TYPE_MAILINGLIST) {
+        openViewProfileDialog(screenContext, fullChat.contacts[0].id)
+      } else {
+        screenContext.openDialog(MessageListProfile, {
+          chat: fullChat,
+        })
+      }
     }
     const onLeaveGroup = () =>
       openLeaveChatDialog(screenContext, chatListItem.id)

--- a/src/renderer/components/dialogs/MessageListProfile.tsx
+++ b/src/renderer/components/dialogs/MessageListProfile.tsx
@@ -46,7 +46,6 @@ export default function MessageListProfile(props: {
             color: chat.color,
             isVerified: chat.isProtected,
           })}
-          <div className='group-seperator'>{tx('info')}</div>
           <div style={{ padding: '15px 0px' }}>
             {tx('mailing_list_profile_info')}
           </div>

--- a/src/renderer/components/dialogs/MessageListProfile.tsx
+++ b/src/renderer/components/dialogs/MessageListProfile.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react'
+import { DeltaBackend } from '../../delta-remote'
+import { Card, Classes } from '@blueprintjs/core'
+import {
+  DeltaDialogBase,
+  DeltaDialogHeader,
+  DeltaDialogOkCancelFooter,
+} from './DeltaDialog'
+import {
+  useGroupImage,
+  GroupSettingsSetNameAndProfileImage,
+} from './CreateChat'
+
+import { DialogProps } from './DialogController'
+import { FullChat } from '../../../shared/shared-types'
+
+export default function MessageListProfile(props: {
+  isOpen: DialogProps['isOpen']
+  onClose: DialogProps['onClose']
+  chat: FullChat
+}) {
+  const { isOpen, onClose, chat } = props
+
+  const tx = window.static_translate
+
+  const [groupName, setGroupName] = useState(chat.name)
+  const [errorMissingGroupName, setErrorMissingGroupName] = useState(false)
+  const [groupImage, onSetGroupImage, onUnsetGroupImage] = useGroupImage(
+    chat.profileImage
+  )
+  const onUpdateGroup = useEdit(groupName, groupImage, chat.id, onClose)
+
+  return (
+    <DeltaDialogBase isOpen={isOpen} onClose={onClose} fixed>
+      <DeltaDialogHeader title={tx('mailing_list')} />
+      <div className={Classes.DIALOG_BODY}>
+        <Card>
+          {GroupSettingsSetNameAndProfileImage({
+            groupImage,
+            onSetGroupImage,
+            onUnsetGroupImage,
+            groupName,
+            setGroupName,
+            errorMissingGroupName,
+            setErrorMissingGroupName,
+            color: chat.color,
+            isVerified: chat.isProtected,
+          })}
+          <div className='group-seperator'>{tx('info')}</div>
+          <div style={{ padding: '15px 0px' }}>
+            {tx('mailing_list_profile_info')}
+          </div>
+        </Card>
+      </div>
+      <DeltaDialogOkCancelFooter onCancel={onClose} onOk={onUpdateGroup} />
+    </DeltaDialogBase>
+  )
+}
+
+const useEdit = (
+  groupName: string,
+  groupImage: string,
+  groupId: number,
+  onClose: DialogProps['onClose']
+) => {
+  const updateGroup = async () => {
+    await DeltaBackend.call(
+      'chat.modifyGroup',
+      groupId,
+      groupName,
+      groupImage,
+      [],
+      []
+    )
+  }
+  const onUpdateGroup = async () => {
+    if (groupName === '') return
+    await updateGroup()
+    onClose()
+  }
+  return onUpdateGroup
+}

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -329,6 +329,10 @@ const Message = (props: {
 
   const hasQuote = message.msg.quotedText !== null
 
+  /** Whether to show author name and avatar */
+  const showAuthor =
+    conversationType.hasMultipleParticipants || message?.msg.overrideSenderName
+
   return (
     <div
       onContextMenu={showMenu}
@@ -341,7 +345,7 @@ const Message = (props: {
         { 'has-html': hasHTML }
       )}
     >
-      {conversationType.hasMultipleParticipants &&
+      {showAuthor &&
         direction === 'incoming' &&
         Avatar(message.contact, onContactClick)}
       <div
@@ -359,9 +363,7 @@ const Message = (props: {
         {!message.msg.isForwarded && (
           <div
             className={classNames('author-wrapper', {
-              'can-hide':
-                direction === 'outgoing' ||
-                !conversationType.hasMultipleParticipants,
+              'can-hide': direction === 'outgoing' || !showAuthor,
             })}
           >
             {AuthorName(

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -31,6 +31,7 @@ import { DeltaBackend } from '../../delta-remote'
 import { runtime } from '../../runtime'
 import { AvatarFromContact } from '../Avatar'
 import { openDeadDropDecisionDialog } from '../dialogs/DeadDrop'
+import { ConversationType } from './MessageList'
 // const log = getLogger('renderer/message')
 
 const Avatar = (
@@ -108,7 +109,7 @@ const ForwardedTitle = (
   contact: DCContact,
   onContactClick: (contact: DCContact) => void,
   direction: string,
-  conversationType: string
+  conversationType: ConversationType
 ) => {
   const tx = useTranslationFunction()
 
@@ -117,7 +118,7 @@ const ForwardedTitle = (
       className='forwarded-indicator'
       onClick={() => onContactClick(contact)}
     >
-      {conversationType === 'group' && direction !== 'outgoing'
+      {conversationType.hasMultipleParticipants && direction !== 'outgoing'
         ? tx('forwared_by', contact.displayName)
         : tx('forwarded_message')}
     </div>
@@ -132,7 +133,6 @@ function buildContextMenu(
     message,
     text,
     conversationType,
-    isDeviceChat,
   }: // onRetrySend,
   {
     attachment: MessageTypeAttachment
@@ -140,8 +140,7 @@ function buildContextMenu(
     status: msgStatus
     message: MessageType | { msg: null }
     text?: string
-    conversationType: 'group' | 'direct'
-    isDeviceChat: boolean
+    conversationType: ConversationType
     // onRetrySend: Function
   },
   link: string,
@@ -159,12 +158,12 @@ function buildContextMenu(
 
   return [
     // Reply
-    !isDeviceChat && {
+    !conversationType.isDeviceChat && {
       label: tx('reply_noun'),
       action: setQuoteInDraft.bind(null, message.msg.id),
     },
     // Reply privately -> only show in groups, don't show on info messages or outgoing messages
-    conversationType === 'group' &&
+    conversationType.chatType === C.DC_CHAT_TYPE_GROUP &&
       message.msg.fromId > C.DC_CONTACT_ID_LAST_SPECIAL && {
         label: tx('reply_privately'),
         action: privateReply.bind(null, message.msg),
@@ -229,11 +228,10 @@ function buildContextMenu(
 
 const Message = (props: {
   message: MessageType
-  conversationType: 'group' | 'direct'
-  isDeviceChat: boolean
+  conversationType: ConversationType
   /* onRetrySend */
 }) => {
-  const { message, conversationType, isDeviceChat } = props
+  const { message, conversationType } = props
   const {
     id,
     direction,
@@ -265,7 +263,6 @@ const Message = (props: {
         message,
         text,
         conversationType,
-        isDeviceChat,
       },
       link,
       chatStoreDispatch
@@ -364,7 +361,7 @@ const Message = (props: {
         { 'has-html': hasHTML }
       )}
     >
-      {conversationType === 'group' &&
+      {conversationType.hasMultipleParticipants &&
         direction === 'incoming' &&
         Avatar(message.contact, onContactClick)}
       <div
@@ -383,7 +380,8 @@ const Message = (props: {
           <div
             className={classNames('author-wrapper', {
               'can-hide':
-                direction === 'outgoing' || conversationType === 'direct',
+                direction === 'outgoing' ||
+                !conversationType.hasMultipleParticipants,
             })}
           >
             {Author(message.contact, onContactClick)}

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -67,41 +67,21 @@ const Avatar = (
   }
 }
 
-const ContactName = (props: {
-  name: string
-  profileName?: string
-  color: string
-  onClick: (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void
-}) => {
-  const { name, profileName, color, onClick } = props
-
-  const title = name
-  const shouldShowProfile = Boolean(profileName && !name)
-  const profileElement = shouldShowProfile ? (
-    <span style={{ color: color }}>~{profileName || ''}</span>
-  ) : null
-
-  return (
-    <span className='author' style={{ color: color }} onClick={onClick}>
-      {title}
-      {shouldShowProfile ? ' ' : null}
-      {profileElement}
-    </span>
-  )
-}
-
-const Author = (
+const AuthorName = (
   contact: DCContact,
-  onContactClick: (contact: DCContact) => void
+  onContactClick: (contact: DCContact) => void,
+  overrideSenderName?: string
 ) => {
   const { color, displayName } = contact
 
   return (
-    <ContactName
-      name={displayName}
-      color={color}
+    <span
+      className='author'
+      style={{ color: color }}
       onClick={() => onContactClick(contact)}
-    />
+    >
+      {overrideSenderName ? `~${overrideSenderName}` : displayName}
+    </span>
   )
 }
 
@@ -384,7 +364,11 @@ const Message = (props: {
                 !conversationType.hasMultipleParticipants,
             })}
           >
-            {Author(message.contact, onContactClick)}
+            {AuthorName(
+              message.contact,
+              onContactClick,
+              message?.msg.overrideSenderName
+            )}
           </div>
         )}
         <div
@@ -462,11 +446,9 @@ export const Quote = ({
       className='quote has-message'
       style={{ borderLeftColor: message && message.contact.color }}
     >
-      <div
-        className='quote-author'
-        style={{ color: message && message.contact.color }}
-      >
-        {message && message.contact.displayName}
+      <div className='quote-author'>
+        {message &&
+          AuthorName(message.contact, () => {}, message.msg.overrideSenderName)}
       </div>
       <div className='quoted-text'>
         <MessageBody text={quotedText} />

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -3,6 +3,7 @@ import { MessageWrapper } from './MessageWrapper'
 import { useChatStore, ChatStoreState } from '../../stores/chat'
 import { useDebouncedCallback } from 'use-debounce'
 import { C } from 'deltachat-node/dist/constants'
+import type { ChatTypes } from 'deltachat-node'
 import moment from 'moment'
 
 import { getLogger } from '../../../shared/logger'
@@ -149,6 +150,14 @@ export default function MessageList({
   )
 }
 
+/** Object holding type information about a chat for messages in that chat */
+export type ConversationType = {
+  /* whether this chat has multiple participants */
+  hasMultipleParticipants: boolean
+  isDeviceChat: boolean
+  chatType: ChatTypes
+}
+
 export const MessageListInner = React.memo(
   (props: {
     onScroll: (event: React.UIEvent<HTMLDivElement>) => void
@@ -175,8 +184,13 @@ export const MessageListInner = React.memo(
 
     let specialMessageIdCounter = 0
 
-    const conversationType: 'group' | 'direct' =
-      chat.type === C.DC_CHAT_TYPE_GROUP ? 'group' : 'direct'
+    const conversationType: ConversationType = {
+      hasMultipleParticipants:
+        chat.type === C.DC_CHAT_TYPE_GROUP ||
+        chat.type === C.DC_CHAT_TYPE_MAILINGLIST,
+      isDeviceChat: chat.isDeviceChat,
+      chatType: chat.type,
+    }
 
     return (
       <div id='message-list' ref={messageListRef} onScroll={onScroll}>
@@ -201,7 +215,6 @@ export const MessageListInner = React.memo(
                 key={messageId}
                 message={message as MessageType}
                 conversationType={conversationType}
-                isDeviceChat={chat.isDeviceChat}
               />
             )
           })}

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -151,6 +151,8 @@ export default function MessageListAndComposer({
       return [true, 'messaging_disabled_deaddrop']
     } else if (chat.isDeviceChat === true) {
       return [true, 'messaging_disabled_device_chat']
+    } else if (chat.type === C.DC_CHAT_TYPE_MAILINGLIST) {
+      return [true, 'mailing_list_diabled_composer']
     } else if (isGroup && !selfInGroup) {
       return [true, 'messaging_disabled_not_in_group']
     } else {

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import Message from './Message'
 import { MessageType } from '../../../shared/shared-types'
+import { ConversationType } from './MessageList'
 
 type RenderMessageProps = {
   message: MessageType
-  conversationType: 'group' | 'direct'
-  isDeviceChat: boolean
+  conversationType: ConversationType
 }
 
 export const MessageWrapper = (props: RenderMessageProps) => {


### PR DESCRIPTION
- [X] subtitle
 - [x] mailing-list profile (currently it opens the profile view for the self contact)
   - [x] mailing list don't show members yet - so hide them
   - [x] basically like group profile view but with hidden members section. ("we decided to allow editing names/avatars for now, even if they are not synced, it is useful as there is still some chance we do not detect the mailing-list name correctly." ~ r10s on #2128)
 - [x] disable composer for mailing lists with message (with short explanation text)
 - [X] Impersonation (prefix with `~`)
 - [x] add line to changelog

closes #2128
closes #2215