### PR TITLE
scroll messageList with `PageUp`/`PageDown` keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - `PageUp` and `PageDown` keys can now be used to scroll in the MessageList
+- Keeping `Alt + ArrowUp/ArrowDown` pressed now keeps selecting the next chat until the key is released
 
 ## [1.25.1] - 2021-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- `PageUp` and `PageDown` keys can now be used to scroll in the MessageList
+
 ## [1.25.1] - 2021-11-30
 
 ### Fixed

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -1,5 +1,7 @@
 # Keybindings
 
+> If you are on mac replace alt with the option key.
+
 Switch between chats: `alt + arrow down`, `alt + arrow up`
 
 Scroll active chat into view ~~`alt + arrow left`~~ _(disabled until we find a better key combo, because this one collides with to mac system shortcut to move a word (see [#1796](https://github.com/deltachat/deltachat-desktop/issues/1796)))_
@@ -11,3 +13,5 @@ Focus message composer: `ctrl + n`
 Open settings: `cmd + ,` or `ctrl + ,`
 
 Call MaybeNetwork (can help if deltachat doesn't detect that it is online again after resuming standby): `F5`
+
+Scroll up/down a page in the messagelist: `PageUp` and `PageDown`

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -14,6 +14,7 @@ import { getLogger } from '../../../shared/logger'
 import { MessageType, FullChat } from '../../../shared/shared-types'
 import { MessagesDisplayContext, useTranslationFunction } from '../../contexts'
 import { useDCConfigOnce } from '../helpers/useDCConfigOnce'
+import { KeybindAction, useKeyBindingAction } from '../../keybindings'
 const log = getLogger('render/msgList')
 
 const messageIdsToShow = (
@@ -216,6 +217,23 @@ export const MessageListInner = React.memo(
       isDeviceChat: chatStore.chat.isDeviceChat as boolean,
       chatType: chatStore.chat.type as number,
     }
+
+    useKeyBindingAction(KeybindAction.MessageList_PageUp, () => {
+      if (messageListRef.current) {
+        messageListRef.current.scrollBy({
+          top: -messageListRef.current.clientHeight,
+          behavior: 'auto',
+        })
+      }
+    })
+    useKeyBindingAction(KeybindAction.MessageList_PageDown, () => {
+      if (messageListRef.current) {
+        messageListRef.current.scrollBy({
+          top: messageListRef.current.clientHeight,
+          behavior: 'auto',
+        })
+      }
+    })
 
     return (
       <div id='message-list' ref={messageListRef} onScroll={onScroll}>

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -14,6 +14,8 @@ export enum KeybindAction {
   ChatList_ClearSearchInput = 'chatlist:clear-search',
   Composer_Focus = 'composer:focus',
   Settings_Open = 'settings:open',
+  MessageList_PageUp = 'msglist:pageup',
+  MessageList_PageDown = 'msglist:pagedown',
 
   // Actions that are not necessarily triggered by keybindings
   ChatList_SwitchToArchiveView = 'chatlist:switch-to-archive-view',
@@ -98,6 +100,10 @@ function keyDownEvent2Action(ev: KeyboardEvent): KeybindAction | undefined {
       return KeybindAction.ChatList_SearchSelectFirstChat
     } else if (ev.key === 'F5') {
       return KeybindAction.Debug_MaybeNetwork
+    } else if (ev.key === 'PageUp') {
+      return KeybindAction.MessageList_PageUp
+    } else if (ev.key === 'PageDown') {
+      return KeybindAction.MessageList_PageDown
     }
   } else {
     // fire continuesly as long as button is pressed

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -107,6 +107,11 @@ function keyDownEvent2Action(ev: KeyboardEvent): KeybindAction | undefined {
     }
   } else {
     // fire continuesly as long as button is pressed
+    if (ev.key === 'PageUp') {
+      return KeybindAction.MessageList_PageUp
+    } else if (ev.key === 'PageDown') {
+      return KeybindAction.MessageList_PageDown
+    }
   }
 }
 

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -111,6 +111,10 @@ function keyDownEvent2Action(ev: KeyboardEvent): KeybindAction | undefined {
       return KeybindAction.MessageList_PageUp
     } else if (ev.key === 'PageDown') {
       return KeybindAction.MessageList_PageDown
+    } else if (ev.altKey && ev.key === 'ArrowDown') {
+      return KeybindAction.ChatList_SelectNextChat
+    } else if (ev.altKey && ev.key === 'ArrowUp') {
+      return KeybindAction.ChatList_SelectPreviousChat
     }
   }
 }


### PR DESCRIPTION
- scroll up & down with pageUp/Down keys in msglist
- keep scrolling as long as the buttons are pressed
- update changelog
- also add keeping key pressed for switching chats
- update keybindings documentation
