### PR TITLE
don't show logo twice in notifications on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- don't show logo twice in notifications (because macOS already shows applogo)
+
 ## [1.22.1] - 2021-09-22
 
 ### Removed

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -7,8 +7,11 @@ import { ExtendedAppMainProcess } from './types'
 import { FullChat, MessageType } from '../shared/shared-types'
 import { C } from 'deltachat-node/dist/constants'
 import { getLogger } from '../shared/logger'
+import { platform } from 'os'
 
 const log = getLogger('main/notifications')
+
+const isMac = platform() === 'darwin'
 
 export default function (dc: DeltaChatController, settings: any) {
   if (!Notification.isSupported()) return
@@ -53,8 +56,10 @@ export default function (dc: DeltaChatController, settings: any) {
       }
 
       if (!icon || icon.isEmpty()) {
-        // fallback: show app icon instead
-        icon = nativeImage.createFromPath(appIcon())
+        // fallback: show app icon instead (if not on mac, because mac aready shows the app icon)
+        if (!isMac) {
+          icon = nativeImage.createFromPath(appIcon())
+        }
       }
 
       const notificationOptions: Electron.NotificationConstructorOptions = {


### PR DESCRIPTION
(because macOS already shows applogo)
before:
<img width="382" alt="Screenshot 2021-09-22 at 20 37 30" src="https://user-images.githubusercontent.com/18725968/134403128-e91074a6-3d3f-447e-8621-b5a59b7c8d6f.png">
after:
<img width="382" alt="Screenshot 2021-09-22 at 20 38 58" src="https://user-images.githubusercontent.com/18725968/134403305-aa2ae94a-f177-43e3-998f-b1ce0239aadf.png">
(electron logo is replaced by our logo when we release)