### PR TITLE
sticker qoute styling and fix `Forwarded by $author` header in messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Fix "Forwarded by $author" in message and add support for overwritten sender name to it.
+- Fix cursor type on hovering over sticker
+
+### Changed
+
+- Adjust sticker styling (quote styling).
+
 ## [1.20.1] - 2021-05-28
 
 ### Fixed

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -237,18 +237,39 @@
 .message.type-sticker {
   .msg-container {
     background-color: transparent !important;
+
+    .author-wrapper,
+    .forwarded-indicator {
+      display: none;
+    }
+
+    .quote-background {
+      background: #01010159;
+      padding: 5px;
+      padding-left: 6px;
+      border-radius: 7px;
+
+      & > .quote {
+        margin: 0;
+
+        .quoted-text {
+          color: white;
+        }
+      }
+    }
   }
 
   .message-attachment-media {
     background-color: transparent;
     & > .attachment-content {
       margin-bottom: 20px;
+      cursor: default;
     }
   }
 
   .metadata {
     float: right;
-    padding: 4px 10px 1px 10px;
+    padding: 4px 8px 1px 8px;
     margin-bottom: -7px;
     background-color: #01010159;
     border-radius: 4px;

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -9,6 +9,7 @@ import {
   openMessageHTML,
 } from './messageFunctions'
 import React, { useContext, useState, useEffect } from 'react'
+import reactStringReplace from 'react-string-replace'
 
 import classNames from 'classnames'
 import MessageBody from './MessageBody'
@@ -89,9 +90,12 @@ const ForwardedTitle = (
   contact: DCContact,
   onContactClick: (contact: DCContact) => void,
   direction: string,
-  conversationType: ConversationType
+  conversationType: ConversationType,
+  overrideSenderName?: string
 ) => {
   const tx = useTranslationFunction()
+
+  const { displayName, color } = contact
 
   return (
     <div
@@ -99,7 +103,15 @@ const ForwardedTitle = (
       onClick={() => onContactClick(contact)}
     >
       {conversationType.hasMultipleParticipants && direction !== 'outgoing'
-        ? tx('forwared_by', contact.displayName)
+        ? reactStringReplace(
+            tx('forwarded_by', '$$forwarder$$'),
+            '$$forwarder$$',
+            () => (
+              <span style={{ color: color }}>
+                {overrideSenderName ? `~${overrideSenderName}` : displayName}
+              </span>
+            )
+          )
         : tx('forwarded_message')}
     </div>
   )
@@ -358,7 +370,8 @@ const Message = (props: {
             message.contact,
             onContactClick,
             direction,
-            conversationType
+            conversationType,
+            message?.msg.overrideSenderName
           )}
         {!message.msg.isForwarded && (
           <div
@@ -444,16 +457,22 @@ export const Quote = ({
   }, [quotedMessageId])
 
   return (
-    <div
-      className='quote has-message'
-      style={{ borderLeftColor: message && message.contact.color }}
-    >
-      <div className='quote-author'>
-        {message &&
-          AuthorName(message.contact, () => {}, message.msg.overrideSenderName)}
-      </div>
-      <div className='quoted-text'>
-        <MessageBody text={quotedText} />
+    <div className='quote-background'>
+      <div
+        className='quote has-message'
+        style={{ borderLeftColor: message && message.contact.color }}
+      >
+        <div className='quote-author'>
+          {message &&
+            AuthorName(
+              message.contact,
+              () => {},
+              message.msg.overrideSenderName
+            )}
+        </div>
+        <div className='quoted-text'>
+          <MessageBody text={quotedText} />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
- Adjust sticker styling (quote styling).
- Fix "Forwarded by $author" in message and add support for overwritten sender name to it.
- Fix cursor type on hovering over sticker (fixes #2279)
- Reduce side margin on sticker metadata

### Before:
![2021-06-03_21-03](https://user-images.githubusercontent.com/18725968/120698560-82efb300-c4af-11eb-87fc-a280a8b2bc8f.png)
![2021-06-03_21-02](https://user-images.githubusercontent.com/18725968/120698576-871bd080-c4af-11eb-9d19-9a9c97da821a.png)

### After:
![2021-06-03_19-06](https://user-images.githubusercontent.com/18725968/120698612-90a53880-c4af-11eb-9a8d-39bcb4bc9c3d.png)
![2021-06-03_20-54](https://user-images.githubusercontent.com/18725968/120698630-9438bf80-c4af-11eb-8df5-2e8cca3425f4.png)
