### PR TITLE
don't double log core events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix overflow in long links inside quotes @naomiceron #2467
 - Show error if writing an attachment fails @IrvinLara9 #2479
 - Fix connectivity view title @IrvinLara9 #2480
+- Do not double log core events
 
 ## [1.26.0] - 2021-12-15
 

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -35,10 +35,14 @@ export function startBackendLogging() {
     return log.error('Backend logging is already started!')
   backendLoggingStarted = true
 
-  ipcBackend.on('ALL', (_e, eName, ...args) =>
-    log.debug('backend', eName, ...args)
+  ipcBackend.on('ALL', (_e, eName, [data1, data2]) =>
+    /* ignore-console-log */
+    console.debug(
+      `%c📡 ${eName}%c ${data1} ${data2}`,
+      'background:rgba(125,125,125,0.15);border-radius:2px;padding:2px 4px;',
+      'color:grey'
+    )
   )
-  ipcBackend.on('error', (_e, ...args) => log.error(...args))
 }
 
 export function sendToBackend(event: string, ...args: any[]) {


### PR DESCRIPTION
Problem: renderer also logs the core events which then get sent back to the main process, so core events are currently logged twice.

also style core events in dev console:
<img width="676" alt="Screenshot 2022-01-02 at 19 53 31" src="https://user-images.githubusercontent.com/18725968/147886488-8d407e1f-f192-40a0-9cb4-6da963ff6fc8.png">


also I removed `ipcBackend.on('error')`,
as I could not find the place where that event would be emitted.
