### PR TITLE
Max bubble width fixed but still wrong for quotes of long user names

### DIFF
--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -185,7 +185,6 @@
 .message.incoming {
   margin-left: 0;
   margin-right: 32px;
-  max-width: 100%;
 
   .metadata:not(.with-image-no-caption) {
     & > .padlock-icon {
@@ -223,7 +222,6 @@
   float: right;
   margin-right: 0;
   margin-left: 32px;
-  max-width: 100%;
 
   .metadata:not(.with-image-no-caption) {
     & > .date {


### PR DESCRIPTION
Hotfix. Want to address problems with bubble width for small devices and long user names in quotes separately.