### PR TITLE
use less muted color for "recently seen"

### DIFF
--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -183,7 +183,7 @@ $hover-contrast-change: 2%;
   --addMemberChipBackgroundColor: #{$bgSecondary};
   --searchInputBackgroundColor: #52768700;
   --galleryWebxdcItem: #{changeContrast($bgPrimary, 10%)};
-  --recently-seen-indicator-color: #4caf50;
+  --recently-seen-indicator-color: #34c759;
 
   @if lightness($bgPrimary) < 50 {
     // dark theme


### PR DESCRIPTION
with the "connectivity view",
we already have a green indicating sth. as "online", reuse that. the green used before is a bit too much of a muted color, this does not reflect "activity" well.

the difference is not huge, however,
this pr also synchronizes the color with android and ios and also comparable indicators
in other apps have less muted colors for showing activity.

cmp https://github.com/deltachat/deltachat-android/pull/2393 and https://github.com/deltachat/deltachat-ios/pull/1707 (there are also some screenshots)