### PR TITLE
fix #2647

### DIFF
--- a/scss/dialogs/_settings.scss
+++ b/scss/dialogs/_settings.scss
@@ -172,8 +172,8 @@
     background-color: unset;
     border: none;
 
-    text-align: center;
-    line-height: 40px;
+    text-align: left;
+    line-height: normal;
     color: var(--globalText);
   }
 


### PR DESCRIPTION
Modifying button label under SettingsSelector class to align left and have a normal height
This should fix #2647