### PR TITLE
change composer keybindings shift+enter now always adds a newline and crtl/cmd+enter now always sends regardless of what the enter key is set up to do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - remove unessesary deltachat-node files from release package
 
 ### Changed
+- change composer keybindings (shift+enter now always adds a newline and crtl/cmd+enter now always sends regardless of what the enter key is set up to do)
 
 
 ## [1.29.1] - 2022-05-20

--- a/src/renderer/components/KeyboardShortcutHint.tsx
+++ b/src/renderer/components/KeyboardShortcutHint.tsx
@@ -163,22 +163,22 @@ export function enterKeySendsKeyboardShortcuts(
     return [
       {
         title: tx('desktop_keybindings_action_send_message'),
-        keyBindings: [Enter],
+        keyBindings: [Enter, CtrlOrMetaEnter],
       },
       {
         title: tx('desktop_keybindings_action_insert_newline'),
-        keyBindings: [ShiftEnter, CtrlOrMetaEnter],
+        keyBindings: [ShiftEnter],
       },
     ]
   } else {
     return [
       {
         title: tx('desktop_keybindings_action_send_message'),
-        keyBindings: [CtrlOrMetaEnter, ShiftEnter],
+        keyBindings: [CtrlOrMetaEnter],
       },
       {
         title: tx('desktop_keybindings_action_insert_newline'),
-        keyBindings: [Enter],
+        keyBindings: [Enter, ShiftEnter],
       },
     ]
   }

--- a/src/renderer/components/composer/ComposerMessageInput.tsx
+++ b/src/renderer/components/composer/ComposerMessageInput.tsx
@@ -129,10 +129,10 @@ export default class ComposerMessageInput extends React.Component<
 
     // ENTER + SHIFT
     if (e.key === 'Enter' && e.shiftKey) {
-      return enterKeySends ? 'NEWLINE' : 'SEND'
+      return 'NEWLINE'
       // ENTER + CTRL
     } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
-      return enterKeySends ? 'NEWLINE' : 'SEND'
+      return 'SEND'
       // ENTER
     } else if (e.key === 'Enter' && !e.shiftKey) {
       return enterKeySends ? 'SEND' : 'NEWLINE'


### PR DESCRIPTION
<img width="260" alt="image" src="https://user-images.githubusercontent.com/18725968/170703611-22fb08d5-ad23-4e1a-abe0-8be336addc0f.png">

change composer keybindings shift+enter now always adds a newline
and crtl/cmd+enter now always sends
regardless of what the enter key is set up to do