### PR TITLE
Add error message when you try to download an image in a folder with no write permission

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -140,6 +140,11 @@ export async function init(cwd: string, logHandler: LogHandler) {
             'Permission Error',
             `Cannot write in this folder. You don't have write permission`
           )
+        } else {
+          dialog.showErrorBox(
+            'Unhandled Error',
+            `Cannot copy file. Error: ${error}`
+          )
         }
       }
     }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -132,7 +132,16 @@ export async function init(cwd: string, logHandler: LogHandler) {
       options
     )
     if (!canceled && filePath) {
-      await copyFile(source, filePath)
+      try {
+        await copyFile(source, filePath)
+      } catch (error) {
+        if (error.code == 'EACCES') {
+          dialog.showErrorBox(
+            'Permission Error',
+            `Cannot write in this folder. You don't have write permission`
+          )
+        }
+      }
     }
   })
 }


### PR DESCRIPTION
Solves #2474 (Saving a file does not report failures)

**Description**
Now when you try to download an image in a folder where you don't have write permission, an error alert is displayed to the user, indicating the problem.

**Why**
When the error of the write permission occurred, the app didn't notify the user that an error occurred.

**Additional information**

- Photo of the current error message:
<img width="1000" alt="Screen Shot 2021-12-28 at 20 14 50" src="https://user-images.githubusercontent.com/42971574/147624054-1f5cdd70-05c5-4626-894e-9844862ed3b8.png">
