### PR TITLE
Truncate long names and mails in sidebar, navbar, quotes and composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,15 @@
 
 ### Fixed
 - Fix crash on migrating accounts from an older version (before 1.21.0)
-- add a guard against selecting accounts with impossible ids (smaller than 0)
-- fix stock translations set too late (after I/0 is started) #2735
+- Add a guard against selecting accounts with impossible ids (smaller than 0)
+- Fix stock translations set too late (after I/0 is started) #2735
 - Fix jumping to send video chat invitation
 - Fix jumping to last message if sending multiple attachments through drag&drop
+- Fix truncating of names and emails
 
 ### Changed
 - Update `@deltachat/message_parser_wasm` to `0.4.0` (fixes a email parsing issue)
+
 
 ## [1.29.0] - 2022-05-05
 

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -13,6 +13,8 @@
   top: 0;
   left: 0;
   min-width: 250px;
+  width: 30%;
+  max-width: 90vw;
   height: 100vh;
   background-color: var(--sideBarBackground);
   z-index: 100;
@@ -71,11 +73,15 @@
     }
     .displayname {
       font-weight: bolder;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
     .emailAddress {
       font-size: small;
       font-weight: 100;
       color: var(--sideBarAccountEmailText);
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -3,6 +3,8 @@
     font-size: medium;
     font-weight: bold;
     cursor: pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     img.verified-icon {
       width: 0.8em;
@@ -24,6 +26,8 @@
     font-weight: 100;
     cursor: pointer;
     color: var(--navBarGroupSubtitle);
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .no-chat-selected-screen {

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -182,11 +182,6 @@
 
 // States that modify the message bubble appearance
 
-.quote-text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .message.incoming {
   margin-left: 0;
   margin-right: 32px;
@@ -432,11 +427,6 @@
 
 // quote
 
-.quote-author {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .quote-background {
   overflow: hidden;
   max-width: 100%;
@@ -462,6 +452,12 @@
     line-height: 13px;
     margin-bottom: 2px;
     font-weight: 300;
+  }
+
+  .quote-author,
+  .quote-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .quoted-text {

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -180,11 +180,17 @@
   }
 }
 
-// States that modify the message buble appearance
+// States that modify the message bubble appearance
+
+.quote-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 
 .message.incoming {
   margin-left: 0;
   margin-right: 32px;
+  max-width: 100%;
 
   .metadata:not(.with-image-no-caption) {
     & > .padlock-icon {
@@ -222,6 +228,7 @@
   float: right;
   margin-right: 0;
   margin-left: 32px;
+  max-width: 100%;
 
   .metadata:not(.with-image-no-caption) {
     & > .date {
@@ -396,6 +403,7 @@
   width: 100%;
   text-align: center;
   margin: 26px 0px;
+  overflow-wrap: anywhere;
 
   .bubble {
     display: inline-block;
@@ -423,6 +431,16 @@
 }
 
 // quote
+
+.quote-author {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.quote-background {
+  overflow: hidden;
+  max-width: 100%;
+}
 
 .message .msg-container .quote,
 .composer .quote {

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -209,7 +209,7 @@ export default function MainScreen() {
                   cursor: 'pointer',
                   display: 'flex',
                   alignItems: 'center',
-                  width: '100%',
+                  marginRight: '15px',
                 }}
                 onClick={onTitleClick}
               >
@@ -220,7 +220,7 @@ export default function MainScreen() {
                   avatarPath={selectedChat.chat.profileImage || undefined}
                   small
                 />
-                <div style={{ marginLeft: '7px' }}>
+                <div style={{ marginLeft: '7px', overflow: 'hidden' }}>
                   <div className='navbar-chat-name'>
                     {selectedChat.chat.name}
                     {selectedChat.chat.ephemeralTimer !== 0 && (


### PR DESCRIPTION
before:
![not_truncated](https://user-images.githubusercontent.com/28535045/167622322-439f0648-164b-49ea-b9de-ba17b95629bb.png)
after:
![truncated](https://user-images.githubusercontent.com/28535045/167622328-8ac19046-715a-4864-866f-9dd623af9036.png)

before:
![image](https://user-images.githubusercontent.com/28535045/167623319-24e6212a-c483-49d4-9e2c-e9aca91f7650.png)
after:
![image](https://user-images.githubusercontent.com/28535045/167623396-ff99e270-44aa-47a7-9acc-a3dbbb7a2d0d.png)
before:
![image](https://user-images.githubusercontent.com/28535045/167623674-d1b85408-5362-4baa-be20-1aa3c43bcd71.png)
after:
![image](https://user-images.githubusercontent.com/28535045/167623777-196c1e6c-467c-4fc1-919a-1734f3f4fd7e.png)


closes #2564

