### PR TITLE
fix a startup crash on mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fix contact name has color in quote when replying with sticker
+- Fix startup crash when spam clicking on app icon on mac.
 
 ### Added
 - Implement expandable settings

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -186,10 +186,11 @@ export function quit(e?: Electron.Event) {
   }, 4000)
 }
 app.on('activate', () => {
-  if (!mainWindow.window) {
-    throw new Error('window does not exist, this should never happen')
-  }
   log.debug("app.on('activate')")
+  if (!mainWindow.window) {
+    log.warn('window not set, this is normal on startup')
+    return
+  }
   if (mainWindow.window.isVisible() === false) {
     log.debug("app.on('activate') showing main window")
     showDeltaChat()


### PR DESCRIPTION
when spam clicking on app icon the activate method is called
and expected the window to be ready, and threw an error otherwise (for example on startup).
To fix it I converted the "throw an error" to a "log the error" and keep working.