### PR TITLE
context menu only show one copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - update deltachat-node to v1.65.0
 - Fetch more messages if as close as 200px to top of MessageList
 - Join group via qr-code is now async (group already opens, no wait time)
+- show only the relevant copy action in the context menu (selection, link, email or text depending on where the context menu was invoked)
 
 ### Fixed
 - don't show logo twice in notifications (because macOS already shows applogo)

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -34,5 +34,8 @@
   },
   "ask_add_members_desktop": {
     "message": "Add %1$s to group?"
+  },
+  "menu_copy_email_to_clipboard":{
+    "message": "Copy Email"
   }
 }

--- a/src/renderer/components/message/Link.tsx
+++ b/src/renderer/components/message/Link.tsx
@@ -69,6 +69,7 @@ export const LabeledLink = ({
       x-target-url={target}
       title={realUrl}
       onClick={onClick}
+      onContextMenu={ev => ((ev as any).t = ev.currentTarget)}
     >
       {label}
     </a>
@@ -167,12 +168,7 @@ export const Link = ({ destination }: { destination: LinkDestination }) => {
     }
   }
   return (
-    <a
-      href='#'
-      {...{ 'x-target-url': asciiUrl }}
-      title={asciiUrl}
-      onClick={onClick}
-    >
+    <a href='#' x-target-url={asciiUrl} title={asciiUrl} onClick={onClick}>
       {target}
     </a>
   )

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -147,7 +147,7 @@ function buildContextMenu(
   const selectedText = window.getSelection()?.toString()
   const textSelected: boolean = selectedText !== null && selectedText !== ''
 
-  /** Copy actions, is on e of the following, (in that order):
+  /** Copy action, is one of the following, (in that order):
    *
    * - Copy [selection] to clipboard
    * - OR Copy link to clipboard

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -107,7 +107,12 @@ function EmailLink({ email }: { email: string }): JSX.Element {
   }
 
   return (
-    <a href={'#'} {...{ 'x-not-a-link': 'email' }} onClick={openChatWithEmail}>
+    <a
+      href={'#'}
+      x-not-a-link='email'
+      x-target-email={email}
+      onClick={openChatWithEmail}
+    >
       {email}
     </a>
   )
@@ -127,7 +132,7 @@ function TagLink({ tag }: { tag: string }) {
   }
 
   return (
-    <a href={'#'} {...{ 'x-not-a-link': 'tag' }} onClick={setSearch}>
+    <a href={'#'} x-not-a-link='tag' onClick={setSearch}>
       {tag}
     </a>
   )
@@ -199,7 +204,7 @@ function BotCommandSuggestion({ suggestion }: { suggestion: string }) {
   }
 
   return (
-    <a href='#' {...{ 'x-not-a-link': 'bcs' }} onClick={applySuggestion}>
+    <a href='#' x-not-a-link='bcs' onClick={applySuggestion}>
       {suggestion}
     </a>
   )

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -107,7 +107,7 @@ function EmailLink({ email }: { email: string }): JSX.Element {
   }
 
   return (
-    <a href={'#'} onClick={openChatWithEmail}>
+    <a href={'#'} {...{ 'x-not-a-link': 'email' }} onClick={openChatWithEmail}>
       {email}
     </a>
   )
@@ -127,7 +127,7 @@ function TagLink({ tag }: { tag: string }) {
   }
 
   return (
-    <a href={'#'} onClick={setSearch}>
+    <a href={'#'} {...{ 'x-not-a-link': 'tag' }} onClick={setSearch}>
       {tag}
     </a>
   )
@@ -199,7 +199,7 @@ function BotCommandSuggestion({ suggestion }: { suggestion: string }) {
   }
 
   return (
-    <a href='#' onClick={applySuggestion}>
+    <a href='#' {...{ 'x-not-a-link': 'bcs' }} onClick={applySuggestion}>
       {suggestion}
     </a>
   )


### PR DESCRIPTION
 - don't show copy link, when right-clicking on tags, emails or bot commands
- also allow copying of email addresses
- fix copy of labled links
- update changelog

Only one Copy action, which can be one of the following, (in that order):
- Copy [selection] to clipboard
- Copy link to clipboard
- Copy email to clipboard
- Fallback: OR Copy message text to copy
 