### PR TITLE
WIP: Implement account sidebar to quickly switch between accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- Added experimental account sidebar for quick switching between accounts
+
 ## [1.27.0] - 2021-03-04
 
 ### Added
@@ -11,7 +14,6 @@
 - Logging for unhandled frontend errors
 - Copying image now possible from gallery and chat view
 - Add image zoom for full screen views
-- Added experimental account sidebar for quick switching between accounts
 
 ### Changed
 - Update `@deltachat/message_parser_wasm` to `0.3.0` (fixes some link parsing issues)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Logging for unhandled frontend errors
 - Copying image now possible from gallery and chat view
 - Add image zoom for full screen views
+- Added experimental account sidebar for quick switching between accounts
 
 ### Changed
 - Update `@deltachat/message_parser_wasm` to `0.3.0` (fixes some link parsing issues)

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -19,5 +19,8 @@
   },
   "pref_send_copy_to_self_explain": {
     "message": "Required for multi-device setup."
+  },
+  "menu_show_account_sidebar": {
+    "message": "Show account sidebar"
   }
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -3,7 +3,6 @@
     left: 0;
     width: 5vw;
     height: 100vh;
-    z-index: 100;
     background-color: gray;
     overflow-y: scroll;
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -1,0 +1,9 @@
+.account-sidebar {
+    position: absolute;
+    left: 0;
+    width: 5vw;
+    height: 100vh;
+    z-index: 100;
+    background-color: gray;
+    overflow-y: scroll;
+}

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -3,9 +3,18 @@
     left: 0;
     width: $account-sidebar-width;
     height: 100vh;
-    background-color: gray;
+    background-color: var(--chatListItemBgPinned);
     overflow-y: scroll;
