### PR TITLE
Fix ghost message pages

### DIFF
--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -198,7 +198,7 @@ export type ConversationType = {
   chatType: ChatTypes
 }
 
-export const MessageListInner = 
+export const MessageListInner = React.memo(
   (props: {
     onScroll: (event: React.UIEvent<HTMLDivElement>) => void
     oldestFetchedMessageIndex: number
@@ -261,9 +261,19 @@ export const MessageListInner =
         </ul>
       </div>
     )
-  }
+  },
+  (prevProps, nextProps) => {
+    const areEqual =
+      prevProps.messageIds === nextProps.messageIds &&
+      prevProps.messagePages === nextProps.messagePages &&
+      prevProps.oldestFetchedMessageIndex ===
+        nextProps.oldestFetchedMessageIndex
 
-const MessagePageComponent = 
+    return areEqual
+  }
+)
+
+const MessagePageComponent = React.memo(
   function MessagePageComponent({
     messagePage,
     conversationType,
@@ -305,7 +315,15 @@ const MessagePageComponent =
         {messageElements}
       </div>
     )
+  },
+  (prevProps, nextProps) => {
+    const areEqual =
+      prevProps.messagePage.pageKey === nextProps.messagePage.pageKey &&
+      prevProps.messagePage.messages === nextProps.messagePage.messages
+
+    return areEqual
   }
+)
 
 function EmptyChatMessage() {
   const tx = useTranslationFunction()

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -43,9 +43,11 @@ const defaultState: ChatStoreState = {
 class ChatStore extends Store<ChatStoreState> {
   isLocked = false
   guardReducerTriesToAddDuplicatePageKey(pageKeyToAdd: string) {
-    const isDuplicatePageKey = this.state.messagePages.findIndex(messagePage => messagePage.pageKey === pageKeyToAdd) !== -1
+    const isDuplicatePageKey =
+      this.state.messagePages.findIndex(
+        messagePage => messagePage.pageKey === pageKeyToAdd
+      ) !== -1
     return isDuplicatePageKey
-
   }
   guardReducerIfChatIdIsDifferent(payload: { id: number }) {
     if (
@@ -138,7 +140,10 @@ class ChatStore extends Store<ChatStoreState> {
         }
 
         if (this.guardReducerTriesToAddDuplicatePageKey(incomingPageKey)) {
-          throw new Error('We almost added the same page twice! We should prevent this in code duplicate pageKey: ' + incomingPageKey)
+          throw new Error(
+            'We almost added the same page twice! We should prevent this in code duplicate pageKey: ' +
+              incomingPageKey
+          )
         }
 
         if (this.guardReducerIfChatIdIsDifferent(payload)) return

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -42,6 +42,11 @@ const defaultState: ChatStoreState = {
 
 class ChatStore extends Store<ChatStoreState> {
   isLocked = false
+  guardReducerTriesToAddDuplicatePageKey(pageKeyToAdd: string) {
+    const isDuplicatePageKey = this.state.messagePages.findIndex(messagePage => messagePage.pageKey === pageKeyToAdd) !== -1
+    return isDuplicatePageKey
+
+  }
   guardReducerIfChatIdIsDifferent(payload: { id: number }) {
     if (
       typeof payload.id !== 'undefined' &&
@@ -119,8 +124,9 @@ class ChatStore extends Store<ChatStoreState> {
           }
         }) as OrderedMap<number, MessageType | null>
 
+        const incomingPageKey = calculatePageKey(messages)
         const incomingMessagePage: MessagePage = {
-          pageKey: calculatePageKey(messages),
+          pageKey: incomingPageKey,
           messages,
         }
 
@@ -131,7 +137,12 @@ class ChatStore extends Store<ChatStoreState> {
           scrollToBottomIfClose: true,
         }
 
+        if (this.guardReducerTriesToAddDuplicatePageKey(incomingPageKey)) {
+          throw new Error('We almost added the same page twice! We should prevent this in code duplicate pageKey: ' + incomingPageKey)
+        }
+
         if (this.guardReducerIfChatIdIsDifferent(payload)) return
+
         return modifiedState
       }, 'fetchedIncomingMessages')
     },


### PR DESCRIPTION
This adds a guard to make sure we're not adding already existing pages to the store. The better way to prevent this, is by either filter duplicate actions/effects (maybe we can be smarter about this) or checking it way before. But this guard is good to prevent this shit from happening again.