### PR TITLE
fix build4production to work on its own

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "watch:frontend:ts": "npm run build:frontend:ts -- -w",
     "watch:frontend:static": "npm run build:frontend:static -- -w",
     "watch:frontend:scss": "npm run build:frontend:scss -- --watch",
-    "build4production": "npm run check-types && NODE_ENV=\"production\" npm run build",
+    "build4production": "NODE_ENV=\"production\" npm run build && npm run check-types",
     "translations-pull": "tx pull -l en && tx pull -f --parallel",
     "translations-update": "npm run translations-pull && npm run build:shared:translations",
     "hallmark": "hallmark --fix",


### PR DESCRIPTION
move check-types to the end,
because it relies on the build:shared:version script


@Jikstra please also backport this to the 1.15 series, because it could help with the flatpak process

https://github.com/flathub/chat.delta.desktop/pull/52#issuecomment-803410820

Note: there is also the question of windows compatibility with the environment variable, but I don't want to pull in an extra npm package to solve it or create a script that spawns the command with the specific env var/-s in this pr.