### PR TITLE
Add current account to contacts in locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- own location and path in maps is not visible in single chats
+
 ### Changed
 - Switch back to file scheme #2171 fixes audio and video seeking issues
 

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -1,5 +1,5 @@
 import { DeltaBackend, sendMessageParams } from '../../delta-remote'
-import { C } from 'deltachat-node'
+import { C } from 'deltachat-node/dist/constants'
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import ReactDOM from 'react-dom'

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -172,21 +172,25 @@ export default class MapComponent extends React.Component<
     const currentContacts: JsonContact[] = []
     ;(this.mapDataStore as any).locationCount = locations.length
     if (locations.length > 0) {
-      const contacts = selectedChat.contacts;
+      const contacts = selectedChat.contacts
 
       if (!selectedChat.isGroup || !selectedChat.selfInGroup) {
         // add current account to contact list to see own location and path
         contacts.push({
-           id: C.DC_CONTACT_ID_SELF,
-           address: this.context.account.address,
-           displayName: this.context.account.displayname,
-           firstName: this.context.account.displayname,
-           name: this.context.account.displayname,
-           color: this.context.account.color,
-           nameAndAddr: this.context.account.displayname + '(' + this.context.account.addr + ')',
-           profileImage: this.context.account.profileImage,
-           isBlocked: false,
-           isVerified: true
+          id: C.DC_CONTACT_ID_SELF,
+          address: this.context.account.address,
+          displayName: this.context.account.displayname,
+          firstName: this.context.account.displayname,
+          name: this.context.account.displayname,
+          color: this.context.account.color,
+          nameAndAddr:
+            this.context.account.displayname +
+            '(' +
+            this.context.account.addr +
+            ')',
+          profileImage: this.context.account.profileImage,
+          isBlocked: false,
+          isVerified: true,
         })
       }
       contacts.forEach(contact => {

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -1,4 +1,5 @@
 import { DeltaBackend, sendMessageParams } from '../../delta-remote'
+import { C } from 'deltachat-node'
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
 import ReactDOM from 'react-dom'
@@ -171,7 +172,24 @@ export default class MapComponent extends React.Component<
     const currentContacts: JsonContact[] = []
     ;(this.mapDataStore as any).locationCount = locations.length
     if (locations.length > 0) {
-      selectedChat.contacts.map(contact => {
+      const contacts = selectedChat.contacts;
+
+      if (!selectedChat.isGroup || !selectedChat.selfInGroup) {
+        // add current account to contact list to see own location and path
+        contacts.push({
+           id: C.DC_CONTACT_ID_SELF,
+           address: this.context.account.address,
+           displayName: this.context.account.displayname,
+           firstName: this.context.account.displayname,
+           name: this.context.account.displayname,
+           color: this.context.account.color,
+           nameAndAddr: this.context.account.displayname + '(' + this.context.account.addr + ')',
+           profileImage: this.context.account.profileImage,
+           isBlocked: false,
+           isVerified: true
+        })
+      }
+      contacts.forEach(contact => {
         const locationsForContact = locations.filter(
           location =>
             location.contactId === contact.id && !location.isIndependent

--- a/src/renderer/components/map/MapLayerFactory.ts
+++ b/src/renderer/components/map/MapLayerFactory.ts
@@ -37,7 +37,8 @@ export default class MapLayerFactory {
         'line-cap': 'round',
       },
       paint: {
-        'line-color': color.indexOf('#') > -1 ? color : '#' + color.toString(16),
+        'line-color':
+          color.indexOf('#') > -1 ? color : '#' + color.toString(16),
         'line-opacity': 0.7,
         'line-width': 4,
       },

--- a/src/renderer/components/map/MapLayerFactory.ts
+++ b/src/renderer/components/map/MapLayerFactory.ts
@@ -27,7 +27,10 @@ export default class MapLayerFactory {
     }
   }
 
-  static getGeoJSONLineLayer(pathLayerId: string, color: todo): mapboxgl.Layer {
+  static getGeoJSONLineLayer(
+    pathLayerId: string,
+    color: string
+  ): mapboxgl.Layer {
     return {
       id: pathLayerId,
       type: 'line',
@@ -37,8 +40,7 @@ export default class MapLayerFactory {
         'line-cap': 'round',
       },
       paint: {
-        'line-color':
-          color.indexOf('#') > -1 ? color : '#' + color.toString(16),
+        'line-color': color,
         'line-opacity': 0.7,
         'line-width': 4,
       },

--- a/src/renderer/components/map/MapLayerFactory.ts
+++ b/src/renderer/components/map/MapLayerFactory.ts
@@ -37,7 +37,7 @@ export default class MapLayerFactory {
         'line-cap': 'round',
       },
       paint: {
-        'line-color': '#' + color.toString(16),
+        'line-color': color.indexOf('#') > -1 ? color : '#' + color.toString(16),
         'line-opacity': 0.7,
         'line-width': 4,
       },


### PR DESCRIPTION
The own location and paths were not displayed in the map since only selectedChat.contacts were shown and the current account is not included in the contacts