### PR TITLE
fix some blobs not loading sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - fix right click on image mesage opens both context menus #2122
+- Fix Attachment sometimes not being displayed (#2144)
 
 ### Changed
 - update translations (02.03.2021)

--- a/src/main/internal-app-schemes.ts
+++ b/src/main/internal-app-schemes.ts
@@ -75,7 +75,10 @@ app.once('ready', () => {
           log.warn('error while fetching blob file', file, e)
           cb({ statusCode: 404 })
         } else {
-          cb(b)
+          cb({
+            mimeType: lookup(extname(file.replace(/:$/, ''))) || undefined,
+            data: b,
+          })
         }
       })
     }


### PR DESCRIPTION
since the electron upgrade we use custom uri schemes, this pr fixes a bug in the function handling the blob scheme which resulted in some blobs/attachments being not send to the render-process correctly - they seemed to be corrupted. (appeared on the [deltachat-logo-svg file](https://github.com/deltachat/interface/blob/master/icons/delta-v7-pathed.svg) for me)