+    &::-webkit-scrollbar {
+      width: 3px;
+    }
+    &::-webkit-scrollbar-track {
+      background-color: var(--chatListItemBgPinned);
+    }
+    &.hideScrollbarThumb::-webkit-scrollbar-thumb {
+      background: transparent;
+    }
     .account {
-        padding-left: calc(#{$account-sidebar-width} / 10);
+        padding-left: calc((100% - 48px) / 2);
     }
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -16,12 +16,12 @@
     }
     .account {
       padding-left: calc((100% + 3px - 48px) / 2);
-      border-left: solid 1px transparent;
+      border-left: solid 3px transparent;
       &:hover {
         border-left-color: lightgrey;
       }
       &.selected {
-        border-left-color: blue;
+        border-left-color: var(--colorPrimary);
       }
     }
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -15,6 +15,13 @@
       background: transparent;
     }
     .account {
-        padding-left: calc((100% + 3px - 48px) / 2);
+      padding-left: calc((100% + 3px - 48px) / 2);
+      border-left: solid 1px transparent;
+      &:hover {
+        border-left-color: lightgrey;
+      }
+      &.selected {
+        border-left-color: blue;
+      }
     }
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -15,7 +15,7 @@
       background: transparent;
     }
     .account {
-      padding-left: calc((100% + 3px - 48px) / 2);
+      padding-left: calc((100% - 48px) / 2);
       border-left: solid 3px transparent;
       &:hover {
         border-left-color: lightgrey;

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -15,6 +15,6 @@
       background: transparent;
     }
     .account {
-        padding-left: calc((100% - 48px) / 2);
+        padding-left: calc((100% + 3px - 48px) / 2);
     }
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -1,8 +1,11 @@
 .account-sidebar {
     position: absolute;
     left: 0;
-    width: 5vw;
+    width: $account-sidebar-width;
     height: 100vh;
     background-color: gray;
     overflow-y: scroll;
+    .account {
+        padding-left: calc(#{$account-sidebar-width} / 10);
+    }
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -1,38 +1,38 @@
-
 .account-sidebar {
-    position: absolute;
-    left: 0;
-    width: var(--accountSidebarWidth);
-    height: 100vh;
+  position: absolute;
+  left: 0;
+  width: var(--accountSidebarWidth);
+  height: 100vh;
+  background-color: var(--chatListItemBgPinned);
+  overflow-y: scroll;
+  &::-webkit-scrollbar {
+    width: 3px;
+  }
+  &::-webkit-scrollbar-track {
     background-color: var(--chatListItemBgPinned);
-    overflow-y: scroll;
-    &::-webkit-scrollbar {
-      width: 3px;
+  }
+  &.hideScrollbarThumb::-webkit-scrollbar-thumb {
+    background: transparent;
+  }
+  .account {
+    --account-avatar-size: 40px;
+    padding-left: calc((100% - var(--account-avatar-size) - 6px) / 2);
+    border-left: solid 3px transparent;
+    &:hover {
+      border-left-color: var(--colorNone);
     }
-    &::-webkit-scrollbar-track {
-      background-color: var(--chatListItemBgPinned);
+    &.selected {
+      border-left-color: var(--colorPrimary);
     }
-    &.hideScrollbarThumb::-webkit-scrollbar-thumb {
-      background: transparent;
-    }
-    .account {
-      --account-avatar-size: 40px;
-      padding-left: calc((100% - var(--account-avatar-size) - 6px) / 2);
-      border-left: solid 3px transparent;
-      &:hover {
-        border-left-color: var(--colorNone);
-      }
-      &.selected {
-        border-left-color: var(--colorPrimary);
-      }
 
-      .avatar {
-        --local-avatar-size: var(--account-avatar-size);
-        --local-avatar-vertical-margin: 8px;
-        --local-avatar-font-size: 25px;
-        div.content, img.content {
-          border-radius: 4px;
-        }
+    .avatar {
+      --local-avatar-size: var(--account-avatar-size);
+      --local-avatar-vertical-margin: 8px;
+      --local-avatar-font-size: 25px;
+      div.content,
+      img.content {
+        border-radius: 4px;
       }
     }
+  }
 }

--- a/scss/_account-sidebar.scss
+++ b/scss/_account-sidebar.scss
@@ -1,7 +1,8 @@
+
 .account-sidebar {
     position: absolute;
     left: 0;
-    width: $account-sidebar-width;
+    width: var(--accountSidebarWidth);
     height: 100vh;
     background-color: var(--chatListItemBgPinned);
     overflow-y: scroll;
@@ -15,13 +16,23 @@
       background: transparent;
     }
     .account {
-      padding-left: calc((100% - 48px) / 2);
+      --account-avatar-size: 40px;
+      padding-left: calc((100% - var(--account-avatar-size) - 6px) / 2);
       border-left: solid 3px transparent;
       &:hover {
-        border-left-color: lightgrey;
+        border-left-color: var(--colorNone);
       }
       &.selected {
         border-left-color: var(--colorPrimary);
+      }
+
+      .avatar {
+        --local-avatar-size: var(--account-avatar-size);
+        --local-avatar-vertical-margin: 8px;
+        --local-avatar-font-size: 25px;
+        div.content, img.content {
+          border-radius: 4px;
+        }
       }
     }
 }

--- a/scss/_connectivity-toast.scss
+++ b/scss/_connectivity-toast.scss
@@ -1,7 +1,7 @@
 .ConnectivityToast {
   position: fixed;
   bottom: 5px;
-  left: 8px;
+  left: calc(8px + #{$account-sidebar-width});
   text-align: center;
   z-index: 99;
   background-color: var(--contextMenuBg);

--- a/scss/_connectivity-toast.scss
+++ b/scss/_connectivity-toast.scss
@@ -1,7 +1,7 @@
 .ConnectivityToast {
   position: fixed;
   bottom: 5px;
-  left: calc(8px + #{$account-sidebar-width});
+  left: calc(8px + var(--accountSidebarWidth));
   text-align: center;
   z-index: 99;
   background-color: var(--contextMenuBg);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -25,3 +25,5 @@ $button-height: 24px;
 $border-radius: 5px;
 
 $font-size: 14px;
+
+$account-sidebar-width: 70px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -26,4 +26,6 @@ $border-radius: 5px;
 
 $font-size: 14px;
 
-$account-sidebar-width: 70px;
+:root {
+  --accountSidebarWidth: 65px;
+}

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,5 +1,6 @@
 .chat-list {
-  width: 30%;
+  width: 30vw;
+  margin-left: 5vw;
   height: $content-height;
   float: left;
   overflow-y: auto;

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,6 +1,6 @@
 .chat-list {
   width: 30vw;
-  margin-left: 5vw;
+  margin-left: $account-sidebar-width;
   height: $content-height;
   float: left;
   overflow-y: auto;

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,6 +1,6 @@
 .chat-list {
   width: 30vw;
-  margin-left: $account-sidebar-width;
+  margin-left: var(--accountSidebarWidth);
   height: $content-height;
   float: left;
   overflow-y: auto;

--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -1,5 +1,6 @@
 .navbar-wrapper {
   .bp3-navbar {
+    margin-left: 5vw;
     padding: 0px;
     background-color: var(--navBarBackground);
     color: var(--navBarText);
@@ -17,12 +18,12 @@
   }
 
   .bp3-align-left {
-    width: 30%;
+    width: 30vw;
     padding: 0px 10px;
   }
 
   .bp3-align-right {
-    width: 70%;
+    width: 65vw;
     float: none;
   }
 

--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -1,6 +1,6 @@
 .navbar-wrapper {
   .bp3-navbar {
-    margin-left: 5vw;
+    margin-left: $account-sidebar-width;
     padding: 0px;
     background-color: var(--navBarBackground);
     color: var(--navBarText);
@@ -8,7 +8,7 @@
   }
 
   .bp3-navbar-heading {
-    margin-left: 5px;
+    margin-left: $account-sidebar-width;
     margin-right: 0px;
     overflow-x: hidden;
     white-space: nowrap;

--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -8,7 +8,7 @@
   }
 
   .bp3-navbar-heading {
-    margin-left: $account-sidebar-width;
+    margin-left: 5px;
     margin-right: 0px;
     overflow-x: hidden;
     white-space: nowrap;
@@ -23,7 +23,7 @@
   }
 
   .bp3-align-right {
-    width: 65vw;
+    width: calc(70vw - #{$account-sidebar-width});
     float: none;
   }
 

--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -1,6 +1,6 @@
 .navbar-wrapper {
   .bp3-navbar {
-    margin-left: $account-sidebar-width;
+    margin-left: var(--accountSidebarWidth);
     padding: 0px;
     background-color: var(--navBarBackground);
     color: var(--navBarText);
@@ -23,7 +23,7 @@
   }
 
   .bp3-align-right {
-    width: calc(70vw - #{$account-sidebar-width});
+    width: calc(70vw - var(--accountSidebarWidth));
     float: none;
   }
 

--- a/scss/manifest.scss
+++ b/scss/manifest.scss
@@ -78,3 +78,5 @@
 @import '_connectivity-toast';
 
 @import '_icons';
+
+@import '_account-sidebar';

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -1,5 +1,5 @@
 .message-list-and-composer {
-  width: 70%;
+  width: 65vw;
   float: right;
   display: flex;
   flex-direction: column;

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -1,5 +1,5 @@
 .message-list-and-composer {
-  width: calc(70vw - $account-sidebar-width);
+  width: calc(70vw - #{$account-sidebar-width});
   float: right;
   display: flex;
   flex-direction: column;

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -1,5 +1,5 @@
 .message-list-and-composer {
-  width: 65vw;
+  width: calc(70vw - $account-sidebar-width);
   float: right;
   display: flex;
   flex-direction: column;

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -1,5 +1,5 @@
 .message-list-and-composer {
-  width: calc(70vw - #{$account-sidebar-width});
+  width: calc(70vw - var(--accountSidebarWidth));
   float: right;
   display: flex;
   flex-direction: column;

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -197,13 +197,13 @@ export default class ScreenController extends Component {
           selectAccount={this.selectAccount}
         />
       case Screens.Login:
-        if (this.selectedAccountId === undefined) {
+        if (this.state.selectedAccountId === undefined) {
           throw new Error('Selected account not defined')
         }
         return (
           <AccountSetupScreen
             selectAccount={this.selectAccount}
-            accountId={this.selectedAccountId}
+            accountId={this.state.selectedAccountId}
           />
         )
       case Screens.Accounts:

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -38,16 +38,17 @@ export default class ScreenController extends Component {
     message: userFeedback | false;
     screen: Screens;
     logins: DeltaChatAccount[] | null
+    selectedAccountId: number | undefined
   }
   onShowAbout: any
-  selectedAccountId: number | undefined
 
   constructor(public props: {}) {
     super(props)
     this.state = {
       message: false,
       screen: Screens.Loading,
-      logins: []
+      logins: [],
+      selectedAccountId: undefined
     }
 
     this.onError = this.onError.bind(this)
@@ -83,7 +84,10 @@ export default class ScreenController extends Component {
 
   async selectAccount(accountId: number) {
     await DeltaBackend.call('login.selectAccount', accountId)
-    this.selectedAccountId = accountId
+    this.setState({
+      ...this.state,
+      selectedAccountId: accountId
+    })
     const account = await DeltaBackend.call('login.accountInfo', accountId)
     if (account.type === 'configured') {
       this.changeScreen(Screens.Main)
@@ -188,6 +192,7 @@ export default class ScreenController extends Component {
     switch (this.state.screen) {
       case Screens.Main:
         return <MainScreen
+          selectedAccountId={this.state.selectedAccountId}
           logins={this.state.logins}
           selectAccount={this.selectAccount}
         />

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -35,8 +35,8 @@ export default class ScreenController extends Component {
   dialogController: React.RefObject<DialogController>
   contextMenuShowFn: showFnType | null = null
   state: {
-    message: userFeedback | false;
-    screen: Screens;
+    message: userFeedback | false
+    screen: Screens
     logins: DeltaChatAccount[] | null
     selectedAccountId: number | undefined
   }
@@ -48,7 +48,7 @@ export default class ScreenController extends Component {
       message: false,
       screen: Screens.Loading,
       logins: [],
-      selectedAccountId: undefined
+      selectedAccountId: undefined,
     }
 
     this.onError = this.onError.bind(this)
@@ -86,7 +86,7 @@ export default class ScreenController extends Component {
     await DeltaBackend.call('login.selectAccount', accountId)
     this.setState({
       ...this.state,
-      selectedAccountId: accountId
+      selectedAccountId: accountId,
     })
     const account = await DeltaBackend.call('login.accountInfo', accountId)
     if (account.type === 'configured') {
@@ -119,11 +119,9 @@ export default class ScreenController extends Component {
     const logins = await DeltaBackend.call('login.getAllAccounts')
     this.setState({
       ...this.state,
-      logins
+      logins,
     })
   }
-
-
 
   componentDidMount() {
     ipcRenderer.on('error', this.onError)
@@ -134,7 +132,6 @@ export default class ScreenController extends Component {
 
     ipcRenderer.send('frontendReady')
     window.dispatchEvent(new Event('frontendReady'))
-
 
     this.startup()
     this.refreshAccounts()
@@ -191,11 +188,13 @@ export default class ScreenController extends Component {
   renderScreen() {
     switch (this.state.screen) {
       case Screens.Main:
-        return <MainScreen
-          selectedAccountId={this.state.selectedAccountId}
-          logins={this.state.logins}
-          selectAccount={this.selectAccount}
-        />
+        return (
+          <MainScreen
+            selectedAccountId={this.state.selectedAccountId}
+            logins={this.state.logins}
+            selectAccount={this.selectAccount}
+          />
+        )
       case Screens.Login:
         if (this.state.selectedAccountId === undefined) {
           throw new Error('Selected account not defined')
@@ -207,11 +206,13 @@ export default class ScreenController extends Component {
           />
         )
       case Screens.Accounts:
-        return <AccountsScreen
-         selectAccount={this.selectAccount}
-         logins={this.state.logins}
-         refreshAccounts={this.refreshAccounts}
-       />
+        return (
+          <AccountsScreen
+            selectAccount={this.selectAccount}
+            logins={this.state.logins}
+            refreshAccounts={this.refreshAccounts}
+          />
+        )
       default:
         return null
     }

--- a/src/renderer/ThemeManager.tsx
+++ b/src/renderer/ThemeManager.tsx
@@ -21,6 +21,14 @@ export namespace ThemeManager {
       themeVars.innerText = theme.data
       currentThemeChangeHook()
     }
+    const { showAccountSidebar } = await DeltaBackend.call('settings.getDesktopSettings')
+    const globalVars = window.document.getElementById('global-vars')
+    if (!globalVars) return
+    if (showAccountSidebar) {
+      globalVars.innerText = ''
+    } else {
+      globalVars.innerText = ':root { --accountSidebarWidth: 0px }'
+    }
   }
 
   ipcBackend.on('theme-update', _e => refresh())

--- a/src/renderer/ThemeManager.tsx
+++ b/src/renderer/ThemeManager.tsx
@@ -21,7 +21,9 @@ export namespace ThemeManager {
       themeVars.innerText = theme.data
       currentThemeChangeHook()
     }
-    const { showAccountSidebar } = await DeltaBackend.call('settings.getDesktopSettings')
+    const { showAccountSidebar } = await DeltaBackend.call(
+      'settings.getDesktopSettings'
+    )
     const globalVars = window.document.getElementById('global-vars')
     if (!globalVars) return
     if (showAccountSidebar) {

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { DeltaChatAccount } from "../../shared/shared-types";
-import ScreenController from "../ScreenController";
+import ScreenController, { Screens } from "../ScreenController";
 import { Avatar } from "./Avatar";
+import { PseudoListItemAddContact } from "./helpers/PseudoListItem";
 
 export default function AccountSidebar ({
     selectAccount,
@@ -12,18 +13,24 @@ export default function AccountSidebar ({
   }) {
     return (
         <div className="account-sidebar">
-            {logins !== null && logins.map(account => {
-                if (account.type === 'unconfigured') return null
-                return (
-                        <div className="account" onClick={() => selectAccount(account.id)}>
-                            <Avatar
-                                displayName={account.display_name === null ? '' : account.display_name}
-                                avatarPath={account.profile_image === null ? undefined : account.profile_image}
-                            />
-                        </div>
-                )
-            })}
-
+                {logins !== null && logins.map(account => {
+                    if (account.type === 'unconfigured') return null
+                    return (
+                            <div className="account" onClick={() => selectAccount(account.id)}>
+                                <Avatar
+                                    displayName={account.display_name === null ? '' : account.display_name}
+                                    avatarPath={account.profile_image === null ? undefined : account.profile_image}
+                                />
+                            </div>
+                    )
+                })}
+            <div onClick={() => {window.__changeScreen(Screens.Login)}}>
+                <Avatar
+                    avatarPath={undefined}
+                    color={'#505050'}
+                    displayName={"+"}
+                />
+            </div>
         </div>
     )
 }

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { DeltaChatAccount } from "../../shared/shared-types";
+import ScreenController from "../ScreenController";
+import { Avatar } from "./Avatar";
+
+export default function AccountSidebar ({
+    selectAccount,
+    logins,
+  }: {
+    selectAccount: typeof ScreenController.prototype.selectAccount,
+    logins: DeltaChatAccount[] | null
+  }) {
+    return (
+        <div className="account-sidebar">
+            {logins !== null && logins.map(account => {
+                if (account.type === 'unconfigured') return null
+                return (
+                        <div className="account" onClick={() => selectAccount(account.id)}>
+                            <Avatar
+                                displayName={account.display_name === null ? '' : account.display_name}
+                                avatarPath={account.profile_image === null ? undefined : account.profile_image}
+                            />
+                        </div>
+                )
+            })}
+
+        </div>
+    )
+}

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from "react";
+import React, {useCallback, useRef} from "react";
 import { DeltaChatAccount, FullChat } from "../../shared/shared-types";
 import {DeltaBackend} from "../delta-remote";
 import ScreenController, { Screens } from "../ScreenController";
@@ -14,6 +14,17 @@ export default function AccountSidebar ({
     selectAccount: typeof ScreenController.prototype.selectAccount,
     logins: DeltaChatAccount[] | null
   }) {
+    const accountSidebarRef = useRef<HTMLDivElement>(null)
+    const toggleHideScrollbar = useCallback((show: boolean) => {
+      console.log("Haaaaalllooo")
+      if (accountSidebarRef.current === null) return
+
+      show === true ?
+        accountSidebarRef.current.classList.remove('hideScrollbarThumb') :
+        accountSidebarRef.current.classList.add('hideScrollbarThumb')
+
+    }, [accountSidebarRef])
+
     const switchAccount = useCallback(async (accountId: number) => {
       if (selectedChat) {
         unselectChat()
@@ -22,7 +33,7 @@ export default function AccountSidebar ({
       selectAccount(accountId)
     }, [selectedChat, selectAccount])
     return (
-        <div className="account-sidebar">
+        <div className="account-sidebar hideScrollbarThumb" ref={accountSidebarRef} onMouseEnter={() => { toggleHideScrollbar(true)} } onMouseLeave={() => toggleHideScrollbar(false)}>
                 {logins !== null && logins.map(account => {
                     if (account.type === 'unconfigured') return null
                     return (
@@ -35,7 +46,7 @@ export default function AccountSidebar ({
                             </div>
                     )
                 })}
-            <div onClick={() => {window.__changeScreen(Screens.Login)}}>
+            <div className="account" onClick={() => {window.__changeScreen(Screens.Login)}}>
                 <Avatar
                     avatarPath={undefined}
                     color={'#505050'}

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -16,7 +16,6 @@ export default function AccountSidebar ({
   }) {
     const accountSidebarRef = useRef<HTMLDivElement>(null)
     const toggleHideScrollbar = useCallback((show: boolean) => {
-      console.log("Haaaaalllooo")
       if (accountSidebarRef.current === null) return
 
       show === true ?

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -33,6 +33,7 @@ export default function AccountSidebar ({
                                 <Avatar
                                     displayName={account.display_name === null ? '' : account.display_name}
                                     avatarPath={account.profile_image === null ? undefined : account.profile_image}
+                                    color={account.color}
                                 />
                             </div>
                     )

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import React, {useCallback, useRef} from "react";
 import { DeltaChatAccount, FullChat } from "../../shared/shared-types";
 import {DeltaBackend} from "../delta-remote";
@@ -8,10 +9,12 @@ import {unselectChat} from "./helpers/ChatMethods";
 export default function AccountSidebar ({
     selectedChat,
     selectAccount,
+    selectedAccountId,
     logins,
   }: {
     selectedChat: FullChat | null,
     selectAccount: typeof ScreenController.prototype.selectAccount,
+    selectedAccountId: number | undefined,
     logins: DeltaChatAccount[] | null
   }) {
     const accountSidebarRef = useRef<HTMLDivElement>(null)
@@ -36,7 +39,7 @@ export default function AccountSidebar ({
                 {logins !== null && logins.map(account => {
                     if (account.type === 'unconfigured') return null
                     return (
-                            <div className="account" onClick={() => switchAccount(account.id)}>
+                            <div className={classNames("account", { selected: account.id === selectedAccountId})} onClick={() => switchAccount(account.id)}>
                                 <Avatar
                                     displayName={account.display_name === null ? '' : account.display_name}
                                     avatarPath={account.profile_image === null ? undefined : account.profile_image}

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -39,7 +39,7 @@ export default function AccountSidebar ({
                 {logins !== null && logins.map(account => {
                     if (account.type === 'unconfigured') return null
                     return (
-                            <div className={classNames("account", { selected: account.id === selectedAccountId})} onClick={() => switchAccount(account.id)}>
+                            <div key={account.id} className={classNames("account", { selected: account.id === selectedAccountId})} onClick={() => switchAccount(account.id)}>
                                 <Avatar
                                     displayName={account.display_name === null ? '' : account.display_name}
                                     avatarPath={account.profile_image === null ? undefined : account.profile_image}
@@ -48,7 +48,7 @@ export default function AccountSidebar ({
                             </div>
                     )
                 })}
-            <div className="account" onClick={() => {window.__changeScreen(Screens.Login)}}>
+            <div key="add" className="account" onClick={() => {window.__changeScreen(Screens.Login)}}>
                 <Avatar
                     avatarPath={undefined}
                     color={'#505050'}

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -39,7 +39,7 @@ export default function AccountSidebar ({
                 {logins !== null && logins.map(account => {
                     if (account.type === 'unconfigured') return null
                     return (
-                            <div key={account.id} className={classNames("account", { selected: account.id === selectedAccountId})} onClick={() => switchAccount(account.id)}>
+                            <div key={account.id} className={classNames("account", { selected: account.id === selectedAccountId})} onClick={() => switchAccount(account.id)} title={account.display_name ? account.display_name : (account.addr ? account.addr : '')}>
                                 <Avatar
                                     displayName={account.display_name === null ? '' : account.display_name}
                                     avatarPath={account.profile_image === null ? undefined : account.profile_image}

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -83,7 +83,8 @@ export default function AccountSidebar({
       <div
         key='add'
         className='account'
-        onClick={() => {
+        onClick={async () => {
+          await DeltaBackend.call('login.logout')
           window.__changeScreen(Screens.Login)
         }}
       >

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -1,22 +1,35 @@
-import React from "react";
-import { DeltaChatAccount } from "../../shared/shared-types";
+import React, {useCallback} from "react";
+import { DeltaChatAccount, FullChat } from "../../shared/shared-types";
+import {DeltaBackend} from "../delta-remote";
 import ScreenController, { Screens } from "../ScreenController";
 import { Avatar } from "./Avatar";
-import { PseudoListItemAddContact } from "./helpers/PseudoListItem";
+import {unselectChat} from "./helpers/ChatMethods";
 
 export default function AccountSidebar ({
+    selectedChat,
     selectAccount,
     logins,
   }: {
+    selectedChat: FullChat | null,
     selectAccount: typeof ScreenController.prototype.selectAccount,
     logins: DeltaChatAccount[] | null
   }) {
+    const switchAccount = useCallback(async (accountId: number) => {
+      if (selectedChat) {
+        unselectChat()
+      }
+      await DeltaBackend.call('login.logout')
+      window.__changeScreen(Screens.Accounts)
+      selectAccount(accountId)
+      window.__changeScreen(Screens.Main)
+
+    }, [selectedChat])
     return (
         <div className="account-sidebar">
                 {logins !== null && logins.map(account => {
                     if (account.type === 'unconfigured') return null
                     return (
-                            <div className="account" onClick={() => selectAccount(account.id)}>
+                            <div className="account" onClick={() => switchAccount(account.id)}>
                                 <Avatar
                                     displayName={account.display_name === null ? '' : account.display_name}
                                     avatarPath={account.profile_image === null ? undefined : account.profile_image}

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -19,11 +19,8 @@ export default function AccountSidebar ({
         unselectChat()
       }
       await DeltaBackend.call('login.logout')
-      window.__changeScreen(Screens.Accounts)
       selectAccount(accountId)
-      window.__changeScreen(Screens.Main)
-
-    }, [selectedChat])
+    }, [selectedChat, selectAccount])
     return (
         <div className="account-sidebar">
                 {logins !== null && logins.map(account => {

--- a/src/renderer/components/AccountSidebar.tsx
+++ b/src/renderer/components/AccountSidebar.tsx
@@ -1,60 +1,94 @@
-import classNames from "classnames";
-import React, {useCallback, useRef} from "react";
-import { DeltaChatAccount, FullChat } from "../../shared/shared-types";
-import {DeltaBackend} from "../delta-remote";
-import ScreenController, { Screens } from "../ScreenController";
-import { Avatar } from "./Avatar";
-import {unselectChat} from "./helpers/ChatMethods";
+import classNames from 'classnames'
+import React, { useCallback, useRef } from 'react'
+import { DeltaChatAccount, FullChat } from '../../shared/shared-types'
+import { DeltaBackend } from '../delta-remote'
+import ScreenController, { Screens } from '../ScreenController'
+import { Avatar } from './Avatar'
+import { unselectChat } from './helpers/ChatMethods'
 
-export default function AccountSidebar ({
-    selectedChat,
-    selectAccount,
-    selectedAccountId,
-    logins,
-  }: {
-    selectedChat: FullChat | null,
-    selectAccount: typeof ScreenController.prototype.selectAccount,
-    selectedAccountId: number | undefined,
-    logins: DeltaChatAccount[] | null
-  }) {
-    const accountSidebarRef = useRef<HTMLDivElement>(null)
-    const toggleHideScrollbar = useCallback((show: boolean) => {
+export default function AccountSidebar({
+  selectedChat,
+  selectAccount,
+  selectedAccountId,
+  logins,
+}: {
+  selectedChat: FullChat | null
+  selectAccount: typeof ScreenController.prototype.selectAccount
+  selectedAccountId: number | undefined
+  logins: DeltaChatAccount[] | null
+}) {
+  const accountSidebarRef = useRef<HTMLDivElement>(null)
+  const toggleHideScrollbar = useCallback(
+    (show: boolean) => {
       if (accountSidebarRef.current === null) return
 
-      show === true ?
-        accountSidebarRef.current.classList.remove('hideScrollbarThumb') :
-        accountSidebarRef.current.classList.add('hideScrollbarThumb')
+      show === true
+        ? accountSidebarRef.current.classList.remove('hideScrollbarThumb')
+        : accountSidebarRef.current.classList.add('hideScrollbarThumb')
+    },
+    [accountSidebarRef]
+  )
 
-    }, [accountSidebarRef])
-
-    const switchAccount = useCallback(async (accountId: number) => {
+  const switchAccount = useCallback(
+    async (accountId: number) => {
       if (selectedChat) {
         unselectChat()
       }
       await DeltaBackend.call('login.logout')
       selectAccount(accountId)
-    }, [selectedChat, selectAccount])
-    return (
-        <div className="account-sidebar hideScrollbarThumb" ref={accountSidebarRef} onMouseEnter={() => { toggleHideScrollbar(true)} } onMouseLeave={() => toggleHideScrollbar(false)}>
-                {logins !== null && logins.map(account => {
-                    if (account.type === 'unconfigured') return null
-                    return (
-                            <div key={account.id} className={classNames("account", { selected: account.id === selectedAccountId})} onClick={() => switchAccount(account.id)} title={account.display_name ? account.display_name : (account.addr ? account.addr : '')}>
-                                <Avatar
-                                    displayName={account.display_name === null ? '' : account.display_name}
-                                    avatarPath={account.profile_image === null ? undefined : account.profile_image}
-                                    color={account.color}
-                                />
-                            </div>
-                    )
-                })}
-            <div key="add" className="account" onClick={() => {window.__changeScreen(Screens.Login)}}>
-                <Avatar
-                    avatarPath={undefined}
-                    color={'#505050'}
-                    displayName={"+"}
-                />
+    },
+    [selectedChat, selectAccount]
+  )
+  return (
+    <div
+      className='account-sidebar hideScrollbarThumb'
+      ref={accountSidebarRef}
+      onMouseEnter={() => {
+        toggleHideScrollbar(true)
+      }}
+      onMouseLeave={() => toggleHideScrollbar(false)}
+    >
+      {logins !== null &&
+        logins.map(account => {
+          if (account.type === 'unconfigured') return null
+          return (
+            <div
+              key={account.id}
+              className={classNames('account', {
+                selected: account.id === selectedAccountId,
+              })}
+              onClick={() => switchAccount(account.id)}
+              title={
+                account.display_name
+                  ? account.display_name
+                  : account.addr
+                  ? account.addr
+                  : ''
+              }
+            >
+              <Avatar
+                displayName={
+                  account.display_name === null ? '' : account.display_name
+                }
+                avatarPath={
+                  account.profile_image === null
+                    ? undefined
+                    : account.profile_image
+                }
+                color={account.color}
+              />
             </div>
-        </div>
-    )
+          )
+        })}
+      <div
+        key='add'
+        className='account'
+        onClick={() => {
+          window.__changeScreen(Screens.Login)
+        }}
+      >
+        <Avatar avatarPath={undefined} color={'#505050'} displayName={'+'} />
+      </div>
+    </div>
+  )
 }

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -98,12 +98,13 @@ export function ChatListPart({
 }
 
 export default function ChatList(props: {
+  selectedAccountId: number | undefined
   selectedChatId: number | null
   showArchivedChats: boolean
   queryStr?: string
   onChatClick: (chatId: number) => void
 }) {
-  const { selectedChatId, showArchivedChats, onChatClick, queryStr } = props
+  const { selectedAccountId, selectedChatId, showArchivedChats, onChatClick, queryStr } = props
   const isSearchActive = queryStr !== ''
 
   const {
@@ -118,11 +119,14 @@ export default function ChatList(props: {
     queryStrIsValidEmail,
   } = useContactAndMessageLogic(queryStr)
 
-  const { chatListIds, isChatLoaded, loadChats, chatCache } = useLogicChatPart(
+  const { chatListIds, isChatLoaded, loadChats, chatCache, refresh } = useLogicChatPart(
     queryStr,
     showArchivedChats
   )
 
+  useEffect(() => {
+    refresh()
+  }, [selectedAccountId, refresh])
   const openContextMenu = useChatListContextMenu()
 
   const addContactOnClick = async () => {
@@ -501,7 +505,7 @@ function useLogicChatPart(
   queryStr: string | undefined,
   showArchivedChats: boolean
 ) {
-  const { chatListIds, setQueryStr, setListFlags } = useChatList()
+  const { chatListIds, setQueryStr, setListFlags, refresh } = useChatList()
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
     chatListIds
   )
@@ -519,7 +523,7 @@ function useLogicChatPart(
     [showArchivedChats, queryStr, setListFlags]
   )
 
-  return { chatListIds, isChatLoaded, loadChats, chatCache }
+  return { chatListIds, isChatLoaded, loadChats, chatCache, refresh }
 }
 
 function useContactAndMessageLogic(queryStr: string | undefined) {

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -104,7 +104,13 @@ export default function ChatList(props: {
   queryStr?: string
   onChatClick: (chatId: number) => void
 }) {
-  const { selectedAccountId, selectedChatId, showArchivedChats, onChatClick, queryStr } = props
+  const {
+    selectedAccountId,
+    selectedChatId,
+    showArchivedChats,
+    onChatClick,
+    queryStr,
+  } = props
   const isSearchActive = queryStr !== ''
 
   const {
@@ -119,10 +125,13 @@ export default function ChatList(props: {
     queryStrIsValidEmail,
   } = useContactAndMessageLogic(queryStr)
 
-  const { chatListIds, isChatLoaded, loadChats, chatCache, refresh } = useLogicChatPart(
-    queryStr,
-    showArchivedChats
-  )
+  const {
+    chatListIds,
+    isChatLoaded,
+    loadChats,
+    chatCache,
+    refresh,
+  } = useLogicChatPart(queryStr, showArchivedChats)
 
   useEffect(() => {
     refresh()

--- a/src/renderer/components/chat/ChatListHelpers.tsx
+++ b/src/renderer/components/chat/ChatListHelpers.tsx
@@ -81,8 +81,8 @@ export function useChatList(
       'useChatList: listFlags, queryStr or queryContactId changed, refetching chatlistids'
     )
 
-      log.debug('useChatList: refetchingChatlist')
-      debouncedGetChatListEntries(listFlags, queryStr, queryContactId)
+    log.debug('useChatList: refetchingChatlist')
+    debouncedGetChatListEntries(listFlags, queryStr, queryContactId)
 
     debouncedGetChatListEntries(listFlags, queryStr, queryContactId)
   }, [debouncedGetChatListEntries, listFlags, queryContactId, queryStr])
@@ -102,6 +102,6 @@ export function useChatList(
     setQueryStr,
     queryContactId,
     setQueryContactId,
-    refresh
+    refresh,
   }
 }

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -323,6 +323,10 @@ export default function Settings(props: DialogProps) {
           <Card elevation={Elevation.ONE}>
             <H5>{tx('pref_experimental_features')}</H5>
             {renderDTSettingSwitch(
+              'showAccountSidebar',
+              tx('menu_show_account_sidebar')
+            )}
+            {renderDTSettingSwitch(
               'enableOnDemandLocationStreaming',
               tx('pref_on_demand_location_streaming')
             )}

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -25,7 +25,7 @@ import { getLogger } from '../../../shared/logger'
 import SettingsCommunication from './Settings-Communication'
 import { runtime } from '../../runtime'
 import SettingsDownloadOnDemand from './Settings-DownloadOnDemand'
-import {ThemeManager} from '../../ThemeManager'
+import { ThemeManager } from '../../ThemeManager'
 
 const log = getLogger('renderer/dialogs/Settings')
 

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -25,6 +25,7 @@ import { getLogger } from '../../../shared/logger'
 import SettingsCommunication from './Settings-Communication'
 import { runtime } from '../../runtime'
 import SettingsDownloadOnDemand from './Settings-DownloadOnDemand'
+import {ThemeManager} from '../../ThemeManager'
 
 const log = getLogger('renderer/dialogs/Settings')
 
@@ -162,6 +163,9 @@ export default function Settings(props: DialogProps) {
       true
     ) {
       setDesktopSetting(key, value)
+    }
+    if (key === 'showAccountSidebar') {
+      ThemeManager.refresh()
     }
   }
 

--- a/src/renderer/components/screens/AccountsScreen.tsx
+++ b/src/renderer/components/screens/AccountsScreen.tsx
@@ -146,11 +146,14 @@ const ScanQRCodeButton = React.memo(function ScanQRCode(_) {
 
 export default function AccountsScreen({
   selectAccount,
+  logins,
+  refreshAccounts
 }: {
-  selectAccount: typeof ScreenController.prototype.selectAccount
+  selectAccount: typeof ScreenController.prototype.selectAccount,
+  logins: DeltaChatAccount[] | null
+  refreshAccounts: () => Promise<void>
 }) {
   const tx = useTranslationFunction()
-  const [logins, setLogins] = useState<DeltaChatAccount[] | null>(null)
 
   const [syncAllAccounts, setSyncAllAccounts] = useState<boolean | null>(null)
 
@@ -163,24 +166,6 @@ export default function AccountsScreen({
     })()
   }, [])
 
-  const refreshAccounts = async () => {
-    const logins = await DeltaBackend.call('login.getAllAccounts')
-    setLogins(logins)
-  }
-
-  useEffect(() => {
-    let mounted = true
-    ;(async () => {
-      const logins = await DeltaBackend.call('login.getAllAccounts')
-      if (mounted === true) {
-        setLogins(logins)
-      }
-    })()
-
-    return () => {
-      mounted = false
-    }
-  }, [])
 
   const addAccount = async () => {
     const accountId = await DeltaBackend.call('login.addAccount')

--- a/src/renderer/components/screens/AccountsScreen.tsx
+++ b/src/renderer/components/screens/AccountsScreen.tsx
@@ -147,9 +147,9 @@ const ScanQRCodeButton = React.memo(function ScanQRCode(_) {
 export default function AccountsScreen({
   selectAccount,
   logins,
-  refreshAccounts
+  refreshAccounts,
 }: {
-  selectAccount: typeof ScreenController.prototype.selectAccount,
+  selectAccount: typeof ScreenController.prototype.selectAccount
   logins: DeltaChatAccount[] | null
   refreshAccounts: () => Promise<void>
 }) {
@@ -165,7 +165,6 @@ export default function AccountsScreen({
       setSyncAllAccounts(desktopSettings.syncAllAccounts)
     })()
   }, [])
-
 
   const addAccount = async () => {
     const accountId = await DeltaBackend.call('login.addAccount')

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -172,7 +172,7 @@ export default function MainScreen({
   // compares with showArchivedChats twice.
   return (
     <div className='main-screen'>
-      <AccountSidebar logins={logins} selectAccount={selectAccount}/>
+      <AccountSidebar selectedChat={selectedChat.chat} logins={logins} selectAccount={selectAccount}/>
       <div className='navbar-wrapper'>
         <Navbar fixedToTop>
           <NavbarGroup align={Alignment.LEFT}>

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -191,7 +191,13 @@ export default function MainScreen({
   // compares with showArchivedChats twice.
   return (
     <div className='main-screen'>
-      <AccountSidebar selectedAccountId={selectedAccountId} selectedChat={selectedChat.chat} logins={logins} selectAccount={selectAccount}/>
+      <SettingsContext.Consumer>
+        {({ desktopSettings }) =>
+          desktopSettings?.showAccountSidebar ?
+            <AccountSidebar selectedAccountId={selectedAccountId} selectedChat={selectedChat.chat} logins={logins} selectAccount={selectAccount}/> :
+            null
+        }
+      </SettingsContext.Consumer>
       <div className='navbar-wrapper'>
         <Navbar fixedToTop>
           <NavbarGroup align={Alignment.LEFT}>

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -36,8 +36,10 @@ import ConnectivityToast from '../ConnectivityToast'
 import { C } from 'deltachat-node/dist/constants'
 import MapComponent from '../map/MapComponent'
 import MailingListProfile from '../dialogs/MessageListProfile'
-import { FullChat } from '../../../shared/shared-types'
+import { DeltaChatAccount, FullChat } from '../../../shared/shared-types'
 import { getLogger } from '../../../shared/logger'
+import AccountSidebar from '../AccountSidebar'
+import ScreenController from '../../ScreenController'
 
 const log = getLogger('renderer/main-screen')
 
@@ -47,7 +49,13 @@ export enum View {
   Map,
 }
 
-export default function MainScreen() {
+export default function MainScreen({
+  selectAccount,
+  logins,
+}: {
+  selectAccount: typeof ScreenController.prototype.selectAccount,
+  logins: DeltaChatAccount[] | null
+}) {
   const [queryStr, setQueryStr] = useState('')
   const [view, setView] = useState(View.MessageList)
   window.__setMainScreenView = setView
@@ -164,6 +172,7 @@ export default function MainScreen() {
   // compares with showArchivedChats twice.
   return (
     <div className='main-screen'>
+      <AccountSidebar logins={logins} selectAccount={selectAccount}/>
       <div className='navbar-wrapper'>
         <Navbar fixedToTop>
           <NavbarGroup align={Alignment.LEFT}>

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -191,7 +191,7 @@ export default function MainScreen({
   // compares with showArchivedChats twice.
   return (
     <div className='main-screen'>
-      <AccountSidebar selectedChat={selectedChat.chat} logins={logins} selectAccount={selectAccount}/>
+      <AccountSidebar selectedAccountId={selectedAccountId} selectedChat={selectedChat.chat} logins={logins} selectAccount={selectAccount}/>
       <div className='navbar-wrapper'>
         <Navbar fixedToTop>
           <NavbarGroup align={Alignment.LEFT}>

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useRef } from 'react'
+import React, { useState, useContext, useRef, useEffect, useCallback } from 'react'
 import {
   ScreenContext,
   SettingsContext,
@@ -49,15 +49,34 @@ export enum View {
   Map,
 }
 
+
+//create your forceUpdate hook
+function useForceUpdate(){
+    const [_value, setValue] = useState(0); // integer state
+    const forceUpdate = useCallback(() => {
+      () => setValue(value => value + 1)
+    }, [])
+    return forceUpdate; // update the state to force render
+}
+
 export default function MainScreen({
+  selectedAccountId,
   selectAccount,
   logins,
 }: {
+  selectedAccountId: number | undefined,
   selectAccount: typeof ScreenController.prototype.selectAccount,
   logins: DeltaChatAccount[] | null
 }) {
   const [queryStr, setQueryStr] = useState('')
   const [view, setView] = useState(View.MessageList)
+  const forceRerender = useForceUpdate()
+
+  useEffect(() => {
+    log.debug("selectedAccountId changed, force rerender")
+    forceRerender()
+    setFirstLoad(true)
+  }, [forceRerender, selectedAccountId])
   window.__setMainScreenView = setView
   const [showArchivedChats, setShowArchivedChats] = useState(false)
   // Small hack/misuse of keyBindingAction to setShowArchivedChats from other components (especially
@@ -294,6 +313,7 @@ export default function MainScreen({
       </div>
       <div>
         <ChatList
+          selectedAccountId={selectedAccountId}
           queryStr={queryStr}
           showArchivedChats={showArchivedChats}
           onChatClick={onChatClick}

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -1,4 +1,10 @@
-import React, { useState, useContext, useRef, useEffect, useCallback } from 'react'
+import React, {
+  useState,
+  useContext,
+  useRef,
+  useEffect,
+  useCallback,
+} from 'react'
 import {
   ScreenContext,
   SettingsContext,
@@ -49,14 +55,13 @@ export enum View {
   Map,
 }
 
-
 //create your forceUpdate hook
-function useForceUpdate(){
-    const [_value, setValue] = useState(0); // integer state
-    const forceUpdate = useCallback(() => {
-      () => setValue(value => value + 1)
-    }, [])
-    return forceUpdate; // update the state to force render
+function useForceUpdate() {
+  const [_value, setValue] = useState(0) // integer state
+  const forceUpdate = useCallback(() => {
+    ;() => setValue(value => value + 1)
+  }, [])
+  return forceUpdate // update the state to force render
 }
 
 export default function MainScreen({
@@ -64,8 +69,8 @@ export default function MainScreen({
   selectAccount,
   logins,
 }: {
-  selectedAccountId: number | undefined,
-  selectAccount: typeof ScreenController.prototype.selectAccount,
+  selectedAccountId: number | undefined
+  selectAccount: typeof ScreenController.prototype.selectAccount
   logins: DeltaChatAccount[] | null
 }) {
   const [queryStr, setQueryStr] = useState('')
@@ -73,7 +78,7 @@ export default function MainScreen({
   const forceRerender = useForceUpdate()
 
   useEffect(() => {
-    log.debug("selectedAccountId changed, force rerender")
+    log.debug('selectedAccountId changed, force rerender')
     forceRerender()
     setFirstLoad(true)
   }, [forceRerender, selectedAccountId])
@@ -193,9 +198,14 @@ export default function MainScreen({
     <div className='main-screen'>
       <SettingsContext.Consumer>
         {({ desktopSettings }) =>
-          desktopSettings?.showAccountSidebar ?
-            <AccountSidebar selectedAccountId={selectedAccountId} selectedChat={selectedChat.chat} logins={logins} selectAccount={selectAccount}/> :
-            null
+          desktopSettings?.showAccountSidebar ? (
+            <AccountSidebar
+              selectedAccountId={selectedAccountId}
+              selectedChat={selectedChat.chat}
+              logins={logins}
+              selectAccount={selectAccount}
+            />
+          ) : null
         }
       </SettingsContext.Consumer>
       <div className='navbar-wrapper'>

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -49,6 +49,7 @@ export interface DesktopSettingsType {
   activeTheme: string
   minimizeToTray: boolean
   syncAllAccounts: boolean
+  showAccountSidebar: boolean
 }
 
 export interface RC_Config {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -22,7 +22,7 @@ export function getDefaultState(): DesktopSettingsType {
       activeTheme: 'system',
       minimizeToTray: false,
       syncAllAccounts: true,
-      showAccountSidebar: false
+      showAccountSidebar: false,
     },
     logins: [],
   }

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -5,21 +5,25 @@ export function getDefaultState(): DesktopSettingsType {
    * Persisted state. Must be JSON.
    */
   return {
-    bounds: {},
-    enterKeySends: true,
-    notifications: true,
-    showNotificationContent: true,
-    locale: null, // if this is null, the system chooses the system language electron reports
-    credentials: undefined,
-    lastAccount: undefined,
-    enableAVCalls: false,
-    enableChatAuditLog: false,
-    enableOnDemandLocationStreaming: false,
-    chatViewBgImg: undefined,
-    lastChats: {},
-    zoomFactor: 1,
-    activeTheme: 'system',
-    minimizeToTray: false,
-    syncAllAccounts: true,
+    saved: {
+      bounds: {},
+      enterKeySends: false,
+      notifications: true,
+      showNotificationContent: true,
+      locale: null, // if this is null, the system chooses the system language electron reports
+      credentials: undefined,
+      lastAccount: undefined,
+      enableAVCalls: false,
+      enableChatAuditLog: false,
+      enableOnDemandLocationStreaming: false,
+      chatViewBgImg: undefined,
+      lastChats: {},
+      zoomFactor: 1,
+      activeTheme: 'system',
+      minimizeToTray: false,
+      syncAllAccounts: true,
+      showAccountSidebar: false
+    },
+    logins: [],
   }
 }

--- a/static/main.html
+++ b/static/main.html
@@ -19,6 +19,7 @@
     <link rel="stylesheet" href="main.css" />
     <link rel="stylesheet" href="fallback-theme.css" />
     <style id="theme-vars"></style>
+    <style id="global-vars"></style>
   </head>
   <body>
     <div id='root'></div>


### PR DESCRIPTION
Small hacking session with @Jikstra :) (I don't really know typescript)

- [x] messagelist doesn't update yet when switching account
- [x] "connecting..." toast needs to be margin-lefted or overlayed
- [x] some account changes don't work yet
- [x] + icon to add more accounts
- [x] add experimental feature flag
- [x] highlight selected account
- [ ] account_add is broken; it reconfigures the currently selected account instead of creating a new one.
- [ ] the sidebar doesn't refresh, when an account is added.


![Screenshot_20220222_003847](https://user-images.githubusercontent.com/34889164/155038790-78f98519-5a96-49a9-a92c-b5765b90a663.png)


Fixes https://github.com/deltachat/deltachat-desktop/issues/2331

