### PR TITLE
Texture style change

### DIFF
--- a/scss/login/_login.scss
+++ b/scss/login/_login.scss
@@ -201,13 +201,14 @@ div.delta-form-group {
   textarea {
     width: 100%;
     padding: 0px;
-
     margin-top: 5px;
-
     border: none;
     border-radius: 0px;
     border-bottom: 2px solid;
     border-bottom-color: var(--deltaChatPrimaryFgLight);
+    
+    background-color: transparent;
+    color: var(--bp3InputText);
 
     box-shadow: none !important;
     &:focus,

--- a/scss/login/_login.scss
+++ b/scss/login/_login.scss
@@ -206,10 +206,8 @@ div.delta-form-group {
     border-radius: 0px;
     border-bottom: 2px solid;
     border-bottom-color: var(--deltaChatPrimaryFgLight);
-    
     background-color: transparent;
     color: var(--bp3InputText);
-
     box-shadow: none !important;
     &:focus,
     &:active {


### PR DESCRIPTION
**Solves #2442 (Styling for signature textarea needed)**

**Style change in Textarea when editing the profile**

**Description**
The color of the Textarea when editing the profile was inconsistent with the style
<img width="513" alt="Screen Shot 2022-01-06 at 10 34 40 AM" src="https://user-images.githubusercontent.com/70716664/148416935-e4e53991-239e-4cfc-b99d-c59acc26bdaa.png">

**Why**
There was no consistency in the "textarea" with the rest of the element in Edit profile

**Additional information** 
A transparent background is added and the color is specified: var (- bp3InputText) for the Textarea
- Photo of the "textarea" view in the dark theme and light theme
<img width="482" alt="Screen Shot 2022-01-06 at 10 38 19 AM" src="https://user-images.githubusercontent.com/70716664/148417503-d60dc0a8-1d37-4b7e-b916-66a17dbfbe88.png">

<img width="488" alt="Screen Shot 2022-01-06 at 10 38 39 AM" src="https://user-images.githubusercontent.com/70716664/148417547-c3124d9d-3098-4249-b250-76da9b953304.png">




