### PR TITLE
fix error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - click on offline toast now opens the connectivity view
+- fix error object logging and make "core could not be loaded" error dialog more useful
 
 ## [1.27.0] - 2021-03-04
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,6 +9,7 @@ import { openHelpWindow } from './windows/help'
 import { join } from 'path'
 import { DesktopSettings } from './desktop_settings'
 import { getConfigPath } from './application-constants'
+import { inspect } from 'util'
 
 const log = getLogger('main/ipc')
 const DeltaChatController: typeof import('./deltachat/controller').default = (() => {
@@ -22,7 +23,14 @@ const DeltaChatController: typeof import('./deltachat/controller').default = (()
     )
     dialog.showErrorBox(
       'Fatal Error',
-      `The DeltaChat Module couldn't be loaded.\n Please check if all dependencies for deltachat-core are installed!\n The Log file is located in this folder: ${getLogsPath()}`
+      `The DeltaChat Module couldn't be loaded.
+ Please check if all dependencies for deltachat-core are installed!
+ The Log file is located in this folder: ${getLogsPath()}\n
+ ${
+   error instanceof Error
+     ? error.message
+     : inspect(error, { depth: null })
+ }`
     )
   }
 })()

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -26,11 +26,7 @@ const DeltaChatController: typeof import('./deltachat/controller').default = (()
       `The DeltaChat Module couldn't be loaded.
  Please check if all dependencies for deltachat-core are installed!
  The Log file is located in this folder: ${getLogsPath()}\n
- ${
-   error instanceof Error
-     ? error.message
-     : inspect(error, { depth: null })
- }`
+ ${error instanceof Error ? error.message : inspect(error, { depth: null })}`
     )
   }
 })()

--- a/src/renderer/experimental.ts
+++ b/src/renderer/experimental.ts
@@ -33,8 +33,8 @@ These functions are highly experimental, use at your own risk.
   }
 
   testErrorLogging() {
-    log.debug(new Error("a test error - should be logged to logfile"))
-    throw new Error("a test error - should be catched and logged to logfile");
+    log.debug(new Error('a test error - should be logged to logfile'))
+    throw new Error('a test error - should be catched and logged to logfile')
   }
 }
 

--- a/src/renderer/experimental.ts
+++ b/src/renderer/experimental.ts
@@ -31,6 +31,11 @@ These functions are highly experimental, use at your own risk.
     }
     log.info(`Imported ${contacts.length - error_count} contacts`)
   }
+
+  testErrorLogging() {
+    log.debug(new Error("a test error - should be logged to logfile"))
+    throw new Error("a test error - should be catched and logged to logfile");
+  }
 }
 
 export const exp = new Experimental()

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -46,10 +46,10 @@ export function startBackendLogging() {
 
   const log2 = getLogger('renderer')
   window.addEventListener('error', event => {
-    log2.error('Unhandled Error:', event)
+    log2.error('Unhandled Error:', event.error)
   })
   window.addEventListener('unhandledrejection', event => {
-    log2.error('Unhandled Rejection:', event)
+    log2.error('Unhandled Rejection:', event, event.reason)
   })
 }
 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -171,3 +171,19 @@ export class Logger {
 export function getLogger(channel: string) {
   return new Logger(channel)
 }
+
+// Fix for error not being able to be converted into json
+// From https://stackoverflow.com/a/18391400
+if (!('toJSON' in Error.prototype))
+  Object.defineProperty(Error.prototype, 'toJSON', {
+    value: function () {
+      var alt = {}
+      Object.getOwnPropertyNames(this).forEach(function (key) {
+        //@ts-ignore
+        alt[key] = this[key]
+      }, this)
+      return alt
+    },
+    configurable: true,
+    writable: true,
+  })


### PR DESCRIPTION
- fix error logging (error objects were not logged properly before) also show error message in core-coulnot-be-loaded dialog
- fix logging of catched errors

before:
```
2022-03-10T15:16:19.270Z	renderer/experiments  	DEBUG	""	{}
```

after:
```
2022-03-10T15:19:08.201Z	renderer/experiments  	DEBUG	""	{"stack":"Error: a test error - should be logged to logfile\n    at Experimental.testErrorLogging (file:///./src/renderer/experimental.ts:36:15)\n    at <anonymous>:1:5","message":"a test error - should be logged to logfile"}
```
