### PR TITLE
use addr if displayname is not set for webxdc selfName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+## Fixed
+- use addr if displayname is not set for webxdc selfName #2803
+
 ## [1.30.1] - 2022-06-07
 
 ### Added

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -115,7 +115,9 @@ export default class DCWebxdc extends SplitOut {
 
             if (filename === 'webxdc.js') {
               const displayName = Buffer.from(
-                this.controller.settings.getConfig('displayname')
+                this.controller.settings.getConfig('displayname') ||
+                  this.controller.settings.getConfig('addr') ||
+                  'unknown'
               ).toString('base64')
               const seflAddr = Buffer.from(
                 this.controller.settings.getConfig('addr')


### PR DESCRIPTION
closes #2803
same behaviour as https://github.com/deltachat/deltachat-ios/blob/2a091b1ab2eadc6109f362527bc099c9bdeb3d25/deltachat-ios/Controller/WebxdcViewController.swift#L82