### PR TITLE
add `--minimized` CLI option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - add Mailinglist support
 - add support for overwritten sender name (also sometimes referred to as impersonation)
 - add experimental audit log to chats (view where only info/system messages are shown such as member added/removed)
+- add `--minimized` CLI option to start DeltaChat minimized as a tray icon. This is useful for setting DeltaChat as a startup application that starts up with your computer.
 
 ## Fixed
 - Fix source-mapped stack trace on crash screen in bundled production builds

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -99,6 +99,6 @@
     "message": "This view shows only System- and Info-Messages. Useful for finding the last chat actions without scrolling through many normal messages."
   },
   "explain_desktop_minimized_disabled_tray_pref": {
-    "message": "Tray icon is shown because Deltachat was started with the `--minimized` option."
+    "message": "Tray icon cannot be disabled as Delta Chat was started with the --minimized option"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -97,5 +97,8 @@
   },
   "chat_audit_log_description": {
     "message": "This view shows only System- and Info-Messages. Useful for finding the last chat actions without scrolling through many normal messages."
+  },
+  "explain_desktop_minimized_disabled_tray_pref": {
+    "message": "Tray icon is shown because Deltachat was started in with the `--minimized` option."
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -99,6 +99,6 @@
     "message": "This view shows only System- and Info-Messages. Useful for finding the last chat actions without scrolling through many normal messages."
   },
   "explain_desktop_minimized_disabled_tray_pref": {
-    "message": "Tray icon is shown because Deltachat was started in with the `--minimized` option."
+    "message": "Tray icon is shown because Deltachat was started with the `--minimized` option."
   }
 }

