### PR TITLE
added `Cmd ⌘ + Enter` as alias for `Ctrl + Enter` to send message when `Press Enter to Send` is deactivated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Added option to only watch Deltachat folder to advanced settings
 - Update error-stack-parser to 2.0.7
 - Sending messages on pressing enter is now activated per default
+- added `Command ⌘ + Enter` as alias for `Ctrl + Enter` to send message when `Press Enter to Send` is deactivated
 - Disabled fetching account provider info as it causes the ui to be blocked
 - migrate backend to strict typescript
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -10,8 +10,14 @@ Search contact list: `ctrl + k`
 
 Focus message composer: `ctrl + n`
 
-Open settings: `cmd + ,` or `ctrl + ,`
+Open settings: `cmd ⌘ + ,` or `ctrl + ,`
 
 Call MaybeNetwork (can help if deltachat doesn't detect that it is online again after resuming standby): `F5`
 
 Scroll up/down a page in the messagelist: `PageUp` and `PageDown`
+
+## Composer
+
+When `Press Enter to Send` is deactivated: `ctrl + enter` or `cmd ⌘ + enter` to send the message.
+
+When `Press Enter to Send` activated: `shift + enter` to add a newline instead of sending

--- a/src/renderer/components/composer/ComposerMessageInput.tsx
+++ b/src/renderer/components/composer/ComposerMessageInput.tsx
@@ -128,13 +128,13 @@ export default class ComposerMessageInput extends React.Component<
     const enterKeySends = this.props.enterKeySends
 
     // ENTER + SHIFT
-    if (e.keyCode === 13 && e.shiftKey) {
+    if (e.key === 'Enter' && e.shiftKey) {
       return 'NEWLINE'
       // ENTER + CTRL
-    } else if (e.keyCode === 13 && e.ctrlKey) {
+    } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       return 'SEND'
       // ENTER
-    } else if (e.keyCode === 13 && !e.shiftKey) {
+    } else if (e.key === 'Enter' && !e.shiftKey) {
       return enterKeySends ? 'SEND' : 'NEWLINE'
     }
   }


### PR DESCRIPTION
https://github.com/deltachat/deltachat-desktop/issues/2559#issuecomment-1052143842