### PR TITLE
fix media files with invalid uri chars in name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - "New contact" button hidden if contact already exists (#2646)
 - Fix too wide clickable area on forwarded messages @andresmc98 (#2782)
 - Fix button label saying open instead of save in export backup file dialog
+- Fix display/playing of media files that contain invalid url chars in filename (such as `#`) (#2527)
 
 ### Changed
 - Updated minimal theme

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -191,7 +191,8 @@ class Electron implements Runtime {
     })
   }
   transformBlobURL(blob: string): string {
-    return blob
+    let filename = basename(blob)
+    return blob.replace(filename, encodeURIComponent(filename))
   }
   async showOpenFileDialog(
     options: Electron.OpenDialogOptions


### PR DESCRIPTION
(such as `#`)
closes #2527

@gerryfrancis can you try if this works on windows?