### PR TITLE
Add format image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update translations (3.1.2022)
 - Make disabled "delete profile image" button more readable in dark themes @ejgonzalez17 #2478
 - Update inApp help (3.1.2022)
+- Add image formats when selecting the image profile @ejgonzalez17 #2492
 
 ### Fixed
 - Fix overflow in long links inside quotes @naomiceron #2467
@@ -14,6 +15,7 @@
 - Do not double log core events
 - Fix Bulgarian language name (uppercase first letter)
 - Fix signature text styling @ejgonzalez17 
+- Fix Add image formats @ejgonzalez17
 
 ## [1.26.0] - 2021-12-15
 

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -147,7 +147,7 @@ export function ProfileImageSelector({
   const onClickSelectPicture = async () => {
     const file = await runtime.showOpenFileDialog({
       title: tx('select_your_new_profile_image'),
-      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif'] }],
+      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','icon','apng','ico','webp'] }],
       properties: ['openFile'],
       defaultPath: runtime.getAppPath('pictures'),
     })

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -147,7 +147,7 @@ export function ProfileImageSelector({
   const onClickSelectPicture = async () => {
     const file = await runtime.showOpenFileDialog({
       title: tx('select_your_new_profile_image'),
-      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','icon','apng','ico','webp'] }],
+      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','jpe'] }],
       properties: ['openFile'],
       defaultPath: runtime.getAppPath('pictures'),
     })

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -147,7 +147,12 @@ export function ProfileImageSelector({
   const onClickSelectPicture = async () => {
     const file = await runtime.showOpenFileDialog({
       title: tx('select_your_new_profile_image'),
-      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','jpe'] }],
+      filters: [
+        {
+          name: tx('images'),
+          extensions: ['jpg', 'png', 'gif', 'jpeg', 'jpe'],
+        },
+      ],
       properties: ['openFile'],
       defaultPath: runtime.getAppPath('pictures'),
     })

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -430,7 +430,7 @@ export function GroupImageSelector({
   const onClickSelectGroupImage = async () => {
     const file = await runtime.showOpenFileDialog({
       title: tx('select_your_new_profile_image'),
-      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif'] }],
+      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','icon','apng','ico','webp'] }],
       properties: ['openFile'],
       defaultPath: runtime.getAppPath('pictures'),
     })

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -430,7 +430,12 @@ export function GroupImageSelector({
   const onClickSelectGroupImage = async () => {
     const file = await runtime.showOpenFileDialog({
       title: tx('select_your_new_profile_image'),
-      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','jpe'] }],
+      filters: [
+        {
+          name: tx('images'),
+          extensions: ['jpg', 'png', 'gif', 'jpeg', 'jpe'],
+        },
+      ],
       properties: ['openFile'],
       defaultPath: runtime.getAppPath('pictures'),
     })

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -430,7 +430,7 @@ export function GroupImageSelector({
   const onClickSelectGroupImage = async () => {
     const file = await runtime.showOpenFileDialog({
       title: tx('select_your_new_profile_image'),
-      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','icon','apng','ico','webp'] }],
+      filters: [{ name: tx('images'), extensions: ['jpg', 'png', 'gif','jpeg','jpe'] }],
       properties: ['openFile'],
       defaultPath: runtime.getAppPath('pictures'),
     })


### PR DESCRIPTION
**Solves #2491 (When selecting the image profile, it does not accept .jpeg .ico .apng format)**

**Description**
Add image formats in the process of selecting a new image in the profile

**Why**
When trying to select an image in the profile photo, formats such as .jpeg or .ico are not accepted.

**Additional information** 
Formats are added in Setting-Profile.tsx and in ViewGroup.tsx
<img width="758" alt="Screen Shot 2022-01-06 at 4 21 25 PM" src="https://user-images.githubusercontent.com/70716664/148460536-84a468d3-e6a5-4ae3-9f36-1f695a6a88de.png">

<img width="863" alt="Screen Shot 2022-01-06 at 4 21 58 PM" src="https://user-images.githubusercontent.com/70716664/148460757-2b6211d8-df0e-40f3-9996-6cd1bd405dc5.png">


