### PR TITLE
remove double click to qoute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 - update translations (02.05.2021)
 - Update deltachat-node to `v1.54.0`
+- Remove double-click to quote → this allows users to properly use double and triple click to select stuff again
 
 ## [1.15.5] - 2021-03-27
 

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -352,12 +352,6 @@ const Message = (props: {
 
   const hasQuote = message.msg.quotedText !== null
 
-  const onMessageDoubleClick = (event: React.MouseEvent<HTMLInputElement>) => {
-    event.preventDefault()
-    setQuoteInDraft(message.msg.id)
-    window.getSelection().empty()
-  }
-
   return (
     <div
       onContextMenu={showMenu}
@@ -368,7 +362,6 @@ const Message = (props: {
         { error: status === 'error' },
         { forwarded: message.msg.isForwarded }
       )}
-      onDoubleClick={onMessageDoubleClick}
     >
       {conversationType === 'group' &&
         direction === 'incoming' &&


### PR DESCRIPTION
closes #2226
Remove double-click to quote → this allows users to properly use double and triple click to select stuff again