### PR TITLE
fix wrong message in chatlistitem bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - selecting chat now closes all notifications about it again
 - fix quotes without message text are empty (#2434)
 - Fix react warning in about dialog (#2428)
+- Fix bug where wrong message is shown in chatlist item
 
 ### Changed
 - use strict typescript for ui code

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -41,17 +41,28 @@ export default class DCChatList extends SplitOut {
     return list.getChatId(index)
   }
 
-  async getChatListEntries(
+  getChatListEntries(
     ...args: Parameters<typeof Context.prototype.getChatList>
   ) {
     const chatList = this.selectedAccountContext.getChatList(...args)
     const chatListJson: [number, number][] = []
     for (let counter = 0; counter < chatList.getCount(); counter++) {
-      const chatId = await chatList.getChatId(counter)
-      const messageId = await chatList.getMessageId(counter)
+      const chatId = chatList.getChatId(counter)
+      const messageId = chatList.getMessageId(counter)
       chatListJson.push([chatId, messageId])
     }
     return chatListJson
+  }
+
+  getChatListEntryMessageIdForChatId(chatID: number): number {
+    // workaround until this is in core
+    const chatList = this.selectedAccountContext.getChatList(0,'',null)
+    for (let counter = 0; counter < chatList.getCount(); counter++) {
+      if(chatID == chatList.getChatId(counter)) {
+        return chatList.getMessageId(counter)
+      }
+    }
+    return null
   }
 
   async getChatListItemsByEntries(entries: [number, number][]) {

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -56,9 +56,9 @@ export default class DCChatList extends SplitOut {
 
   getChatListEntryMessageIdForChatId(chatID: number): number {
     // workaround until this is in core
-    const chatList = this.selectedAccountContext.getChatList(0,'',null)
+    const chatList = this.selectedAccountContext.getChatList(0, '', null)
     for (let counter = 0; counter < chatList.getCount(); counter++) {
-      if(chatID == chatList.getChatId(counter)) {
+      if (chatID == chatList.getChatId(counter)) {
         return chatList.getMessageId(counter)
       }
     }

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -404,7 +404,10 @@ export function useLogicVirtualChatList(chatListIds: [number, number][]) {
     const updateChatListItem = async (chatId: number) => {
       debouncingChatlistItemRequests[chatId] = 1
       // the message id of the event could be an older message than the newest message (for example msg-read event)
-      const messageId = await DeltaBackend.call('chatList.getChatListEntryMessageIdForChatId', chatId)
+      const messageId = await DeltaBackend.call(
+        'chatList.getChatListEntryMessageIdForChatId',
+        chatId
+      )
       setChatLoading(state => ({
         ...state,
         [chatId]: LoadStatus.FETCHING,

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -209,6 +209,7 @@ export default class MapComponent extends React.Component<
           profileImage: this.currentUser.profileImage,
           isBlocked: false,
           isVerified: true,
+          lastSeen: this.currentUser.lastSeen,
         })
       }
       contacts.forEach(contact => {

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -70,6 +70,7 @@ class DeltaRemote {
   ): Promise<{
     [key: number]: ChatListItemType
   }>
+  call(fnName: 'chatList.getChatListEntryMessageIdForChatId', chatID: number): Promise<number>
   call(fnName: 'chatList.getFullChatById', chatId: number): Promise<FullChat>
   call(fnName: 'chatList.getGeneralFreshMessageCounter'): Promise<number> // this method might be used for a favicon badge counter
   // contacts ------------------------------------------------------------

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -70,7 +70,10 @@ class DeltaRemote {
   ): Promise<{
     [key: number]: ChatListItemType
   }>
-  call(fnName: 'chatList.getChatListEntryMessageIdForChatId', chatID: number): Promise<number>
+  call(
+    fnName: 'chatList.getChatListEntryMessageIdForChatId',
+    chatID: number
+  ): Promise<number>
   call(fnName: 'chatList.getFullChatById', chatId: number): Promise<FullChat>
   call(fnName: 'chatList.getGeneralFreshMessageCounter'): Promise<number> // this method might be used for a favicon badge counter
   // contacts ------------------------------------------------------------

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -15,9 +15,9 @@ export const ipcBackend = ipcRenderer
 // as an array of strings.
 export function onDCEvent(
   event: string | string[],
-  cb: (data1: string, data2: string) => void
+  cb: (data1: number, data2: string | number) => void
 ) {
-  const wrapperCb = (_: any, [data1, data2]: [string, string]) => {
+  const wrapperCb = (_: any, [data1, data2]: [number, string | number]) => {
     cb(data1, data2)
   }
   if (Array.isArray(event)) {


### PR DESCRIPTION
when the message that changed state was not the last one it got displayed in the chat-list regardless (like when an older message got a read receipt).

though we should really move this into the core (& making it more efficient), even if @r10s should still be against that method, desktop needs it:
```js
  getChatListEntryMessageIdForChatId(chatID: number): number {
    // workaround until this is in core
    const chatList = this.selectedAccountContext.getChatList(0,'',null)
    for (let counter = 0; counter < chatList.getCount(); counter++) {
      if(chatID == chatList.getChatId(counter)) {
        return chatList.getMessageId(counter)
      }
    }
    return null
  }
```