### PR TITLE
disallow edit name of device message chat in profile view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Fixed
+- Fix disable contact name edit field on device message
 - fix right click on image mesage opens both context menus #2122
 - Fix Attachment sometimes not being displayed (#2144)
 

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -19,15 +19,15 @@ import { useLogicVirtualChatList, ChatListPart } from '../chat/ChatList'
 import { AutoSizer } from 'react-virtualized'
 
 const ProfileInfoName = ({
-  contactId,
   displayName,
   setDisplayName,
   address,
+  disabled,
 }: {
-  contactId: Number
   displayName: string
   setDisplayName: (displayName: string) => void
   address: string
+  disabled: boolean
 }) => {
   const onChange = async (ev: React.ChangeEvent<HTMLInputElement>) => {
     const newName = ev.target.value
@@ -42,7 +42,7 @@ const ProfileInfoName = ({
           placeholder={displayName}
           value={displayName}
           onChange={onChange}
-          disabled={contactId === C.DC_CONTACT_ID_SELF}
+          disabled={disabled}
           autoFocus
           style={{ marginLeft: '0px', marginBottom: '10px' }}
         />
@@ -126,7 +126,10 @@ export default function ViewProfile(props: {
                   <ProfileInfoAvatar contact={contact} />
                 </div>
                 <ProfileInfoName
-                  contactId={contact.id}
+                  disabled={
+                    contact.id === C.DC_CONTACT_ID_SELF ||
+                    contact.id === C.DC_CONTACT_ID_DEVICE
+                  }
                   displayName={displayName}
                   setDisplayName={setDisplayName}
                   address={contact.address}
@@ -139,14 +142,16 @@ export default function ViewProfile(props: {
                   justifyContent: 'center',
                 }}
               >
-                <button
-                  aria-label={tx('send_message')}
-                  onClick={onSendMessage}
-                  className={'delta-button-round'}
-                  style={{ marginTop: '0px' }}
-                >
-                  {tx('send_message')}
-                </button>
+                {contact.id !== C.DC_CONTACT_ID_DEVICE && (
+                  <button
+                    aria-label={tx('send_message')}
+                    onClick={onSendMessage}
+                    className={'delta-button-round'}
+                    style={{ marginTop: '0px' }}
+                  >
+                    {tx('send_message')}
+                  </button>
+                )}
               </div>
               <DeltaDialogContentTextSeperator
                 text={tx('profile_shared_chats')}


### PR DESCRIPTION
also hide the send message button for that chat
closes #2135

we can still think about hiding the option in the context menu / disabling on-click on chat-name in navbar-header like @r10s mentioned in https://github.com/deltachat/deltachat-desktop/issues/2135#issuecomment-781960617, but I suppose this already solves the issue and the ideal solution would be to show a small explanation/description of the special chat:
- in saved messages for what it is and for what it can be used
- in device messages what it is and why you can't write

this text could be displayed in the bio/status that is added with the new core. 
But when we show the profile view for those chats, there is also the question if we should show the saved messages chat name and avatar instead of the own self-contact-avatar and name.