### PR TITLE
Change the color style in the "Delete Profile Image" button when it is disabled

### DIFF
--- a/scss/misc/_delta-buttons.scss
+++ b/scss/misc/_delta-buttons.scss
@@ -17,7 +17,7 @@ button.delta-button-round {
     border-color: rgba(206, 217, 224, 0.5);
     background-image: none;
     cursor: not-allowed;
-    color: rgba(92, 112, 128, 0.6);
+    color:white;
     &:hover {
       background-color: rgba(206, 217, 224, 0.5);
     }

--- a/scss/misc/_delta-buttons.scss
+++ b/scss/misc/_delta-buttons.scss
@@ -1,3 +1,4 @@
+
 button.delta-button-round {
   margin-top: 10px;
   background-color: var(--bp3-input-focused);
@@ -17,7 +18,7 @@ button.delta-button-round {
     border-color: rgba(206, 217, 224, 0.5);
     background-image: none;
     cursor: not-allowed;
-    color:white;
+    color:rgb(51, 49, 49);
     &:hover {
       background-color: rgba(206, 217, 224, 0.5);
     }
@@ -29,3 +30,5 @@ button.delta-button-round {
     background-clip: unset;
   }
 }
+
+

--- a/scss/misc/_delta-buttons.scss
+++ b/scss/misc/_delta-buttons.scss
@@ -1,4 +1,3 @@
-
 button.delta-button-round {
   margin-top: 10px;
   background-color: var(--bp3-input-focused);
@@ -12,23 +11,19 @@ button.delta-button-round {
   color: white;
   text-transform: uppercase;
   font-weight: bold;
-
   &:disabled {
     background-color: rgba(206, 217, 224, 0.5);
     border-color: rgba(206, 217, 224, 0.5);
     background-image: none;
     cursor: not-allowed;
-    color:rgb(51, 49, 49);
+    color: var(--globalText);
     &:hover {
       background-color: rgba(206, 217, 224, 0.5);
     }
   }
-
   &:hover {
     background-color: var(--bp3-input-focused);
     box-shadow: none;
     background-clip: unset;
   }
 }
-
-


### PR DESCRIPTION
**Solves #2442 (Styling for signature textarea needed)**

**Description**
The text color of the "Delete Profile Image" button when disabled was not displayed correctly for some Themes, mainly for the dark theme.

<img width="480" alt="Screen Shot 2021-12-23 at 8 41 03 AM" src="https://user-images.githubusercontent.com/70716664/147255439-90244b02-c619-4ac1-99c8-acadaf2d3bb7.png">

**Why**
The color that was set for all themes in the disabled button when editing the profile was suitable only for light themes, since in dark themes it did not display the text.

**Additional information** 
The style bug in the "Delete Profile Image" button is corrected when it is disabled, the change is tested in the different themes.

- Photo of the button view in the different themes

<img width="411" alt="Screen Shot 2021-12-23 at 8 59 32 AM" src="https://user-images.githubusercontent.com/70716664/147257851-2aa6fd1c-8fbb-4b02-8a58-743fe1021966.png">


