### PR TITLE
[Refactor] Use settings store in Settings.tsx

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,19 +1,16 @@
 import React, { useState, useEffect, useLayoutEffect } from 'react'
-import { SettingsContext, i18nContext } from './contexts'
+import { i18nContext } from './contexts'
 import ScreenController from './ScreenController'
 import { sendToBackend, ipcBackend, startBackendLogging } from './ipc'
 import attachKeybindingsListener from './keybindings'
 
 import { translate, LocaleData } from '../shared/localize'
-import { getLogger } from '../shared/logger'
-const log = getLogger('renderer/App')
 import { DeltaBackend } from './delta-remote'
 import { ThemeManager, ThemeContext } from './ThemeManager'
 
 import moment from 'moment'
 import { CrashScreen } from './components/screens/CrashScreen'
 import { runtime } from './runtime'
-import { DesktopSettingsType } from '../shared/shared-types'
 
 attachKeybindingsListener()
 
@@ -83,66 +80,25 @@ export default function App(_props: any) {
   if (!localeData) return null
   return (
     <CrashScreen>
-      <SettingsContextWrapper>
+      <ThemeContextWrapper>
         <i18nContext.Provider value={window.static_translate}>
           <ScreenController />
         </i18nContext.Provider>
-      </SettingsContextWrapper>
+      </ThemeContextWrapper>
     </CrashScreen>
   )
 }
-function SettingsContextWrapper({ children }: { children: React.ReactChild }) {
-  const [
-    desktopSettings,
-    _setDesktopSettings,
-  ] = useState<DesktopSettingsType | null>(null)
-  window.__desktopSettings = desktopSettings
-
-  useEffect(() => {
-    ;(async () => {
-      const desktopSettings = await DeltaBackend.call(
-        'settings.getDesktopSettings'
-      )
-      _setDesktopSettings(desktopSettings)
-      window.__desktopSettings = desktopSettings
-    })()
-  }, [])
-
-  const setDesktopSetting = async (
-    key: keyof DesktopSettingsType,
-    value: string | number | boolean
-  ) => {
-    if (
-      (await DeltaBackend.call('settings.setDesktopSetting', key, value)) ===
-      true
-    ) {
-      _setDesktopSettings((prevState: DesktopSettingsType | null) => {
-        if (prevState === null) {
-          log.warn(
-            'trying to update local version of desktop settings object, but it was not loaded yet'
-          )
-          return prevState
-        }
-        const newState = { ...prevState, [key]: value }
-        window.__desktopSettings = newState
-        return newState
-      })
-    }
-  }
-
+function ThemeContextWrapper({ children }: { children: React.ReactChild }) {
   /** on each theme change this var changes */
   const [theme_rand, setThemeRand] = useState(0)
   useEffect(() => {
     ThemeManager.setUpdateHook(() => setThemeRand(Math.random()))
   }, [])
 
-  if (!desktopSettings) return null
 
   return (
-    <SettingsContext.Provider value={{ desktopSettings, setDesktopSetting }}>
-      <ThemeContext.Provider value={theme_rand}>
-        {children}
-      </ThemeContext.Provider>
-    </SettingsContext.Provider>
+    <ThemeContext.Provider value={theme_rand}>
+      {children}
+    </ThemeContext.Provider>
   )
 }

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -95,10 +95,7 @@ function ThemeContextWrapper({ children }: { children: React.ReactChild }) {
     ThemeManager.setUpdateHook(() => setThemeRand(Math.random()))
   }, [])
 
-
   return (
-    <ThemeContext.Provider value={theme_rand}>
-      {children}
-    </ThemeContext.Provider>
+    <ThemeContext.Provider value={theme_rand}>{children}</ThemeContext.Provider>
   )
 }

--- a/src/renderer/components/ThreeDotMenu.tsx
+++ b/src/renderer/components/ThreeDotMenu.tsx
@@ -1,9 +1,6 @@
 import { C } from 'deltachat-node/dist/constants'
 import React, { useContext } from 'react'
