### PR TITLE
Fix react warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - fix right click on image mesage opens both context menus #2122
 - Fix Attachment sometimes not being displayed (#2144)
+- Fix some react warnings (#2152)
 
 ### Changed
 - update translations (02.03.2021)

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -358,7 +358,7 @@ export function useDraft(
       quotedMessageId: 0,
       quotedText: null,
     }))
-    inputRef.current.focus()
+    inputRef.current?.focus()
   }
 
   useEffect(() => {

--- a/src/renderer/components/message/MessageMetaData.tsx
+++ b/src/renderer/components/message/MessageMetaData.tsx
@@ -64,7 +64,7 @@ export default class MessageMetaData extends React.Component<{
               <div
                 className={classNames('status-icon', status)}
                 aria-label={tx(`a11y_delivery_status_${status}`)}
-                onClick={status === 'error' && onClickError}
+                onClick={status === 'error' ? onClickError : undefined}
               />
             ) : null}
           </div>


### PR DESCRIPTION
This solves 2 of the 3 issues that @jikstra reported in #2117

I'd say it closes #2117 because the "message body missing keys" bug is not easily reproduced and we plan to refactor/replace the message-markdown-parser later anyway, so as long as it is only a warning and nothing more serious (like elements missing) we can ignore it IMO.