### PR TITLE
reduce notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Update translations (19.10.2022)
 - Tray icon is now by default enabled. Settings got moved to Settings->Advanced
 - instantly react to changing chat background color
+- reduce notifications when many messages are received at once.
 
 ### Fixed
 
@@ -19,6 +20,7 @@
 - fix that results of search in chat are not ordered by newest first
 - Fix chat name/avatar in navbar take full width
 - don't show dash in mailinlist title if there is no mailinglist address #2965
+- Fix notifications when showNotificationContent was disabled
 
 ## [1.33.0] - 2022-10-16
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -46,5 +46,8 @@
   },
   "pref_system_integration_menu_title": {
     "message": "System integration"
+  },
+  "notify_new_messages": {
+    "message": "New messages"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -49,5 +49,11 @@
   },
   "notify_new_messages": {
     "message": "New messages"
+  },
+  "notify_bundle_new_messages_in_one_chat": {
+    "message": "%1$d new messages"
+  },
+  "notify_bundle_new_messages": {
+    "message": "%1$d messages in %2$d chats"
   }
 }

--- a/src/renderer/system-integration/notifications.ts
+++ b/src/renderer/system-integration/notifications.ts
@@ -1,7 +1,6 @@
 import { T } from 'deltachat-node/deltachat-jsonrpc/typescript/src/lib'
 import { appName } from '../../shared/constants'
 import { getLogger } from '../../shared/logger'
-import { DcNotification } from '../../shared/shared-types'
 import { BackendRemote } from '../backend-com'
 import { isImage } from '../components/attachment/Attachment'
 import { jumpToMessage } from '../components/helpers/ChatMethods'
@@ -14,16 +13,20 @@ function isMuted(accountId: number, chatId: number) {
   return BackendRemote.rpc.isChatMuted(accountId, chatId)
 }
 