--- a/docs/CLI_FLAGS.md
+++ b/docs/CLI_FLAGS.md
@@ -1,0 +1,22 @@
+# CLI Options
+
+Options:
+| Flag | Effect |
+|------|--------|
+|`--minimized` | Start deltachat in minimized mode with trayicon (trayicon will be activated for this session regardless whether it's disabled) |
+| `--multiple-instances` | [Possible unstable] allows you do open multiple deltachat instances\* |
+| **Development Options** | |
+| `--translation-watch` | enable auto-reload for `_locales/_untranslated_en.json` |
+| `--debug` | opens electron devtools and activates `--log-debug` & `--log-to-console` |
+| **Theme** | |
+| `--theme <themeid>` | set a specific theme (see [THEMES.md](./THEMES.md)) |
+| `--theme-watch` | enable auto-reload for the active theme |
+| **Logging** | |
+| `--log-debug` | Log debug messages |
+| `--log-to-console` | Output the log to stdout / Chrome dev console |
+| `--machine-readable-stacktrace` | Enable JSON stack trace |
+| `--no-color` | Disable colors in the output of main process |
+
+For more info on logging see [LOGGING.md](./LOGGING.md).
+
+\*`--multiple-instances` is possible unstable - to avoid risks don't open the same account in multiple windows at a time

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -103,7 +103,7 @@ function onReady([logins, _appReady, loadedState]: [
   log.info(`cwd ${cwd}`)
   ipc.init(cwd, logHandler)
 
-  mainWindow.init(app, { hidden: false })
+  mainWindow.init(app, { hidden: app.rc['minimized'] })
   initMenu(logHandler)
 
   if (rc.debug) {
@@ -138,7 +138,7 @@ function onReady([logins, _appReady, loadedState]: [
     log.debug("mainWindow.window.on('close')")
     if (!app.isQuitting) {
       e.preventDefault()
-      if (app.state.saved.minimizeToTray) {
+      if (app.rc['minimized'] || app.state.saved.minimizeToTray) {
         log.debug("mainWindow.window.on('close') Hiding main window")
         hideDeltaChat()
       } else {

--- a/src/main/rc.ts
+++ b/src/main/rc.ts
@@ -10,6 +10,7 @@ const defaults: RC_Config = {
   debug: false,
   'translation-watch': false,
   'theme-watch': false,
+  minimized: false,
 }
 
 const config = rc('DeltaChat', defaults) as RC_Config

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -46,7 +46,7 @@ export function quitDeltaChat() {
 
 export function updateTrayIcon() {
   // User doesn't want tray icon => destroy it
-  if (app.state.saved.minimizeToTray !== true) {
+  if (!app.rc['minimized'] && app.state.saved.minimizeToTray !== true) {
     if (tray != null) destroyTrayIcon()
     return
   }

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -195,11 +195,12 @@ export default function Settings(props: DialogProps) {
   const renderDTSettingSwitch = (
     configKey: keyof DesktopSettings,
     label: string,
-    disabled = false
+    disabled = false,
+    disabled_is_checked = false
   ) => {
     return (
       <Switch
-        checked={desktopSettings[configKey] === true}
+        checked={desktopSettings[configKey] === true || disabled_is_checked}
         className={desktopSettings[configKey] ? 'active' : 'inactive'}
         label={label}
         disabled={disabled}
@@ -295,6 +296,7 @@ export default function Settings(props: DialogProps) {
               {renderDTSettingSwitch(
                 'minimizeToTray',
                 tx('pref_show_tray_icon'),
+                state.rc?.minimized,
                 state.rc?.minimized
               )}
               {state.rc?.minimized && (

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -6,7 +6,7 @@ import { Elevation, H5, Card, Classes, Switch, Label } from '@blueprintjs/core'
 const { ipcRenderer } = window.electron_functions
 import { SettingsContext, useTranslationFunction } from '../../contexts'
 
-import { DesktopSettings } from '../../../shared/shared-types'
+import { DesktopSettings, RC_Config } from '../../../shared/shared-types'
 import { DialogProps } from './DialogController'
 import SettingsAutodelete from './Settings-Autodelete'
 import SettingsManageKeys from './Settings-ManageKeys'
@@ -23,6 +23,7 @@ import SettingsAppearance from './Settings-Appearance'
 import SettingsProfile, { SettingsEditProfile } from './Settings-Profile'
 import { getLogger } from '../../../shared/logger'
 import SettingsCommunication from './Settings-Communication'
+import { runtime } from '../../runtime'
 
 const log = getLogger('renderer/dialogs/Settings')
 
@@ -111,11 +112,13 @@ export default function Settings(props: DialogProps) {
     settings: any
     show: string
     selfContact: todo
+    rc: RC_Config
   }>({
     showSettingsDialog: false,
     settings: {},
     show: 'main',
     selfContact: {},
+    rc: ({} as any) as RC_Config,
   })
   const setState = (updatedState: any) => {
     _setState((prevState: any) => {
@@ -144,8 +147,10 @@ export default function Settings(props: DialogProps) {
       'delete_server_after',
       'webrtc_instance',
     ])
-
     setState({ settings })
+
+    const rc = await runtime.getRC_Config()
+    setState({ rc })
   }
 
   /*
@@ -189,17 +194,15 @@ export default function Settings(props: DialogProps) {
    */
   const renderDTSettingSwitch = (
     configKey: keyof DesktopSettings,
-    label: string
+    label: string,
+    disabled = false
   ) => {
     return (
       <Switch
         checked={desktopSettings[configKey] === true}
         className={desktopSettings[configKey] ? 'active' : 'inactive'}
         label={label}
-        disabled={
-          configKey === 'showNotificationContent' &&
-          !desktopSettings['notifications']
-        }
+        disabled={disabled}
         onChange={() =>
           handleDesktopSettingsChange(configKey, !desktopSettings[configKey])
         }
@@ -279,7 +282,8 @@ export default function Settings(props: DialogProps) {
               )}
               {renderDTSettingSwitch(
                 'showNotificationContent',
-                tx('pref_show_notification_content_explain')
+                tx('pref_show_notification_content_explain'),
+                !desktopSettings['notifications']
               )}
             </Card>
             <Card elevation={Elevation.ONE}>
@@ -290,7 +294,13 @@ export default function Settings(props: DialogProps) {
               )}
               {renderDTSettingSwitch(
                 'minimizeToTray',
-                tx('pref_show_tray_icon')
+                tx('pref_show_tray_icon'),
+                state.rc?.minimized
+              )}
+              {state.rc?.minimized && (
+                <div className='bp3-callout'>
+                  {tx('explain_desktop_minimized_disabled_tray_pref')}
+                </div>
               )}
               {renderDTSettingSwitch(
                 'enableChatAuditLog',

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -59,6 +59,7 @@ export interface RC_Config {
   'theme-watch': boolean
   debug: boolean
   'translation-watch': boolean
+  minimized: boolean
 }
 
 import { App } from 'electron'


### PR DESCRIPTION
related forum topic: https://support.delta.chat/t/option-to-start-on-system-start/1663

![2021-05-19_03-00](https://user-images.githubusercontent.com/18725968/118840127-65272900-b8c7-11eb-8d5f-e91913b8e07d.png)
when started minimized the tray-icon is enabled and its option is disabled for the session.