### PR TITLE
Disable get provider info as its blocking the ui sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Added option to only watch Deltachat folder to advanced settings
 - Update error-stack-parser to 2.0.7
 - Sending messages on pressing enter is now activated per default
+- Disabled fetching account provider info as it causes the ui to be blocked
 
 ### Fixed
 - Fix overflow in long links inside quotes @naomiceron #2467

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -452,7 +452,9 @@ export default class DeltaChatController extends EventEmitter {
     }
   }
 
-  getProviderInfo(_email: string) : ReturnType<typeof DeltaChat.getProviderFromEmail> {
+  getProviderInfo(
+    _email: string
+  ): ReturnType<typeof DeltaChat.getProviderFromEmail> {
     // TODO: Disabled until fixed in core
     /*if (DeltaChatNode.maybeValidAddr(email)) {
       return this.selectedAccountContext.getProviderFromEmail(email)

--- a/src/main/deltachat/controller.ts
+++ b/src/main/deltachat/controller.ts
@@ -452,8 +452,12 @@ export default class DeltaChatController extends EventEmitter {
     }
   }
 
-  getProviderInfo(email: string) {
-    return this.selectedAccountContext.getProviderFromEmail(email)
+  getProviderInfo(_email: string) : ReturnType<typeof DeltaChat.getProviderFromEmail> {
+    // TODO: Disabled until fixed in core
+    /*if (DeltaChatNode.maybeValidAddr(email)) {
+      return this.selectedAccountContext.getProviderFromEmail(email)
+    }*/
+    return
   }
 
   checkValidEmail(email: string) {

--- a/src/renderer/components/Login-Styles.tsx
+++ b/src/renderer/components/Login-Styles.tsx
@@ -137,13 +137,20 @@ export const DeltaInput = React.memo(
       onChange: (
         event: React.FormEvent<HTMLElement> &
           React.ChangeEvent<HTMLInputElement>
+      ) => void,
+      onBlur?: (
+        event: React.FormEvent<HTMLElement> &
+          React.FocusEvent<HTMLInputElement>
       ) => void
     }>
   ) => {
     const [isFocused, setIsFocused] = useState(false)
 
     const onFocus = () => setIsFocused(true)
-    const onBlur = () => setIsFocused(false)
+    const onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+      setIsFocused(false)
+      if(props.onBlur) props.onBlur(event)
+    }
     const showLabel =
       isFocused ||
       props.value?.length > 0 ||

--- a/src/renderer/components/Login-Styles.tsx
+++ b/src/renderer/components/Login-Styles.tsx
@@ -137,10 +137,9 @@ export const DeltaInput = React.memo(
       onChange: (
         event: React.FormEvent<HTMLElement> &
           React.ChangeEvent<HTMLInputElement>
-      ) => void,
+      ) => void
       onBlur?: (
-        event: React.FormEvent<HTMLElement> &
-          React.FocusEvent<HTMLInputElement>
+        event: React.FormEvent<HTMLElement> & React.FocusEvent<HTMLInputElement>
       ) => void
     }>
   ) => {
@@ -149,7 +148,7 @@ export const DeltaInput = React.memo(
     const onFocus = () => setIsFocused(true)
     const onBlur = (event: React.FocusEvent<HTMLInputElement>) => {
       setIsFocused(false)
-      if(props.onBlur) props.onBlur(event)
+      if (props.onBlur) props.onBlur(event)
     }
     const showLabel =
       isFocused ||

--- a/src/renderer/components/LoginForm.tsx
+++ b/src/renderer/components/LoginForm.tsx
@@ -148,6 +148,16 @@ export default function LoginForm({
       setProviderInfo(undefined)
       return
     }
+  }
+
+  const onEmailBlur = (
+    event: React.FormEvent<HTMLElement> & React.FocusEvent<HTMLInputElement>
+  ) => {
+    const email = event.target.value
+    if (email === '') {
+      setProviderInfo(undefined)
+      return
+    }
     debouncedGetProviderInfo(email)
   }
 
@@ -185,6 +195,7 @@ export default function LoginForm({
             disabled={addrDisabled}
             value={addr}
             onChange={onEmailChange}
+            onBlur={onEmailBlur}
           />
 
           <DeltaPasswordInput

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -34,11 +34,14 @@ class DeltaRemote {
   call(
     fnName: 'getProviderInfo',
     email: string
-  ): Promise<{
-    before_login_hint: string
-    overview_page: string
-    status: any
-  } | undefined>
+  ): Promise<
+    | {
+        before_login_hint: string
+        overview_page: string
+        status: any
+      }
+    | undefined
+  >
   call(fnName: 'checkValidEmail', email: string): Promise<boolean>
   call(fnName: 'joinSecurejoin', qrCode: string): Promise<number>
   call(fnName: 'stopOngoingProcess'): Promise<number>

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -38,7 +38,7 @@ class DeltaRemote {
     before_login_hint: string
     overview_page: string
     status: any
-  }>
+  } | undefined>
   call(fnName: 'checkValidEmail', email: string): Promise<boolean>
   call(fnName: 'joinSecurejoin', qrCode: string): Promise<number>
   call(fnName: 'stopOngoingProcess'): Promise<number>


### PR DESCRIPTION
Right now, especially with poor internet connection, deltachat blocks for an annoying amount of time when entering the email address when trying to add a new account. Therefore, before this is fixed in the core we want to disable the provider check. Afterwards we want to get the provider infos only when moving the focus away from the email input field, as we don't need to check it after every key hit.

Fixes https://github.com/deltachat/deltachat-desktop/issues/2506