### PR TITLE
add check for compatible node while installing dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
+- add check for compatible node while installing dependencies (#2724)
 
 ### Fixed
 

--- a/bin/check-nodejs-version.js
+++ b/bin/check-nodejs-version.js
@@ -1,0 +1,11 @@
+const { versions } = require('process')
+
+const MIN_NODE_VERSION = 16
+
+const majorVersion = versions.node.split('.')[0]
+if (majorVersion < MIN_NODE_VERSION) {
+  console.log(
+    `ERROR:\n!!!\nThe oldest nodejs you may use is ${MIN_NODE_VERSION}, but you have ${majorVersion}\n!!!`
+  )
+  process.exit(1)
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "deltachat-desktop",
       "version": "1.29.1",
+      "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@blueprintjs/core": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Desktop Application for delta.chat",
   "main": "index.js",
   "scripts": {
+    "preinstall": "node ./bin/check-nodejs-version.js",
     "test": "npm run check-types && npm run lint && npm run check-formatting && npm run test-log-conventions && npm run test-unit && npm run test-misc",
     "test-misc": "node ./bin/test_package_lock_version",
     "test-log-conventions": "node ./bin/log-conventions",


### PR DESCRIPTION
this adds a check for the nodejs version to `npm install`, in order to fix #2724