### PR TITLE
increase debounce timeout to one second

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Set default of enterKeySends to false again
 - remove webxdc clear domstorage settings for now until we know what we want (see https://github.com/deltachat/deltachat-desktop/issues/2638)
+- increase debounce timeout to one second
 
 ## [1.27.2] - 2022-03-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 - Set default of enterKeySends to false again
 - remove webxdc clear domstorage settings for now until we know what we want (see https://github.com/deltachat/deltachat-desktop/issues/2638)
-- increase debounce timeout to one second
+- increase composer draft saving debounce timeout to one second
 
 ## [1.27.2] - 2022-03-15
 

--- a/src/renderer/components/composer/ComposerMessageInput.tsx
+++ b/src/renderer/components/composer/ComposerMessageInput.tsx
@@ -48,7 +48,7 @@ export default class ComposerMessageInput extends React.Component<
     this.saveDraft = debounce(() => {
       const { text, chatId } = this.state
       this.props.updateDraftText(text, chatId)
-    }, 500)
+    }, 1000)
 
     this.textareaRef = React.createRef()
     this.focus = this.focus.bind(this)


### PR DESCRIPTION
this makes typing and long-pressing a key like backspace more smooth