### PR TITLE
move "Copy link to clipboard" to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Changed
+- move "Copy link to clipboard" to top in message context menu
+
 ## [1.21.1] - 2021-09-18
 
 ### Added

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -138,6 +138,11 @@ function buildContextMenu(
   const selectedText = window.getSelection()?.toString()
 
   return [
+    // Copy link to clipboard
+    link !== '' && {
+      label: tx('menu_copy_link_to_clipboard'),
+      action: () => runtime.writeClipboardText(link),
+    },
     // Reply
     !conversationType.isDeviceChat && {
       label: tx('reply_noun'),
@@ -164,11 +169,6 @@ function buildContextMenu(
             runtime.writeClipboardText(text)
           },
         },
-    // Copy link to clipboard
-    link !== '' && {
-      label: tx('menu_copy_link_to_clipboard'),
-      action: () => runtime.writeClipboardText(link),
-    },
     // Copy videocall link to clipboard
     message.videochatUrl !== '' && {
       label: tx('menu_copy_link_to_clipboard'),


### PR DESCRIPTION
in message context menu.

Why? because when I right click a link its the most relevant option for me.