### PR TITLE
Webxdc window title: show Webxdc name first

### DIFF
--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -171,7 +171,7 @@ export default class DCWebxdc extends SplitOut {
             'webxdc-preload.js'
           ),
         },
-        title: `${chat_name} – ${webxdc_message.webxdcInfo.name}`,
+        title: `${webxdc_message.webxdcInfo.name} – ${chat_name}`,
         icon: app_icon || undefined,
         width: 375,
         height: 667,


### PR DESCRIPTION
this gives more focus to the app name and looks more natural.
if we add an additional document name,
that will be prepended or will replace the Webxdc Name.

cmp. deltachat/deltachat-core-rust#3317 and https://github.com/deltachat/deltachat-core-rust/issues/3316