### PR TITLE
Update README.md for arch installation guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Otherwise you can still do it manually:
 
 ```sh
 # Download the latest snapshot of the PKGBUILD
-wget https://aur.archlinux.org/cgit/aur.git/snapshot/deltachat-desktop-git.tar.gz
+wget --no-config https://aur.archlinux.org/cgit/aur.git/snapshot/deltachat-desktop-git.tar.gz
 
 # extract the archive and rm the archive file afterwards
 tar xzfv deltachat-desktop-git.tar.gz && rm deltachat-desktop-git.tar.gz


### PR DESCRIPTION
Hello,
    I suggest to use wget with `--no-config` so if a config file for wget exist, it won't temper with the installation instructions and follow default wget behavior.

Kind regards,
ererielili.