### PR TITLE
upgrade error-stack-parser to 2.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Copying image now possible from gallery and chat view
 - Removed options to watch inbox and Deltachat folder from advanced settings
 - Added option to only watch Deltachat folder to advanced settings
+- Update error-stack-parser to 2.0.7
 
 ### Fixed
 - Fix overflow in long links inside quotes @naomiceron #2467

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "emoji-js-clean": "^4.0.0",
         "emoji-mart": "^3.0.0",
         "emoji-regex": "^9.2.2",
-        "error-stack-parser": "^2.0.6",
+        "error-stack-parser": "^2.0.7",
         "filesize": "^8.0.6",
         "immutable": "^4.0.0",
         "mapbox-gl": "^1.12.0",
@@ -38,6 +38,7 @@
         "react-window-infinite-loader": "^1.0.7",
         "react-zoom-pan-pinch": "^2.1.3",
         "source-map-support": "^0.5.19",
+        "stackframe": "^1.2.1",
         "tempy": "^0.3.0",
         "url-parse": "^1.5.3",
         "use-debounce": "^3.3.0"
@@ -7517,9 +7518,9 @@
       }
     },
     "node_modules/error-stack-parser": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
+      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
       "dependencies": {
         "stackframe": "^1.1.1"
       }
@@ -14604,9 +14605,9 @@
       }
     },
     "node_modules/stackframe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
+      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
     },
     "node_modules/stat-mode": {
       "version": "1.0.0",
@@ -24935,9 +24936,9 @@
       }
     },
     "error-stack-parser": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
+      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
       "requires": {
         "stackframe": "^1.1.1"
       }
@@ -30873,9 +30874,9 @@
       }
     },
     "stackframe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
+      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
     },
     "stat-mode": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "emoji-js-clean": "^4.0.0",
     "emoji-mart": "^3.0.0",
     "emoji-regex": "^9.2.2",
-    "error-stack-parser": "^2.0.6",
+    "error-stack-parser": "^2.0.7",
     "filesize": "^8.0.6",
     "immutable": "^4.0.0",
     "mapbox-gl": "^1.12.0",
@@ -104,6 +104,7 @@
     "react-window-infinite-loader": "^1.0.7",
     "react-zoom-pan-pinch": "^2.1.3",
     "source-map-support": "^0.5.19",
+    "stackframe": "^1.2.1",
     "tempy": "^0.3.0",
     "url-parse": "^1.5.3",
     "use-debounce": "^3.3.0"

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,4 +1,5 @@
-import errorStackParser, { StackFrame } from 'error-stack-parser'
+import errorStackParser from 'error-stack-parser'
+import StackFrame from 'stackframe'
 import { RC_Config } from './shared-types'
 
 const startTime = Date.now()


### PR DESCRIPTION
StackFrame is not exported anymore:
https://github.com/stacktracejs/error-stack-parser/pull/54#commitcomment-66531802