### PR TITLE
Offline Toast Style Update

### DIFF
--- a/scss/_connectivity-toast.scss
+++ b/scss/_connectivity-toast.scss
@@ -22,7 +22,7 @@
   }
 
   div {
-    display: inline-block;
+    display: block;
     color: var(--colorPrimary);
     margin-left: 4px;
     cursor: pointer;


### PR DESCRIPTION
Issue description:
Fixes #2454 

![](https://user-images.githubusercontent.com/18725968/144772920-7906200c-c75f-400e-9578-78b8ce94fdc4.png)

Offline Toast obscures message composer on small width window.


Proposed Solution:

As suggested, I modified the file `_conncetivity-toast.scss` for the divs inside the ConnectivityToast class to have a display type of block, instead of line-block.

![Screen Shot 2022-01-07 at 5 03 35 PM](https://user-images.githubusercontent.com/54916945/148618279-4d1ab0a0-7e22-4396-b749-e2d6e538709e.png)

The new behavior of the toast message can be observed here. The Archived Chats button is still clickable when the Offline Toast message appears to the user. At no moment does the toast obscure the message composer.

![recording](https://user-images.githubusercontent.com/54916945/148617955-f483c039-9356-454f-a8b1-a5e550acd27d.gif)

Suggestions are welcomed! 😁