### PR TITLE
make contact last seen always display relative time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - remember last path in "save as" dialog
 - allow using `dclogin:` and `dcaccount:` from logged in account, without logging out first
 - register in os as handler for the `dcaccount:` and `dclogin:` scheme
+- make contact last seen always display relative time
 
 ## Fixed
 - allow scanning of certain qr code types on welcome screen (account, url and text)

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -34,5 +34,8 @@
   },
   "clear_chat": {
     "message": "Clear Chat"
+  },
+  "last_seen":{
+    "message": "Last seen %1$s"
   }
 }

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -28,6 +28,7 @@ import { DeltaInput } from '../Login-Styles'
 import { selectChat } from '../helpers/ChatMethods'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
+import moment from 'moment'
 
 const ProfileInfoName = ({
   name,
@@ -40,13 +41,15 @@ const ProfileInfoName = ({
 }) => {
   const tx = useTranslationFunction()
   let lastSeenString = ''
+  let lastSeenAbsolute:string|undefined = undefined
 
   // Dates from 1970 mean that contact has never been seen
   if (lastSeen == 0) {
     lastSeenString = tx('last_seen_unknown')
   } else {
-    const date = formatRelativeTime(lastSeen * 1000, { extended: false })
-    lastSeenString = tx('last_seen_at', date)
+    const date = moment(lastSeen * 1000).fromNow()
+    lastSeenString = tx('last_seen', date)
+    lastSeenAbsolute =  tx('last_seen_at', moment(lastSeen*1000).toLocaleString())
   }
 
   return (
@@ -55,7 +58,7 @@ const ProfileInfoName = ({
         <p className='group-name'>{name}</p>
       </div>
       <div className='address'>{address}</div>
-      <div className='last-seen'>{lastSeenString}</div>
+      <div className='last-seen' title={lastSeenAbsolute}>{lastSeenString}</div>
     </div>
   )
 }


### PR DESCRIPTION
<img width="332" src="https://user-images.githubusercontent.com/18725968/193432643-1b597943-cda7-4484-bf81-edefc84e4058.png">

Before: `Last seen at 3min ago`
After: `Last seen 3min ago`

now show always the relative time and on hover it shows exact time:
<img width="332" alt="Bildschirmfoto 2022-10-02 um 02 13 13" src="https://user-images.githubusercontent.com/18725968/193432686-f45dc34f-6175-4575-a17c-3260fcc8126f.png">


before merging we should consider pushing translations to android so that `last_seen` can be translated