### PR TITLE
remove wrong line from changelog in device msg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Changed
 - Update translations (25.03.2022)
 
+### Fixed
+- remove wrong line (about send on enter) from changelog in device msg
 
 ## [1.28.0] - 2022-03-25
 

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -141,8 +141,6 @@ export default class DCLoginController extends SplitOut {
 
 🖼️Images can now be copied from the context menu
 
-↩️Sending messages on pressing enter is now the default
-
 ✨Many bugfixes and improvements
 
 Full changelog: https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md#1270---2021-03-04`


### PR DESCRIPTION
I kept the version code (label of the device message) to not annoy users with a new device message