### PR TITLE
more jsonrpc progress that is already mergable

### DIFF
--- a/src/main/deltachat/chat.ts
+++ b/src/main/deltachat/chat.ts
@@ -1,15 +1,9 @@
 import { C } from 'deltachat-node'
 import { getLogger } from '../../shared/logger'
 import SplitOut from './splitout'
-import { set_has_unread } from '../tray'
-import { app } from 'electron'
 
 const log = getLogger('main/deltachat/chat')
 export default class DCChat extends SplitOut {
-  getEncryptionInfo(chatId: number) {
-    return this.selectedAccountContext.getChatEncrytionInfo(chatId)
-  }
-
   getQrCode(chatId = 0) {
     return this.selectedAccountContext.getSecurejoinQrCode(chatId)
   }
@@ -98,24 +92,8 @@ export default class DCChat extends SplitOut {
     this.selectedAccountContext.setChatVisibility(chatId, visibility)
   }
 
-  setMuteDuration(chatId: number, duration: number) {
-    log.debug(`action - set chat ${chatId} muteduration ${duration}`)
-    return this.selectedAccountContext.setChatMuteDuration(chatId, duration)
-  }
-
   getChatContacts(chatId: number) {
     return this.selectedAccountContext.getChatContacts(chatId)
-  }
-
-  /**
-   * @param {number} chatId
-   */
-  markNoticedChat(chatId: number) {
-    this.selectedAccountContext.markNoticedChat(chatId)
-    this.controller.emit('DESKTOP_CLEAR_NOTIFICATIONS_FOR_CHAT', chatId)
-    const count = this.controller.chatList.getGeneralFreshMessageCounter()
-    app.setBadgeCount(count)
-    set_has_unread(count !== 0)
   }
 
   getChatEphemeralTimer(chatId: number) {

--- a/src/main/deltachat/chatlist.ts
+++ b/src/main/deltachat/chatlist.ts
@@ -21,7 +21,7 @@ export default class DCChatList extends SplitOut {
   async _getChatContacts(contactIds: number[]): Promise<JsonContact[]> {
     const contacts = []
     for (let i = 0; i < contactIds.length; i++) {
-      const contact = this.controller.contacts.getContact(contactIds[i])
+      const contact = this.controller.contacts._getContact(contactIds[i])
       contacts.push(contact)
     }
     return contacts

--- a/src/main/deltachat/contacts.ts
+++ b/src/main/deltachat/contacts.ts
@@ -13,7 +13,7 @@ export default class JsonContacts extends SplitOut {
     return result
   }
 
-  getContact(contactId: number) {
+  _getContact(contactId: number) {
     const contact = this.selectedAccountContext.getContact(contactId)?.toJson()
     if (!contact) {
       throw new Error('contact not found')

--- a/src/main/deltachat/login.ts
+++ b/src/main/deltachat/login.ts
@@ -76,11 +76,6 @@ export default class DCLoginController extends SplitOut {
     log.info('Logged out')
   }
 
-  async addAccount(): Promise<number> {
-    const accountId = this.accounts.addAccount()
-    return accountId
-  }
-
   close() {
     this.controller.webxdc._closeAll()
     this.controller.emit('DESKTOP_CLEAR_ALL_NOTIFICATIONS')
@@ -142,10 +137,6 @@ Full changelog: https://github.com/deltachat/deltachat-desktop/blob/master/CHANG
     const account_dir = join(accountContext.getBlobdir(), '..')
     accountContext.unref()
     return await _getAccountSize(account_dir)
-  }
-
-  getAllAccountIds(): number[] {
-    return super.accounts.getAllAccountIds()
   }
 
   async getLastLoggedInAccount() {

--- a/src/main/deltachat/messagelist.ts
+++ b/src/main/deltachat/messagelist.ts
@@ -43,7 +43,7 @@ export default class DCMessageList extends SplitOut {
     const file_bytes = msg.getFilebytes()
     const fromId = msg.getFromId()
     const setupCodeBegin = msg.getSetupcodebegin()
-    const contact = fromId && this.controller.contacts.getContact(fromId)
+    const contact = fromId && this.controller.contacts._getContact(fromId)
 
     const jsonMSG = msg.toJson()
 

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -79,11 +79,11 @@ export default class ScreenController extends Component {
     if (lastLoggedInAccountId && !(lastLoggedInAccountId < 0)) {
       await this.selectAccount(lastLoggedInAccountId)
     } else {
-      const allAccountIds = await DeltaBackend.call('login.getAllAccountIds')
+      const allAccountIds = await BackendRemote.rpc.getAllAccountIds()
       if (allAccountIds && allAccountIds.length > 0) {
         this.changeScreen(Screens.AccountList)
       } else {
-        const accountId = await DeltaBackend.call('login.addAccount')
+        const accountId = await BackendRemote.rpc.addAccount()
         await this.selectAccount(accountId)
       }
     }
@@ -221,7 +221,7 @@ export default class ScreenController extends Component {
             {...{
               selectAccount: this.selectAccount,
               onAddAccount: async () => {
-                const accountId = await DeltaBackend.call('login.addAccount')
+                const accountId = await BackendRemote.rpc.addAccount()
                 await this.selectAccount(accountId)
               },
             }}

--- a/src/renderer/components/dialogs/EncryptionInfo.tsx
+++ b/src/renderer/components/dialogs/EncryptionInfo.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { DeltaBackend } from '../../delta-remote'
 import { DialogProps } from './DialogController'
 import {
   SmallDialog,

--- a/src/renderer/components/dialogs/EncryptionInfo.tsx
+++ b/src/renderer/components/dialogs/EncryptionInfo.tsx
@@ -26,7 +26,10 @@ export default function EncryptionInfo({
           selectedAccountId(),
           chatListItem.dmChatContact
         )
-      : DeltaBackend.call('chat.getEncryptionInfo', chatListItem.id)
+      : BackendRemote.rpc.getChatEncryptionInfo(
+          selectedAccountId(),
+          chatListItem.id
+        )
     ).then(setEncryptionInfo)
   }, [chatListItem])
 

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -101,11 +101,14 @@ export default function MessageList({
       threshold: [0, 1],
     })
   )
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     return () => {
+      // eslint-disable-next-line react-hooks/exhaustive-deps
       unreadMessageInViewIntersectionObserver.current?.disconnect()
     }
-  }, [unreadMessageInViewIntersectionObserver.current])
+  }, [])
 
   const onScroll = useCallback(
     (Event: React.UIEvent<HTMLDivElement> | null) => {

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -61,9 +61,8 @@ export default function MessageList({
   const onUnreadMessageInView: IntersectionObserverCallback = entries => {
     if (ChatStore.state.chat === null) return
     // Don't mark messages as read if window is not focused
-    if (document.hasFocus() === false) return 
+    if (document.hasFocus() === false) return
 
-    const chatId = ChatStore.state.chat.id
     setTimeout(() => {
       log.debug(`onUnreadMessageInView: entries.length: ${entries.length}`)
 
@@ -106,7 +105,7 @@ export default function MessageList({
     return () => {
       unreadMessageInViewIntersectionObserver.current?.disconnect()
     }
-  }, [])
+  }, [unreadMessageInViewIntersectionObserver.current])
 
   const onScroll = useCallback(
     (Event: React.UIEvent<HTMLDivElement> | null) => {

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -54,7 +54,7 @@ export const MessageWrapper = (props: RenderMessageProps) => {
       props.unreadMessageInViewIntersectionObserver.current?.unobserve(
         messageBottomElement
       )
-  }, [])
+  }, [props.key2,props.unreadMessageInViewIntersectionObserver, shouldInViewObserve])
   return (
     <li id={props.key2}>
       <Message {...props} />

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -54,7 +54,11 @@ export const MessageWrapper = (props: RenderMessageProps) => {
       props.unreadMessageInViewIntersectionObserver.current?.unobserve(
         messageBottomElement
       )
-  }, [props.key2,props.unreadMessageInViewIntersectionObserver, shouldInViewObserve])
+  }, [
+    props.key2,
+    props.unreadMessageInViewIntersectionObserver,
+    shouldInViewObserve,
+  ])
   return (
     <li id={props.key2}>
       <Message {...props} />

--- a/src/renderer/delta-remote.ts
+++ b/src/renderer/delta-remote.ts
@@ -37,7 +37,6 @@ class DeltaRemote {
   call(fnName: 'contacts.lookupContactIdByAddr', email: string): Promise<number>
   call(fnName: 'contacts.deleteContact', contactId: number): Promise<boolean>
   // chat ---------------------------------------------------------------
-  call(fnName: 'chat.getEncryptionInfo', chatId: number): Promise<string>
   call(fnName: 'chat.getQrCode', chatId?: number): Promise<string>
   call(fnName: 'chat.leaveGroup', chatId: number): Promise<void>
   call(fnName: 'chat.setName', chatId: number, name: string): Promise<boolean>
@@ -75,7 +74,6 @@ class DeltaRemote {
       | C.DC_CHAT_VISIBILITY_PINNED
   ): Promise<void>
   call(fnName: 'chat.getChatContacts', chatId: number): Promise<number[]>
-  call(fnName: 'chat.markNoticedChat', chatId: number): Promise<void>
   call(fnName: 'chat.getChatEphemeralTimer', chatId: number): Promise<number>
   call(
     fnName: 'chat.setChatEphemeralTimer',
@@ -104,9 +102,7 @@ class DeltaRemote {
   ): Promise<JsonLocations>
   // login ----------------------------------------------------
   call(fnName: 'login.selectAccount', accountId: number): Promise<boolean>
-  call(fnName: 'login.addAccount'): Promise<number>
   call(fnName: 'login.getAccountSize', accountId: number): Promise<number>
-  call(fnName: 'login.getAllAccountIds'): Promise<number[]>
   call(fnName: 'login.getLastLoggedInAccount'): Promise<number>
 
   // NOTHING HERE that is called directly from the frontend, yet

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -784,6 +784,8 @@ class ChatStore extends Store<ChatStoreState> {
           return false
         }
 
+        // TODO:  this.controller.emit('DESKTOP_CLEAR_NOTIFICATIONS_FOR_CHAT', chatId)
+        // TODO: update badge counter
         await BackendRemote.rpc.marknoticedChat(accountId, chatId)
 
         let oldestFetchedMessageIndex = -1

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -769,8 +769,6 @@ class ChatStore extends Store<ChatStoreState> {
           chatId
         )
         if (firstUnreadMsgId !== null) {
-          console.log({ firstUnreadMsgId })
-
           setTimeout(() => {
             this.effect.jumpToMessage(firstUnreadMsgId, false)
             ActionEmitter.emitAction(


### PR DESCRIPTION
- more jsonrpc progress that is already mergable
- fix eslint stuff
- fix formatting


@Jikstra can you look into these warnings and into the last 2 commits:
```
./src/renderer/components/message/MessageList.tsx
  106:47  warning  The ref value 
'unreadMessageInViewIntersectionObserver.current' will likely have changed by 
the time this effect cleanup function runs. If this ref points to a node 
rendered by React, copy 'unreadMessageInViewIntersectionObserver.current' to 
a variable inside the effect, and use that variable in the cleanup function  
react-hooks/exhaustive-deps
  108:6   warning  React Hook useEffect has an unnecessary dependency: 
'unreadMessageInViewIntersectionObserver.current'. Either exclude it or 
remove the dependency array. Mutable values like 
'unreadMessageInViewIntersectionObserver.current' aren't valid dependencies 
because mutating them doesn't re-render the component                 
react-hooks/exhaustive-deps
```

Lets ensure the eslint fixes are not breaking anything.
