### PR TITLE
fix display of quoted forwarded message fix typo in log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## [Unreleased][unreleased]
 
+## Added
+- Broadcast lists as experimental feature
+
+## Fixed
+- fix display of quoted forwarded messages
+
 ## [1.31.0] - 2022-07-17
 
 ## Added
 - Floating action button in chatlist to start a new chat
-- Broadcast lists as experimental feature
 
 ## Fixed
 - use addr if displayname is not set for webxdc selfName #2803

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -141,7 +141,7 @@ export default class DCMessageList extends SplitOut {
           quotedMessage.getFromId()
         )
         if (!contact) {
-          throw new Error('qoute author contact is undefined')
+          throw new Error('quote author contact is undefined')
         }
         message = {
           messageId: quotedMessage.getId(),
@@ -153,6 +153,7 @@ export default class DCMessageList extends SplitOut {
             quotedMessage.getViewType().isGif()
               ? quotedMessage.getFile()
               : null,
+          isForwarded: quotedMessage.isForwarded(),
         }
       }
       quote = {

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -493,31 +493,53 @@ export const Quote = ({
   quote: MessageQuote
   isSticker?: Boolean
 }) => {
+  const tx = window.static_translate
+
+  const authorStyle = isSticker ? {} : { color: quote.message?.displayColor }
+  const borderStyle =
+    isSticker || quote.message?.isForwarded
+      ? {}
+      : { borderLeftColor: quote.message?.displayColor }
+
   return (
     <div
       className='quote-background'
-      style={{ borderLeftColor: quote.message?.displayColor }}
       onClick={() => {
         quote.message && jumpToMessage(quote.message.messageId)
       }}
     >
       <div
-        className='quote has-message'
-        style={
-          !isSticker ? { borderLeftColor: quote.message?.displayColor } : {}
-        }
+        className={`quote ${quote.message && 'has-message'}`}
+        style={borderStyle}
       >
         <div className='quote-text'>
-          <div
-            className='quote-author'
-            style={!isSticker ? { color: quote.message?.displayColor } : {}}
-          >
-            {quote.message &&
-              getAuthorName(
-                quote.message.displayName,
-                quote.message.overrideSenderName
+          {quote.message && (
+            <>
+              {quote.message.isForwarded ? (
+                <div className='quote-author'>
+                  {reactStringReplace(
+                    tx('forwarded_by', '$$forwarder$$'),
+                    '$$forwarder$$',
+                    () => (
+                      <span key='displayname' style={authorStyle}>
+                        {getAuthorName(
+                          quote.message?.displayName as string,
+                          quote.message?.overrideSenderName
+                        )}
+                      </span>
+                    )
+                  )}
+                </div>
+              ) : (
+                <div className='quote-author' style={authorStyle}>
+                  {getAuthorName(
+                    quote.message.displayName,
+                    quote.message.overrideSenderName
+                  )}
+                </div>
               )}
-          </div>
+            </>
+          )}
           <div className='quoted-text'>
             <MessageBody text={quote.text} />
           </div>

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -521,7 +521,7 @@ export const Quote = ({
                     tx('forwarded_by', '$$forwarder$$'),
                     '$$forwarder$$',
                     () => (
-                      <span key='displayname' style={authorStyle}>
+                      <span key='displayname'>
                         {getAuthorName(
                           quote.message?.displayName as string,
                           quote.message?.overrideSenderName

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -132,6 +132,7 @@ export type MessageQuote = {
     displayColor: string
     overrideSenderName: string
     image: null | string
+    isForwarded: boolean
   } | null
 }
 


### PR DESCRIPTION
<img width="713" alt="Bildschirmfoto 2022-07-30 um 19 35 58" src="https://user-images.githubusercontent.com/18725968/181935438-db56af12-bedb-4ecc-84e9-37c68226c5dd.png">

fixes #2836
also fix changelog order