### PR TITLE
disable font ligature globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Fixed
 - Fix qrcode unscanable in darktheme #2163
 
+### Changed
+- Disable fontligatures completely
+
 ## [1.15.2] - 2021-03-03
 
 ### Fixed

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -1,5 +1,6 @@
 * {
   box-sizing: border-box;
+  font-variant-ligatures: none;
 }
 
 html {


### PR DESCRIPTION
we decided in https://github.com/deltachat/deltachat-desktop/pull/2166 to disable font ligatures completely.

Themes could theoretically enable it again with this code if they make use of it:
```
* {
  font-variant-ligatures: normal !important;
}
```


related feature request: 
https://support.delta.chat/t/disabling-font-ligatures/1490