### PR TITLE
🚧 Button to request a quotareport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- Add `Request Quota Report` button menu (shows up when in devicechat)
+
 ## [1.20.3] - 2021-06-30
 
 ### Fixed

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -1,17 +1,20 @@
 {
-  "request_quota_report": {
-    "message": "Request Quota Report"
-  },
-  "quota_mailbox_full_message": {
-    "message": "Your mailbox on your email account is running full!\nPossible Solutions:\n- Delete old messages on the server\n- or enable \"Delete old messages from server\" in the deltachat settings\n- or upgrade your plan with your email provider\nIf you don't take action you will soon be unable to receive messages."
-  },
-  "quota_not_supported_message": {
-    "message": "Your email server does not support the quota extension"
-  },
-  "quota_resource_message": {
-    "message": "Message"
-  },
-  "quota_resource_storage": {
-    "message": "Storage"
-  }
+    "request_quota_report": {
+        "message": "Request Quota Report"
+    },
+    "quota_mailbox_full_message": {
+        "message": "Your mailbox on your email account is running full!\nPossible Solutions:\n- Delete old messages on the server\n- or enable \"Delete old messages from server\" in the deltachat settings\n- or upgrade your plan with your email provider\nIf you don't take action you will soon be unable to receive messages."
+    },
+    "quota_not_supported_message": {
+        "message": "Your email server does not support the quota extension"
+    },
+    "quota_resource_message": {
+        "message": "Message"
+    },
+    "quota_resource_storage": {
+        "message": "Storage"
+    },
+    "pref_disable_quota_check": {
+        "message": "Disable daily Quota-Check"
+    }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -1,5 +1,17 @@
 {
   "request_quota_report": {
-      "message": "Request Quota Report"
+    "message": "Request Quota Report"
+  },
+  "quota_mailbox_full_message": {
+    "message": "Your mailbox on your email account is running full!\nPossible Solutions:\n- Delete old messages on the server\n- or enable \"Delete old messages from server\" in the deltachat settings\n- or upgrade your plan with your email provider\nIf you don't take action you will soon be unable to receive messages."
+  },
+  "quota_not_supported_message": {
+    "message": "Your email server does not support the quota extension"
+  },
+  "quota_resource_message": {
+    "message": "Message"
+  },
+  "quota_resource_storage": {
+    "message": "Storage"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -1,1 +1,5 @@
-{}
+{
+  "request_quota_report": {
+      "message": "Request Quota Report"
+  }
+}

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -14,6 +14,9 @@
     "quota_resource_storage": {
         "message": "Storage"
     },
+    "quota_resource_usage_format": {
+        "message": "%1$s: %2$s/%3$s"
+    },
     "pref_disable_quota_check": {
         "message": "Disable daily Quota-Check"
     }

--- a/src/main/deltachat/context.ts
+++ b/src/main/deltachat/context.ts
@@ -5,7 +5,7 @@ export default class DCContext extends SplitOut {
     this._dc.maybeNetwork()
   }
 
-  requestQuotaReport(){
+  requestQuotaReport() {
     this._dc.requestQuotaReport()
   }
 }

--- a/src/main/deltachat/context.ts
+++ b/src/main/deltachat/context.ts
@@ -4,4 +4,8 @@ export default class DCContext extends SplitOut {
   maybeNetwork() {
     this._dc.maybeNetwork()
   }
+
+  requestQuotaReport(){
+    this._dc.requestQuotaReport()
+  }
 }

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -301,6 +301,10 @@ export function txCoreStrings() {
   )
   strings[C.DC_STR_REPLY_NOUN] = tx('reply_noun')
   strings[C.DC_STR_FORWARDED] = tx('forwarded')
+  strings[C.DC_STR_QUOTA_MAILBOX_NEARLY_FULL] = tx('quota_mailbox_full_message')
+  strings[C.DC_STR_QUOTA_NOT_SUPPORTED] = tx('quota_not_supported_message')
+  strings[C.DC_STR_QUOTA_MESSAGES] = tx('quota_resource_message')
+  strings[C.DC_STR_QUOTA_STORAGE] = tx('quota_resource_storage')
 
   return strings
 }

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -305,6 +305,7 @@ export function txCoreStrings() {
   strings[C.DC_STR_QUOTA_NOT_SUPPORTED] = tx('quota_not_supported_message')
   strings[C.DC_STR_QUOTA_MESSAGES] = tx('quota_resource_message')
   strings[C.DC_STR_QUOTA_STORAGE] = tx('quota_resource_storage')
+  strings[C.DC_STR_QUOTA_USAGE] = tx('quota_resource_usage_format')
 
   return strings
 }

--- a/src/renderer/components/Menu.tsx
+++ b/src/renderer/components/Menu.tsx
@@ -88,6 +88,9 @@ export default function DeltaMenu(props: { selectedChat: FullChat }) {
     screenContext.changeScreen(Screens.Login)
   }
 
+  const requestQuotaReport = async () =>
+    await DeltaBackend.call('context.requestQuotaReport')
+
   if (selectedChat && selectedChat.id && !selectedChat.isDeaddrop) {
     const { isGroup, selfInGroup, isSelfTalk, isDeviceChat } = selectedChat
 
@@ -167,6 +170,13 @@ export default function DeltaMenu(props: { selectedChat: FullChat }) {
           key='disappearing'
           text={tx('ephemeral_messages')}
           onClick={onDisappearingMessages}
+        />
+      ),
+      isDeviceChat && (
+        <DeltaMenuItem
+          key='req_quota'
+          text={tx('request_quota_report')}
+          onClick={requestQuotaReport}
         />
       ),
       !(isSelfTalk || isDeviceChat) &&

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -146,6 +146,7 @@ export default function Settings(props: DialogProps) {
       'delete_device_after',
       'delete_server_after',
       'webrtc_instance',
+      'disable_quota_check'
     ])
     setState({ settings })
 
@@ -328,6 +329,7 @@ export default function Settings(props: DialogProps) {
               {renderDeltaSwitch('mvbox_watch', tx('pref_watch_mvbox_folder'))}
               {renderDeltaSwitch('bcc_self', tx('pref_send_copy_to_self'))}
               {renderDeltaSwitch('mvbox_move', tx('pref_auto_folder_moves'))}
+              {renderDeltaSwitch('disable_quota_check', tx('pref_disable_quota_check'))}
             </Card>
             <SettingsManageKeys />
             <SettingsBackup />

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -335,6 +335,7 @@ class DeltaRemote {
   }>
   // context ------------------------------------------------------------
   call(fnName: 'context.maybeNetwork'): Promise<void>
+  call(fnName: 'context.requestQuotaReport'): Promise<void>
   // burner accounts ------------------------------------------------------------
   call(
     fnName: 'burnerAccounts.create',

--- a/src/renderer/experimental.ts
+++ b/src/renderer/experimental.ts
@@ -31,6 +31,10 @@ These functions are highly experimental, use at your own risk.
     }
     log.info(`Imported ${contacts.length - error_count} contacts`)
   }
+
+  async requestQuotaReport() {
+    await DeltaBackend.call('context.requestQuotaReport')
+  }
 }
 
 export const exp = new Experimental()


### PR DESCRIPTION
- Experimental function to trigger quota report
- Button to request a quota-report (appears in menu while in device chat)
![2021-06-23_20-54](https://user-images.githubusercontent.com/18725968/123153875-7931ed80-d466-11eb-847d-800dccd15682.png)
- Setting to disable automatic/daily quota check

# todo
 
- [ ] wait for core & node release with quota feature
     - https://github.com/deltachat/deltachat-core-rust/pull/2462
     - https://github.com/deltachat/deltachat-node/pull/506

# related

- https://github.com/deltachat/deltachat-android/issues/1973
- https://github.com/deltachat/deltachat-ios/issues/1296