### PR TITLE
fix copy image to clipboard compatibility on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- fix copy image to clipboard compatibility on windows (see #2323)
+
 ## [1.22.1] - 2021-09-22
 
 ### Removed

--- a/src/main/deltachat/extras.ts
+++ b/src/main/deltachat/extras.ts
@@ -61,7 +61,10 @@ export default class Extras extends SplitOut {
       rawApp.getPath('temp'),
       `paste.${mimeTypes.extension(formats[0]) || 'bin'}`
     )
-    const buf = clipboard.readBuffer(formats[0])
+    const buf =
+      mimeTypes.extension(formats[0]) === 'png'
+        ? clipboard.readImage().toPNG()
+        : clipboard.readBuffer(formats[0])
     log.debug(`Writing clipboard ${formats[0]} to file ${pathToFile}`)
     await writeFile(pathToFile, buf, 'binary')
     return pathToFile


### PR DESCRIPTION
closes #2323

do the prebuild of this pr work for you, @YamatoRyou?

https://download.delta.chat/desktop/preview/deltachat-desktop-2378.portable.exe