### PR TITLE
register for `dcaccount:` and `dclogin:` scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ## Added
 - Floating action button in chatlist to start a new chat
+- register in os as handler for the `dcaccount:` scheme
 
 ## Fixed
 - use addr if displayname is not set for webxdc selfName #2803

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - click on selected chat in chatlist now goes to bottom or first unread message
 - remember last path in "save as" dialog
 - allow using `dclogin:` and `dcaccount:` from logged in account, without logging out first
+- register in os as handler for the `dcaccount:` and `dclogin:` scheme
 
 ## Fixed
 - allow scanning of certain qr code types on welcome screen (account, url and text)
@@ -49,7 +50,6 @@
 
 ## Added
 - Floating action button in chatlist to start a new chat
-- register in os as handler for the `dcaccount:` scheme
 
 ## Fixed
 - use addr if displayname is not set for webxdc selfName #2803

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Update translations (22.09.2022)
 - click on selected chat in chatlist now goes to bottom or first unread message
 - remember last path in "save as" dialog
+- allow using `dclogin:` and `dcaccount:` from logged in account, without logging out first
 
 ## Fixed
 - allow scanning of certain qr code types on welcome screen (account, url and text)

--- a/build/gen-electron-builder-config.js
+++ b/build/gen-electron-builder-config.js
@@ -21,7 +21,7 @@ build['protocols'] = [
   {
     name: 'QR code data',
     role: 'Viewer',
-    schemes: ['openpgp4fpr', 'dcaccount'],
+    schemes: ['openpgp4fpr', 'dcaccount', 'dclogin:'],
   },
   {
     name: 'Send Mails via MailTo Scheme',

--- a/build/gen-electron-builder-config.js
+++ b/build/gen-electron-builder-config.js
@@ -21,7 +21,7 @@ build['protocols'] = [
   {
     name: 'QR code data',
     role: 'Viewer',
-    schemes: ['openpgp4fpr'],
+    schemes: ['openpgp4fpr', 'dcaccount'],
   },
   {
     name: 'Send Mails via MailTo Scheme',

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -6,7 +6,7 @@
     {
       name: 'QR code data',
       role: 'Viewer',
-      schemes: ['openpgp4fpr', 'dcaccount'],
+      schemes: ['openpgp4fpr', 'dcaccount', 'dclogin:'],
     },
     {
       name: 'Send Mails via MailTo Scheme',

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -3,7 +3,11 @@
 {
   appId: 'chat.delta.desktop.electron',
   protocols: [
-    { name: 'QR code data', role: 'Viewer', schemes: ['openpgp4fpr'] },
+    {
+      name: 'QR code data',
+      role: 'Viewer',
+      schemes: ['openpgp4fpr', 'dcaccount'],
+    },
     {
       name: 'Send Mails via MailTo Scheme',
       role: 'Viewer',

--- a/src/main/application-constants.ts
+++ b/src/main/application-constants.ts
@@ -59,4 +59,4 @@ export function getCustomThemesPath() {
   return join(getConfigPath(), 'custom-themes')
 }
 
-export const supportedURISchemes = ['OPENPGP4FPR:', 'MAILTO:']
+export const supportedURISchemes = ['OPENPGP4FPR:', 'MAILTO:', 'DCACCOUNT:']

--- a/src/main/application-constants.ts
+++ b/src/main/application-constants.ts
@@ -59,4 +59,9 @@ export function getCustomThemesPath() {
   return join(getConfigPath(), 'custom-themes')
 }
 
-export const supportedURISchemes = ['OPENPGP4FPR:', 'MAILTO:', 'DCACCOUNT:']
+export const supportedURISchemes = [
+  'OPENPGP4FPR:',
+  'MAILTO:',
+  'DCACCOUNT:',
+  'DCLOGIN:',
+]

--- a/src/main/open_url.ts
+++ b/src/main/open_url.ts
@@ -15,6 +15,8 @@ app.setAsDefaultProtocolClient('openpgp4fpr')
 app.setAsDefaultProtocolClient('OPENPGP4FPR')
 app.setAsDefaultProtocolClient('dcaccount')
 app.setAsDefaultProtocolClient('DCACCOUNT')
+app.setAsDefaultProtocolClient('dclogin')
+app.setAsDefaultProtocolClient('DCLOGIN')
 // do not forcefully set DC as standard email handler to not annoy users
 
 let frontend_ready = false

--- a/src/main/open_url.ts
+++ b/src/main/open_url.ts
@@ -13,6 +13,8 @@ const app = rawApp as ExtendedAppMainProcess
 // These calls are for mac and windows, on linux it uses the desktop file.
 app.setAsDefaultProtocolClient('openpgp4fpr')
 app.setAsDefaultProtocolClient('OPENPGP4FPR')
+app.setAsDefaultProtocolClient('dcaccount')
+app.setAsDefaultProtocolClient('DCACCOUNT')
 // do not forcefully set DC as standard email handler to not annoy users
 
 let frontend_ready = false

--- a/src/renderer/components/helpers/OpenQrUrl.tsx
+++ b/src/renderer/components/helpers/OpenQrUrl.tsx
@@ -154,7 +154,7 @@ export default async function processOpenQrUrl(
     return
   }
 
-  const allowedQrCodesOnWelcomeScreen: Qr['type'][] = ['account', 'text', 'url']
+  const allowedQrCodesOnWelcomeScreen: Qr['type'][] = ['account', 'login', 'text', 'url']
 
   if (
     !allowedQrCodesOnWelcomeScreen.includes(checkQr.type) &&
@@ -166,7 +166,8 @@ export default async function processOpenQrUrl(
       cb: callback,
     })
     return
-  } else if (checkQr.type === 'account' && screen !== Screens.Welcome) {
+  } else if (checkQr.type === 'account' || checkQr.type === 'login' && screen !== Screens.Welcome) {
+    // TODO ask if user wants it, then log them out and then run the qrcode
     closeProcessDialog()
     window.__openDialog('AlertDialog', {
       message: tx('Please logout first'),
@@ -175,7 +176,8 @@ export default async function processOpenQrUrl(
     return
   }
 
-  if (checkQr.type === 'account') {
+  if (checkQr.type === 'account'|| checkQr.type === 'login') {
+    // TODO ask if user wants it 
     try {
       if (window.__selectedAccountId === undefined) {
         throw new Error('error: no context selected')

--- a/src/renderer/components/helpers/OpenQrUrl.tsx
+++ b/src/renderer/components/helpers/OpenQrUrl.tsx
@@ -180,21 +180,21 @@ export default async function processOpenQrUrl(
 
     if (!skipLoginConfirmation) {
       // ask if user wants it
-      let singular_term =
+      const is_singular_term =
         (await BackendRemote.rpc.getAllAccountIds()).length == 1
 
-      let message: string =
+      const message: string =
         checkQr.type === 'account'
-          ? singular_term
+          ? is_singular_term
             ? 'qraccount_ask_create_and_login'
             : 'qraccount_ask_create_and_login_another'
           : checkQr.type === 'login'
-          ? singular_term
+          ? is_singular_term
             ? 'qrlogin_ask_login'
             : 'qrlogin_ask_login_another'
           : '?'
 
-      let yes = await new Promise(resolve => {
+      const yes = await new Promise(resolve => {
         window.__openDialog(ConfirmationDialog, {
           message: tx(message),
           cb: resolve,

--- a/src/renderer/components/screens/WelcomeScreen.tsx
+++ b/src/renderer/components/screens/WelcomeScreen.tsx
@@ -16,6 +16,7 @@ import { DeltaProgressBar } from '../Login-Styles'
 import { DialogProps } from '../dialogs/DialogController'
 import { Screens } from '../../ScreenController'
 import { BackendRemote, EffectfulBackendActions } from '../../backend-com'
+import processOpenQrUrl from '../helpers/OpenQrUrl'
 
 const log = getLogger('renderer/components/AccountsScreen')
 
@@ -132,6 +133,12 @@ export default function WelcomeScreen({
       const allAccountIds = await BackendRemote.listAccounts()
       if (allAccountIds && allAccountIds.length > 1) {
         setShowBackButton(true)
+      }
+      if (window.__welcome_qr) {
+        // this is the "callback" when opening dclogin or dcaccount from an already existing account,
+        // the app needs to switch to the welcome screen first.
+        await processOpenQrUrl(window.__welcome_qr, undefined, true)
+        window.__welcome_qr = undefined
       }
     })()
   }, [])

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -33,5 +33,6 @@ declare global {
     __chatlistSetSearch: ((searchTerm: string) => void) | undefined
     __chatStore: any
     __refetchChatlist: undefined | (() => void)
+    __welcome_qr: undefined | string
   }
 }


### PR DESCRIPTION
- [x] rebase
- [x] dclogin
- [x] ask before applying/logging in to anything
- [x] ﻿should log out of the currenlty logged-in account, so that the 
code actually works always, like I did it for iOS in 
https://github.com/deltachat/deltachat-ios/pull/1640 or make it even 
better like I suggested in 
https://github.com/deltachat/deltachat-ios/pull/1640#discussion_r915110725

this is mainly so that we can make the code on http://webxdc.org 
clickable


cyberta found out that we already have a translation string for the already have an account case: `qraccount_ask_create_and_login_another`