### PR TITLE
Rename message context menu entry "Copy" to "Copy Text"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - Disable fontligatures completely
+- Rename message context menu entry "Copy" to "Copy Text" #2294 
 
 ## [1.15.2] - 2021-03-03
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -64,5 +64,8 @@
   },
   "forwared_by": {
     "message": "Forwarded by %1$s"
+  },
+  "menu_copy_text_to_clipboard": {
+    "message": "Copy Text"
   }
 }

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -179,7 +179,7 @@ function buildContextMenu(
           },
         }
       : {
-          label: tx('global_menu_edit_copy_desktop'),
+          label: tx('menu_copy_text_to_clipboard'),
           action: () => {
             runtime.writeClipboardText(text)
           },


### PR DESCRIPTION
closes #2294