### PR TITLE
add switch to toggle "all account syncing"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+
+- add switch to toggle simultaneous account syncing off
 ## [1.21.0] - 2021-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### Added
 
 - add switch to toggle simultaneous account syncing off
+
+### Fixed
+
+- fix flashing up account list on startup
+
 ## [1.21.0] - 2021-09-08
 
 ### Added

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -1,4 +1,7 @@
 {
+  "sync_all": {
+    "message": "Sync all"
+  },
   "account_info_hover_tooltip_desktop": {
     "message": "E-Mail: %1$s\nSize: %2$s\nAccount Id: %3$s"
   },

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -86,9 +86,11 @@ export default class DeltaChatController extends EventEmitter {
     log.debug('Starting event handler')
     this.registerEventHandler(this.account_manager)
 
-    log.info('Ready, starting accounts io...')
-    this.account_manager.startIO()
-    log.info('Started accounts io.')
+    if (app.state.saved.syncAllAccounts) {
+      log.info('Ready, starting accounts io...')
+      this.account_manager.startIO()
+      log.info('Started accounts io.')
+    }
   }
 
   async migrateToAccountsApiIfNeeded() {

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -72,6 +72,12 @@ export default class DCLoginController extends SplitOut {
     app.state.saved.lastAccount = null
     app.saveState()
 
+    if (!app.state.saved.syncAllAccounts) {
+      this.selectedAccountContext.stopIO()
+    }
+    this.controller.selectedAccountId = null
+    this.controller.selectedAccountContext = null
+
     log.info('Logged out')
 
     if (typeof this.controller._sendStateToRenderer === 'function')

--- a/src/main/deltachat/settings.ts
+++ b/src/main/deltachat/settings.ts
@@ -57,6 +57,14 @@ export default class DCSettings extends SplitOut {
 
     if (key === 'minimizeToTray') updateTrayIcon()
 
+    if (key === 'syncAllAccounts') {
+      if (value) {
+        this.accounts.startIO()
+      } else {
+        this.accounts.stopIO()
+      }
+    }
+
     return true
   }
 

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -27,6 +27,7 @@ export enum Screens {
   Accounts = 'accounts',
   Main = 'main',
   Login = 'login',
+  Loading = 'loading',
 }
 
 export default class ScreenController extends Component {
@@ -40,7 +41,7 @@ export default class ScreenController extends Component {
     super(props)
     this.state = {
       message: false,
-      screen: Screens.Accounts,
+      screen: Screens.Loading,
     }
 
     this.onError = this.onError.bind(this)
@@ -69,6 +70,8 @@ export default class ScreenController extends Component {
     )
     if (lastLoggedInAccountId) {
       await this.selectAccount(lastLoggedInAccountId)
+    } else {
+      this.changeScreen(Screens.Accounts)
     }
   }
 
@@ -170,6 +173,8 @@ export default class ScreenController extends Component {
         )
       case Screens.Accounts:
         return <AccountsScreen selectAccount={this.selectAccount} />
+      default:
+        return null
     }
   }
 

--- a/src/renderer/components/screens/AccountsScreen.tsx
+++ b/src/renderer/components/screens/AccountsScreen.tsx
@@ -150,14 +150,14 @@ export default function AccountsScreen({
   const tx = useTranslationFunction()
   const [logins, setLogins] = useState(null)
 
-  const [sync_all_accounts, set_sync_all_accounts] = useState(null)
+  const [syncAllAccounts, setSyncAllAccounts] = useState(null)
 
   useEffect(() => {
     ;(async () => {
       const desktopSettings = await DeltaBackend.call(
         'settings.getDesktopSettings'
       )
-      set_sync_all_accounts(desktopSettings.syncAllAccounts)
+      setSyncAllAccounts(desktopSettings.syncAllAccounts)
     })()
   }, [])
 
@@ -232,16 +232,16 @@ export default function AccountsScreen({
                     {tx('login_known_accounts_title_desktop')}
                   </h4>
                   <Switch
-                    checked={sync_all_accounts}
-                    label='Sync all'
+                    checked={syncAllAccounts}
+                    label={tx('sync_all')}
                     onChange={async () => {
-                      const new_state = !sync_all_accounts
+                      const new_state = !syncAllAccounts
                       await DeltaBackend.call(
                         'settings.setDesktopSetting',
                         'syncAllAccounts',
                         new_state
                       )
-                      set_sync_all_accounts(new_state)
+                      setSyncAllAccounts(new_state)
                     }}
                     alignIndicator={Alignment.RIGHT}
                   />
@@ -254,7 +254,7 @@ export default function AccountsScreen({
                         addAccount,
                         selectAccount,
                         logins,
-                        showUnread: sync_all_accounts,
+                        showUnread: syncAllAccounts,
                       }}
                     />
                   </DeltaDialogContent>

--- a/src/renderer/components/screens/AccountsScreen.tsx
+++ b/src/renderer/components/screens/AccountsScreen.tsx
@@ -1,6 +1,14 @@
 import React, { useState, useEffect, useContext, useMemo } from 'react'
 import { ipcBackend } from '../../ipc'
-import { Classes, Elevation, Intent, Card, Icon } from '@blueprintjs/core'
+import {
+  Classes,
+  Elevation,
+  Intent,
+  Card,
+  Icon,
+  Switch,
+  Alignment,
+} from '@blueprintjs/core'
 import { DeltaProgressBar } from '../Login-Styles'
 import { getLogger } from '../../../shared/logger'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
@@ -10,7 +18,6 @@ import DeltaDialog, {
   DeltaDialogBase,
   DeltaDialogBody,
   DeltaDialogContent,
-  DeltaDialogHeader,
 } from '../dialogs/DeltaDialog'
 import { DeltaChatAccount } from '../../../shared/shared-types'
 import filesizeConverter from 'filesize'
@@ -22,6 +29,7 @@ import { PseudoContact } from '../contact/Contact'
 import { runtime } from '../../runtime'
 import type ScreenController from '../../ScreenController'
 import debounce from 'debounce'
+import classNames from 'classnames'
 
 const log = getLogger('renderer/components/AccountsScreen')
 
@@ -142,6 +150,17 @@ export default function AccountsScreen({
   const tx = useTranslationFunction()
   const [logins, setLogins] = useState(null)
 
+  const [sync_all_accounts, set_sync_all_accounts] = useState(null)
+
+  useEffect(() => {
+    ;(async () => {
+      const desktopSettings = await DeltaBackend.call(
+        'settings.getDesktopSettings'
+      )
+      set_sync_all_accounts(desktopSettings.syncAllAccounts)
+    })()
+  }, [])
+
   const refreshAccounts = async () => {
     const logins = await DeltaBackend.call('login.getAllAccounts')
     setLogins(logins)
@@ -203,9 +222,30 @@ export default function AccountsScreen({
             )}
             {logins && logins.length > 0 && (
               <>
-                <DeltaDialogHeader
-                  title={tx('login_known_accounts_title_desktop')}
-                />
+                <div
+                  className={classNames(
+                    Classes.DIALOG_HEADER,
+                    'bp3-dialog-header-border-bottom'
+                  )}
+                >
+                  <h4 className='bp3-heading'>
+                    {tx('login_known_accounts_title_desktop')}
+                  </h4>
+                  <Switch
+                    checked={sync_all_accounts}
+                    label='Sync all'
+                    onChange={async () => {
+                      const new_state = !sync_all_accounts
+                      await DeltaBackend.call(
+                        'settings.setDesktopSetting',
+                        'syncAllAccounts',
+                        new_state
+                      )
+                      set_sync_all_accounts(new_state)
+                    }}
+                    alignIndicator={Alignment.RIGHT}
+                  />
+                </div>
                 <DeltaDialogBody>
                   <DeltaDialogContent noPadding={true}>
                     <AccountSelection
@@ -214,6 +254,7 @@ export default function AccountsScreen({
                         addAccount,
                         selectAccount,
                         logins,
+                        showUnread: sync_all_accounts,
                       }}
                     />
                   </DeltaDialogContent>
@@ -240,11 +281,13 @@ function AccountSelection({
   addAccount,
   selectAccount,
   logins,
+  showUnread,
 }: {
   refreshAccounts: () => Promise<void>
   addAccount: () => {}
   selectAccount: typeof ScreenController.prototype.selectAccount
   logins: any
+  showUnread: boolean
 }) {
   const tx = useTranslationFunction()
   const { openDialog } = useContext(ScreenContext)
@@ -317,6 +360,7 @@ function AccountSelection({
           login={login}
           selectAccount={selectAccount}
           removeAccount={removeAccount}
+          showUnread={showUnread}
         />
       ))}
     </div>
@@ -327,10 +371,12 @@ function AccountItem({
   login,
   selectAccount,
   removeAccount,
+  showUnread,
 }: {
   login: DeltaChatAccount
   selectAccount: typeof ScreenController.prototype.selectAccount
   removeAccount: (account: DeltaChatAccount) => void
+  showUnread: boolean
 }) {
   const removeAction = (ev: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     ev?.stopPropagation()
@@ -401,7 +447,7 @@ function AccountItem({
             </div>
           </div>
         </div>
-        {unreadCount > 0 && (
+        {showUnread && unreadCount > 0 && (
           <div className='unread-badge-container'>
             <div className='fresh-message-counter'>{unreadCount}</div>
           </div>

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -43,6 +43,7 @@ export interface DesktopSettings {
   /** address to the active theme file scheme: "custom:name" or "dc:name" */
   activeTheme: string
   minimizeToTray: boolean
+  syncAllAccounts: boolean
 }
 
 export interface AppState {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -21,6 +21,7 @@ export function getDefaultState(): AppState {
       zoomFactor: 1,
       activeTheme: 'system',
       minimizeToTray: false,
+      syncAllAccounts: true,
     },
     logins: [],
   }


### PR DESCRIPTION
<img width="400" alt="image_2021-09-12_00-54-09" src="https://user-images.githubusercontent.com/18725968/132967184-da22d6a2-e4e8-4ee7-8d73-96b04423a496.png">

- hides unread badges when syncing is off.

- also fix flashing up account list on startup