### PR TITLE
fix: remove profile picture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Do not double log core events
 - Fix Bulgarian language name (uppercase first letter)
 - Fix signature text styling @ejgonzalez17 
+- Fix the profile picture removal @cavesdev #2472
 
 ## [1.26.0] - 2021-12-15
 

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -209,7 +209,10 @@ export function SettingsEditProfileDialogInner({
     onClose()
   }
   const onOk = async () => {
-    await DeltaBackend.call('setProfilePicture', profilePicture)
+    await DeltaBackend.call(
+      'setProfilePicture',
+      profilePicture ? profilePicture : null
+    )
     handleDeltaSettingsChange('displayname', displayname)
     handleDeltaSettingsChange('selfstatus', selfstatus)
     onClose()

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -28,7 +28,7 @@ export type sendMessageParams = {
 
 class DeltaRemote {
   // root ---------------------------------------------------------------
-  call(fnName: 'setProfilePicture', newImage: string): Promise<void>
+  call(fnName: 'setProfilePicture', newImage: string | null): Promise<void>
   call(fnName: 'getProfilePicture'): Promise<string>
   call(fnName: 'getInfo'): Promise<{ [key: string]: any }>
   call(


### PR DESCRIPTION
Fixes #2472  

## Solution
Changed the empty string representation to 'null' when there was no profile picture. Apparently, when sending an empty string to the backend it gets interpreted as a path (which is obviously an invalid path) and throws an I/O error. 

To avoid changing many type annotations, I only added an if statement when sending the profile picture representation to the backend and added the null type on that function's parameter.