### PR TITLE
fix windows account removal bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 ### Added
 - Windows installer: enable logging for installer
 
+### Fixed
+- fix account removal on windows
+
 ## [1.21.1] - 2021-09-18
 
 ### Added

--- a/src/main/deltachat/backup.ts
+++ b/src/main/deltachat/backup.ts
@@ -59,12 +59,14 @@ export default class DCBackup extends SplitOut {
       const onFail = (reason: String) => {
         this.accounts.removeAccount(accountId)
         this.controller.selectedAccountId = null
+        this.controller.selectedAccountContext.unref()
         this.controller.selectedAccountContext = null
         reject(reason)
       }
 
       const onSuccess = () => {
         this.controller.selectedAccountId = null
+        this.controller.selectedAccountContext.unref()
         this.controller.selectedAccountContext = null
         resolve(this.controller.login.accountInfo(accountId))
       }

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -187,8 +187,10 @@ export default class DeltaChatController extends EventEmitter {
               'found stickers, migrating them',
               old_sticker_folder
             )
+            let ctx: null | Context
             try {
-              const blobdir = tmp_dc.accountContext(account_id).getBlobdir()
+              ctx = tmp_dc.accountContext(account_id)
+              const blobdir = ctx.getBlobdir()
               const new_sticker_folder = join(blobdir, '../stickers')
               await rename(old_sticker_folder, new_sticker_folder)
             } catch (error) {
@@ -197,6 +199,8 @@ export default class DeltaChatController extends EventEmitter {
                 old_sticker_folder,
                 error
               )
+            } finally {
+              ctx?.unref()
             }
           }
 

--- a/src/renderer/components/screens/AccountSetupScreen.tsx
+++ b/src/renderer/components/screens/AccountSetupScreen.tsx
@@ -39,11 +39,18 @@ export default function AccountSetupScreen({
     })
 
   const onCancel = async () => {
-    const acInfo = await DeltaBackend.call('login.accountInfo', accountId)
-    if (acInfo.type == 'unconfigured') {
-      await DeltaBackend.call('login.removeAccount', accountId)
+    try {
+      const acInfo = await DeltaBackend.call('login.accountInfo', accountId)
+      if (acInfo.type == 'unconfigured') {
+        await DeltaBackend.call('login.removeAccount', accountId)
+      }
+      window.__changeScreen(Screens.Accounts)
+    } catch (error) {
+      window.__openDialog('AlertDialog', {
+        message: error?.message || error,
+        cb: () => {},
+      })
     }
-    window.__changeScreen(Screens.Accounts)
   }
 
   return (

--- a/src/renderer/components/screens/AccountsScreen.tsx
+++ b/src/renderer/components/screens/AccountsScreen.tsx
@@ -308,8 +308,17 @@ function AccountSelection({
       isConfirmDanger: true,
       cb: async (yes: boolean) => {
         if (yes) {
-          await DeltaBackend.call('login.removeAccount', account.id)
-          refreshAccounts()
+          try {
+            await DeltaBackend.call('login.removeAccount', account.id)
+            refreshAccounts()
+          } catch (error) {
+            window.__openDialog('AlertDialog', {
+              message: error?.message || error,
+              cb: () => {
+                refreshAccounts()
+              },
+            })
+          }
         }
       },
     })


### PR DESCRIPTION
(make sure to unref all contexts after use)

also make sure the account is deselected when removing the selected account

and display an error if it fails

- [x]  TODO changelog entry 

supersedes #2371 