### PR TITLE
use a forked version of react-qr-reader to fix the peer dependency warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - update webxdc setUpdateListener api
 - Remove dependency tempy
 - Update @blueprintjs/core to `4.1.2`
+- use forked version of `react-qr-reader` (@deltachat/react-qr-reader@4.0.0)
 
 ### Removed
 - remove dependency `react-qr-svg`

--- a/package-lock.json
+++ b/package-lock.json
@@ -2794,6 +2794,16 @@
       "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.3.0.tgz",
       "integrity": "sha512-qMa6iZ5o8NoN3AE7orF71sL/FC9aqj0weP7X7dU1IwGsaWKSy1Ix1Pup5sw55HHlcfR1v61VXxnfHEmpQioydA=="
     },
+    "@deltachat/react-qr-reader": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@deltachat/react-qr-reader/-/react-qr-reader-4.0.0.tgz",
+      "integrity": "sha512-MdsQTo1Q18IUP3yMADQHDeWlVCq9p+LV96+dKCyNSBffaZ/5nE4J+Rbldd9QjPyVL615Hp4m9cubVfk/iAIjyA==",
+      "requires": {
+        "jsqr": "^1.1.1",
+        "prop-types": "^15.5.8",
+        "webrtc-adapter": "^6.4.0"
+      }
+    },
     "@develar/schema-utils": {
       "version": "2.6.5",
       "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
@@ -8694,9 +8704,9 @@
       }
     },
     "jsqr": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.2.0.tgz",
-      "integrity": "sha512-wKcQS9QC2VHGk7aphWCp1RrFyC0CM6fMgC5prZZ2KV/Lk6OKNoCod9IR6bao+yx3KPY0gZFC5dc+h+KFzCI0Wg=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A=="
     },
     "jszip": {
       "version": "3.7.1",
@@ -11195,16 +11205,6 @@
         "prop-types": "^15.6.1",
         "typed-styles": "^0.0.7",
         "warning": "^4.0.2"
-      }
-    },
-    "react-qr-reader": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-qr-reader/-/react-qr-reader-2.2.1.tgz",
-      "integrity": "sha512-EL5JEj53u2yAOgtpAKAVBzD/SiKWn0Bl7AZy6ZrSf1lub7xHwtaXe6XSx36Wbhl1VMGmvmrwYMRwO1aSCT2fwA==",
-      "requires": {
-        "jsqr": "^1.2.0",
-        "prop-types": "^15.7.2",
-        "webrtc-adapter": "^7.2.1"
       }
     },
     "react-string-replace": {
@@ -15404,12 +15404,12 @@
       "dev": true
     },
     "webrtc-adapter": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-7.5.1.tgz",
-      "integrity": "sha512-R5LkIR/APjODkstSXFOztOmINXQ0nqIGfUoKTtCzjyiDXHNgwhkqZ9vi8UzGyjfUBibuZ0ZzVyV10qtuLGW3CQ==",
+      "version": "6.4.8",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-6.4.8.tgz",
+      "integrity": "sha512-YM8yl545c/JhYcjGHgaCoA7jRK/KZuMwEDFeP2AcP0Auv5awEd+gZE0hXy9z7Ed3p9HvAXp8jdbe+4ESb1zxAw==",
       "requires": {
-        "rtcpeerconnection-shim": "^1.2.15",
-        "sdp": "^2.12.0"
+        "rtcpeerconnection-shim": "^1.2.14",
+        "sdp": "^2.9.0"
       }
     },
     "whatwg-fetch": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "dependencies": {
     "@blueprintjs/core": "^4.1.2",
     "@deltachat/message_parser_wasm": "^0.3.0",
+    "@deltachat/react-qr-reader": "^4.0.0",
     "@mapbox/geojson-extent": "^1.0.0",
     "application-config": "^1.0.1",
     "classnames": "^2.3.1",
@@ -96,7 +97,6 @@
     "rc": "^1.2.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-qr-reader": "^2.2.1",
     "react-string-replace": "^1.0.0",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",

--- a/src/renderer/components/dialogs/QrCode.tsx
+++ b/src/renderer/components/dialogs/QrCode.tsx
@@ -15,7 +15,7 @@ import {
 import { DialogProps } from './DialogController'
 import { useTranslationFunction, ScreenContext } from '../../contexts'
 import classNames from 'classnames'
-import QrReader from 'react-qr-reader'
+import QrReader from '@deltachat/react-qr-reader'
 import processOpenQrUrl from '../helpers/OpenQrUrl'
 import { getLogger } from '../../../shared/logger'
 import { useContextMenu } from '../ContextMenu'

--- a/src/renderer/types.d.ts
+++ b/src/renderer/types.d.ts
@@ -1,5 +1,5 @@
 declare module '@mapbox/geojson-extent'
-declare module 'react-qr-reader'
+declare module '@deltachat/react-qr-reader'
 
 type todo = any
 


### PR DESCRIPTION
fixes the peer dependency warning which is an error with newer npm versions

this pr is needed for #2687 