### PR TITLE
"remove account" fails now allways on windows, before it tries because it…

### DIFF
--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -10,6 +10,7 @@ import { ExtendedAppMainProcess } from '../types'
 import { stat, readdir } from 'fs/promises'
 import { join } from 'path'
 import { Context } from 'deltachat-node/dist/context'
+import { platform } from 'os'
 const log = getLogger('main/deltachat/login')
 
 const app = rawApp as ExtendedAppMainProcess
@@ -91,7 +92,22 @@ export default class DCLoginController extends SplitOut {
   }
 
   async removeAccount(accountId: number) {
-    this.accounts.removeAccount(accountId)
+    if (platform() == 'win32') {
+      throw new Error(
+        "Unfortunately account removal is broken in this version on windows, we'll fix it in the next version"
+      )
+    }
+
+    if (this.selectedAccountId === accountId) {
+      log.warn(
+        'account that should be removed is still selected, unselecting it first..'
+      )
+      await this.logout()
+    }
+
+    if (this.accounts.removeAccount(accountId) !== 1) {
+      throw new Error('Account deletion failed')
+    }
   }
 
   async getFreshMessageCounter(accountId: number) {

--- a/src/renderer/components/screens/AccountSetupScreen.tsx
+++ b/src/renderer/components/screens/AccountSetupScreen.tsx
@@ -39,11 +39,18 @@ export default function AccountSetupScreen({
     })
 
   const onCancel = async () => {
-    const acInfo = await DeltaBackend.call('login.accountInfo', accountId)
-    if (acInfo.type == 'unconfigured') {
-      await DeltaBackend.call('login.removeAccount', accountId)
+    try {
+      const acInfo = await DeltaBackend.call('login.accountInfo', accountId)
+      if (acInfo.type == 'unconfigured') {
+        await DeltaBackend.call('login.removeAccount', accountId)
+      }
+      window.__changeScreen(Screens.Accounts)
+    } catch (error) {
+      window.__openDialog('AlertDialog', {
+        message: error?.message || error,
+        cb: () => {},
+      })
     }
-    window.__changeScreen(Screens.Accounts)
   }
 
   return (

--- a/src/renderer/components/screens/AccountsScreen.tsx
+++ b/src/renderer/components/screens/AccountsScreen.tsx
@@ -308,8 +308,17 @@ function AccountSelection({
       isConfirmDanger: true,
       cb: async (yes: boolean) => {
         if (yes) {
-          await DeltaBackend.call('login.removeAccount', account.id)
-          refreshAccounts()
+          try {
+            await DeltaBackend.call('login.removeAccount', account.id)
+            refreshAccounts()
+          } catch (error) {
+            window.__openDialog('AlertDialog', {
+              message: error?.message || error,
+              cb: () => {
+                refreshAccounts()
+              },
+            })
+          }
         }
       },
     })


### PR DESCRIPTION
… doesn't work anyway:

![b](https://user-images.githubusercontent.com/18725968/134253149-ef4ef665-7542-4fd2-b6e6-635540bf0fc5.PNG)

![a](https://user-images.githubusercontent.com/18725968/134253143-097c4091-6ac1-4acc-a52d-dd662f5e58fd.PNG)

also make sure the account is deselected when removing the selected account

and display an error if it fails