### PR TITLE
fix: removed horizontal scroll in autocrypt dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix connectivity status hiding composer @trujillo9616
 - Fix overflow in Confirmation Dialog @Abhijnan-Bajpai 
 - Fix the profile picture removal @cavesdev #2472
+- Fix the horizontal scroll in autocrypt dialogs @cavesdev #2277
 
 ## [1.26.0] - 2021-12-15
 

--- a/src/renderer/components/dialogs/EnterAutocryptSetupMessage.tsx
+++ b/src/renderer/components/dialogs/EnterAutocryptSetupMessage.tsx
@@ -61,7 +61,7 @@ export function SetupMessagePanel({
 
   return (
     <>
-      <div className={Classes.DIALOG_BODY}>
+      <div>
         <Card>
           <Callout>
             {tx('autocrypt_continue_transfer_please_enter_code')}

--- a/src/renderer/components/dialogs/Settings-Encryption.tsx
+++ b/src/renderer/components/dialogs/Settings-Encryption.tsx
@@ -27,10 +27,10 @@ export function KeyViewPanel({
   const tx = window.static_translate
   return (
     <React.Fragment>
-      <div className={Classes.DIALOG_BODY}>
+      <div>
         <Card>
           <Callout>{tx('show_key_transfer_message_desktop')}</Callout>
-          <div className={Classes.DIALOG_BODY}>
+          <div>
             <InputTransferKey
               autocryptkey={autocryptKey.split('-')}
               disabled


### PR DESCRIPTION
Fixes #2277 

## Solution
The solution was to remove the BlueprintJS's classes on parent `div`s (`Classes.BODY_DIALOG`). It does not affect in any way the styles of the dialogs apart from disabling horizontal scroll. 