### PR TITLE
Add context menu for videochat messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - hide show encryption info for saved messages (resulted in error)
 - remove "file://" scheme from filenames before calling `dc_msg_set_file` for stickers
 - initialize name field in contact profile dialog with previouly manually set name and use authname as a placeholder
+- show context menu also for videochat messages
 
 ## [1.15.5] - 2021-03-27
 

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -318,6 +318,7 @@ const Message = (props: {
         <div className='break' />
         <div
           className='info-button'
+          onContextMenu={showMenu}
           onClick={joinCall.bind(null, screenContext, id)}
         >
           {direction === 'incoming'

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -188,6 +188,11 @@ function buildContextMenu(
       label: tx('menu_copy_link_to_clipboard'),
       action: () => runtime.writeClipboardText(link),
     },
+    // Copy videocall link to clipboard
+    message.msg.videochatUrl !== '' && {
+      label: tx('menu_copy_link_to_clipboard'),
+      action: () => runtime.writeClipboardText(message.msg.videochatUrl),
+    },
     // Open Attachment
     showAttachmentOptions &&
       isGenericAttachment(attachment) && {


### PR DESCRIPTION
The videochat messages currently do not have a context menu. As they are basically also normal messages things like forwarding, replying and message details are also present and interesting for the user (at least for me ;).

This pull request adds the already existing context menu to the text part of the videochat message.

Secondly it adds a context menu entry for this messages that allows to copy the URL for  the videochat into the clipboard. The same strings as copying a link from a normal message is used.