### PR TITLE
ignore .html files in programming language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# excluding html-help-files from programming-language-stats;
+# otherwise, the repos language would be come "html" instead of "typescript".
+# see https://github.com/github/linguist/blob/master/docs/overrides.md
+*.html linguist-vendored


### PR DESCRIPTION
github shows the "main" language very prominently beside a respository;
for deltachat-desktop, this is meanwhile wrongly "HTML",
probably because of more help-translations
(not far ago, it was "Typescript")

this pr just let github ignore .html files from stat
so that the result should be "Typescript" again.