### PR TITLE
bundle.js.map is only needed for debugging

### DIFF
--- a/build/packageignore_list
+++ b/build/packageignore_list
@@ -51,6 +51,7 @@ tsc-dist/renderer/
 **/*.tsbuildinfo
 **/*.css.map
 html-dist/report.htm
+html-dist/bundle.js.map
 node_modules/typescript/
 node_modules/@babel/
 


### PR DESCRIPTION
Removing another 8.3 MiB from the build. Cubans rejoice!