### PR TITLE
make notifications more reliable and prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Switch back to file scheme #2171 fixes audio and video seeking issues
 - adjust warning/hint color of before-login-hint
 - increase `DAYS_UNTIL_UPDATE_SUGGESTION` to 120 days
+- improve notifications (show chat name and avatar)
 
 ## [1.15.3] - 2021-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix dragging out file attachments #2177
 - own location and path in maps is not visible in single chats
 - Fix crash in settings-profile if account object is empty
+- make notifications more reliable and allow multiple ones at a time
 
 ### Changed
 - Switch back to file scheme #2171 fixes audio and video seeking issues

--- a/src/main/deltachat/chat.ts
+++ b/src/main/deltachat/chat.ts
@@ -74,6 +74,7 @@ export default class DCChat extends SplitOut {
     log.debug(`action - deleting chat ${chatId}`)
     this._dc.deleteChat(chatId)
     this._controller.chatList.updateChatList()
+    this._controller.emit('DESKTOP_CLEAR_NOTIFICATIONS_FOR_CHAT', chatId)
   }
 
   setVisibility(

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -21,6 +21,7 @@ export default class DCChatList extends SplitOut {
     }
     if (chat.id !== C.DC_CHAT_ID_DEADDROP && chat.freshMessageCounter > 0) {
       this._dc.markNoticedChat(chat.id)
+      this._controller.emit('DESKTOP_CLEAR_NOTIFICATIONS_FOR_CHAT', chat.id)
       chat.freshMessageCounter = 0
       app.setBadgeCount(this.getGeneralFreshMessageCounter())
     }

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -133,6 +133,7 @@ export default class DCLoginController extends SplitOut {
   }
 
   close() {
+    this._controller.emit('DESKTOP_CLEAR_ALL_NOTIFICATIONS')
     if (!this._dc) return
     this._dc.stopIO()
     this._controller.unregisterEventHandler(this._dc)

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -50,6 +50,7 @@ export default function (dc: DeltaChatController, settings: any) {
       }
 
       if (!icon || icon.isEmpty()) {
+        // fallback: show app icon instead
         icon = nativeImage.createFromPath(appIcon())
         console.log(icon.isEmpty())
       }

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -8,8 +8,6 @@ import { ExtendedAppMainProcess } from './types'
 export default function (dc: DeltaChatController, settings: any) {
   if (!Notification.isSupported()) return
 
-  let notifications: Notification[] = []
-
   async function isMuted(chatId: number) {
     return await dc.callMethod(null, 'chatList.isChatMuted', [chatId])
   }
@@ -41,14 +39,9 @@ export default function (dc: DeltaChatController, settings: any) {
         dc.sendToRenderer('ClickOnNotification', { chatId, msgId })
         mainWindow.show()
         app.focus()
-        notifications = notifications.filter(n => n === notify)
       })
-      notify.on('close', () => {
-        notifications = notifications.filter(n => n === notify)
-      })
+      notify.on('close', () => {})
       notify.show()
-
-      notifications.push(notify)
     }
   })
 }

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -52,7 +52,6 @@ export default function (dc: DeltaChatController, settings: any) {
       if (!icon || icon.isEmpty()) {
         // fallback: show app icon instead
         icon = nativeImage.createFromPath(appIcon())
-        console.log(icon.isEmpty())
       }
 
       return new Notification({
@@ -90,8 +89,6 @@ export default function (dc: DeltaChatController, settings: any) {
     msgId: number,
     _ev: Electron.Event
   ) {
-    console.log('onClickNotification', chatId, msgId)
-
     dc.sendToRenderer('ClickOnNotification', { chatId, msgId })
     clearNotificationsForChat(chatId)
     mainWindow.show()

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -6,6 +6,9 @@ import DeltaChatController from './deltachat/controller'
 import { ExtendedAppMainProcess } from './types'
 import { FullChat, MessageType } from '../shared/shared-types'
 import { C } from 'deltachat-node/dist/constants'
+import { getLogger } from '../shared/logger'
+
+const log = getLogger('main/notifications')
 
 export default function (dc: DeltaChatController, settings: any) {
   if (!Notification.isSupported()) return
@@ -54,14 +57,21 @@ export default function (dc: DeltaChatController, settings: any) {
         icon = nativeImage.createFromPath(appIcon())
       }
 
-      return new Notification({
+      let notificationOptions: Electron.NotificationConstructorOptions = {
         title: `${chatInfo.name} | ${appName}`,
         body: summary.text1
           ? `${summary.text1}: ${summary.text2}`
           : summary.text2,
         icon,
-        timeoutType: 'never',
-      })
+        timeoutType: 'default',
+      }
+
+      if (process.platform === 'win32') {
+        // Workaround for disabling close button on windows. Undefined electron behaviour. Yey.
+        notificationOptions.closeButtonText = null
+      }
+
+      return new Notification(notificationOptions)
     }
   }
 
@@ -113,7 +123,13 @@ export default function (dc: DeltaChatController, settings: any) {
         return
       }
       const notify = await createNotification(chatId, msgId)
-      notify.on('click', onClickNotification.bind(null, chatId, msgId))
+      notify.on('click', (Event) => {
+        console.log(Event.type)
+        onClickNotification(chatId, msgId, Event)
+      })
+      notify.on('close', (Event) => {
+        log.debug(`Closing notification for chatId: ${chatId} msgId: ${msgId}`)
+      })
       // notify.on('close', () => {})
       addNotificationForChat(chatId, notify)
       notify.show()

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -32,7 +32,7 @@ export default function (dc: DeltaChatController, settings: any) {
       if (await isMuted(chatId)) {
         return
       }
-      let notify = new Notification({
+      const notify = new Notification({
         title: appName,
         body: await getMsgBody(msgId),
         icon: appIcon(),

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -65,7 +65,7 @@ export default function (dc: DeltaChatController, settings: any) {
     }
   }
 
-  const notifications: { [key: number]: Notification[] } = {}
+  let notifications: { [key: number]: Notification[] } = {}
 
   function clearNotificationsForChat(chatId: number) {
     if (notifications[chatId]) {
@@ -74,6 +74,15 @@ export default function (dc: DeltaChatController, settings: any) {
       }
       notifications[chatId] = null
     }
+  }
+
+  function clearAllNotifications() {
+    for (const chatId of Object.keys(notifications)) {
+      if (isNaN(Number(chatId))) {
+        clearNotificationsForChat(Number(chatId))
+      }
+    }
+    notifications = {}
   }
 
   function addNotificationForChat(chatId: number, notify: Notification) {
@@ -109,5 +118,13 @@ export default function (dc: DeltaChatController, settings: any) {
       addNotificationForChat(chatId, notify)
       notify.show()
     }
+  })
+
+  dc.on('DESKTOP_CLEAR_NOTIFICATIONS_FOR_CHAT', (_ev, chatId) => {
+    clearNotificationsForChat(chatId)
+  })
+
+  dc.on('DESKTOP_CLEAR_ALL_NOTIFICATIONS', _ev => {
+    clearAllNotifications()
   })
 }

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -1,9 +1,11 @@
 import * as mainWindow from './windows/main'
-import { app, Notification } from 'electron'
+import { app, Notification, NativeImage, nativeImage } from 'electron'
 import { appName } from '../shared/constants'
 import { appIcon } from './application-constants'
 import DeltaChatController from './deltachat/controller'
 import { ExtendedAppMainProcess } from './types'
+import { FullChat, MessageType } from '../shared/shared-types'
+import { C } from 'deltachat-node/dist/constants'
 
 export default function (dc: DeltaChatController, settings: any) {
   if (!Notification.isSupported()) return
@@ -12,14 +14,87 @@ export default function (dc: DeltaChatController, settings: any) {
     return await dc.callMethod(null, 'chatList.isChatMuted', [chatId])
   }
 
-  async function getMsgBody(msgId: number) {
+  async function createNotification(
+    chatId: number,
+    msgId: number
+  ): Promise<Notification> {
     const tx = (app as ExtendedAppMainProcess).translate
-    if (!settings.showNotificationContent) return tx('notify_new_message')
-    const json = await dc.callMethod(null, 'messageList.messageIdToJson', [
-      msgId,
-    ])
-    const summary = json.msg.summary
-    return `${summary.text1 || json.contact.displayName}: ${summary.text2}`
+
+    if (!settings.showNotificationContent) {
+      // Notification which does not show content
+      return new Notification({
+        title: appName,
+        body: tx('notify_new_message'),
+        icon: appIcon(),
+      })
+    } else {
+      const [chatInfo, message_json]: [
+        FullChat,
+        { msg: null } | MessageType
+      ] = await Promise.all([
+        dc.callMethod(null, 'chatList.getFullChatById', [chatId]),
+        dc.callMethod(null, 'messageList.messageIdToJson', [msgId]),
+      ])
+
+      const summary = message_json.msg.summary
+
+      let icon: NativeImage
+      if (message_json.msg?.viewType === C.DC_MSG_IMAGE) {
+        // if is image
+        icon = nativeImage.createFromPath(message_json.msg.file)
+        // idea - maybe needs resize
+        // issue/idea - does not work with all imagetypes - idea: have something reliable for thumbnail generation
+      } else if (chatInfo.profileImage) {
+        // if has chat an avatar picture
+        icon = nativeImage.createFromPath(chatInfo.profileImage)
+      }
+
+      if (!icon || icon.isEmpty()) {
+        icon = nativeImage.createFromPath(appIcon())
+        console.log(icon.isEmpty())
+      }
+
+      return new Notification({
+        title: `${chatInfo.name} | ${appName}`,
+        body: summary.text1
+          ? `${summary.text1}: ${summary.text2}`
+          : summary.text2,
+        icon,
+        timeoutType: 'never',
+      })
+    }
+  }
+
+  const notifications: { [key: number]: Notification[] } = {}
+
+  function clearNotificationsForChat(chatId: number) {
+    if (notifications[chatId]) {
+      for (const notify of notifications[chatId]) {
+        notify.close()
+      }
+      notifications[chatId] = null
+    }
+  }
+
+  function addNotificationForChat(chatId: number, notify: Notification) {
+    if (notifications[chatId]) {
+      notifications[chatId].push(notify)
+    } else {
+      notifications[chatId] = [notify]
+    }
+  }
+
+  function onClickNotification(
+    chatId: number,
+    msgId: number,
+    _ev: Electron.Event
+  ) {
+    console.log('onClickNotification', chatId, msgId)
+
+    dc.sendToRenderer('ClickOnNotification', { chatId, msgId })
+    clearNotificationsForChat(chatId)
+    mainWindow.show()
+    app.focus()
   }
 
   dc._dc.on('DC_EVENT_INCOMING_MSG', async (chatId: number, msgId: number) => {
@@ -30,17 +105,10 @@ export default function (dc: DeltaChatController, settings: any) {
       if (await isMuted(chatId)) {
         return
       }
-      const notify = new Notification({
-        title: appName,
-        body: await getMsgBody(msgId),
-        icon: appIcon(),
-      })
-      notify.on('click', () => {
-        dc.sendToRenderer('ClickOnNotification', { chatId, msgId })
-        mainWindow.show()
-        app.focus()
-      })
-      notify.on('close', () => {})
+      const notify = await createNotification(chatId, msgId)
+      notify.on('click', onClickNotification.bind(null, chatId, msgId))
+      // notify.on('close', () => {})
+      addNotificationForChat(chatId, notify)
       notify.show()
     }
   })

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -6,9 +6,6 @@ import DeltaChatController from './deltachat/controller'
 import { ExtendedAppMainProcess } from './types'
 import { FullChat, MessageType } from '../shared/shared-types'
 import { C } from 'deltachat-node/dist/constants'
-import { getLogger } from '../shared/logger'
-
-const log = getLogger('main/notifications')
 
 export default function (dc: DeltaChatController, settings: any) {
   if (!Notification.isSupported()) return
@@ -57,8 +54,8 @@ export default function (dc: DeltaChatController, settings: any) {
         icon = nativeImage.createFromPath(appIcon())
       }
 
-      let notificationOptions: Electron.NotificationConstructorOptions = {
-        title: `${chatInfo.name} | ${appName}`,
+      const notificationOptions: Electron.NotificationConstructorOptions = {
+        title: `${chatInfo.name}`,
         body: summary.text1
           ? `${summary.text1}: ${summary.text2}`
           : summary.text2,
@@ -123,12 +120,8 @@ export default function (dc: DeltaChatController, settings: any) {
         return
       }
       const notify = await createNotification(chatId, msgId)
-      notify.on('click', (Event) => {
-        console.log(Event.type)
+      notify.on('click', Event => {
         onClickNotification(chatId, msgId, Event)
-      })
-      notify.on('close', (Event) => {
-        log.debug(`Closing notification for chatId: ${chatId} msgId: ${msgId}`)
       })
       // notify.on('close', () => {})
       addNotificationForChat(chatId, notify)


### PR DESCRIPTION
closes #2191 
## Progress
- [X] fix that only one was shown
- [X] show chat icon or image if available
- [X] add group/chat name
- [X] close all notifications for a chat when one notification for that chat was shown
- [x] on chat-select, close notifications that belong to that chat
- [x] on account change, close all notifications (avoids problems for now)
- [ ] Testing, maybe it solves the recent notification problems (#2087, #2095)

## Preview
![Screenshot from 2021-03-22 21-30-50](https://user-images.githubusercontent.com/18725968/112055482-3276e380-8b57-11eb-9bec-4fec064783fc.png)
![Screenshot from 2021-03-22 21-35-12](https://user-images.githubusercontent.com/18725968/112055589-55a19300-8b57-11eb-93be-5d281822f127.png)
 