-import {
-  ScreenContext,
-  useTranslationFunction
-} from '../contexts'
+import { ScreenContext, useTranslationFunction } from '../contexts'
 import {
   openLeaveChatDialog,
   openDeleteChatDialog,
@@ -14,7 +11,7 @@ import {
 } from './helpers/ChatMethods'
 import { FullChat } from '../../shared/shared-types'
 import { ContextMenuItem } from './ContextMenu'
-import {useSettingsStore} from '../stores/settings'
+import { useSettingsStore } from '../stores/settings'
 
 export function DeltaMenuItem({
   text,

--- a/src/renderer/components/ThreeDotMenu.tsx
+++ b/src/renderer/components/ThreeDotMenu.tsx
@@ -2,8 +2,7 @@ import { C } from 'deltachat-node/dist/constants'
 import React, { useContext } from 'react'
 import {
   ScreenContext,
-  useTranslationFunction,
-  SettingsContext,
+  useTranslationFunction
 } from '../contexts'
 import {
   openLeaveChatDialog,
@@ -15,6 +14,7 @@ import {
 } from './helpers/ChatMethods'
 import { FullChat } from '../../shared/shared-types'
 import { ContextMenuItem } from './ContextMenu'
+import {useSettingsStore} from '../stores/settings'
 
 export function DeltaMenuItem({
   text,
@@ -34,7 +34,7 @@ export function DeltaMenuItem({
 
 export function useThreeDotMenu(selectedChat: FullChat | null) {
   const screenContext = useContext(ScreenContext)
-  const settingsContext = useContext(SettingsContext)
+  const settingsStore = useSettingsStore()[0]
   const tx = useTranslationFunction()
 
   let menu: (ContextMenuItem | false)[] = [false]
@@ -69,8 +69,8 @@ export function useThreeDotMenu(selectedChat: FullChat | null) {
         action: onDisappearingMessages,
       },
       !(isSelfTalk || isDeviceChat) &&
-        settingsContext.desktopSettings !== null &&
-        settingsContext.desktopSettings.enableChatAuditLog && {
+        settingsStore !== null &&
+        settingsStore.desktopSettings.enableChatAuditLog && {
           label: tx('menu_chat_audit_log'),
           action: openChatAuditLog,
         },

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -22,7 +22,7 @@ import { Quote } from '../message/Message'
 import { DeltaBackend } from '../../delta-remote'
 import { DraftAttachment } from '../attachment/messageAttachment'
 import { sendMessage, unselectChat } from '../helpers/ChatMethods'
-import {useSettingsStore} from '../../stores/settings'
+import { useSettingsStore } from '../../stores/settings'
 
 const log = getLogger('renderer/composer')
 
@@ -256,7 +256,7 @@ const Composer = forwardRef<
             addFileToDraft={addFileToDraft}
             selectedChat={selectedChat}
           />
-          { settingsStore &&
+          {settingsStore && (
             <ComposerMessageInput
               ref={messageInputRef}
               enterKeySends={settingsStore?.desktopSettings.enterKeySends}
@@ -265,7 +265,7 @@ const Composer = forwardRef<
               updateDraftText={updateDraftText}
               onPaste={handlePaste}
             />
-          }
+          )}
           <div
             className='emoji-button'
             ref={pickerButtonRef}

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -7,7 +7,7 @@ import React, {
   useCallback,
 } from 'react'
 import MenuAttachment from '../attachment/menuAttachment'
-import { SettingsContext, useTranslationFunction } from '../../contexts'
+import { useTranslationFunction } from '../../contexts'
 import ComposerMessageInput from './ComposerMessageInput'
 import { getLogger } from '../../../shared/logger'
 import { EmojiAndStickerPicker } from './EmojiAndStickerPicker'
@@ -22,6 +22,7 @@ import { Quote } from '../message/Message'
 import { DeltaBackend } from '../../delta-remote'
 import { DraftAttachment } from '../attachment/messageAttachment'
 import { sendMessage, unselectChat } from '../helpers/ChatMethods'
+import {useSettingsStore} from '../../stores/settings'
 
 const log = getLogger('renderer/composer')
 
@@ -188,6 +189,7 @@ const Composer = forwardRef<
   }
 
   const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
 
   useLayoutEffect(() => {
     // focus composer on chat change
@@ -254,20 +256,16 @@ const Composer = forwardRef<
             addFileToDraft={addFileToDraft}
             selectedChat={selectedChat}
           />
-          <SettingsContext.Consumer>
-            {({ desktopSettings }) =>
-              desktopSettings && (
-                <ComposerMessageInput
-                  ref={messageInputRef}
-                  enterKeySends={desktopSettings.enterKeySends}
-                  sendMessage={composerSendMessage}
-                  chatId={chatId}
-                  updateDraftText={updateDraftText}
-                  onPaste={handlePaste}
-                />
-              )
-            }
-          </SettingsContext.Consumer>
+          { settingsStore &&
+            <ComposerMessageInput
+              ref={messageInputRef}
+              enterKeySends={settingsStore?.desktopSettings.enterKeySends}
+              sendMessage={composerSendMessage}
+              chatId={chatId}
+              updateDraftText={updateDraftText}
+              onPaste={handlePaste}
+            />
+          }
           <div
             className='emoji-button'
             ref={pickerButtonRef}

--- a/src/renderer/components/dialogs/KeybindingCheatSheet.tsx
+++ b/src/renderer/components/dialogs/KeybindingCheatSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect } from 'react'
 import { useTranslationFunction } from '../../contexts'
-import {useSettingsStore} from '../../stores/settings'
+import { useSettingsStore } from '../../stores/settings'
 import {
   CheatSheetKeyboardShortcut,
   getKeybindings,

--- a/src/renderer/components/dialogs/KeybindingCheatSheet.tsx
+++ b/src/renderer/components/dialogs/KeybindingCheatSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useContext, useEffect } from 'react'
-import { SettingsContext, useTranslationFunction } from '../../contexts'
+import { useTranslationFunction } from '../../contexts'
+import {useSettingsStore} from '../../stores/settings'
 import {
   CheatSheetKeyboardShortcut,
   getKeybindings,
@@ -18,7 +19,7 @@ export default function KeybindingCheatSheet(props: {
   const { isOpen, onClose } = props
   const tx = useTranslationFunction()
 
-  const { desktopSettings } = useContext(SettingsContext)
+  const settingsStore = useSettingsStore()[0]
 
   useEffect(() => {
     window.__keybindingsDialogOpened = true
@@ -44,8 +45,8 @@ export default function KeybindingCheatSheet(props: {
 
       <DeltaDialogBody>
         <div className='keyboard-hint-dialog-body'>
-          {desktopSettings &&
-            getKeybindings(desktopSettings).map(entry => {
+          {settingsStore &&
+            getKeybindings(settingsStore.desktopSettings).map(entry => {
               if (entry.type === 'header') {
                 return (
                   <div key={entry.title}>

--- a/src/renderer/components/dialogs/KeybindingCheatSheet.tsx
+++ b/src/renderer/components/dialogs/KeybindingCheatSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import { useTranslationFunction } from '../../contexts'
 import { useSettingsStore } from '../../stores/settings'
 import {

--- a/src/renderer/components/dialogs/Settings-Advanced.tsx
+++ b/src/renderer/components/dialogs/Settings-Advanced.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {SettingsStoreState} from '../../stores/settings'
+import { SettingsStoreState } from '../../stores/settings'
 import { RenderDeltaSwitch2Type } from './Settings'
 import SettingsEncryption from './Settings-Encryption'
 import SettingsImapFolderHandling from './Settings-ImapFolderHandling'
@@ -9,7 +9,7 @@ export function SettingsAdvanced({
   settingsStore,
   renderDeltaSwitch2,
 }: {
-  settingsStore: SettingsStoreState,
+  settingsStore: SettingsStoreState
   renderDeltaSwitch2: RenderDeltaSwitch2Type
 }) {
   return (

--- a/src/renderer/components/dialogs/Settings-Advanced.tsx
+++ b/src/renderer/components/dialogs/Settings-Advanced.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
-import { RenderDeltaSwitch2Type, SettingsState } from './Settings'
+import {SettingsStoreState} from '../../stores/settings'
+import { RenderDeltaSwitch2Type } from './Settings'
 import SettingsEncryption from './Settings-Encryption'
 import SettingsImapFolderHandling from './Settings-ImapFolderHandling'
 import SettingsManageKeys from './Settings-ManageKeys'
 
 export function SettingsAdvanced({
-  state,
+  settingsStore,
   renderDeltaSwitch2,
 }: {
-  state: SettingsState
+  settingsStore: SettingsStoreState,
   renderDeltaSwitch2: RenderDeltaSwitch2Type
 }) {
   return (
@@ -17,7 +18,7 @@ export function SettingsAdvanced({
       <br />
       <br />
       <SettingsImapFolderHandling
-        state={state}
+        settingsStore={settingsStore}
         renderDeltaSwitch2={renderDeltaSwitch2}
       />
       <br />

--- a/src/renderer/components/dialogs/Settings-Appearance.tsx
+++ b/src/renderer/components/dialogs/Settings-Appearance.tsx
@@ -1,7 +1,4 @@
-import {
-  ScreenContext,
-  useTranslationFunction,
-} from '../../contexts'
+import { ScreenContext, useTranslationFunction } from '../../contexts'
 import React, { useContext, useEffect, useState } from 'react'
 import { H6, Icon } from '@blueprintjs/core'
 import { DeltaBackend } from '../../delta-remote'
@@ -9,7 +6,11 @@ import { ThemeManager } from '../../ThemeManager'
 import { SettingsSelector } from './Settings'
 import { SmallSelectDialog, SelectDialogOption } from './DeltaDialog'
 import { runtime } from '../../runtime'
-import { DesktopSettingsType, RC_Config, Theme } from '../../../shared/shared-types'
+import {
+  DesktopSettingsType,
+  RC_Config,
+  Theme,
+} from '../../../shared/shared-types'
 import { join } from 'path'
 import SettingsStoreInstance from '../../stores/settings'
 
@@ -23,7 +24,7 @@ const enum SetBackgroundAction {
 
 function BackgroundSelector({
   onChange,
-  desktopSettings
+  desktopSettings,
 }: {
   onChange: (value: string) => void
   desktopSettings: DesktopSettingsType
@@ -119,9 +120,7 @@ function BackgroundSelector({
                   )}")`,
                 }
               : {
-                  backgroundColor: desktopSettings.chatViewBgImg?.slice(
-                    7
-                  ),
+                  backgroundColor: desktopSettings.chatViewBgImg?.slice(7),
                   backgroundImage: 'unset',
                 }),
             backgroundSize: 'cover',
@@ -187,9 +186,9 @@ function BackgroundSelector({
 
 export default function SettingsAppearance({
   rc,
-  desktopSettings
+  desktopSettings,
 }: {
-  rc: RC_Config,
+  rc: RC_Config
   desktopSettings: DesktopSettingsType
 }) {
   const { activeTheme } = desktopSettings
@@ -270,8 +269,14 @@ export default function SettingsAppearance({
         desktopSettings={desktopSettings}
         onChange={(val: string) => {
           val.startsWith('#')
-            ? SettingsStoreInstance.effect.setDesktopSetting('chatViewBgImg', `color: ${val}`)
-            : SettingsStoreInstance.effect.setDesktopSetting('chatViewBgImg', val)
+            ? SettingsStoreInstance.effect.setDesktopSetting(
+                'chatViewBgImg',
+                `color: ${val}`
+              )
+            : SettingsStoreInstance.effect.setDesktopSetting(
+                'chatViewBgImg',
+                val
+              )
         }}
       />
     </>

--- a/src/renderer/components/dialogs/Settings-Appearance.tsx
+++ b/src/renderer/components/dialogs/Settings-Appearance.tsx
@@ -1,5 +1,4 @@
 import {
-  SettingsContext,
   ScreenContext,
   useTranslationFunction,
 } from '../../contexts'
@@ -10,8 +9,9 @@ import { ThemeManager } from '../../ThemeManager'
 import { SettingsSelector } from './Settings'
 import { SmallSelectDialog, SelectDialogOption } from './DeltaDialog'
 import { runtime } from '../../runtime'
-import { RC_Config, Theme } from '../../../shared/shared-types'
+import { DesktopSettingsType, RC_Config, Theme } from '../../../shared/shared-types'
 import { join } from 'path'
+import SettingsStoreInstance from '../../stores/settings'
 
 const enum SetBackgroundAction {
   default,
@@ -23,13 +23,13 @@ const enum SetBackgroundAction {
 
 function BackgroundSelector({
   onChange,
+  desktopSettings
 }: {
   onChange: (value: string) => void
+  desktopSettings: DesktopSettingsType
 }) {
   // the #color-input element is located in index.html outside of react
   const colorInput = document.getElementById('color-input') as HTMLInputElement
-
-  const { setDesktopSetting, desktopSettings } = useContext(SettingsContext)
 
   useEffect(() => {
     colorInput.onchange = (ev: any) => onChange(ev.target.value)
@@ -80,13 +80,13 @@ function BackgroundSelector({
         if (!url) {
           break
         }
-        setDesktopSetting(
+        SettingsStoreInstance.effect.setDesktopSetting(
           'chatViewBgImg',
           await DeltaBackend.call('settings.saveBackgroundImage', url, false)
         )
         break
       case SetBackgroundAction.presetImage:
-        setDesktopSetting(
+        SettingsStoreInstance.effect.setDesktopSetting(
           'chatViewBgImg',
           await DeltaBackend.call(
             'settings.saveBackgroundImage',
@@ -108,33 +108,27 @@ function BackgroundSelector({
   return (
     <div>
       <div className={'bg-option-wrap'}>
-        <SettingsContext.Consumer>
-          {({ desktopSettings }) =>
-            desktopSettings && (
-              <div
-                style={{
-                  ...(desktopSettings.chatViewBgImg?.startsWith('img: ')
-                    ? {
-                        backgroundImage: `url("file://${join(
-                          runtime.getConfigPath(),
-                          'background/',
-                          desktopSettings.chatViewBgImg.slice(5)
-                        )}")`,
-                      }
-                    : {
-                        backgroundColor: desktopSettings.chatViewBgImg?.slice(
-                          7
-                        ),
-                        backgroundImage: 'unset',
-                      }),
-                  backgroundSize: 'cover',
-                }}
-                aria-label={tx('a11y_background_preview_label')}
-                className={'background-preview'}
-              />
-            )
-          }
-        </SettingsContext.Consumer>
+        <div
+          style={{
+            ...(desktopSettings.chatViewBgImg?.startsWith('img: ')
+              ? {
+                  backgroundImage: `url("file://${join(
+                    runtime.getConfigPath(),
+                    'background/',
+                    desktopSettings.chatViewBgImg.slice(5)
+                  )}")`,
+                }
+              : {
+                  backgroundColor: desktopSettings.chatViewBgImg?.slice(
+                    7
+                  ),
+                  backgroundImage: 'unset',
+                }),
+            backgroundSize: 'cover',
+          }}
+          aria-label={tx('a11y_background_preview_label')}
+          className={'background-preview'}
+        />
         <div className={'background-options'}>
           <div
             onClick={onButton.bind(null, SetBackgroundAction.default)}
@@ -192,18 +186,12 @@ function BackgroundSelector({
 }
 
 export default function SettingsAppearance({
-  handleDesktopSettingsChange,
   rc,
+  desktopSettings
 }: {
-  handleDesktopSettingsChange: todo
-  rc: RC_Config
+  rc: RC_Config,
+  desktopSettings: DesktopSettingsType
 }) {
-  const { desktopSettings, setDesktopSetting } = useContext(SettingsContext)
-  if (!desktopSettings) {
-    throw new Error(
-      'desktop settings not initialiyed yet, this should not happen'
-    )
-  }
   const { activeTheme } = desktopSettings
 
   const { openDialog } = useContext(ScreenContext)
@@ -225,7 +213,7 @@ export default function SettingsAppearance({
 
   const setTheme = async (theme: string) => {
     if (await DeltaBackend.call('extras.setTheme', theme)) {
-      setDesktopSetting('activeTheme', theme)
+      SettingsStoreInstance.effect.setDesktopSetting('activeTheme', theme)
       await ThemeManager.refresh()
     }
   }
@@ -279,10 +267,11 @@ export default function SettingsAppearance({
       <br />
       <H6>{tx('pref_background')}</H6>
       <BackgroundSelector
+        desktopSettings={desktopSettings}
         onChange={(val: string) => {
           val.startsWith('#')
-            ? handleDesktopSettingsChange('chatViewBgImg', `color: ${val}`)
-            : handleDesktopSettingsChange('chatViewBgImg', val)
+            ? SettingsStoreInstance.effect.setDesktopSetting('chatViewBgImg', `color: ${val}`)
+            : SettingsStoreInstance.effect.setDesktopSetting('chatViewBgImg', val)
         }}
       />
     </>

--- a/src/renderer/components/dialogs/Settings-Autodelete.tsx
+++ b/src/renderer/components/dialogs/Settings-Autodelete.tsx
@@ -16,7 +16,9 @@ import { SettingsSelector } from './Settings'
 import { AutodeleteDuration } from '../../../shared/constants'
 import { DeltaCheckbox } from '../contact/ContactListItem'
 import classNames from 'classnames'
-import SettingsStoreInstance, { SettingsStoreState } from '../../stores/settings'
+import SettingsStoreInstance, {
+  SettingsStoreState,
+} from '../../stores/settings'
 
 function durationToString(configValue: number | string) {
   if (typeof configValue === 'string') configValue = Number(configValue)
@@ -50,7 +52,7 @@ export function AutodeleteConfirmationDialog({
   estimateCount,
   seconds,
   isOpen,
-  onClose
+  onClose,
 }: {
   fromServer: boolean
   estimateCount: number
@@ -120,7 +122,11 @@ export function AutodeleteConfirmationDialog({
   )
 }
 
-export default function SettingsAutodelete({settingsStore}:{settingsStore: SettingsStoreState}) {
+export default function SettingsAutodelete({
+  settingsStore,
+}: {
+  settingsStore: SettingsStoreState
+}) {
   const { openDialog } = useContext(ScreenContext)
 
   const tx = useTranslationFunction()
@@ -176,7 +182,7 @@ export default function SettingsAutodelete({settingsStore}:{settingsStore: Setti
         openDialog(AutodeleteConfirmationDialog, {
           fromServer,
           estimateCount,
-          seconds
+          seconds,
         })
       },
     })
@@ -187,13 +193,17 @@ export default function SettingsAutodelete({settingsStore}:{settingsStore: Setti
       <H5>{tx('delete_old_messages')}</H5>
       <SettingsSelector
         onClick={onOpenDialog.bind(null, false)}
-        currentValue={durationToString(settingsStore.settings['delete_device_after'])}
+        currentValue={durationToString(
+          settingsStore.settings['delete_device_after']
+        )}
       >
         {tx('autodel_device_title')}
       </SettingsSelector>
       <SettingsSelector
         onClick={onOpenDialog.bind(null, true)}
-        currentValue={durationToString(settingsStore.settings['delete_server_after'])}
+        currentValue={durationToString(
+          settingsStore.settings['delete_server_after']
+        )}
       >
         {tx('autodel_server_title')}
       </SettingsSelector>

--- a/src/renderer/components/dialogs/Settings-Autodelete.tsx
+++ b/src/renderer/components/dialogs/Settings-Autodelete.tsx
@@ -16,6 +16,7 @@ import { SettingsSelector } from './Settings'
 import { AutodeleteDuration } from '../../../shared/constants'
 import { DeltaCheckbox } from '../contact/ContactListItem'
 import classNames from 'classnames'
+import SettingsStoreInstance, { SettingsStoreState } from '../../stores/settings'
 
 function durationToString(configValue: number | string) {
   if (typeof configValue === 'string') configValue = Number(configValue)
@@ -49,8 +50,7 @@ export function AutodeleteConfirmationDialog({
   estimateCount,
   seconds,
   isOpen,
-  onClose,
-  handleDeltaSettingsChange,
+  onClose
 }: {
   fromServer: boolean
   estimateCount: number
@@ -61,9 +61,9 @@ export function AutodeleteConfirmationDialog({
 
   const onOk = () => {
     if (isConfirmed === false) return
-    handleDeltaSettingsChange(
+    SettingsStoreInstance.effect.setCoreSetting(
       fromServer ? 'delete_server_after' : 'delete_device_after',
-      seconds
+      seconds.toString()
     )
     onClose()
   }
@@ -120,9 +120,8 @@ export function AutodeleteConfirmationDialog({
   )
 }
 
-export default function SettingsAutodelete(props: any) {
+export default function SettingsAutodelete({settingsStore}:{settingsStore: SettingsStoreState}) {
   const { openDialog } = useContext(ScreenContext)
-  const { handleDeltaSettingsChange, settings } = props
 
   const tx = useTranslationFunction()
 
@@ -153,8 +152,8 @@ export default function SettingsAutodelete(props: any) {
         ? AUTODELETE_DURATION_OPTIONS_SERVER
         : AUTODELETE_DURATION_OPTIONS_DEVICE,
       selectedValue: fromServer
-        ? settings['delete_server_after']
-        : settings['delete_device_after'],
+        ? settingsStore.settings['delete_server_after']
+        : settingsStore.settings['delete_device_after'],
       title: fromServer
         ? tx('autodel_server_title')
         : tx('autodel_device_title'),
@@ -168,17 +167,16 @@ export default function SettingsAutodelete(props: any) {
 
         if (seconds === 0) {
           // No need to have a confirmation dialog on disabling
-          handleDeltaSettingsChange(
+          SettingsStoreInstance.effect.setCoreSetting(
             fromServer ? 'delete_server_after' : 'delete_device_after',
-            seconds
+            seconds.toString()
           )
           return
         }
         openDialog(AutodeleteConfirmationDialog, {
           fromServer,
           estimateCount,
-          seconds,
-          handleDeltaSettingsChange,
+          seconds
         })
       },
     })
@@ -189,13 +187,13 @@ export default function SettingsAutodelete(props: any) {
       <H5>{tx('delete_old_messages')}</H5>
       <SettingsSelector
         onClick={onOpenDialog.bind(null, false)}
-        currentValue={durationToString(settings['delete_device_after'])}
+        currentValue={durationToString(settingsStore.settings['delete_device_after'])}
       >
         {tx('autodel_device_title')}
       </SettingsSelector>
       <SettingsSelector
         onClick={onOpenDialog.bind(null, true)}
-        currentValue={durationToString(settings['delete_server_after'])}
+        currentValue={durationToString(settingsStore.settings['delete_server_after'])}
       >
         {tx('autodel_server_title')}
       </SettingsSelector>

--- a/src/renderer/components/dialogs/Settings-ChatsAndMedia.tsx
+++ b/src/renderer/components/dialogs/Settings-ChatsAndMedia.tsx
@@ -1,10 +1,6 @@
 import { H5 } from '@blueprintjs/core'
 import React from 'react'
-import {
-  RenderDeltaSwitch2Type,
-  RenderDTSettingSwitchType,
-  SettingsState,
-} from './Settings'
+import { RenderDeltaSwitch2Type, RenderDTSettingSwitchType } from './Settings'
 import SettingsAutodelete from './Settings-Autodelete'
 import SettingsBackup from './Settings-Backup'
 import SettingsCommunication from './Settings-Communication'

--- a/src/renderer/components/dialogs/Settings-ChatsAndMedia.tsx
+++ b/src/renderer/components/dialogs/Settings-ChatsAndMedia.tsx
@@ -14,17 +14,16 @@ import {
   KeybordShortcutHintInSettings,
 } from '../KeyboardShortcutHint'
 import { DesktopSettingsType } from '../../../shared/shared-types'
+import {SettingsStoreState} from '../../stores/settings'
 
 export function SettingsChatsAndMedia({
-  state,
+  settingsStore,
   desktopSettings,
-  handleDeltaSettingsChange,
   renderDeltaSwitch2,
   renderDTSettingSwitch,
 }: {
-  state: SettingsState
+  settingsStore: SettingsStoreState
   desktopSettings: DesktopSettingsType
-  handleDeltaSettingsChange: any
   renderDeltaSwitch2: RenderDeltaSwitch2Type
   renderDTSettingSwitch: RenderDTSettingSwitchType
 }) {
@@ -33,8 +32,7 @@ export function SettingsChatsAndMedia({
   return (
     <>
       <SettingsCommunication
-        handleDeltaSettingsChange={handleDeltaSettingsChange}
-        settings={state.settings}
+        settingsStore={settingsStore}
       />
       {renderDTSettingSwitch({
         key: 'enterKeySends',
@@ -46,8 +44,8 @@ export function SettingsChatsAndMedia({
         )}
       />
       <SettingsDownloadOnDemand
-        handleDeltaSettingsChange={handleDeltaSettingsChange}
-        settings={state.settings}
+        
+        settings={settingsStore.settings}
       />
       <br />
       <br />
@@ -59,8 +57,7 @@ export function SettingsChatsAndMedia({
       <br />
       <br />
       <SettingsAutodelete
-        handleDeltaSettingsChange={handleDeltaSettingsChange}
-        settings={state.settings}
+        settingsStore={settingsStore}
       />
       <br />
       <br />

--- a/src/renderer/components/dialogs/Settings-ChatsAndMedia.tsx
+++ b/src/renderer/components/dialogs/Settings-ChatsAndMedia.tsx
@@ -14,7 +14,7 @@ import {
   KeybordShortcutHintInSettings,
 } from '../KeyboardShortcutHint'
 import { DesktopSettingsType } from '../../../shared/shared-types'
-import {SettingsStoreState} from '../../stores/settings'
+import { SettingsStoreState } from '../../stores/settings'
 
 export function SettingsChatsAndMedia({
   settingsStore,
@@ -31,9 +31,7 @@ export function SettingsChatsAndMedia({
 
   return (
     <>
-      <SettingsCommunication
-        settingsStore={settingsStore}
-      />
+      <SettingsCommunication settingsStore={settingsStore} />
       {renderDTSettingSwitch({
         key: 'enterKeySends',
         label: tx('pref_enter_sends_explain'),
@@ -43,10 +41,7 @@ export function SettingsChatsAndMedia({
           desktopSettings['enterKeySends']
         )}
       />
-      <SettingsDownloadOnDemand
-        
-        settings={settingsStore.settings}
-      />
+      <SettingsDownloadOnDemand settings={settingsStore.settings} />
       <br />
       <br />
       <H5>{tx('pref_privacy')}</H5>
@@ -56,9 +51,7 @@ export function SettingsChatsAndMedia({
       })}
       <br />
       <br />
-      <SettingsAutodelete
-        settingsStore={settingsStore}
-      />
+      <SettingsAutodelete settingsStore={settingsStore} />
       <br />
       <br />
       <SettingsBackup />

--- a/src/renderer/components/dialogs/Settings-Communication.tsx
+++ b/src/renderer/components/dialogs/Settings-Communication.tsx
@@ -4,7 +4,9 @@ import { ScreenContext, useTranslationFunction } from '../../contexts'
 import { SmallSelectDialog, SelectDialogOption } from './DeltaDialog'
 import { SettingsSelector } from './Settings'
 import { C } from 'deltachat-node/dist/constants'
-import SettingsStoreInstance, { SettingsStoreState } from '../../stores/settings'
+import SettingsStoreInstance, {
+  SettingsStoreState,
+} from '../../stores/settings'
 
 function showToString(configValue: number | string) {
   if (typeof configValue === 'string') configValue = Number(configValue)
@@ -21,7 +23,11 @@ function showToString(configValue: number | string) {
   }
 }
 
-export default function SettingsCommunication({settingsStore}:{settingsStore: SettingsStoreState}) {
+export default function SettingsCommunication({
+  settingsStore,
+}: {
+  settingsStore: SettingsStoreState
+}) {
   const { openDialog } = useContext(ScreenContext)
 
   const tx = useTranslationFunction()

--- a/src/renderer/components/dialogs/Settings-Communication.tsx
+++ b/src/renderer/components/dialogs/Settings-Communication.tsx
@@ -4,6 +4,7 @@ import { ScreenContext, useTranslationFunction } from '../../contexts'
 import { SmallSelectDialog, SelectDialogOption } from './DeltaDialog'
 import { SettingsSelector } from './Settings'
 import { C } from 'deltachat-node/dist/constants'
+import SettingsStoreInstance, { SettingsStoreState } from '../../stores/settings'
 
 function showToString(configValue: number | string) {
   if (typeof configValue === 'string') configValue = Number(configValue)
@@ -20,9 +21,8 @@ function showToString(configValue: number | string) {
   }
 }
 
-export default function SettingsCommunication(props: any) {
+export default function SettingsCommunication({settingsStore}:{settingsStore: SettingsStoreState}) {
   const { openDialog } = useContext(ScreenContext)
-  const { handleDeltaSettingsChange, settings } = props
 
   const tx = useTranslationFunction()
   const SHOW_EMAIL_OPTIONS: SelectDialogOption[] = [
@@ -37,22 +37,22 @@ export default function SettingsCommunication(props: any) {
   const onOpenDialog = async () => {
     openDialog(SmallSelectDialog, {
       values: SHOW_EMAIL_OPTIONS,
-      selectedValue: String(settings['show_emails']),
+      selectedValue: String(settingsStore.settings['show_emails']),
       title: tx('pref_show_emails'),
       onSave: async (show: string) => {
-        handleDeltaSettingsChange('show_emails', show)
+        SettingsStoreInstance.effect.setCoreSetting('show_emails', show)
       },
     })
   }
 
-  if (!settings['show_emails']) return null
+  if (!settingsStore.settings['show_emails']) return null
 
   return (
     <>
       <H5>{tx('pref_chats')}</H5>
       <SettingsSelector
         onClick={onOpenDialog.bind(null, false)}
-        currentValue={showToString(settings['show_emails'])}
+        currentValue={showToString(settingsStore.settings['show_emails'])}
       >
         {tx('pref_show_emails')}
       </SettingsSelector>

--- a/src/renderer/components/dialogs/Settings-DownloadOnDemand.tsx
+++ b/src/renderer/components/dialogs/Settings-DownloadOnDemand.tsx
@@ -4,7 +4,9 @@ import { SmallSelectDialog, SelectDialogOption } from './DeltaDialog'
 import { SettingsSelector } from './Settings'
 
 import filesizeConverter from 'filesize'
-import SettingsStoreInstance, { SettingsStoreState } from '../../stores/settings'
+import SettingsStoreInstance, {
+  SettingsStoreState,
+} from '../../stores/settings'
 
 export default function SettingsDownloadOnDemand(props: {
   settings: SettingsStoreState['settings']
@@ -37,7 +39,10 @@ export default function SettingsDownloadOnDemand(props: {
       title: tx('auto_download_messages'),
       onSave: async (bytes: string) => {
         const seconds = Number(bytes)
-        SettingsStoreInstance.effect.setCoreSetting('download_limit', seconds.toString())
+        SettingsStoreInstance.effect.setCoreSetting(
+          'download_limit',
+          seconds.toString()
+        )
       },
     })
   }
@@ -47,7 +52,9 @@ export default function SettingsDownloadOnDemand(props: {
       ? tx('pref_show_emails_all')
       : tx(
           'up_to_x',
-          filesizeConverter(Number.parseInt(settings['download_limit']), { base: 2 })
+          filesizeConverter(Number.parseInt(settings['download_limit']), {
+            base: 2,
+          })
         )
 
   return (

--- a/src/renderer/components/dialogs/Settings-DownloadOnDemand.tsx
+++ b/src/renderer/components/dialogs/Settings-DownloadOnDemand.tsx
@@ -2,16 +2,15 @@ import React, { useContext } from 'react'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
 import { SmallSelectDialog, SelectDialogOption } from './DeltaDialog'
 import { SettingsSelector } from './Settings'
-import { todo } from '../../../shared/shared-types'
 
 import filesizeConverter from 'filesize'
+import SettingsStoreInstance, { SettingsStoreState } from '../../stores/settings'
 
 export default function SettingsDownloadOnDemand(props: {
-  handleDeltaSettingsChange: (key: string, value: any) => void
-  settings: todo
+  settings: SettingsStoreState['settings']
 }) {
   const { openDialog } = useContext(ScreenContext)
-  const { handleDeltaSettingsChange, settings } = props
+  const { settings } = props
   const tx = useTranslationFunction()
 
   const options: { label: string; value: number }[] = [
@@ -38,17 +37,17 @@ export default function SettingsDownloadOnDemand(props: {
       title: tx('auto_download_messages'),
       onSave: async (bytes: string) => {
         const seconds = Number(bytes)
-        handleDeltaSettingsChange('download_limit', seconds)
+        SettingsStoreInstance.effect.setCoreSetting('download_limit', seconds.toString())
       },
     })
   }
 
   const current_limit =
-    settings['download_limit'] == 0
+    settings['download_limit'] == '0'
       ? tx('pref_show_emails_all')
       : tx(
           'up_to_x',
-          filesizeConverter(settings['download_limit'], { base: 2 })
+          filesizeConverter(Number.parseInt(settings['download_limit']), { base: 2 })
         )
 
   return (

--- a/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
+++ b/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
@@ -1,10 +1,6 @@
 import React, { useState, useContext, FormEvent } from 'react'
 import { Card, Elevation, Radio, RadioGroup } from '@blueprintjs/core'
-import {
-  RenderDTSettingSwitchType,
-  SettingsSelector,
-  SettingsState,
-} from './Settings'
+import { RenderDTSettingSwitchType, SettingsSelector } from './Settings'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
 import { DeltaInput } from '../Login-Styles'
 import {

--- a/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
+++ b/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
@@ -21,11 +21,9 @@ import SettingsStoreInstance, {
 const WEBRTC_INSTANCE_JITSI = 'https://meet.jit.si/$ROOM'
 
 export function SettingsExperimentalFeatures({
-  state,
   settingsStore,
   renderDTSettingSwitch,
 }: {
-  state: SettingsState
   renderDTSettingSwitch: RenderDTSettingSwitchType
   settingsStore: SettingsStoreState
 }) {
@@ -67,10 +65,10 @@ export function SettingsExperimentalFeatures({
       {renderDTSettingSwitch({
         key: 'minimizeToTray',
         label: tx('pref_show_tray_icon'),
-        disabled: state.rc?.minimized,
-        disabledValue: state.rc?.minimized,
+        disabled: settingsStore.rc.minimized,
+        disabledValue: settingsStore.rc.minimized,
       })}
-      {state.rc?.minimized && (
+      {settingsStore.rc.minimized && (
         <div className='bp3-callout'>
           {tx('explain_desktop_minimized_disabled_tray_pref')}
         </div>

--- a/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
+++ b/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
@@ -14,7 +14,9 @@ import {
   DeltaDialogOkCancelFooter,
 } from './DeltaDialog'
 import { DialogProps } from './DialogController'
-import SettingsStoreInstance, {SettingsStoreState} from '../../stores/settings'
+import SettingsStoreInstance, {
+  SettingsStoreState,
+} from '../../stores/settings'
 
 const WEBRTC_INSTANCE_JITSI = 'https://meet.jit.si/$ROOM'
 
@@ -23,9 +25,9 @@ export function SettingsExperimentalFeatures({
   settingsStore,
   renderDTSettingSwitch,
 }: {
-  state: SettingsState,
-  renderDTSettingSwitch: RenderDTSettingSwitchType,
-  settingsStore: SettingsStoreState,
+  state: SettingsState
+  renderDTSettingSwitch: RenderDTSettingSwitchType
+  settingsStore: SettingsStoreState
 }) {
   const tx = window.static_translate
   const { openDialog } = useContext(ScreenContext)
@@ -33,14 +35,17 @@ export function SettingsExperimentalFeatures({
   const onClickEdit = async () => {
     openDialog(EditVideochatInstanceDialog, {
       onOk: async (configValue: string) => {
-        SettingsStoreInstance.effect.setCoreSetting('webrtc_instance', configValue)
+        SettingsStoreInstance.effect.setCoreSetting(
+          'webrtc_instance',
+          configValue
+        )
         if (configValue === '') {
           SettingsStoreInstance.effect.setDesktopSetting('enableAVCalls', false)
         } else {
           SettingsStoreInstance.effect.setDesktopSetting('enableAVCalls', true)
         }
       },
-      settingsStore
+      settingsStore,
     })
   }
 
@@ -76,7 +81,9 @@ export function SettingsExperimentalFeatures({
       })}
       <SettingsSelector
         onClick={onClickEdit.bind(null, false)}
-        currentValue={showVideochatInstance(settingsStore.settings['webrtc_instance'])}
+        currentValue={showVideochatInstance(
+          settingsStore.settings['webrtc_instance']
+        )}
       >
         {tx('videochat')}
       </SettingsSelector>
@@ -91,8 +98,8 @@ export function EditVideochatInstanceDialog({
   onClose,
   onOk,
   onCancel,
-  settingsStore
-}: DialogProps & {settingsStore: SettingsStoreState}) {
+  settingsStore,
+}: DialogProps & { settingsStore: SettingsStoreState }) {
   const tx = useTranslationFunction()
   const [configValue, setConfigValue] = useState(
     settingsStore.settings['webrtc_instance']

--- a/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
+++ b/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
@@ -14,19 +14,18 @@ import {
   DeltaDialogOkCancelFooter,
 } from './DeltaDialog'
 import { DialogProps } from './DialogController'
+import SettingsStoreInstance, {SettingsStoreState} from '../../stores/settings'
 
 const WEBRTC_INSTANCE_JITSI = 'https://meet.jit.si/$ROOM'
 
 export function SettingsExperimentalFeatures({
-  renderDTSettingSwitch,
   state,
-  handleDeltaSettingsChange,
-  handleDesktopSettingsChange,
+  settingsStore,
+  renderDTSettingSwitch,
 }: {
-  renderDTSettingSwitch: RenderDTSettingSwitchType
-  state: SettingsState
-  handleDeltaSettingsChange: any
-  handleDesktopSettingsChange: any
+  state: SettingsState,
+  renderDTSettingSwitch: RenderDTSettingSwitchType,
+  settingsStore: SettingsStoreState,
 }) {
   const tx = window.static_translate
   const { openDialog } = useContext(ScreenContext)
@@ -34,14 +33,14 @@ export function SettingsExperimentalFeatures({
   const onClickEdit = async () => {
     openDialog(EditVideochatInstanceDialog, {
       onOk: async (configValue: string) => {
-        handleDeltaSettingsChange('webrtc_instance', configValue)
+        SettingsStoreInstance.effect.setCoreSetting('webrtc_instance', configValue)
         if (configValue === '') {
-          handleDesktopSettingsChange('enableAVCalls', false)
+          SettingsStoreInstance.effect.setDesktopSetting('enableAVCalls', false)
         } else {
-          handleDesktopSettingsChange('enableAVCalls', true)
+          SettingsStoreInstance.effect.setDesktopSetting('enableAVCalls', true)
         }
       },
-      state: state,
+      settingsStore
     })
   }
 
@@ -77,7 +76,7 @@ export function SettingsExperimentalFeatures({
       })}
       <SettingsSelector
         onClick={onClickEdit.bind(null, false)}
-        currentValue={showVideochatInstance(state.settings['webrtc_instance'])}
+        currentValue={showVideochatInstance(settingsStore.settings['webrtc_instance'])}
       >
         {tx('videochat')}
       </SettingsSelector>
@@ -92,11 +91,11 @@ export function EditVideochatInstanceDialog({
   onClose,
   onOk,
   onCancel,
-  state,
-}: DialogProps) {
+  settingsStore
+}: DialogProps & {settingsStore: SettingsStoreState}) {
   const tx = useTranslationFunction()
   const [configValue, setConfigValue] = useState(
-    state.settings['webrtc_instance']
+    settingsStore.settings['webrtc_instance']
   )
   const [radioValue, setRadioValue] = useState<RadioButtonValue>(() => {
     if (configValue === '') {
@@ -126,7 +125,7 @@ export function EditVideochatInstanceDialog({
       newConfigValue = WEBRTC_INSTANCE_JITSI
       setRadioValue('jitsi')
     } else {
-      newConfigValue = state.settings['webrtc_instance']
+      newConfigValue = settingsStore.settings['webrtc_instance']
       setRadioValue('custom')
     }
     setConfigValue(newConfigValue)

--- a/src/renderer/components/dialogs/Settings-ImapFolderHandling.tsx
+++ b/src/renderer/components/dialogs/Settings-ImapFolderHandling.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
 import { H5 } from '@blueprintjs/core'
 
-import { SettingsState, RenderDeltaSwitch2Type } from './Settings'
+import { RenderDeltaSwitch2Type } from './Settings'
+import {SettingsStoreState} from '../../stores/settings'
 
 export default function SettingsImapFolderHandling({
-  state,
+  settingsStore,
   renderDeltaSwitch2,
 }: {
-  state: SettingsState
+  settingsStore: SettingsStoreState,
   renderDeltaSwitch2: RenderDeltaSwitch2Type
 }) {
   const tx = window.static_translate
-  const disableIfOnlyFetchMvBoxIsTrue = state.settings.only_fetch_mvbox === '1'
+  const disableIfOnlyFetchMvBoxIsTrue = settingsStore.settings.only_fetch_mvbox === '1'
 
   return (
     <>

--- a/src/renderer/components/dialogs/Settings-ImapFolderHandling.tsx
+++ b/src/renderer/components/dialogs/Settings-ImapFolderHandling.tsx
@@ -2,17 +2,18 @@ import React from 'react'
 import { H5 } from '@blueprintjs/core'
 
 import { RenderDeltaSwitch2Type } from './Settings'
-import {SettingsStoreState} from '../../stores/settings'
+import { SettingsStoreState } from '../../stores/settings'
 
 export default function SettingsImapFolderHandling({
   settingsStore,
   renderDeltaSwitch2,
 }: {
-  settingsStore: SettingsStoreState,
+  settingsStore: SettingsStoreState
   renderDeltaSwitch2: RenderDeltaSwitch2Type
 }) {
   const tx = window.static_translate
-  const disableIfOnlyFetchMvBoxIsTrue = settingsStore.settings.only_fetch_mvbox === '1'
+  const disableIfOnlyFetchMvBoxIsTrue =
+    settingsStore.settings.only_fetch_mvbox === '1'
 
   return (
     <>

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -20,17 +20,6 @@ import SettingsAccountDialog from './Settings-Account'
 import SettingsConnectivityDialog from './Settings-Connectivity'
 import SettingsStoreInstance, {SettingsStoreState} from '../../stores/settings'
 
-export function useProfileImage() {
-  const [profileImage, setProfileImage] = useState('')
-  useEffect(() => {
-    DeltaBackend.call('getProfilePicture').then(setProfileImage)
-    return onDCEvent('DC_EVENT_SELFAVATAR_CHANGED', () =>
-      DeltaBackend.call('getProfilePicture').then(setProfileImage)
-    )
-  }, [])
-  return profileImage
-}
-
 export default function SettingsProfile({
   settingsStore,
 }: {
@@ -193,10 +182,7 @@ export function SettingsEditProfileDialogInner({
   const [displayname, setDisplayname] = useState(settingsStore.settings.displayname)
   const [selfstatus, setSelfstatus] = useState(settingsStore.settings.selfstatus)
 
-  const [profilePicture, setProfilePicture] = useState('')
-  useEffect(() => {
-    DeltaBackend.call('getProfilePicture').then(setProfilePicture)
-  }, [])
+  const [profilePicture, setProfilePicture] = useState(settingsStore.selfContact.profileImage)
 
   const onCancel = () => {
     onClose()

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -33,17 +33,18 @@ export function useProfileImage() {
 export default function SettingsProfile({
   addr,
   displayname,
+  profileImage,
   state,
   handleDeltaSettingsChange,
 }: {
   onClose: any
   addr: string | undefined
   displayname: string | undefined
+  profileImage: string,
   state: any
   handleDeltaSettingsChange: (key: string, value: string) => void
 }) {
   const { openDialog } = useContext(ScreenContext)
-  const profileImagePreview = useProfileImage()
   const [connectivityString, setConnectivityString] = useState('')
 
   const updateConnectivity = async () => {
@@ -74,12 +75,12 @@ export default function SettingsProfile({
   }, [])
 
   const tx = useTranslationFunction()
-  const profileBlobUrl = runtime.transformBlobURL(profileImagePreview)
+  const profileBlobUrl = runtime.transformBlobURL(profileImage)
   return (
     <>
       <div className='profile-image-username' style={{ marginBottom: '10px' }}>
         <div className='profile-image-selector'>
-          {profileImagePreview ? (
+          {profileBlobUrl ? (
             <ClickForFullscreenAvatarWrapper filename={profileBlobUrl}>
               <img src={profileBlobUrl} alt={tx('pref_profile_photo')} />
             </ClickForFullscreenAvatarWrapper>

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -18,12 +18,14 @@ import { DialogProps } from './DialogController'
 import { onDCEvent } from '../../ipc'
 import SettingsAccountDialog from './Settings-Account'
 import SettingsConnectivityDialog from './Settings-Connectivity'
-import SettingsStoreInstance, {SettingsStoreState} from '../../stores/settings'
+import SettingsStoreInstance, {
+  SettingsStoreState,
+} from '../../stores/settings'
 
 export default function SettingsProfile({
   settingsStore,
 }: {
-  settingsStore: SettingsStoreState,
+  settingsStore: SettingsStoreState
   onClose: any
 }) {
   const { openDialog } = useContext(ScreenContext)
@@ -49,7 +51,10 @@ export default function SettingsProfile({
     setConnectivityString(`(${connectivityString})`)
   }
 
-  const initial = avatarInitial(settingsStore.selfContact.displayName || '', settingsStore.selfContact.address)
+  const initial = avatarInitial(
+    settingsStore.selfContact.displayName || '',
+    settingsStore.selfContact.address
+  )
   useEffect(() => {
     updateConnectivity()
 
@@ -57,7 +62,9 @@ export default function SettingsProfile({
   }, [])
 
   const tx = useTranslationFunction()
-  const profileBlobUrl = runtime.transformBlobURL(settingsStore.selfContact.profileImage)
+  const profileBlobUrl = runtime.transformBlobURL(
+    settingsStore.selfContact.profileImage
+  )
   return (
     <>
       <div className='profile-image-username' style={{ marginBottom: '10px' }}>
@@ -73,14 +80,16 @@ export default function SettingsProfile({
           )}
         </div>
         <div className='profile-displayname-addr'>
-          <div className='displayname'>{settingsStore.settings.displayname}</div>
+          <div className='displayname'>
+            {settingsStore.settings.displayname}
+          </div>
           <div className='addr'>{settingsStore.selfContact.address}</div>
         </div>
       </div>
       <SettingsButton
         onClick={() =>
           openDialog(SettingsProfileDialog, {
-            settingsStore
+            settingsStore,
           })
         }
       >
@@ -89,7 +98,7 @@ export default function SettingsProfile({
       <SettingsButton
         onClick={() =>
           openDialog(SettingsAccountDialog, {
-            settingsStore
+            settingsStore,
           })
         }
       >
@@ -98,7 +107,7 @@ export default function SettingsProfile({
       <SettingsButton
         onClick={async () => {
           openDialog(SettingsConnectivityDialog, {
-            settingsStore
+            settingsStore,
           })
         }}
       >
@@ -173,16 +182,22 @@ export function ProfileImageSelector({
 
 export function SettingsEditProfileDialogInner({
   onClose,
-  settingsStore
+  settingsStore,
 }: {
   onClose: DialogProps['onClose']
   settingsStore: SettingsStoreState
 }) {
   const tx = useTranslationFunction()
-  const [displayname, setDisplayname] = useState(settingsStore.settings.displayname)
-  const [selfstatus, setSelfstatus] = useState(settingsStore.settings.selfstatus)
+  const [displayname, setDisplayname] = useState(
+    settingsStore.settings.displayname
+  )
+  const [selfstatus, setSelfstatus] = useState(
+    settingsStore.settings.selfstatus
+  )
 
-  const [profilePicture, setProfilePicture] = useState(settingsStore.selfContact.profileImage)
+  const [profilePicture, setProfilePicture] = useState(
+    settingsStore.selfContact.profileImage
+  )
 
   const onCancel = () => {
     onClose()
@@ -246,7 +261,7 @@ export function SettingsEditProfileDialogInner({
 export function SettingsProfileDialog({
   onClose,
   isOpen,
-  settingsStore
+  settingsStore,
 }: {
   isOpen: DialogProps['isOpen']
   onClose: DialogProps['onClose']
@@ -266,7 +281,7 @@ export function SettingsProfileDialog({
       <DeltaDialogHeader title={tx('pref_edit_profile')} />
       {SettingsEditProfileDialogInner({
         settingsStore,
-        onClose
+        onClose,
       })}
     </DeltaDialogBase>
   )

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -4,7 +4,7 @@ import { Elevation, Card } from '@blueprintjs/core'
 const { ipcRenderer } = window.electron_functions
 import { useTranslationFunction } from '../../contexts'
 
-import { DesktopSettingsType, RC_Config } from '../../../shared/shared-types'
+import { DesktopSettingsType } from '../../../shared/shared-types'
 import { DialogProps } from './DialogController'
 import { SettingsExperimentalFeatures } from './Settings-ExperimentalFeatures'
 import {
@@ -15,7 +15,6 @@ import {
 } from './DeltaDialog'
 import SettingsAppearance from './Settings-Appearance'
 import SettingsProfile from './Settings-Profile'
-import { getLogger } from '../../../shared/logger'
 import { SettingsChatsAndMedia } from './Settings-ChatsAndMedia'
 import { SettingsAdvanced } from './Settings-Advanced'
 import SettingsNotifications from './Settings-Notifications'
@@ -23,8 +22,6 @@ import SettingsStoreInstance, {
   SettingsStoreState,
   useSettingsStore,
 } from '../../stores/settings'
-
-const log = getLogger('renderer/dialogs/Settings')
 
 export function flipDeltaBoolean(value: string) {
   return value === '1' ? '0' : '1'
@@ -93,11 +90,6 @@ export type RenderDeltaSwitch2Type = ({
   disabledValue?: boolean
 }) => void
 
-export interface SettingsState {
-  showSettingsDialog: boolean
-  show: string
-}
-
 export default function Settings(props: DialogProps) {
   useEffect(() => {
     if (window.__settingsOpened) {
@@ -110,16 +102,6 @@ export default function Settings(props: DialogProps) {
       window.__settingsOpened = false
     }
   })
-
-  const [state, _setState] = useState<SettingsState>({
-    showSettingsDialog: false,
-    show: 'main',
-  })
-  const setState = (updatedState: any) => {
-    _setState((prevState: any) => {
-      return { ...prevState, ...updatedState }
-    })
-  }
 
   const settingsStore = useSettingsStore()[0]
 
@@ -372,7 +354,6 @@ export default function Settings(props: DialogProps) {
     <DeltaDialogBase
       isOpen={props.isOpen}
       onClose={() => {
-        setState({ showSettingsDialog: false })
         props.onClose()
       }}
       className='SettingsDialog'

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -1,6 +1,4 @@
-import React, { useState, useEffect, useContext } from 'react'
-import { DeltaBackend } from '../../delta-remote'
-import { C } from 'deltachat-node/dist/constants'
+import React, { useState, useEffect } from 'react'
 import { Elevation, Card } from '@blueprintjs/core'
 
 const { ipcRenderer } = window.electron_functions
@@ -18,7 +16,6 @@ import {
 import SettingsAppearance from './Settings-Appearance'
 import SettingsProfile from './Settings-Profile'
 import { getLogger } from '../../../shared/logger'
-import { runtime } from '../../runtime'
 import { SettingsChatsAndMedia } from './Settings-ChatsAndMedia'
 import { SettingsAdvanced } from './Settings-Advanced'
 import SettingsNotifications from './Settings-Notifications'
@@ -99,7 +96,6 @@ export type RenderDeltaSwitch2Type = ({
 export interface SettingsState {
   showSettingsDialog: boolean
   show: string
-  rc: RC_Config
 }
 
 export default function Settings(props: DialogProps) {
@@ -118,7 +114,6 @@ export default function Settings(props: DialogProps) {
   const [state, _setState] = useState<SettingsState>({
     showSettingsDialog: false,
     show: 'main',
-    rc: ({} as any) as RC_Config,
   })
   const setState = (updatedState: any) => {
     _setState((prevState: any) => {
@@ -204,7 +199,7 @@ export default function Settings(props: DialogProps) {
     )
   }
 
-  const renderDialogContent = ({ rc }: typeof state) => {
+  const renderDialogContent = () => {
     if (!settingsStore) return null
 
     if (
@@ -276,9 +271,8 @@ export default function Settings(props: DialogProps) {
             <DeltaDialogBody>
               <Card elevation={Elevation.ONE}>
                 <SettingsExperimentalFeatures
-                  renderDTSettingSwitch={renderDTSettingSwitch}
-                  state={state}
                   settingsStore={settingsStore}
+                  renderDTSettingSwitch={renderDTSettingSwitch}
                 />
               </Card>
             </DeltaDialogBody>
@@ -336,7 +330,7 @@ export default function Settings(props: DialogProps) {
             <DeltaDialogBody>
               <Card elevation={Elevation.ONE}>
                 <SettingsAppearance
-                  rc={rc}
+                  rc={settingsStore.rc}
                   desktopSettings={settingsStore.desktopSettings}
                 />
               </Card>
@@ -367,21 +361,6 @@ export default function Settings(props: DialogProps) {
   }
 
   useEffect(() => {
-    const loadSettings = async () => {
-      const rc = await runtime.getRC_Config()
-      setState({ rc })
-    }
-    ;(async () => {
-      await loadSettings()
-      const selfContact = await DeltaBackend.call(
-        'contacts.getContact',
-        C.DC_CONTACT_ID_SELF
-      )
-      setState({ selfContact })
-    })()
-  }, [state.show])
-
-  useEffect(() => {
     return () => {
       ipcRenderer.removeAllListeners('DC_EVENT_IMEX_FILE_WRITTEN')
     }
@@ -399,7 +378,7 @@ export default function Settings(props: DialogProps) {
       className='SettingsDialog'
       fixed
     >
-      {renderDialogContent(state)}
+      {renderDialogContent()}
     </DeltaDialogBase>
   )
 }

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -22,7 +22,10 @@ import { runtime } from '../../runtime'
 import { SettingsChatsAndMedia } from './Settings-ChatsAndMedia'
 import { SettingsAdvanced } from './Settings-Advanced'
 import SettingsNotifications from './Settings-Notifications'
-import SettingsStoreInstance, {SettingsStoreState, useSettingsStore} from '../../stores/settings'
+import SettingsStoreInstance, {
+  SettingsStoreState,
+  useSettingsStore,
+} from '../../stores/settings'
 
 const log = getLogger('renderer/dialogs/Settings')
 
@@ -157,7 +160,10 @@ export default function Settings(props: DialogProps) {
         description={description}
         value={value}
         onClick={() => {
-          SettingsStoreInstance.effect.setDesktopSetting(key, !settingsStore.desktopSettings[key])
+          SettingsStoreInstance.effect.setDesktopSetting(
+            key,
+            !settingsStore.desktopSettings[key]
+          )
         }}
         disabled={disabled}
       />
@@ -171,13 +177,13 @@ export default function Settings(props: DialogProps) {
     disabled,
     disabledValue,
   }: {
-    key: keyof SettingsStoreState['settings'] 
+    key: keyof SettingsStoreState['settings']
     label: string
     description?: string
     disabled?: boolean
     disabledValue?: boolean
   }) => {
-    if (!settingsStore) return 
+    if (!settingsStore) return
     const value =
       disabled === true && typeof disabledValue !== 'undefined'
         ? disabledValue
@@ -188,7 +194,10 @@ export default function Settings(props: DialogProps) {
         value={value}
         description={description}
         onClick={() => {
-          SettingsStoreInstance.effect.setCoreSetting(key, flipDeltaBoolean(settingsStore.settings[key]))
+          SettingsStoreInstance.effect.setCoreSetting(
+            key,
+            flipDeltaBoolean(settingsStore.settings[key])
+          )
         }}
         disabled={disabled}
       />
@@ -198,7 +207,10 @@ export default function Settings(props: DialogProps) {
   const renderDialogContent = ({ rc }: typeof state) => {
     if (!settingsStore) return null
 
-    if (Object.keys(settingsStore.settings || {}).length === 0 || !settingsStore.desktopSettings) {
+    if (
+      Object.keys(settingsStore.settings || {}).length === 0 ||
+      !settingsStore.desktopSettings
+    ) {
       return null
     }
 
@@ -216,7 +228,6 @@ export default function Settings(props: DialogProps) {
                 <SettingsProfile
                   settingsStore={settingsStore}
                   onClose={props.onClose}
-                  
                 />
                 <br />
                 <SettingsIconButton
@@ -287,7 +298,6 @@ export default function Settings(props: DialogProps) {
                 <SettingsChatsAndMedia
                   settingsStore={settingsStore}
                   desktopSettings={settingsStore.desktopSettings}
-                  
                   renderDeltaSwitch2={renderDeltaSwitch2}
                   renderDTSettingSwitch={renderDTSettingSwitch}
                 />

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -13,7 +13,7 @@ import MapLayerFactory from './MapLayerFactory'
 import { Slider, Button, Collapse } from '@blueprintjs/core'
 import PopupMessage from './PopupMessage'
 import * as SessionStorage from '../helpers/SessionStorage'
-import { MessagesDisplayContext, SettingsContext } from '../../contexts'
+import { MessagesDisplayContext } from '../../contexts'
 import chatStore from '../../stores/chat'
 
 import { state as LocationStoreState } from '../../stores/locations'
@@ -752,5 +752,3 @@ export default class MapComponent extends React.Component<
     )
   }
 }
-
-MapComponent.contextType = SettingsContext

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -11,7 +11,7 @@ import { isChatReadonly } from '../../../shared/util'
 import { join, parse } from 'path'
 import { runtime } from '../../runtime'
 import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
-import {useSettingsStore} from '../../stores/settings'
+import { useSettingsStore } from '../../stores/settings'
 
 const log = getLogger('renderer/MessageListAndComposer')
 
@@ -203,7 +203,9 @@ export default function MessageListAndComposer({
   const [disabled, disabledReason] = isChatReadonly(chatStore.chat)
 
   const settingsStore = useSettingsStore()[0]
-  const style = settingsStore ? getBackgroundImageStyle(settingsStore.desktopSettings) : {}
+  const style = settingsStore
+    ? getBackgroundImageStyle(settingsStore.desktopSettings)
+    : {}
 
   return (
     <div

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -3,7 +3,7 @@ import { DeltaBackend } from '../../delta-remote'
 import Composer, { useDraft } from '../composer/Composer'
 import { getLogger } from '../../../shared/logger'
 import MessageList from './MessageList'
-import { SettingsContext, ScreenContext } from '../../contexts'
+import { ScreenContext } from '../../contexts'
 import { ChatStoreStateWithChatSet } from '../../stores/chat'
 import ComposerMessageInput from '../composer/ComposerMessageInput'
 import { DesktopSettingsType } from '../../../shared/shared-types'
@@ -11,6 +11,7 @@ import { isChatReadonly } from '../../../shared/util'
 import { join, parse } from 'path'
 import { runtime } from '../../runtime'
 import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
+import {useSettingsStore} from '../../stores/settings'
 
 const log = getLogger('renderer/MessageListAndComposer')
 
@@ -201,8 +202,8 @@ export default function MessageListAndComposer({
 
   const [disabled, disabledReason] = isChatReadonly(chatStore.chat)
 
-  const settings = useContext(SettingsContext).desktopSettings
-  const style = settings ? getBackgroundImageStyle(settings) : {}
+  const settingsStore = useSettingsStore()[0]
+  const style = settingsStore ? getBackgroundImageStyle(settingsStore.desktopSettings) : {}
 
   return (
     <div

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -1,8 +1,5 @@
 import React, { useState, useContext, useRef } from 'react'
-import {
-  ScreenContext,
-  useTranslationFunction,
-} from '../../contexts'
+import { ScreenContext, useTranslationFunction } from '../../contexts'
 
 import Gallery from '../Gallery'
 import { useThreeDotMenu } from '../ThreeDotMenu'
@@ -38,7 +35,7 @@ import { FullChat } from '../../../shared/shared-types'
 import { getLogger } from '../../../shared/logger'
 import { RecoverableCrashScreen } from './RecoverableCrashScreen'
 import Sidebar, { SidebarState } from '../Sidebar'
-import SettingsStoreInstance, {useSettingsStore} from '../../stores/settings'
+import SettingsStoreInstance, { useSettingsStore } from '../../stores/settings'
 
 const log = getLogger('renderer/main-screen')
 
@@ -266,7 +263,8 @@ export default function MainScreen() {
                   icon={'media'}
                   aria-label={tx('media')}
                 />
-                { settingsStore?.desktopSettings.enableOnDemandLocationStreaming && (
+                {settingsStore?.desktopSettings
+                  .enableOnDemandLocationStreaming && (
                   <Button
                     minimal
                     large

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useContext, useRef } from 'react'
 import {
   ScreenContext,
-  SettingsContext,
   useTranslationFunction,
 } from '../../contexts'
 
@@ -39,7 +38,7 @@ import { FullChat } from '../../../shared/shared-types'
 import { getLogger } from '../../../shared/logger'
 import { RecoverableCrashScreen } from './RecoverableCrashScreen'
 import Sidebar, { SidebarState } from '../Sidebar'
-import SettingsStoreInstance from '../../stores/settings'
+import SettingsStoreInstance, {useSettingsStore} from '../../stores/settings'
 
 const log = getLogger('renderer/main-screen')
 
@@ -107,6 +106,7 @@ export default function MainScreen() {
   }
 
   const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
 
   const searchRef = useRef<HTMLInputElement>(null)
 
@@ -148,8 +148,8 @@ export default function MainScreen() {
         )
     }
   } else {
-    const style: React.CSSProperties = window.__desktopSettings
-      ? getBackgroundImageStyle(window.__desktopSettings)
+    const style: React.CSSProperties = settingsStore
+      ? getBackgroundImageStyle(settingsStore.desktopSettings)
       : {}
 
     MessageListView = (
@@ -266,20 +266,16 @@ export default function MainScreen() {
                   icon={'media'}
                   aria-label={tx('media')}
                 />
-                <SettingsContext.Consumer>
-                  {({ desktopSettings }) =>
-                    desktopSettings?.enableOnDemandLocationStreaming && (
-                      <Button
-                        minimal
-                        large
-                        icon='map'
-                        onClick={() => setView(View.Map)}
-                        active={view === View.Map}
-                        aria-label={tx('tab_map')}
-                      />
-                    )
-                  }
-                </SettingsContext.Consumer>
+                { settingsStore?.desktopSettings.enableOnDemandLocationStreaming && (
+                  <Button
+                    minimal
+                    large
+                    icon='map'
+                    onClick={() => setView(View.Map)}
+                    active={view === View.Map}
+                    aria-label={tx('tab_map')}
+                  />
+                )}
               </span>
             )}
             <span

--- a/src/renderer/contexts.ts
+++ b/src/renderer/contexts.ts
@@ -28,19 +28,6 @@ export const i18nContext = React.createContext<getMessageFunction>(
  */
 export const useTranslationFunction = () => useContext(i18nContext)
 
-type setDesktopSetting = (
-  key: keyof DesktopSettingsType,
-  value: string | number | boolean
-) => {}
-
-export const SettingsContext: React.Context<{
-  desktopSettings: DesktopSettingsType | null
-  setDesktopSetting: setDesktopSetting
-}> = React.createContext({
-  desktopSettings: null as DesktopSettingsType | null,
-  setDesktopSetting: ((_key, _value) => {}) as setDesktopSetting,
-})
-
 export type unwrapContext<T> = T extends import('react').Context<infer R>
   ? R
   : null

--- a/src/renderer/contexts.ts
+++ b/src/renderer/contexts.ts
@@ -1,5 +1,4 @@
 import React, { useContext } from 'react'
-import { DesktopSettingsType } from '../shared/shared-types'
 import { userFeedback, Screens } from './ScreenController'
 import { getMessageFunction } from '../shared/localize'
 import { showFnType } from './components/ContextMenu'

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,5 +1,4 @@
 import { getMessageFunction, LocaleData } from '../shared/localize'
-import { DesktopSettingsType } from '../shared/shared-types'
 
 import {
   OpenDialogFunctionType,

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -31,7 +31,6 @@ declare global {
     __keybindingsDialogOpened: boolean
     __setQuoteInDraft: ((msgId: number) => void) | null
     __reloadDraft: (() => void) | null
-    __desktopSettings: DesktopSettingsType | null
     __chatlistSetSearch: ((searchTerm: string) => void) | undefined
     __chatStore: any
     __setMainScreenView:

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -1,7 +1,12 @@
 import { C } from 'deltachat-node/dist/constants'
-import { DesktopSettingsType, JsonContact } from '../../shared/shared-types'
+import {
+  DesktopSettingsType,
+  JsonContact,
+  RC_Config,
+} from '../../shared/shared-types'
 import { DeltaBackend } from '../delta-remote'
 import { ipcBackend } from '../ipc'
+import { runtime } from '../runtime'
 import { Store, useStore } from './store'
 
 export interface SettingsStoreState {
@@ -24,6 +29,7 @@ export interface SettingsStoreState {
     only_fetch_mvbox: string
   }
   desktopSettings: DesktopSettingsType
+  rc: RC_Config
 }
 
 const settingsKeys: Array<keyof SettingsStoreState['settings']> = [
@@ -106,18 +112,21 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         'settings.getConfigFor',
         settingsKeys
       )) as SettingsStoreState['settings']
-      const desktopSettings = await DeltaBackend.call(
-        'settings.getDesktopSettings'
-      )
       const selfContact = await DeltaBackend.call(
         'contacts.getContact',
         C.DC_CONTACT_ID_SELF
       )
+      const desktopSettings = await DeltaBackend.call(
+        'settings.getDesktopSettings'
+      )
+
+      const rc = await runtime.getRC_Config()
       this.reducer.setState({
         settings,
         selfContact,
         accountId: -1,
         desktopSettings,
+        rc,
       })
     },
     setDesktopSetting: async (

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -1,7 +1,7 @@
 import { C } from 'deltachat-node/dist/constants'
 import { DesktopSettingsType, JsonContact } from '../../shared/shared-types'
 import { DeltaBackend } from '../delta-remote'
-import {ipcBackend} from '../ipc'
+import { ipcBackend } from '../ipc'
 import { Store, useStore } from './store'
 
 export interface SettingsStoreState {
@@ -22,7 +22,7 @@ export interface SettingsStoreState {
     webrtc_instance: string
     download_limit: string
     only_fetch_mvbox: string
-  },
+  }
   desktopSettings: DesktopSettingsType
 }
 
@@ -55,11 +55,14 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         if (state === null) return
         return {
           ...state,
-          selfContact
+          selfContact,
         }
       }, 'setSelfContact')
     },
-    setDesktopSetting: (key: keyof DesktopSettingsType, value: string | number | boolean) => {
+    setDesktopSetting: (
+      key: keyof DesktopSettingsType,
+      value: string | number | boolean
+    ) => {
       this.setState(state => {
         if (state === null) {
           this.log.warn(
@@ -71,12 +74,15 @@ class SettingsStore extends Store<SettingsStoreState | null> {
           ...state,
           desktopSettings: {
             ...state.desktopSettings,
-            [key]: value
-          }
+            [key]: value,
+          },
         }
       }, 'setDesktopSetting')
     },
-    setCoreSetting: (key: keyof SettingsStoreState['settings'], value: string | boolean) => {
+    setCoreSetting: (
+      key: keyof SettingsStoreState['settings'],
+      value: string | boolean
+    ) => {
       this.setState(state => {
         if (state === null) {
           this.log.warn(
@@ -88,11 +94,11 @@ class SettingsStore extends Store<SettingsStoreState | null> {
           ...state,
           settings: {
             ...state.settings,
-            [key]: value
-          }
+            [key]: value,
+          },
         }
       }, 'setCoreSetting')
-    }
+    },
   }
   effect = {
     load: async () => {
@@ -107,9 +113,17 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         'contacts.getContact',
         C.DC_CONTACT_ID_SELF
       )
-      this.reducer.setState({ settings, selfContact, accountId: -1, desktopSettings })
+      this.reducer.setState({
+        settings,
+        selfContact,
+        accountId: -1,
+        desktopSettings,
+      })
     },
-    setDesktopSetting: async(key: keyof DesktopSettingsType, value: string | number | boolean) => {
+    setDesktopSetting: async (
+      key: keyof DesktopSettingsType,
+      value: string | number | boolean
+    ) => {
       if (
         (await DeltaBackend.call('settings.setDesktopSetting', key, value)) ===
         true
@@ -117,7 +131,10 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         this.reducer.setDesktopSetting(key, value)
       }
     },
-    setCoreSetting: async(key: keyof SettingsStoreState['settings'], value: string | boolean) => {
+    setCoreSetting: async (
+      key: keyof SettingsStoreState['settings'],
+      value: string | boolean
+    ) => {
       if (
         (await DeltaBackend.call('settings.setConfig', key, String(value))) ===
         true
@@ -126,7 +143,7 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         return
       }
       this.log.warn('settings.setConfig returned false for: ', key, value)
-    }
+    },
   }
 }
 


### PR DESCRIPTION
Move all settings (core settings, desktop settings, rc) into SettingsStore.

This improves loading times of Settings dialog (no more flashing avatar) and makes sure that all setting changes are getting announced to all components depending on them.

- [x] get rid of Settings.tsx loading rc config
- [x] get rid of useProfileImage
- [x] get rid of SettingsContext.Consumer