### PR TITLE
Added vertical space between webxdc start-button and message-text

### DIFF
--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -140,6 +140,11 @@
         padding: 6px 13px;
       }
     }
+
+    .webxdc + .text span {
+      display: inline-block;
+      margin-top: 10px;
+    }
   }
 
   .metadata {

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -346,9 +346,9 @@ const Message = (props: {
       <div dir='auto' className='text'>
         {message.isSetupmessage ? (
           tx('autocrypt_asm_click_body')
-        ) : (
-          <MessageBody text={text || ''} />
-        )}
+        ) : text ? (
+          <MessageBody text={text} />
+        ) : null}
       </div>
     )
   }


### PR DESCRIPTION
For bug #2762
I made a selector for adding a top margin of 10px. I had to made the span inside the message inline-block to be able to add the margin(I think that does not create any conflict in other parts but it would be good if you can confirm it).
I also made the MessageBody component not to be rendered at all if there was no text at all. I thought an alternative to rendering the MessageBody conditional might be to use the :not(:empty) selector, but at the same time I considered that if you're not going to have any text, there wasn't even a need to run the code of MessageBody in the first place but I would also love to know your input in that.

Here is an example of the spacing between the button and the message.
![Screen Shot 2022-05-27 at 15 33 37](https://user-images.githubusercontent.com/13797293/170792121-e5c1435f-07e5-48f4-9132-3ca051c02df5.png)

And here is an example without a message.
![Screen Shot 2022-05-27 at 15 34 04](https://user-images.githubusercontent.com/13797293/170792278-bed561c7-86bc-422c-850c-bd4ded160aa1.png)

The styles are only been applied when the there's a webxdc before the message.
![Screen Shot 2022-05-27 at 15 37 47](https://user-images.githubusercontent.com/13797293/170792368-2f83cab4-488d-4ded-b85c-10e94cf6e74e.png)


closes #2762