### PR TITLE
remove dependency `react-qr-svg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Update emoji-mart to `^3.0.1`
 - Update @types/emoji-mart to `^3.0.9`
 
+### Removed
+- remove dependency `react-qr-svg`
+
 ## [1.28.2] - 2022-04-22
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10607,11 +10607,6 @@
         "escape-goat": "^2.0.0"
       }
     },
-    "qr.js": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/qr.js/-/qr.js-0.0.0.tgz",
-      "integrity": "sha1-ys6GOG9ZoNuAUPqQ2baw6IoeNk8="
-    },
     "qrcode-terminal": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.10.0.tgz",
@@ -10705,15 +10700,6 @@
         "jsqr": "^1.2.0",
         "prop-types": "^15.7.2",
         "webrtc-adapter": "^7.2.1"
-      }
-    },
-    "react-qr-svg": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-qr-svg/-/react-qr-svg-2.2.1.tgz",
-      "integrity": "sha512-rLDCZI9pIqD5lbBIatrqUMhP1gqQ7glqubXO/m/X87ikEPhXuY0hMLhYMuKoH4834G36ap8Az0HI4bXEJUN//w==",
-      "requires": {
-        "prop-types": "^15.5.8",
-        "qr.js": "0.0.0"
       }
     },
     "react-string-replace": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-qr-reader": "^2.2.1",
-    "react-qr-svg": "^2.1.0",
     "react-string-replace": "^1.0.0",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",

--- a/src/renderer/components/dialogs/QrCode.tsx
+++ b/src/renderer/components/dialogs/QrCode.tsx
@@ -15,7 +15,6 @@ import {
 import { DialogProps } from './DialogController'
 import { useTranslationFunction, ScreenContext } from '../../contexts'
 import classNames from 'classnames'
-import qr from 'react-qr-svg'
 import QrReader from 'react-qr-reader'
 import processOpenQrUrl from '../helpers/OpenQrUrl'
 import { getLogger } from '../../../shared/logger'
@@ -118,7 +117,7 @@ export function QrCodeShowQrInner({
     <>
       <DeltaDialogBody>
         <DeltaDialogContent noOverflow noPadding style={{ height: '500px' }}>
-          {svgUrl ? (
+          {svgUrl && (
             <img
               style={{
                 width: '100%',
@@ -128,29 +127,6 @@ export function QrCodeShowQrInner({
               }}
               src={svgUrl}
             />
-          ) : (
-            <>
-              <qr.QRCode
-                bgColor='#FFFFFF'
-                fgColor='#000000'
-                level='Q'
-                value={qrCode}
-                style={{
-                  height: 'auto',
-                  padding: '30px',
-                  backgroundColor: 'white',
-                }}
-              />
-              <p
-                style={{
-                  textAlign: 'center',
-                  marginTop: '10px',
-                  overflowWrap: 'break-word',
-                }}
-              >
-                {description}
-              </p>
-            </>
           )}
         </DeltaDialogContent>
       </DeltaDialogBody>

--- a/src/renderer/components/dialogs/QrCode.tsx
+++ b/src/renderer/components/dialogs/QrCode.tsx
@@ -72,7 +72,7 @@ export default function QrCode({
 export function QrCodeShowQrInner({
   qrCode,
   qrCodeSVG,
-  description,
+  description: _description,
   onClose,
   onBack,
 }: {


### PR DESCRIPTION
why? becase we don't need it only as fallback for the core generated svg, which should not fail
also it complains about being deprecated for some time now
