### PR TITLE
update electron to 14.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - Update translations (25.03.2022)
 - Update react-string-replace to `1.0.0`
+- Update electron to `14.2.9`
 
 ### Fixed
 - remove wrong line (about send on enter) from changelog in device msg

--- a/package-lock.json
+++ b/package-lock.json
@@ -2771,9 +2771,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.1.tgz",
-      "integrity": "sha512-U5vkXDZ9DwXtkPqlB45tfYnnYBN8PePp1z/XDCupnSpdrxT8/ThCv9WCwPLf9oqiSGZTkH6dx2jDUPuoXpjkcA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.14.1.tgz",
+      "integrity": "sha512-BrZYyL/6m0ZXz/lDxy/nlVhQz+WF+iPS6qXolEU8atw7h6v1aYkjwJZ63m+bJMBTxDE66X+r2tPS4a/8C82sZw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -5811,9 +5811,9 @@
       }
     },
     "electron": {
-      "version": "14.2.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.7.tgz",
-      "integrity": "sha512-JYK2DviM9l0UDR6PgIKg9w/r7klty2u1+a3hqWIyXi0f3BSFpcswcSpY6kThrsFdSxeeXO9m4sXjWExDl/YquQ==",
+      "version": "14.2.9",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-14.2.9.tgz",
+      "integrity": "sha512-7LdJFmqVzO9NLKO0hwOwPA6Kv4GSybGMcej8f2q7fVT4O8mIfL9oo/v4axVjVWm0+58ROQtHv8hYnnAs3ygG0Q==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@typescript-eslint/eslint-plugin": "^5.3.1",
     "@typescript-eslint/parser": "^5.3.1",
     "chai": "^4.3.4",
-    "electron": "^14.2.6",
+    "electron": "^14.2.9",
     "electron-builder": "^22.12.0",
     "electron-devtools-installer": "^3.1.1",
     "electron-notarize": "^1.0.0",


### PR DESCRIPTION
fixes CVE-2022-0976: https://www.electronjs.org/releases/stable?version=14#14.2.9