### PR TITLE
Webxdc keep dom storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- webxdc content now has access to persistent DOMStorage
 ### Fixed
 - Fix missing key login_socks5_login
 - Fix creating contacts from email address in message

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -106,6 +106,8 @@ export default class DCLoginController extends SplitOut {
 
     if (this.accounts.removeAccount(accountId) !== 1) {
       throw new Error('Account deletion failed')
+    } else {
+      this.controller.webxdc._deleteWebxdcAccountData(accountId)
     }
   }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -79,6 +79,7 @@ import * as devTools from './devtools'
 import { ExtendedAppMainProcess } from './types'
 import { updateTrayIcon, hideDeltaChat, showDeltaChat } from './tray'
 import { acceptThemeCLI } from './themes'
+import { webxdcStartUpCleanup } from './deltachat/webxdc'
 
 app.ipcReady = false
 app.isQuitting = false
@@ -87,6 +88,7 @@ Promise.all([
   new Promise((resolve, _reject) => app.on('ready', resolve)),
   DesktopSettings.load(),
   findOutIfWeAreRunningAsAppx(),
+  webxdcStartUpCleanup(),
 ])
   .then(onReady)
   .catch(error => {
@@ -95,7 +97,12 @@ Promise.all([
     process.exit(1)
   })
 
-async function onReady([_appReady, _loadedState, _]: [any, any, any]) {
+async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
+  any,
+  any,
+  any,
+  any
+]) {
   // can fail due to user error so running it first is better (cli argument)
   acceptThemeCLI()
 

--- a/src/renderer/components/dialogs/Settings-Webxdc.tsx
+++ b/src/renderer/components/dialogs/Settings-Webxdc.tsx
@@ -1,0 +1,68 @@
+import React, { useCallback, useContext, useEffect, useState } from 'react'
+import { Card, Elevation, H5 } from '@blueprintjs/core'
+import filesizeConverter from 'filesize'
+import { ScreenContext } from '../../contexts'
+
+import { DeltaBackend } from '../../delta-remote'
+import ConfirmationDialog from './ConfirmationDialog'
+
+export default function SettingsWebxdc() {
+  const [usage, setUsage] = useState<{
+    total_size: number
+    data_size: number
+  } | null>(null)
+
+  const updateUsage = useCallback(() => {
+    DeltaBackend.call('webxdc.getWebxdcDiskUsage').then(setUsage)
+  }, [])
+
+  useEffect(() => updateUsage(), [])
+
+  const { openDialog } = useContext(ScreenContext)
+  const tx = window.static_translate
+
+  const deleteData = () => {
+    openDialog(ConfirmationDialog, {
+      message:
+        "Delete all webxdc DOMStorage data, if you do that you might use some local settings of your webxdc's",
+      confirmLabel: tx('delete'),
+      cb: yes =>
+        yes &&
+        DeltaBackend.call('webxdc.clearWebxdcDOMStorage').then(updateUsage),
+    })
+  }
+
+  const resetWebxdcSession = () =>
+    DeltaBackend.call('webxdc.deleteWebxdcAccountData')
+
+  return (
+    <>
+      <Card elevation={Elevation.ONE}>
+        <H5>{'Local Webxdc data usage'}</H5>
+        {!usage && tx('loading')}
+        {usage && (
+          <table>
+            <tbody>
+              <tr>
+                <td>DOMStorage</td>
+                <td>~{filesizeConverter(usage.data_size)}</td>
+                <td>
+                  <button onClick={deleteData}>Clear</button>
+                </td>
+              </tr>
+              <tr>
+                <td>Total:</td>
+                <td>{filesizeConverter(usage.total_size)}</td>
+                <td>
+                  <button onClick={resetWebxdcSession}>
+                    Hard Reset (restarts deltachat)
+                  </button>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </>
+  )
+}

--- a/src/renderer/components/dialogs/Settings-Webxdc.tsx
+++ b/src/renderer/components/dialogs/Settings-Webxdc.tsx
@@ -16,7 +16,7 @@ export default function SettingsWebxdc() {
     DeltaBackend.call('webxdc.getWebxdcDiskUsage').then(setUsage)
   }, [])
 
-  useEffect(() => updateUsage(), [])
+  useEffect(() => updateUsage(), [updateUsage])
 
   const { openDialog } = useContext(ScreenContext)
   const tx = window.static_translate

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -26,6 +26,7 @@ import { getLogger } from '../../../shared/logger'
 import SettingsCommunication from './Settings-Communication'
 import { runtime } from '../../runtime'
 import SettingsDownloadOnDemand from './Settings-DownloadOnDemand'
+import SettingsWebxdc from './Settings-Webxdc'
 
 const log = getLogger('renderer/dialogs/Settings')
 
@@ -313,6 +314,7 @@ export default function Settings(props: DialogProps) {
           />
           <SettingsManageKeys />
           <SettingsBackup />
+          <SettingsWebxdc />
         </DeltaDialogBody>
       </>
     )

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -357,6 +357,15 @@ class DeltaRemote {
   call(fnName: 'extras.getAvailableThemes'): Promise<Theme[]>
   call(fnName: 'extras.setTheme', address: string): Promise<boolean>
   call(fnName: 'extras.writeClipboardToTempFile'): Promise<string>
+  // webxdc: ------------------------------------------------------------
+  call(fnName: 'webxdc.clearWebxdcDOMStorage'): Promise<void>
+  call(
+    fnName: 'webxdc.getWebxdcDiskUsage'
+  ): Promise<{
+    total_size: number
+    data_size: number
+  }>
+  call(fnName: 'webxdc.deleteWebxdcAccountData'): Promise<void>
   // catchall: ----------------------------------------------------------
   call(fnName: string): Promise<any>
   call(fnName: string, ...args: any[]): Promise<any> {


### PR DESCRIPTION
- [X] clear webxdc data on account removal
- [X] option in settings to clear webxdc data for account
- ~~[ ] clear webxdc data when message is deleted (and also close the webxdc window if its still open)~~ moved to its own issue: #2630
- [x] rebase this pr

related: https://github.com/deltachat/deltachat-android/pull/2221