### PR TITLE
update react-string-replace to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Update translations (25.03.2022)
+- Update react-string-replace to `1.0.0`
 
 
 ## [1.28.0] - 2022-03-25

--- a/package-lock.json
+++ b/package-lock.json
@@ -8530,7 +8530,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -10705,12 +10706,9 @@
       }
     },
     "react-string-replace": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-0.4.4.tgz",
-      "integrity": "sha512-FAMkhxmDpCsGTwTZg7p/2v+/GTmxAp73so3fbSvlAcBBX36ujiGRNEaM/1u+jiYQrArhns+7eE92g2pi5E5FUA==",
-      "requires": {
-        "lodash": "^4.17.4"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/react-string-replace/-/react-string-replace-1.0.0.tgz",
+      "integrity": "sha512-+iLsyE4AeSmnfctgswXOf1PmKRgns6wJ4LVb+8ADMU6mDK3jvBE11QzfMQf7CYtPUUiBCDjZ9ZppzXOIYrzCRg=="
     },
     "react-transition-group": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "react-dom": "^17.0.2",
     "react-qr-reader": "^2.2.1",
     "react-qr-svg": "^2.1.0",
-    "react-string-replace": "^0.4.4",
+    "react-string-replace": "^1.0.0",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",


### PR DESCRIPTION
This turns lodash into a devDependency, removing 4.8 MiB from the package size.