### PR TITLE
fix settings crash (null check was broken)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - remove "file://" scheme from filenames before calling `dc_msg_set_file` for stickers
 - initialize name field in contact profile dialog with previously manually set name and use authname as a placeholder
 - show context menu also for video chat messages
+- Fix a bug where the settings crashed
 
 ### Changed
 

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -228,8 +228,8 @@ export default function Settings(props: DialogProps) {
     const { settings } = state
 
     if (
-      Object.keys(settings).length === 0 ||
-      Object.keys(account).length === 0
+      Object.keys(settings || {}).length === 0 ||
+      Object.keys(account || {}).length === 0
     ) {
       return null
     }


### PR DESCRIPTION
- [ ] it should be tested if this really fixes the settings crash that is sometimes experienced when importing a fresh backup from an iPhone where the account was created on the iPhone and the setup was single device until this point.