### PR TITLE
Fix connectivity view title

### DIFF
--- a/src/renderer/components/dialogs/Settings-Connectivity.tsx
+++ b/src/renderer/components/dialogs/Settings-Connectivity.tsx
@@ -37,7 +37,7 @@ export default function SettingsConnectivityDialog({
         width: '500px',
       }}
     >
-      <DeltaDialogHeader title={tx('pref_edit_profile')} />
+      <DeltaDialogHeader title={tx('connectivity')} />
       {SettingsConnectivityInner()}
       <DeltaDialogCloseFooter onClose={onClose} />
     </DeltaDialogBase>


### PR DESCRIPTION
Solves #2436 (Connectivity view uses wrong title)

**Description**
Now when you enter the connectivity view, the correct title is shown.

**Why**
When you entered the connectivity view an incorrect title was displayed.

**Additional information**

Photo of the current connectivity view:

![image](https://user-images.githubusercontent.com/42971574/147789802-f103c3d9-8be7-49d3-94dc-ac70f0db0b94.png)