+type queuedNotification = {
+  chatId: number
+  messageId: number
+}
+
+let queuedNotifications: {
+  [accountId: number]: queuedNotification[]
+} = {}
+
 async function incomingMessageHandler(
   accountId: number,
   chatId: number,
   messageId: number
 ) {
-  if (accountId !== window.__selectedAccountId) {
-    // notifications for different accounts are not supported yet
-    return
-  }
-
   log.debug('incomingMessageHandler: ', { chatId, messageId })
 
   if (
@@ -47,18 +50,28 @@ async function incomingMessageHandler(
     return
   }
 
+  if (typeof queuedNotifications[accountId] === 'undefined') {
+    queuedNotifications[accountId] = []
+  }
+  queuedNotifications[accountId].push({ chatId, messageId })
+}
+
+async function showNotification(
+  accountId: number,
+  chatId: number,
+  messageId: number
+) {
   const tx = window.static_translate
 
-  let notification: DcNotification
   if (!SettingsStoreInstance.state?.desktopSettings.showNotificationContent) {
-    notification = {
+    runtime.showNotification({
       title: appName,
       body: tx('notify_new_message'),
       icon: null,
       chatId,
       messageId,
       accountId,
-    }
+    })
   } else {
     try {
       const notificationInfo = await BackendRemote.rpc.getMessageNotificationInfo(
@@ -66,21 +79,100 @@ async function incomingMessageHandler(
         messageId
       )
       const { chatName, summaryPrefix, summaryText } = notificationInfo
-
-      notification = {
+      runtime.showNotification({
         title: chatName,
         body: summaryPrefix ? `${summaryPrefix}: ${summaryText}` : summaryText,
         icon: getNotificationIcon(notificationInfo),
         chatId,
         messageId,
         accountId,
-      }
-
-      runtime.showNotification(notification)
+      })
     } catch (error) {
       log.error('failed to create notification for message: ', messageId, error)
     }
   }
+}
+
+async function showGroupedNotification(
+  accountId: number,
+  notifications: queuedNotification[]
+) {
+  const tx = window.static_translate
+
+  if (!SettingsStoreInstance.state?.desktopSettings.showNotificationContent) {
+    runtime.showNotification({
+      title: appName,
+      body: tx('notify_new_messages'),
+      icon: null,
+      chatId: 0,
+      messageId: 0,
+      accountId,
+    })
+  } else {
+    const chatIds = [...new Set(notifications.map(({ chatId }) => chatId))]
+    const msgCount = notifications.length
+
+    try {
+      if (chatIds.length === 1) {
+        // all messages are from the same chat
+        // can show profile image of chat
+        // title: chatName
+        // body: "5 new Messages in ChatName"
+        const notificationInfo = await BackendRemote.rpc.getMessageNotificationInfo(
+          accountId,
+          notifications[0].messageId
+        )
+        const { chatName, chatProfileImage } = notificationInfo
+        runtime.showNotification({
+          title: chatName,
+          body: `${msgCount} new messages`, // TODO TX
+          icon: chatProfileImage || null,
+          chatId: chatIds[0],
+          messageId: 0, // just select chat on click, no specific message
+          accountId,
+        })
+      } else {
+        // messages from diffent chats
+        // title: "new messages"
+        // body: "324 new messages in 6 chats"
+        const chatCount = chatIds.length
+        runtime.showNotification({
+          title: tx('notify_new_messages'), // IDEA: when we support notifications from multiple accounts, then show account displayname here?
+          body: `${msgCount} messages in ${chatCount} chats`, // TODO TX
+          icon: null, // IDEA: when we support notifications from multiple accounts, then show account profile image here?
+          chatId: 0,
+          messageId: 0,
+          accountId,
+        })
+      }
+    } catch (error) {
+      log.error('failed to create grouped notification: ', notifications, error)
+    }
+  }
+}
+
+// how many notifications can be shown without being grouped
+const STARTUP_LIMIT = 1
+const NORMAL_LIMIT = 3
+
+let notificationLimit = STARTUP_LIMIT
+
+async function flushNotifications(accountId: number) {
+  if (typeof queuedNotifications[accountId] === 'undefined') {
+    // make it work even if there is nothing
+    queuedNotifications[accountId] = []
+  }
+  const notifications = [...queuedNotifications[accountId]]
+  queuedNotifications = []
+
+  if (notifications.length > notificationLimit) {
+    showGroupedNotification(accountId, notifications)
+  } else {
+    for (const { chatId, messageId } of notifications) {
+      await showNotification(accountId, chatId, messageId)
+    }
+  }
+  notificationLimit = NORMAL_LIMIT
 }
 
 export function clearNotificationsForChat(accountId: number, chatId: number) {
@@ -108,15 +200,26 @@ function getNotificationIcon(
 
 export function initNotifications() {
   BackendRemote.on('IncomingMsg', (accountId, { chatId, msgId }) => {
+    if (accountId !== window.__selectedAccountId) {
+      // notifications for different accounts are not supported yet
+      return
+    }
     incomingMessageHandler(accountId, chatId, msgId)
+  })
+  BackendRemote.on('IncomingMsgBunch', accountId => {
+    flushNotifications(accountId)
   })
   runtime.setNotificationCallback(({ accountId, msgId, chatId }) => {
     if (window.__selectedAccountId !== accountId) {
       log.error('notification comes from other account')
       // TODO implement switch account
     } else {
-      clearNotificationsForChat(accountId, chatId)
-      jumpToMessage(msgId, true)
+      if (chatId !== 0) {
+        clearNotificationsForChat(accountId, chatId)
+        if (msgId !== 0) {
+          jumpToMessage(msgId, true)
+        }
+      }
     }
   })
 }

--- a/src/renderer/system-integration/notifications.ts
+++ b/src/renderer/system-integration/notifications.ts
@@ -125,7 +125,7 @@ async function showGroupedNotification(
         const { chatName, chatProfileImage } = notificationInfo
         runtime.showNotification({
           title: chatName,
-          body: `${msgCount} new messages`, // TODO TX
+          body: tx('notify_bundle_new_messages_in_one_chat', String(msgCount)),
           icon: chatProfileImage || null,
           chatId: chatIds[0],
           messageId: 0, // just select chat on click, no specific message
@@ -138,7 +138,10 @@ async function showGroupedNotification(
         const chatCount = chatIds.length
         runtime.showNotification({
           title: tx('notify_new_messages'), // IDEA: when we support notifications from multiple accounts, then show account displayname here?
-          body: `${msgCount} messages in ${chatCount} chats`, // TODO TX
+          body: tx('notify_bundle_new_messages', [
+            String(msgCount),
+            String(chatCount),
+          ]),
           icon: null, // IDEA: when we support notifications from multiple accounts, then show account profile image here?
           chatId: 0,
           messageId: 0,


### PR DESCRIPTION
when many messages are received at once (for example on startup).
Also show notifications when showNotificationContent is disabled (that was broken).

<img width="350" alt="Bildschirmfoto 2022-11-04 um 22 41 44" src="https://user-images.githubusercontent.com/18725968/200079341-c80361c6-826a-4098-bea8-a80a7164eee4.png">

<img width="351" alt="Bildschirmfoto 2022-11-04 um 22 48 19" src="https://user-images.githubusercontent.com/18725968/200080004-6b6a4bf2-7a2a-4702-8781-bc90c5914f12.png">


On first start notifications are grouped as soon as there is more than one, and after that they are grouped as soon as 
there are more than 3 at a time, we could still change that behaviour, both numbers are constants that can be easialy 
changed without the need to understand the code:

https://github.com/deltachat/deltachat-desktop/blob/585faf756bca476b7d429d237cbccfd5328d5631/src/renderer/system-integration/notifications.ts#L154-L156

# TODO

- [x] translation strings


needs a core with https://github.com/deltachat/deltachat-core-rust/pull/3643/ merged


closes #2278 for now, it is not perfect (on importing backup there are multiple `IncomingMsgBunch`-events, so 
multiple grouped notifications) but it already greatly reduces the notifications on startup.
