### PR TITLE
Fixed font and icon color when hovering over settings icon buttons in…

### DIFF
--- a/themes/dev_rocket.scss
+++ b/themes/dev_rocket.scss
@@ -678,6 +678,9 @@ div.group-image-wrapper div.group-image-edit-button {
 
 .bp3-menu-item:hover, .bp3-submenu .bp3-popover-target.bp3-popover-open > .bp3-menu-item, 
 .SettingsSelector:hover button, .SettingsSelector:hover .CurrentValue, 
-.SettingsButton:hover button, .bp3-control.bp3-switch:hover {
+.SettingsButton:hover button, .bp3-control.bp3-switch:hover, .SettingsIconButton:hover button{
   color: white !important;
+}
+.SettingsIconButton:hover .Icon {
+  background-color: white;
 }


### PR DESCRIPTION
… rocket theme

Fixes last issue of #2338
Font and icon color switch to white when hovering over the button.

![image](https://user-images.githubusercontent.com/28535045/164031895-e45aaf16-fa9d-4760-85c2-8e7b96e299d5.png)
