### PR TITLE
seperate messagelist from chat store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - don't show dash in mailinlist title if there is no mailinglist address #2965
 - Fix notifications when showNotificationContent was disabled
 - fix unread count on scroll down button
+- make recently seen dot in navbar disappear automatically #2926
 
 ## [1.33.0] - 2022-10-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix chat name/avatar in navbar take full width
 - don't show dash in mailinlist title if there is no mailinglist address #2965
 - Fix notifications when showNotificationContent was disabled
+- fix unread count on scroll down button
 
 ## [1.33.0] - 2022-10-16
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -36,5 +36,12 @@ declare global {
     __chatStore: any
     __refetchChatlist: undefined | (() => void)
     __welcome_qr: undefined | string
+    __internal_jump_to_message:
+      | undefined
+      | ((
+          msgId: number | undefined,
+          highlight?: boolean,
+          addMessageIdToStack?: undefined | number
+        ) => Promise<void>)
   }
 }

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -105,15 +105,21 @@ class ChatStore extends Store<ChatStoreState> {
       debouncedUpdateBadgeCounter()
       clearNotificationsForChat(accountId, chatId)
       saveLastChatId(chatId)
-      this.reducer.selectedChat({
-        chat,
-        accountId,
-      })
+
       ActionEmitter.emitAction(
         chat.archived
           ? KeybindAction.ChatList_SwitchToArchiveView
           : KeybindAction.ChatList_SwitchToNormalView
       )
+      if (this.state.chat?.id === chatId) {
+        // jump down if reselecting the same chat
+        window.__internal_jump_to_message?.(undefined, false, undefined)
+      } else {
+        this.reducer.selectedChat({
+          chat,
+          accountId,
+        })
+      }
     },
 
     jumpToMessage: async (

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -1,6 +1,5 @@
 import { Store, useStore } from './store'
 import { ActionEmitter, KeybindAction } from '../keybindings'
-import { OrderedMap } from 'immutable'
 import { BackendRemote, Type } from '../backend-com'
 import { selectedAccountId } from '../ScreenController'
 import { debouncedUpdateBadgeCounter } from '../system-integration/badge-counter'
@@ -9,14 +8,6 @@ import { saveLastChatId } from './chat/chat_sideeffects'
 import { onReady } from '../onready'
 
 export const PAGE_SIZE = 11
-
-export interface MessagePage {
-  pageKey: string
-  messages: OrderedMap<
-    number | string,
-    Type.Message | { id: string; ts: number }
-  >
-}
 
 export enum ChatView {
   MessageList,
@@ -124,14 +115,14 @@ class ChatStore extends Store<ChatStoreState> {
 
     jumpToMessage: async (
       msgId: number,
-      highlight: boolean = true,
+      highlight = true,
       msgParentId?: number
     ) => {
       log.debug('jumpToMessage with messageId: ', msgId)
       const accountId = selectedAccountId()
 
       // check if jump to message is in same chat, if not switch
-      let message = await BackendRemote.rpc.getMessage(
+      const message = await BackendRemote.rpc.getMessage(
         accountId,
         msgId as number
       )

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -257,6 +257,8 @@ onReady(() => {
     if (accountId !== window.__selectedAccountId) {
       return
     }
-    chatStore.effect.onEventContactModified(contactId)
+    if (contactId) {
+      chatStore.effect.onEventContactModified(contactId)
+    }
   })
 })

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -1,21 +1,12 @@
 import { Store, useStore } from './store'
 import { ActionEmitter, KeybindAction } from '../keybindings'
-import { C } from '@deltachat/jsonrpc-client'
 import { OrderedMap } from 'immutable'
 import { BackendRemote, Type } from '../backend-com'
 import { selectedAccountId } from '../ScreenController'
 import { debouncedUpdateBadgeCounter } from '../system-integration/badge-counter'
 import { clearNotificationsForChat } from '../system-integration/notifications'
-import { T } from '@deltachat/jsonrpc-client'
-import {
-  ChatViewState,
-  ChatViewReducer,
-  defaultChatViewState,
-} from './chat/chat_view_reducer'
-import { ChatStoreScheduler } from './chat/chat_scheduler'
 import { saveLastChatId } from './chat/chat_sideeffects'
 import { onReady } from '../onready'
-import { sendMessageParams } from '../../shared/shared-types'
 
 export const PAGE_SIZE = 11
 
@@ -34,126 +25,17 @@ export enum ChatView {
 }
 export interface ChatStoreState {
   activeView: ChatView
+  accountId: number | null
   chat: Type.FullChat | null
-  accountId?: number
-  messageListItems: T.MessageListItem[]
-  messagePages: MessagePage[]
-  newestFetchedMessageListItemIndex: number
-  oldestFetchedMessageListItemIndex: number
-  viewState: ChatViewState
-  jumpToMessageStack: number[]
-  countFetchedMessages: number
 }
 
 const defaultState: () => ChatStoreState = () => ({
   activeView: ChatView.MessageList,
+  accountId: null,
   chat: null,
-  accountId: undefined,
-  messageListItems: [],
-  messagePages: [],
-  newestFetchedMessageListItemIndex: -1,
-  oldestFetchedMessageListItemIndex: -1,
-  viewState: defaultChatViewState(),
-  jumpToMessageStack: [],
-  countFetchedMessages: 0,
 })
 
-async function messagePageFromMessageIndexes(
-  accountId: number,
-  chatId: number,
-  indexStart: number,
-  indexEnd: number
-): Promise<MessagePage> {
-  const rawMessages = await getMessagesFromIndex(
-    accountId,
-    chatId,
-    indexStart,
-    indexEnd
-  )
-
-  if (rawMessages.length === 0) {
-    throw new Error(
-      'messagePageFromMessageIndexes: _messages.length equals zero. This should not happen'
-    )
-  }
-
-  // log.debug('messagePageFromMessageIndexes', rawMessages, indexEnd, indexStart)
-
-  if (rawMessages.length !== indexEnd - indexStart + 1) {
-    throw new Error(
-      "messagePageFromMessageIndexes: _messages.length doesn't equal indexEnd - indexStart + 1. This should not happen"
-    )
-  }
-
-  const messages = OrderedMap<
-    number | string,
-    Type.Message | { id: string; ts: number }
-  >().withMutations(messagePages => {
-    for (let i = 0; i < rawMessages.length; i++) {
-      const [messageId, message] = rawMessages[i]
-      messagePages.set(messageId, message)
-    }
-  })
-
-  log.debug('messagePageFromMessageIndexes', messages)
-
-  const messagePage = {
-    pageKey: calculatePageKey(messages, indexStart, indexEnd),
-    messages,
-  }
-
-  return messagePage
-}
-
-async function messagePagesFromMessageIndexes(
-  accountId: number,
-  chatId: number,
-  indexStart: number,
-  indexEnd: number
-): Promise<MessagePage[]> {
-  const rawMessages = await getMessagesFromIndex(
-    accountId,
-    chatId,
-    indexStart,
-    indexEnd
-  )
-
-  const messagePages = []
-  while (rawMessages.length > 0) {
-    const pageMessages = rawMessages.splice(0, PAGE_SIZE)
-
-    const messages = OrderedMap<
-      number | string,
-      Type.Message | { id: string; ts: number }
-    >().withMutations(messagePages => {
-      for (let i = 0; i < pageMessages.length; i++) {
-        const [messageId, message] = pageMessages[i]
-        messagePages.set(messageId, message)
-      }
-    })
-
-    messagePages.push({
-      pageKey: calculatePageKey(messages, indexStart, indexEnd),
-      messages,
-    })
-  }
-
-  return messagePages
-}
-
 class ChatStore extends Store<ChatStoreState> {
-  scheduler = new ChatStoreScheduler()
-
-  guardReducerTriesToAddDuplicatePageKey(pageKeyToAdd: string) {
-    const isDuplicatePageKey =
-      this.state.messagePages.findIndex(
-        messagePage => messagePage.pageKey === pageKeyToAdd
-      ) !== -1
-    if (isDuplicatePageKey) {
-      log.error('Duplicate page key')
-    }
-    return isDuplicatePageKey
-  }
   guardReducerIfChatIdIsDifferent(payload: { id: number }) {
     if (
       typeof payload.id !== 'undefined' &&
@@ -179,7 +61,6 @@ class ChatStore extends Store<ChatStoreState> {
     },
     selectedChat: (payload: Partial<ChatStoreState>) => {
       this.setState(_ => {
-        this.scheduler.unlock('scroll')
         const modifiedState: ChatStoreState = {
           ...defaultState(),
           ...payload,
@@ -187,28 +68,8 @@ class ChatStore extends Store<ChatStoreState> {
         return modifiedState
       }, 'selectedChat')
     },
-    refresh: (
-      messageListItems: T.MessageListItem[],
-      messagePages: MessagePage[],
-      newestFetchedMessageListItemIndex: number,
-      oldestFetchedMessageListItemIndex: number
-    ) => {
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          messageListItems,
-          messagePages,
-          viewState: ChatViewReducer.refresh(state.viewState),
-          countFetchedMessages: messageListItems.length,
-          newestFetchedMessageListItemIndex,
-          oldestFetchedMessageListItemIndex,
-        }
-        return modifiedState
-      }, 'refresh')
-    },
     unselectChat: () => {
       this.setState(_ => {
-        this.scheduler.unlock('scroll')
         const modifiedState: ChatStoreState = { ...defaultState() }
         return modifiedState
       }, 'unselectChat')
@@ -223,199 +84,60 @@ class ChatStore extends Store<ChatStoreState> {
         return modifiedState
       }, 'modifiedChat')
     },
-    appendMessagePageTop: (payload: {
-      id: number
-      messagePage: MessagePage
-      countFetchedMessages: number
-      oldestFetchedMessageListItemIndex: number
-    }) => {
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          messagePages: [payload.messagePage, ...state.messagePages],
-          oldestFetchedMessageListItemIndex:
-            payload.oldestFetchedMessageListItemIndex,
-          viewState: ChatViewReducer.appendMessagePageTop(state.viewState),
-          countFetchedMessages: payload.countFetchedMessages,
-        }
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-        if (
-          this.guardReducerTriesToAddDuplicatePageKey(
-            payload.messagePage.pageKey
-          )
-        ) {
-          return
-        }
-        return modifiedState
-      }, 'appendMessagePageTop')
-    },
-    appendMessagePageBottom: (payload: {
-      id: number
-      messagePage: MessagePage
-      countFetchedMessages: number
-      newestFetchedMessageIndex: number
-    }) => {
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          messagePages: [...state.messagePages, payload.messagePage],
-          newestFetchedMessageListItemIndex: payload.newestFetchedMessageIndex,
-          viewState: ChatViewReducer.appendMessagePageBottom(state.viewState),
-          countFetchedMessages: payload.countFetchedMessages,
-        }
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-        if (
-          this.guardReducerTriesToAddDuplicatePageKey(
-            payload.messagePage.pageKey
-          )
-        )
-          return
-        return modifiedState
-      }, 'appendMessagePageBottom')
-    },
-    fetchedIncomingMessages: (payload: {
-      id: number
-      messageListItems: ChatStoreState['messageListItems']
-      newestFetchedMessageIndex: number
-      messagePage: MessagePage
-    }) => {
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          messageListItems: payload.messageListItems,
-          messagePages: [...state.messagePages, payload.messagePage],
-          // newestFetchedMessageIndex: payload.newestFetchedMessageIndex,
-          viewState: ChatViewReducer.fetchedIncomingMessages(state.viewState),
-        }
-
-        if (
-          this.guardReducerTriesToAddDuplicatePageKey(
-            payload.messagePage.pageKey
-          )
-        ) {
-          throw new Error(
-            'We almost added the same page twice! We should prevent this in code duplicate pageKey: ' +
-              payload.messagePage.pageKey
-          )
-        }
-
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-
-        return modifiedState
-      }, 'fetchedIncomingMessages')
-    },
-    unlockScroll: (payload: { id: number }) => {
-      log.debug('unlockScroll')
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          viewState: ChatViewReducer.unlockScroll(state.viewState),
-        }
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-        setTimeout(() => this.scheduler.unlock('scroll'), 0)
-        return modifiedState
-      }, 'unlockScroll')
-    },
-    messageChanged: (payload: {
-      id: number
-      messagesChanged: Type.Message[]
-    }) => {
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          messagePages: state.messagePages.map(messagePage => {
-            let changed = false
-            const messages = messagePage.messages.withMutations(messages => {
-              for (const changedMessage of payload.messagesChanged) {
-                if (!messages.has(changedMessage.id)) continue
-                changed = true
-                messages.set(changedMessage.id, changedMessage)
-              }
-            })
-            if (changed === false) return messagePage
-            return {
-              ...messagePage,
-              messages,
-            }
-          }),
-        }
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-        return modifiedState
-      }, 'messageChanged')
-    },
-    setMessageState: (payload: {
-      id: number
-      messageId: number
-      messageState: number
-    }) => {
-      const { messageId, messageState } = payload
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          messagePages: state.messagePages.map(messagePage => {
-            if (messagePage.messages.has(messageId)) {
-              const message = messagePage.messages.get(messageId)
-              if (message !== null && message !== undefined) {
-                const updatedMessages = messagePage.messages.set(messageId, {
-                  ...message,
-                  state: messageState,
-                })
-
-                return {
-                  ...messagePage,
-                  messages: updatedMessages,
-                }
-              }
-            }
-
-            return messagePage
-          }),
-        }
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-        return modifiedState
-      }, 'setMessageState')
-    },
-    setMessageListItems: (payload: {
-      id: number
-      messageListItems: ChatStoreState['messageListItems']
-    }) => {
-      this.setState(state => {
-        const modifiedState: ChatStoreState = {
-          ...state,
-          messageListItems: payload.messageListItems,
-          viewState: ChatViewReducer.setMessageListItems(state.viewState),
-        }
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-        return modifiedState
-      }, 'setMessageIds')
-    },
-
-    setFreshMessageCounter: (payload: {
-      id: number
-      freshMessageCounter: number
-    }) => {
-      const { freshMessageCounter } = payload
-      this.setState(state => {
-        if (!state.chat) return
-        const modifiedState: ChatStoreState = {
-          ...state,
-          chat: {
-            ...state.chat,
-            freshMessageCounter,
-          },
-        }
-        if (this.guardReducerIfChatIdIsDifferent(payload)) return
-        return modifiedState
-      }, 'setMessageIds')
-    },
   }
 
   effect = {
-    selectChat: this.scheduler.lockedQueuedEffect(
-      'scroll',
-      async (chatId: number) => {
-        const accountId = selectedAccountId()
-        const chat = await BackendRemote.rpc.getFullChatById(accountId, chatId)
+    setView: (view: ChatView) => {
+      this.reducer.setView(view)
+    },
+    selectChat: async (chatId: number) => {
+      const accountId = selectedAccountId()
+      const chat = await BackendRemote.rpc.getFullChatById(accountId, chatId)
+      if (chat.id === null) {
+        log.debug(
+          'SELECT CHAT chat does not exsits, id is null. chatId:',
+          chat.id
+        )
+        return
+      }
+
+      BackendRemote.rpc.marknoticedChat(accountId, chatId)
+      debouncedUpdateBadgeCounter()
+      clearNotificationsForChat(accountId, chatId)
+      saveLastChatId(chatId)
+      this.reducer.selectedChat({
+        chat,
+        accountId,
+      })
+      ActionEmitter.emitAction(
+        chat.archived
+          ? KeybindAction.ChatList_SwitchToArchiveView
+          : KeybindAction.ChatList_SwitchToNormalView
+      )
+    },
+
+    jumpToMessage: async (
+      msgId: number,
+      highlight: boolean = true,
+      msgParentId?: number
+    ) => {
+      log.debug('jumpToMessage with messageId: ', msgId)
+      const accountId = selectedAccountId()
+
+      // check if jump to message is in same chat, if not switch
+      let message = await BackendRemote.rpc.getMessage(
+        accountId,
+        msgId as number
+      )
+
+      if (
+        message.chatId !== this.state.chat?.id ||
+        this.state.accountId !== accountId
+      ) {
+        const chat = await BackendRemote.rpc.getFullChatById(
+          accountId,
+          message.chatId
+        )
         if (chat.id === null) {
           log.debug(
             'SELECT CHAT chat does not exsits, id is null. chatId:',
@@ -423,455 +145,16 @@ class ChatStore extends Store<ChatStoreState> {
           )
           return
         }
-        const messageListItems = await BackendRemote.rpc.getMessageListItems(
-          accountId,
-          chatId,
-          C.DC_GCM_ADDDAYMARKER
-        )
 
-        BackendRemote.rpc.marknoticedChat(accountId, chatId)
-        debouncedUpdateBadgeCounter()
-        clearNotificationsForChat(accountId, chatId)
-
-        const firstUnreadMsgId = await BackendRemote.rpc.getFirstUnreadMessageOfChat(
-          accountId,
-          chatId
-        )
-        if (firstUnreadMsgId !== null) {
-          setTimeout(() => {
-            this.effect.jumpToMessage(firstUnreadMsgId, false)
-            ActionEmitter.emitAction(
-              chat.archived
-                ? KeybindAction.ChatList_SwitchToArchiveView
-                : KeybindAction.ChatList_SwitchToNormalView
-            )
-            saveLastChatId(chatId)
-          })
-          return false
-        }
-
-        let oldestFetchedMessageListItemIndex = -1
-        let newestFetchedMessageListItemIndex = -1
-        let messagePage: MessagePage | null = null
-        if (messageListItems.length !== 0) {
-          // mesageIds.length = 1767
-          // oldestFetchedMessageListItemIndex = 1767 - 1 = 1766 - 10 = 1756
-          // newestFetchedMessageIndex =                        1766
-          oldestFetchedMessageListItemIndex = Math.max(
-            messageListItems.length - 1 - PAGE_SIZE,
-            0
-          )
-          newestFetchedMessageListItemIndex = messageListItems.length - 1
-
-          messagePage = await messagePageFromMessageIndexes(
-            accountId,
-            chatId,
-            oldestFetchedMessageListItemIndex,
-            newestFetchedMessageListItemIndex
-          )
-        }
-
-        this.reducer.selectedChat({
-          chat,
-          accountId,
-          messagePages: messagePage === null ? [] : [messagePage],
-          messageListItems,
-          oldestFetchedMessageListItemIndex,
-          newestFetchedMessageListItemIndex,
-          viewState: ChatViewReducer.selectChat(this.state.viewState),
-        })
-        ActionEmitter.emitAction(
-          chat.archived
-            ? KeybindAction.ChatList_SwitchToArchiveView
-            : KeybindAction.ChatList_SwitchToNormalView
-        )
-        saveLastChatId(chatId)
-      },
-      'selectChat'
-    ),
-    setView: (view: ChatView) => {
-      this.reducer.setView(view)
-    },
-    // TODO: Probably this should be lockedQueuedEffect too?
-    jumpToMessage: this.scheduler.queuedEffect(
-      this.scheduler.lockedEffect(
-        'scroll',
-        async (
-          msgId: number | undefined,
-          highlight?: boolean,
-          addMessageIdToStack?: undefined | number
-        ) => {
-          log.debug('jumpToMessage with messageId: ', msgId)
-          const accountId = selectedAccountId()
-          highlight = highlight === false ? false : true
-          // these methods were called in backend before
-          // might be an issue if DeltaBackend.call has a significant delay
-
-          if (!accountId) {
-            throw new Error('no account set')
-          }
-          // this function already throws an error if message is not found
-
-          let chatId = -1
-          let jumpToMessageId = -1
-          let jumpToMessageStack: number[] = []
-          let message: Type.Message | undefined = undefined
-          if (msgId === undefined) {
-            const jumpToMessageStackLength = this.state.jumpToMessageStack
-              .length
-            if (jumpToMessageStackLength !== 0) {
-              jumpToMessageStack = this.state.jumpToMessageStack.slice(
-                0,
-                jumpToMessageStackLength - 1
-              )
-              jumpToMessageId = this.state.jumpToMessageStack[
-                jumpToMessageStackLength - 1
-              ]
-              message = await BackendRemote.rpc.getMessage(
-                accountId,
-                jumpToMessageId as number
-              )
-              chatId = message.chatId
-            } else {
-              if (this.state.chat) {
-                this.effect.selectChat(this.state.chat.id)
-              }
-              return
-            }
-          } else if (addMessageIdToStack === undefined) {
-            // reset jumpToMessageStack
-            message = await BackendRemote.rpc.getMessage(
-              accountId,
-              msgId as number
-            )
-            chatId = message.chatId
-
-            jumpToMessageId = msgId as number
-            jumpToMessageStack = []
-          } else {
-            message = await BackendRemote.rpc.getMessage(
-              accountId,
-              msgId as number
-            )
-            chatId = message.chatId
-
-            jumpToMessageId = msgId as number
-            // If we are not switching chats, add current jumpToMessageId to the stack
-            const currentChatId = chatStore.state.chat?.id || -1
-            if (chatId !== currentChatId) {
-              jumpToMessageStack = []
-            } else if (
-              chatStore.state.jumpToMessageStack.indexOf(
-                addMessageIdToStack
-              ) !== -1
-            ) {
-              jumpToMessageStack = chatStore.state.jumpToMessageStack
-            } else {
-              jumpToMessageStack = [
-                ...chatStore.state.jumpToMessageStack,
-                addMessageIdToStack,
-              ]
-            }
-          }
-
-          //@ts-ignore
-          if (message === undefined) {
-            throw new Error(
-              'jumpToMessage: Tried to jump to non existing message with id: ' +
-                msgId
-            )
-          }
-
-          const chat = await BackendRemote.rpc.getFullChatById(
-            accountId,
-            chatId
-          )
-          if (chat.id === null) {
-            log.debug(
-              'SELECT CHAT chat does not exsits, id is null. chatId:',
-              chat.id
-            )
-            return
-          }
-          const messageListItems = await BackendRemote.rpc.getMessageListItems(
-            accountId,
-            chatId,
-            C.DC_GCM_ADDDAYMARKER
-          )
-
-          const jumpToMessageIndex = messageListItems.findIndex(
-            m => m.kind === 'message' && m.msg_id === jumpToMessageId
-          )
-
-          // calculate page indexes, so that jumpToMessageId is in the middle of the page
-          let oldestFetchedMessageListItemIndex = -1
-          let newestFetchedMessageListItemIndex = -1
-          let messagePage: MessagePage | null = null
-          const half_page_size = Math.ceil(PAGE_SIZE / 2)
-          if (messageListItems.length !== 0) {
-            oldestFetchedMessageListItemIndex = Math.max(
-              jumpToMessageIndex - half_page_size,
-              0
-            )
-            newestFetchedMessageListItemIndex = Math.min(
-              jumpToMessageIndex + half_page_size,
-              messageListItems.length - 1
-            )
-
-            const countMessagesOnNewerSide =
-              newestFetchedMessageListItemIndex - jumpToMessageIndex
-            const countMessagesOnOlderSide =
-              jumpToMessageIndex - oldestFetchedMessageListItemIndex
-            if (countMessagesOnNewerSide < half_page_size) {
-              oldestFetchedMessageListItemIndex = Math.max(
-                oldestFetchedMessageListItemIndex -
-                  (half_page_size - countMessagesOnNewerSide),
-                0
-              )
-            } else if (countMessagesOnOlderSide < half_page_size) {
-              newestFetchedMessageListItemIndex = Math.min(
-                newestFetchedMessageListItemIndex +
-                  (half_page_size - countMessagesOnOlderSide),
-                messageListItems.length - 1
-              )
-            }
-
-            messagePage = await messagePageFromMessageIndexes(
-              accountId,
-              chatId,
-              oldestFetchedMessageListItemIndex,
-              newestFetchedMessageListItemIndex
-            )
-          }
-
-          if (messagePage === null) {
-            throw new Error(
-              'jumpToMessage: messagePage is null, this should not happen'
-            )
-          }
-
-          this.reducer.selectedChat({
-            chat,
-            accountId,
-            messagePages: [messagePage],
-            messageListItems,
-            oldestFetchedMessageListItemIndex,
-            newestFetchedMessageListItemIndex: newestFetchedMessageListItemIndex,
-            viewState: ChatViewReducer.jumpToMessage(
-              this.state.viewState,
-              jumpToMessageId,
-              highlight
-            ),
-            jumpToMessageStack,
-          })
-          ActionEmitter.emitAction(
-            chat.archived
-              ? KeybindAction.ChatList_SwitchToArchiveView
-              : KeybindAction.ChatList_SwitchToNormalView
-          )
-          debouncedUpdateBadgeCounter()
-          saveLastChatId(chatId)
-        },
-        'jumpToMessage'
-      ),
-      'jumpToMessage'
-    ),
-    markseenMessages: async (chatId: number, msgIds: number[]) => {
-      if (!this.state.chat || !this.state.chat.id) return
-      if (this.state.chat.id !== chatId) return
-      if (!this.state.accountId) {
-        throw new Error('Account Id unset')
+        await this.effect.selectChat(chat.id)
       }
 
-      await BackendRemote.rpc.markseenMsgs(this.state.accountId, msgIds)
-      const freshMessageCounter = await BackendRemote.rpc.getFreshMsgCnt(
-        this.state.accountId,
-        this.state.chat.id
-      )
-      this.reducer.setFreshMessageCounter({
-        id: this.state.chat.id,
-        freshMessageCounter,
-      })
-
-      debouncedUpdateBadgeCounter()
+      setTimeout(() => {
+        // jump to message
+        window.__internal_jump_to_message?.(msgId, highlight, msgParentId)
+      }, 0)
     },
-    fetchMoreMessagesTop: this.scheduler.queuedEffect(
-      this.scheduler.lockedEffect(
-        'scroll',
-        async () => {
-          log.debug(`fetchMoreMessagesTop`)
-          if (!this.state.accountId) {
-            throw new Error('no account set')
-          }
-          const state = this.state
-          if (state.chat === null) {
-            return false
-          }
-          const id = state.chat.id
-          const oldestFetchedMessageListItemIndex = Math.max(
-            state.oldestFetchedMessageListItemIndex - PAGE_SIZE,
-            0
-          )
-          const lastMessageIndexOnLastPage =
-            state.oldestFetchedMessageListItemIndex
-          if (lastMessageIndexOnLastPage === 0) {
-            log.debug(
-              'FETCH_MORE_MESSAGES: lastMessageIndexOnLastPage is zero, returning'
-            )
-            return false
-          }
-          const fetchedMessageListItems = state.messageListItems.slice(
-            oldestFetchedMessageListItemIndex,
-            lastMessageIndexOnLastPage
-          )
-          if (fetchedMessageListItems.length === 0) {
-            log.debug(
-              'fetchMoreMessagesTop: fetchedMessageListItems.length is zero, returning'
-            )
-            return false
-          }
 
-          const messagePage: MessagePage = await messagePageFromMessageIndexes(
-            this.state.accountId,
-            id,
-            oldestFetchedMessageListItemIndex,
-            lastMessageIndexOnLastPage - 1
-          )
-
-          this.reducer.appendMessagePageTop({
-            id,
-            messagePage,
-            oldestFetchedMessageListItemIndex,
-            countFetchedMessages: fetchedMessageListItems.length,
-          })
-          return true
-        },
-        'fetchMoreMessagesTop'
-      ),
-      'fetchMoreMessagesTop'
-    ),
-    fetchMoreMessagesBottom: this.scheduler.queuedEffect(
-      this.scheduler.lockedEffect(
-        'scroll',
-        async () => {
-          if (!this.state.accountId) {
-            throw new Error('no account set')
-          }
-          const state = this.state
-          if (state.chat === null) {
-            return false
-          }
-          const id = state.chat.id
-
-          const newestFetchedMessageListItemIndex =
-            state.newestFetchedMessageListItemIndex + 1
-          const newNewestFetchedMessageListItemIndex = Math.min(
-            newestFetchedMessageListItemIndex + PAGE_SIZE,
-            state.messageListItems.length - 1
-          )
-          if (
-            newestFetchedMessageListItemIndex === state.messageListItems.length
-          ) {
-            //log.debug('fetchMoreMessagesBottom: no more messages, returning')
-            return false
-          }
-          log.debug(`fetchMoreMessagesBottom`)
-
-          const fetchedMessageListItems = state.messageListItems.slice(
-            newestFetchedMessageListItemIndex,
-            newNewestFetchedMessageListItemIndex + 1
-          )
-          if (fetchedMessageListItems.length === 0) {
-            log.debug(
-              'fetchMoreMessagesBottom: fetchedMessageListItems.length is zero, returning',
-              JSON.stringify({
-                newestFetchedMessageIndex: newestFetchedMessageListItemIndex,
-                newNewestFetchedMessageIndex: newNewestFetchedMessageListItemIndex,
-                messageIds: state.messageListItems,
-              })
-            )
-            return false
-          }
-
-          const messagePage: MessagePage = await messagePageFromMessageIndexes(
-            this.state.accountId,
-            id,
-            newestFetchedMessageListItemIndex,
-            newNewestFetchedMessageListItemIndex
-          )
-
-          this.reducer.appendMessagePageBottom({
-            id,
-            messagePage,
-            newestFetchedMessageIndex: newNewestFetchedMessageListItemIndex,
-            countFetchedMessages: fetchedMessageListItems.length,
-          })
-          return true
-        },
-        'fetchMoreMessagesBottom'
-      ),
-      'fetchMoreMessagesBottom'
-    ),
-    refresh: this.scheduler.queuedEffect(
-      this.scheduler.lockedEffect(
-        'scroll',
-        async (payload: { chatId: number }) => {
-          const { chatId: eventChatId } = payload
-          log.debug(`refresh`, eventChatId)
-          const state = this.state
-          if (state.chat === null) {
-            log.debug('refresh: state.chat is null, returning')
-            return false
-          }
-          if (state.chat.id !== payload.chatId) {
-            log.debug(
-              'refresh: state.chat.id and payload.chatId mismatch, returning',
-              state.chat.id,
-              payload.chatId
-            )
-            return false
-          }
-          const chatId = payload.chatId
-          if (!this.state.accountId) {
-            throw new Error('no account set')
-          }
-          const messageListItems = await BackendRemote.rpc.getMessageListItems(
-            this.state.accountId,
-            chatId,
-            C.DC_GCM_ADDDAYMARKER
-          )
-          let {
-            newestFetchedMessageListItemIndex,
-            oldestFetchedMessageListItemIndex,
-          } = state
-          newestFetchedMessageListItemIndex = Math.min(
-            newestFetchedMessageListItemIndex,
-            messageListItems.length - 1
-          )
-          oldestFetchedMessageListItemIndex = Math.max(
-            oldestFetchedMessageListItemIndex,
-            0
-          )
-
-          const messagePages = await messagePagesFromMessageIndexes(
-            this.state.accountId,
-            chatId,
-            oldestFetchedMessageListItemIndex,
-            newestFetchedMessageListItemIndex
-          )
-
-          this.reducer.refresh(
-            messageListItems,
-            messagePages,
-            newestFetchedMessageListItemIndex,
-            oldestFetchedMessageListItemIndex
-          )
-          return true
-        },
-        'refresh'
-      ),
-      'refresh'
-    ),
     mute: async (payload: {
       chatId: number
       muteDuration: Type.MuteDuration
@@ -884,7 +167,7 @@ class ChatStore extends Store<ChatStoreState> {
         payload.muteDuration
       )
     },
-    onEventChatModified: this.scheduler.queuedEffect(async (chatId: number) => {
+    onEventChatModified: async (chatId: number) => {
       if (this.state.chat?.id !== chatId) {
         return
       }
@@ -898,147 +181,12 @@ class ChatStore extends Store<ChatStoreState> {
           chatId
         ),
       })
-    }, 'onEventChatModified'),
-    onEventIncomingMessage: this.scheduler.queuedEffect(
-      async (chatId: number) => {
-        if (chatId !== this.state.chat?.id) {
-          log.debug(
-            `DC_EVENT_INCOMING_MSG chatId of event (${chatId}) doesn't match id of selected chat (${this.state.chat?.id}). Skipping.`
-          )
-          return
-        }
-        if (!this.state.accountId) {
-          throw new Error('no account set')
-        }
-        const messageListItems = await BackendRemote.rpc.getMessageListItems(
-          this.state.accountId,
-          chatId,
-          C.DC_GCM_ADDDAYMARKER
-        )
-        let indexStart = -1
-        let indexEnd = -1
-        for (let index = 0; index < messageListItems.length; index++) {
-          const msgListItem = messageListItems[index]
-          if (this.state.messageListItems.includes(msgListItem)) continue
-          if (indexStart === -1) {
-            indexStart = index
-          }
-          indexEnd = index
-        }
-        // Only add incoming messages if we could append them directly to messagePages without having a hole
-        if (
-          this.state.newestFetchedMessageListItemIndex !== -1 &&
-          indexStart !== this.state.newestFetchedMessageListItemIndex + 1
-        ) {
-          log.debug(
-            `onEventIncomingMessage: new incoming messages cannot added to state without having a hole (indexStart: ${indexStart}, newestFetchedMessageListItemIndex ${this.state.newestFetchedMessageListItemIndex}), returning`
-          )
-          this.reducer.setMessageListItems({
-            id: chatId,
-            messageListItems,
-          })
-          return
-        }
-        const messagePage = await messagePageFromMessageIndexes(
-          this.state.accountId,
-          chatId,
-          indexStart,
-          indexEnd
-        )
-
-        this.reducer.fetchedIncomingMessages({
-          id: chatId,
-          messageListItems,
-          messagePage,
-          newestFetchedMessageIndex: indexEnd,
-        })
-      },
-      'onEventIncomingMessage'
-    ),
-    onEventMessagesChanged: this.scheduler.queuedEffect(
-      async (eventChatId: number, messageId: number) => {
-        log.debug('DC_EVENT_MSGS_CHANGED', eventChatId, messageId)
-        const chatId = this.state.chat?.id
-        if (chatId === null || chatId === undefined) {
-          return
-        }
-        if (
-          messageId === 0 &&
-          (eventChatId === 0 || eventChatId === this.state.chat?.id)
-        ) {
-          this.effect.refresh({ chatId })
-          return
-        }
-        if (eventChatId !== this.state.chat?.id) return
-        if (!this.state.accountId) {
-          throw new Error('no account set')
-        }
-        if (
-          this.state.messageListItems.findIndex(
-            m => m.kind === 'message' && m.msg_id === messageId
-          ) !== -1
-        ) {
-          log.debug(
-            'DC_EVENT_MSGS_CHANGED',
-            'changed message seems to be message we already know'
-          )
-          try {
-            const message = await BackendRemote.rpc.getMessage(
-              this.state.accountId,
-              messageId
-            )
-            this.reducer.messageChanged({
-              id: chatId,
-              messagesChanged: [message],
-            })
-          } catch (error) {
-            log.warn('failed to fetch message with id', messageId, error)
-            // ignore not found and other errors
-            return
-          }
-        } else {
-          log.debug(
-            'DC_EVENT_MSGS_CHANGED',
-            'changed message seems to be a new message, refetching messageIds'
-          )
-          const messageListItems = await BackendRemote.rpc.getMessageListItems(
-            this.state.accountId,
-            chatId,
-            C.DC_GCM_ADDDAYMARKER
-          )
-          this.reducer.setMessageListItems({ id: chatId, messageListItems })
-        }
-      },
-      'onEventMessagesChanged'
-    ),
+    },
   }
 
   stateToHumanReadable(state: ChatStoreState): any {
     return {
-      //...state,
       ...state,
-      messagePages: state.messagePages.map(messagePage => {
-        return {
-          ...messagePage,
-          messages: messagePage.messages.toArray().map(([msgId, message]) => {
-            return [
-              msgId,
-              typeof message.id !== 'string'
-                ? {
-                    messageId: message.id,
-                    messsage: (message as Type.Message).text,
-                  }
-                : {
-                    messageId: message.id,
-                    timestamp: (message as {
-                      id: string
-                      ts: number
-                    }).ts,
-                  },
-            ]
-          }),
-        }
-      }),
     }
   }
 }
@@ -1058,64 +206,7 @@ onReady(() => {
     }
     chatStore.effect.onEventChatModified(chatId)
   })
-
-  BackendRemote.on('MsgDelivered', (accountId, { chatId: id, msgId }) => {
-    if (accountId !== window.__selectedAccountId) {
-      return
-    }
-    chatStore.reducer.setMessageState({
-      id,
-      messageId: msgId,
-      messageState: C.DC_STATE_OUT_DELIVERED,
-    })
-  })
-
-  BackendRemote.on('IncomingMsg', (accountId, { chatId }) => {
-    if (accountId !== window.__selectedAccountId) {
-      return
-    }
-    chatStore.effect.onEventIncomingMessage(chatId)
-  })
-
-  BackendRemote.on('MsgRead', (accountId, { chatId: id, msgId }) => {
-    if (accountId !== window.__selectedAccountId) {
-      return
-    }
-    chatStore.reducer.setMessageState({
-      id,
-      messageId: msgId,
-      messageState: C.DC_STATE_OUT_MDN_RCVD,
-    })
-  })
-
-  BackendRemote.on('MsgsChanged', (accountId, { chatId, msgId }) => {
-    if (accountId !== window.__selectedAccountId) {
-      return
-    }
-    chatStore.effect.onEventMessagesChanged(chatId, msgId)
-  })
-
-  BackendRemote.on('MsgFailed', (accountId, { chatId, msgId }) => {
-    if (accountId !== window.__selectedAccountId) {
-      return
-    }
-    chatStore.effect.onEventMessagesChanged(chatId, msgId)
-  })
 })
-
-export function calculatePageKey(
-  messages: MessagePage['messages'],
-  indexStart: number,
-  indexEnd: number
-): string {
-  const first = messages.first()?.id
-  const last = messages.last()?.id
-  if (!first && !last && indexStart === 0 && indexEnd === 0) {
-    throw new Error('calculatePageKey: non unique page key of 0')
-  } else {
-    return `page-${first}-${last}-${indexStart}-${indexEnd}`
-  }
-}
 
 export const useChatStore = () => useStore(chatStore)[0]
 export const useChatStore2 = () => {
@@ -1131,34 +222,3 @@ export type ChatStoreDispatch = Store<ChatStoreState>['dispatch']
 export type ChatStoreStateWithChatSet = {
   chat: NonNullable<ChatStoreState['chat']>
 } & Exclude<ChatStoreState, 'chat'>
-
-async function getMessagesFromIndex(
-  accountId: number,
-  chatId: number,
-  indexStart: number,
-  indexEnd: number,
-  flags = C.DC_GCM_ADDDAYMARKER
-): Promise<[number | string, Type.Message | { id: string; ts: number }][]> {
-  const allMessageListItems = (
-    await BackendRemote.rpc.getMessageListItems(accountId, chatId, flags)
-  ).slice(indexStart, indexEnd + 1)
-
-  const messageIds = allMessageListItems
-    .map(m => (m.kind === 'message' ? m.msg_id : C.DC_MSG_ID_LAST_SPECIAL))
-    .filter(msgId => msgId !== C.DC_MSG_ID_LAST_SPECIAL)
-
-  const messages = await BackendRemote.rpc.getMessages(accountId, messageIds)
-
-  log.debug('getMessagesFromIndex', {
-    allMessageListItems,
-    messageIds,
-    messages,
-  })
-
-  return allMessageListItems.map(m => [
-    m.kind === 'message' ? m.msg_id : `d${m.timestamp}`,
-    m.kind === 'message'
-      ? messages[m.msg_id]
-      : { id: `d${m.timestamp}`, ts: m.timestamp },
-  ])
-}

--- a/src/renderer/stores/messagelist.ts
+++ b/src/renderer/stores/messagelist.ts
@@ -1,0 +1,993 @@
+import { Store } from './store'
+import { ActionEmitter, KeybindAction } from '../keybindings'
+import { C } from '@deltachat/jsonrpc-client'
+import { OrderedMap } from 'immutable'
+import { BackendRemote, onDCEvent, Type } from '../backend-com'
+import { selectedAccountId } from '../ScreenController'
+import { debouncedUpdateBadgeCounter } from '../system-integration/badge-counter'
+import { T } from '@deltachat/jsonrpc-client'
+import {
+  ChatViewState,
+  ChatViewReducer,
+  defaultChatViewState,
+} from './chat/chat_view_reducer'
+import { ChatStoreScheduler } from './chat/chat_scheduler'
+import { useEffect, useMemo, useState } from 'react'
+import { useDebouncedCallback } from 'use-debounce'
+
+const PAGE_SIZE = 11
+
+export interface MessagePage {
+  pageKey: string
+  messages: OrderedMap<
+    number | string,
+    Type.Message | { id: string; ts: number }
+  >
+}
+
+interface MessageListState {
+  // chat: Type.FullChat | null
+  messageListItems: T.MessageListItem[]
+  messagePages: MessagePage[]
+  newestFetchedMessageListItemIndex: number
+  oldestFetchedMessageListItemIndex: number
+  viewState: ChatViewState
+  jumpToMessageStack: number[]
+  countFetchedMessages: number
+  freshMessageCounter: number
+}
+
+const defaultState = () =>
+  ({
+    messageListItems: [],
+    messagePages: [],
+    newestFetchedMessageListItemIndex: -1,
+    oldestFetchedMessageListItemIndex: -1,
+    viewState: defaultChatViewState(),
+    jumpToMessageStack: [],
+    countFetchedMessages: 0,
+    freshMessageCounter: 0,
+  } as MessageListState)
+
+async function messagePageFromMessageIndexes(
+  accountId: number,
+  chatId: number,
+  indexStart: number,
+  indexEnd: number
+): Promise<MessagePage> {
+  const rawMessages = await getMessagesFromIndex(
+    accountId,
+    chatId,
+    indexStart,
+    indexEnd
+  )
+
+  if (rawMessages.length === 0) {
+    throw new Error(
+      'messagePageFromMessageIndexes: _messages.length equals zero. This should not happen'
+    )
+  }
+
+  // log.debug('messagePageFromMessageIndexes', rawMessages, indexEnd, indexStart)
+
+  if (rawMessages.length !== indexEnd - indexStart + 1) {
+    throw new Error(
+      "messagePageFromMessageIndexes: _messages.length doesn't equal indexEnd - indexStart + 1. This should not happen"
+    )
+  }
+
+  const messages = OrderedMap<
+    number | string,
+    Type.Message | { id: string; ts: number }
+  >().withMutations(messagePages => {
+    for (let i = 0; i < rawMessages.length; i++) {
+      const [messageId, message] = rawMessages[i]
+      messagePages.set(messageId, message)
+    }
+  })
+
+  // log.debug('messagePageFromMessageIndexes', messages)
+
+  const messagePage = {
+    pageKey: calculatePageKey(messages, indexStart, indexEnd),
+    messages,
+  }
+
+  return messagePage
+}
+
+async function messagePagesFromMessageIndexes(
+  accountId: number,
+  chatId: number,
+  indexStart: number,
+  indexEnd: number
+): Promise<MessagePage[]> {
+  const rawMessages = await getMessagesFromIndex(
+    accountId,
+    chatId,
+    indexStart,
+    indexEnd
+  )
+
+  const messagePages = []
+  while (rawMessages.length > 0) {
+    const pageMessages = rawMessages.splice(0, PAGE_SIZE)
+
+    const messages = OrderedMap<
+      number | string,
+      Type.Message | { id: string; ts: number }
+    >().withMutations(messagePages => {
+      for (let i = 0; i < pageMessages.length; i++) {
+        const [messageId, message] = pageMessages[i]
+        messagePages.set(messageId, message)
+      }
+    })
+
+    messagePages.push({
+      pageKey: calculatePageKey(messages, indexStart, indexEnd),
+      messages,
+    })
+  }
+
+  return messagePages
+}
+
+// select chat
+// and unselect chat
+// and mute need to be done outside of this
+// and sendMessage
+// and onEventChatModified
+
+export function useMessageList(accountId: number, chatId: number) {
+  let store = useMemo(() => {
+    const store = new MessageListStore(accountId, chatId)
+    store.effect.loadChat()
+    return store
+  }, [accountId, chatId])
+
+  useEffect(() => {
+    let cleanup = [
+      onDCEvent(accountId, 'MsgDelivered', ({ chatId: eventChatId, msgId }) => {
+        if (chatId === eventChatId) {
+          store.reducer.setMessageState({
+            messageId: msgId,
+            messageState: C.DC_STATE_OUT_DELIVERED,
+          })
+        }
+      }),
+      onDCEvent(accountId, 'IncomingMsg', ({ chatId: eventChatId }) => {
+        if (chatId === eventChatId) {
+          store.effect.onEventIncomingMessage()
+        } else {
+          store.log.debug(
+            `chatId of IncomingMsg event (${chatId}) doesn't match id of selected chat (${eventChatId}). Skipping.`
+          )
+        }
+      }),
+      onDCEvent(accountId, 'MsgRead', ({ chatId: eventChatId, msgId }) => {
+        if (chatId === eventChatId) {
+          store.reducer.setMessageState({
+            messageId: msgId,
+            messageState: C.DC_STATE_OUT_MDN_RCVD,
+          })
+        }
+      }),
+      onDCEvent(accountId, 'MsgsChanged', ({ chatId: eventChatId, msgId }) => {
+        if (msgId === 0 && (eventChatId === 0 || eventChatId === chatId)) {
+          store.effect.refresh()
+        } else {
+          store.effect.onEventMessagesChanged(msgId)
+        }
+      }),
+      onDCEvent(accountId, 'MsgFailed', ({ chatId: eventChatId, msgId }) => {
+        if (chatId === eventChatId) {
+          store.effect.onEventMessagesChanged(msgId)
+        }
+      }),
+    ]
+    return () => cleanup.forEach(off => off())
+  }, [accountId, chatId])
+
+  const [state, setState] = useState(store.getState())
+
+  useEffect(() => {
+    store.subscribe(setState)
+    return () => store.unsubscribe(setState)
+  }, [store])
+
+  const [fetchMoreTop] = useDebouncedCallback(
+    async () => {
+      await store.effect.fetchMoreMessagesTop()
+    },
+    30,
+    { leading: true }
+  )
+
+  const [fetchMoreBottom] = useDebouncedCallback(
+    async () => {
+      await store.effect.fetchMoreMessagesBottom()
+    },
+    30,
+    { leading: true }
+  )
+
+  return { store, state, fetchMoreTop, fetchMoreBottom }
+}
+
+class MessageListStore extends Store<MessageListState> {
+  scheduler = new ChatStoreScheduler()
+
+  emitter = BackendRemote.getContextEvents(this.accountId)
+
+  constructor(
+    private readonly accountId: number,
+    private readonly chatId: number
+  ) {
+    super(defaultState())
+  }
+
+  guardReducerTriesToAddDuplicatePageKey(pageKeyToAdd: string) {
+    const isDuplicatePageKey =
+      this.state.messagePages.findIndex(
+        messagePage => messagePage.pageKey === pageKeyToAdd
+      ) !== -1
+    if (isDuplicatePageKey) {
+      this.log.error('Duplicate page key')
+    }
+    return isDuplicatePageKey
+  }
+  reducer = {
+    selectedChat: (payload: Partial<MessageListState>) => {
+      this.setState(_ => {
+        this.scheduler.unlock('scroll')
+        const modifiedState: MessageListState = {
+          ...defaultState(),
+          ...payload,
+        }
+        return modifiedState
+      }, 'selectedChat')
+    },
+    refresh: (
+      messageListItems: T.MessageListItem[],
+      messagePages: MessagePage[],
+      newestFetchedMessageListItemIndex: number,
+      oldestFetchedMessageListItemIndex: number
+    ) => {
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          messageListItems,
+          messagePages,
+          viewState: ChatViewReducer.refresh(state.viewState),
+          countFetchedMessages: messageListItems.length,
+          newestFetchedMessageListItemIndex,
+          oldestFetchedMessageListItemIndex,
+        }
+        return modifiedState
+      }, 'refresh')
+    },
+    modifiedChat: (payload: { id: number } & Partial<MessageListState>) => {
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          ...payload,
+        }
+        return modifiedState
+      }, 'modifiedChat')
+    },
+    appendMessagePageTop: (payload: {
+      id: number
+      messagePage: MessagePage
+      countFetchedMessages: number
+      oldestFetchedMessageListItemIndex: number
+    }) => {
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          messagePages: [payload.messagePage, ...state.messagePages],
+          oldestFetchedMessageListItemIndex:
+            payload.oldestFetchedMessageListItemIndex,
+          viewState: ChatViewReducer.appendMessagePageTop(state.viewState),
+          countFetchedMessages: payload.countFetchedMessages,
+        }
+        if (
+          this.guardReducerTriesToAddDuplicatePageKey(
+            payload.messagePage.pageKey
+          )
+        ) {
+          return
+        }
+        return modifiedState
+      }, 'appendMessagePageTop')
+    },
+    appendMessagePageBottom: (payload: {
+      messagePage: MessagePage
+      countFetchedMessages: number
+      newestFetchedMessageIndex: number
+    }) => {
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          messagePages: [...state.messagePages, payload.messagePage],
+          newestFetchedMessageListItemIndex: payload.newestFetchedMessageIndex,
+          viewState: ChatViewReducer.appendMessagePageBottom(state.viewState),
+          countFetchedMessages: payload.countFetchedMessages,
+        }
+        if (
+          this.guardReducerTriesToAddDuplicatePageKey(
+            payload.messagePage.pageKey
+          )
+        )
+          return
+        return modifiedState
+      }, 'appendMessagePageBottom')
+    },
+    fetchedIncomingMessages: (payload: {
+      messageListItems: MessageListState['messageListItems']
+      newestFetchedMessageIndex: number
+      messagePage: MessagePage
+    }) => {
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          messageListItems: payload.messageListItems,
+          messagePages: [...state.messagePages, payload.messagePage],
+          // newestFetchedMessageIndex: payload.newestFetchedMessageIndex,
+          viewState: ChatViewReducer.fetchedIncomingMessages(state.viewState),
+        }
+
+        if (
+          this.guardReducerTriesToAddDuplicatePageKey(
+            payload.messagePage.pageKey
+          )
+        ) {
+          throw new Error(
+            'We almost added the same page twice! We should prevent this in code duplicate pageKey: ' +
+              payload.messagePage.pageKey
+          )
+        }
+
+        return modifiedState
+      }, 'fetchedIncomingMessages')
+    },
+    unlockScroll: () => {
+      this.log.debug('unlockScroll')
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          viewState: ChatViewReducer.unlockScroll(state.viewState),
+        }
+        setTimeout(() => this.scheduler.unlock('scroll'), 0)
+        return modifiedState
+      }, 'unlockScroll')
+    },
+    messageChanged: (payload: { messagesChanged: Type.Message[] }) => {
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          messagePages: state.messagePages.map(messagePage => {
+            let changed = false
+            const messages = messagePage.messages.withMutations(messages => {
+              for (const changedMessage of payload.messagesChanged) {
+                if (!messages.has(changedMessage.id)) continue
+                changed = true
+                messages.set(changedMessage.id, changedMessage)
+              }
+            })
+            if (changed === false) return messagePage
+            return {
+              ...messagePage,
+              messages,
+            }
+          }),
+        }
+        return modifiedState
+      }, 'messageChanged')
+    },
+    setMessageState: (payload: { messageId: number; messageState: number }) => {
+      const { messageId, messageState } = payload
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          messagePages: state.messagePages.map(messagePage => {
+            if (messagePage.messages.has(messageId)) {
+              const message = messagePage.messages.get(messageId)
+              if (message !== null && message !== undefined) {
+                const updatedMessages = messagePage.messages.set(messageId, {
+                  ...message,
+                  state: messageState,
+                })
+
+                return {
+                  ...messagePage,
+                  messages: updatedMessages,
+                }
+              }
+            }
+
+            return messagePage
+          }),
+        }
+        return modifiedState
+      }, 'setMessageState')
+    },
+    setMessageListItems: (
+      messageListItems: MessageListState['messageListItems']
+    ) => {
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          messageListItems,
+          viewState: ChatViewReducer.setMessageListItems(state.viewState),
+        }
+        return modifiedState
+      }, 'setMessageIds')
+    },
+
+    setFreshMessageCounter: (payload: {
+      id: number
+      freshMessageCounter: number
+    }) => {
+      const { freshMessageCounter } = payload
+      this.setState(state => {
+        const modifiedState: MessageListState = {
+          ...state,
+          freshMessageCounter,
+        }
+        return modifiedState
+      }, 'setFreshMessageCounter')
+    },
+  }
+
+  effect = {
+    loadChat: this.scheduler.lockedQueuedEffect(
+      'scroll',
+      async () => {
+        const chat = await BackendRemote.rpc.getFullChatById(
+          this.accountId,
+          this.chatId
+        )
+        if (chat.id === null) {
+          this.log.debug(
+            'SELECT CHAT chat does not exsits, id is null. chatId:',
+            chat.id
+          )
+          return
+        }
+        const messageListItems = await BackendRemote.rpc.getMessageListItems(
+          this.accountId,
+          this.chatId,
+          C.DC_GCM_ADDDAYMARKER
+        )
+
+        const firstUnreadMsgId = await BackendRemote.rpc.getFirstUnreadMessageOfChat(
+          this.accountId,
+          this.chatId
+        )
+        if (firstUnreadMsgId !== null) {
+          setTimeout(() => {
+            this.effect.jumpToMessage(firstUnreadMsgId, false)
+            ActionEmitter.emitAction(
+              chat.archived
+                ? KeybindAction.ChatList_SwitchToArchiveView
+                : KeybindAction.ChatList_SwitchToNormalView
+            )
+          })
+          return false
+        }
+
+        let oldestFetchedMessageListItemIndex = -1
+        let newestFetchedMessageListItemIndex = -1
+        let messagePage: MessagePage | null = null
+        if (messageListItems.length !== 0) {
+          // mesageIds.length = 1767
+          // oldestFetchedMessageListItemIndex = 1767 - 1 = 1766 - 10 = 1756
+          // newestFetchedMessageIndex =                        1766
+          oldestFetchedMessageListItemIndex = Math.max(
+            messageListItems.length - 1 - PAGE_SIZE,
+            0
+          )
+          newestFetchedMessageListItemIndex = messageListItems.length - 1
+
+          messagePage = await messagePageFromMessageIndexes(
+            this.accountId,
+            this.chatId,
+            oldestFetchedMessageListItemIndex,
+            newestFetchedMessageListItemIndex
+          )
+        }
+
+        this.reducer.selectedChat({
+          messagePages: messagePage === null ? [] : [messagePage],
+          messageListItems,
+          oldestFetchedMessageListItemIndex,
+          newestFetchedMessageListItemIndex,
+          viewState: ChatViewReducer.selectChat(this.state.viewState),
+        })
+        ActionEmitter.emitAction(
+          chat.archived
+            ? KeybindAction.ChatList_SwitchToArchiveView
+            : KeybindAction.ChatList_SwitchToNormalView
+        )
+      },
+      'selectChat'
+    ),
+    // TODO: Probably this should be lockedQueuedEffect too?
+    jumpToMessage: this.scheduler.queuedEffect(
+      this.scheduler.lockedEffect(
+        'scroll',
+        async (
+          msgId: number | undefined,
+          highlight?: boolean,
+          addMessageIdToStack?: undefined | number
+        ) => {
+          this.log.debug('jumpToMessage with messageId: ', msgId)
+          const accountId = selectedAccountId()
+          highlight = highlight === false ? false : true
+          // these methods were called in backend before
+          // might be an issue if DeltaBackend.call has a significant delay
+
+          if (!accountId) {
+            throw new Error('no account set')
+          }
+          // this function already throws an error if message is not found
+
+          let chatId = -1
+          let jumpToMessageId = -1
+          let jumpToMessageStack: number[] = []
+          let message: Type.Message | undefined = undefined
+          if (msgId === undefined) {
+            const jumpToMessageStackLength = this.state.jumpToMessageStack
+              .length
+            if (jumpToMessageStackLength !== 0) {
+              jumpToMessageStack = this.state.jumpToMessageStack.slice(
+                0,
+                jumpToMessageStackLength - 1
+              )
+              jumpToMessageId = this.state.jumpToMessageStack[
+                jumpToMessageStackLength - 1
+              ]
+              message = await BackendRemote.rpc.getMessage(
+                accountId,
+                jumpToMessageId as number
+              )
+              chatId = message.chatId
+            } else {
+              this.effect.loadChat()
+              return
+            }
+          } else if (addMessageIdToStack === undefined) {
+            // reset jumpToMessageStack
+            message = await BackendRemote.rpc.getMessage(
+              accountId,
+              msgId as number
+            )
+            chatId = message.chatId
+
+            jumpToMessageId = msgId as number
+            jumpToMessageStack = []
+          } else {
+            message = await BackendRemote.rpc.getMessage(
+              accountId,
+              msgId as number
+            )
+            chatId = message.chatId
+
+            jumpToMessageId = msgId as number
+            // If we are not switching chats, add current jumpToMessageId to the stack
+            const currentChatId = this.chatId || -1
+            if (chatId !== currentChatId) {
+              jumpToMessageStack = []
+            } else if (
+              this.state.jumpToMessageStack.indexOf(addMessageIdToStack) !== -1
+            ) {
+              jumpToMessageStack = this.state.jumpToMessageStack
+            } else {
+              jumpToMessageStack = [
+                ...this.state.jumpToMessageStack,
+                addMessageIdToStack,
+              ]
+            }
+          }
+
+          //@ts-ignore
+          if (message === undefined) {
+            throw new Error(
+              'jumpToMessage: Tried to jump to non existing message with id: ' +
+                msgId
+            )
+          }
+
+          const chat = await BackendRemote.rpc.getFullChatById(
+            accountId,
+            chatId
+          )
+          if (chat.id === null) {
+            this.log.debug(
+              'SELECT CHAT chat does not exsits, id is null. chatId:',
+              chat.id
+            )
+            return
+          }
+          const messageListItems = await BackendRemote.rpc.getMessageListItems(
+            accountId,
+            chatId,
+            C.DC_GCM_ADDDAYMARKER
+          )
+
+          const jumpToMessageIndex = messageListItems.findIndex(
+            m => m.kind === 'message' && m.msg_id === jumpToMessageId
+          )
+
+          // calculate page indexes, so that jumpToMessageId is in the middle of the page
+          let oldestFetchedMessageListItemIndex = -1
+          let newestFetchedMessageListItemIndex = -1
+          let messagePage: MessagePage | null = null
+          const half_page_size = Math.ceil(PAGE_SIZE / 2)
+          if (messageListItems.length !== 0) {
+            oldestFetchedMessageListItemIndex = Math.max(
+              jumpToMessageIndex - half_page_size,
+              0
+            )
+            newestFetchedMessageListItemIndex = Math.min(
+              jumpToMessageIndex + half_page_size,
+              messageListItems.length - 1
+            )
+
+            const countMessagesOnNewerSide =
+              newestFetchedMessageListItemIndex - jumpToMessageIndex
+            const countMessagesOnOlderSide =
+              jumpToMessageIndex - oldestFetchedMessageListItemIndex
+            if (countMessagesOnNewerSide < half_page_size) {
+              oldestFetchedMessageListItemIndex = Math.max(
+                oldestFetchedMessageListItemIndex -
+                  (half_page_size - countMessagesOnNewerSide),
+                0
+              )
+            } else if (countMessagesOnOlderSide < half_page_size) {
+              newestFetchedMessageListItemIndex = Math.min(
+                newestFetchedMessageListItemIndex +
+                  (half_page_size - countMessagesOnOlderSide),
+                messageListItems.length - 1
+              )
+            }
+
+            messagePage = await messagePageFromMessageIndexes(
+              accountId,
+              chatId,
+              oldestFetchedMessageListItemIndex,
+              newestFetchedMessageListItemIndex
+            )
+          }
+
+          if (messagePage === null) {
+            throw new Error(
+              'jumpToMessage: messagePage is null, this should not happen'
+            )
+          }
+
+          this.reducer.selectedChat({
+            messagePages: [messagePage],
+            messageListItems,
+            oldestFetchedMessageListItemIndex,
+            newestFetchedMessageListItemIndex: newestFetchedMessageListItemIndex,
+            viewState: ChatViewReducer.jumpToMessage(
+              this.state.viewState,
+              jumpToMessageId,
+              highlight
+            ),
+            jumpToMessageStack,
+          })
+        },
+        'jumpToMessage'
+      ),
+      'jumpToMessage'
+    ),
+    markseenMessages: async (msgIds: number[]) => {
+      await BackendRemote.rpc.markseenMsgs(this.accountId, msgIds)
+      const freshMessageCounter = await BackendRemote.rpc.getFreshMsgCnt(
+        this.accountId,
+        this.chatId
+      )
+      this.reducer.setFreshMessageCounter({
+        id: this.chatId,
+        freshMessageCounter,
+      })
+      debouncedUpdateBadgeCounter()
+    },
+    fetchMoreMessagesTop: this.scheduler.queuedEffect(
+      this.scheduler.lockedEffect(
+        'scroll',
+        async () => {
+          this.log.debug(`fetchMoreMessagesTop`)
+          const state = this.state
+          const id = this.chatId
+          const oldestFetchedMessageListItemIndex = Math.max(
+            state.oldestFetchedMessageListItemIndex - PAGE_SIZE,
+            0
+          )
+          const lastMessageIndexOnLastPage =
+            state.oldestFetchedMessageListItemIndex
+          if (lastMessageIndexOnLastPage === 0) {
+            this.log.debug(
+              'FETCH_MORE_MESSAGES: lastMessageIndexOnLastPage is zero, returning'
+            )
+            return false
+          }
+          const fetchedMessageListItems = state.messageListItems.slice(
+            oldestFetchedMessageListItemIndex,
+            lastMessageIndexOnLastPage
+          )
+          if (fetchedMessageListItems.length === 0) {
+            this.log.debug(
+              'fetchMoreMessagesTop: fetchedMessageListItems.length is zero, returning'
+            )
+            return false
+          }
+
+          const messagePage: MessagePage = await messagePageFromMessageIndexes(
+            this.accountId,
+            id,
+            oldestFetchedMessageListItemIndex,
+            lastMessageIndexOnLastPage - 1
+          )
+
+          this.reducer.appendMessagePageTop({
+            id,
+            messagePage,
+            oldestFetchedMessageListItemIndex,
+            countFetchedMessages: fetchedMessageListItems.length,
+          })
+          return true
+        },
+        'fetchMoreMessagesTop'
+      ),
+      'fetchMoreMessagesTop'
+    ),
+    fetchMoreMessagesBottom: this.scheduler.queuedEffect(
+      this.scheduler.lockedEffect(
+        'scroll',
+        async () => {
+          const state = this.state
+
+          const id = this.chatId
+
+          const newestFetchedMessageListItemIndex =
+            state.newestFetchedMessageListItemIndex + 1
+          const newNewestFetchedMessageListItemIndex = Math.min(
+            newestFetchedMessageListItemIndex + PAGE_SIZE,
+            state.messageListItems.length - 1
+          )
+          if (
+            newestFetchedMessageListItemIndex === state.messageListItems.length
+          ) {
+            //log.debug('fetchMoreMessagesBottom: no more messages, returning')
+            return false
+          }
+          this.log.debug(`fetchMoreMessagesBottom`)
+
+          const fetchedMessageListItems = state.messageListItems.slice(
+            newestFetchedMessageListItemIndex,
+            newNewestFetchedMessageListItemIndex + 1
+          )
+          if (fetchedMessageListItems.length === 0) {
+            this.log.debug(
+              'fetchMoreMessagesBottom: fetchedMessageListItems.length is zero, returning',
+              JSON.stringify({
+                newestFetchedMessageIndex: newestFetchedMessageListItemIndex,
+                newNewestFetchedMessageIndex: newNewestFetchedMessageListItemIndex,
+                messageIds: state.messageListItems,
+              })
+            )
+            return false
+          }
+
+          const messagePage: MessagePage = await messagePageFromMessageIndexes(
+            this.accountId,
+            this.chatId,
+            newestFetchedMessageListItemIndex,
+            newNewestFetchedMessageListItemIndex
+          )
+
+          this.reducer.appendMessagePageBottom({
+            messagePage,
+            newestFetchedMessageIndex: newNewestFetchedMessageListItemIndex,
+            countFetchedMessages: fetchedMessageListItems.length,
+          })
+          return true
+        },
+        'fetchMoreMessagesBottom'
+      ),
+      'fetchMoreMessagesBottom'
+    ),
+    refresh: this.scheduler.queuedEffect(
+      this.scheduler.lockedEffect(
+        'scroll',
+        async () => {
+          this.log.debug(`refresh`, this)
+          const state = this.state
+          const messageListItems = await BackendRemote.rpc.getMessageListItems(
+            this.accountId,
+            this.chatId,
+            C.DC_GCM_ADDDAYMARKER
+          )
+          let {
+            newestFetchedMessageListItemIndex,
+            oldestFetchedMessageListItemIndex,
+          } = state
+          newestFetchedMessageListItemIndex = Math.min(
+            newestFetchedMessageListItemIndex,
+            messageListItems.length - 1
+          )
+          oldestFetchedMessageListItemIndex = Math.max(
+            oldestFetchedMessageListItemIndex,
+            0
+          )
+
+          const messagePages = await messagePagesFromMessageIndexes(
+            this.accountId,
+            this.chatId,
+            oldestFetchedMessageListItemIndex,
+            newestFetchedMessageListItemIndex
+          )
+
+          this.reducer.refresh(
+            messageListItems,
+            messagePages,
+            newestFetchedMessageListItemIndex,
+            oldestFetchedMessageListItemIndex
+          )
+          return true
+        },
+        'refresh'
+      ),
+      'refresh'
+    ),
+    onEventIncomingMessage: this.scheduler.queuedEffect(async () => {
+      const messageListItems = await BackendRemote.rpc.getMessageListItems(
+        this.accountId,
+        this.chatId,
+        C.DC_GCM_ADDDAYMARKER
+      )
+      let indexStart = -1
+      let indexEnd = -1
+      for (let index = 0; index < messageListItems.length; index++) {
+        const msgListItem = messageListItems[index]
+        if (this.state.messageListItems.includes(msgListItem)) continue
+        if (indexStart === -1) {
+          indexStart = index
+        }
+        indexEnd = index
+      }
+      // Only add incoming messages if we could append them directly to messagePages without having a hole
+      if (
+        this.state.newestFetchedMessageListItemIndex !== -1 &&
+        indexStart !== this.state.newestFetchedMessageListItemIndex + 1
+      ) {
+        this.log.debug(
+          `onEventIncomingMessage: new incoming messages cannot added to state without having a hole (indexStart: ${indexStart}, newestFetchedMessageListItemIndex ${this.state.newestFetchedMessageListItemIndex}), returning`
+        )
+        this.reducer.setMessageListItems(messageListItems)
+        return
+      }
+      const messagePage = await messagePageFromMessageIndexes(
+        this.accountId,
+        this.chatId,
+        indexStart,
+        indexEnd
+      )
+
+      this.reducer.fetchedIncomingMessages({
+        messageListItems,
+        messagePage,
+        newestFetchedMessageIndex: indexEnd,
+      })
+    }, 'onEventIncomingMessage'),
+    onEventMessagesChanged: this.scheduler.queuedEffect(
+      async (messageId: number) => {
+        if (
+          this.state.messageListItems.findIndex(
+            m => m.kind === 'message' && m.msg_id === messageId
+          ) !== -1
+        ) {
+          this.log.debug(
+            'DC_EVENT_MSGS_CHANGED',
+            'changed message seems to be message we already know'
+          )
+          try {
+            const message = await BackendRemote.rpc.getMessage(
+              this.accountId,
+              messageId
+            )
+            this.reducer.messageChanged({
+              messagesChanged: [message],
+            })
+          } catch (error) {
+            this.log.warn('failed to fetch message with id', messageId, error)
+            // ignore not found and other errors
+            return
+          }
+        } else {
+          this.log.debug(
+            'DC_EVENT_MSGS_CHANGED',
+            'changed message seems to be a new message, refetching messageIds'
+          )
+          const messageListItems = await BackendRemote.rpc.getMessageListItems(
+            this.accountId,
+            this.chatId,
+            C.DC_GCM_ADDDAYMARKER
+          )
+          this.reducer.setMessageListItems(messageListItems)
+        }
+      },
+      'onEventMessagesChanged'
+    ),
+  }
+
+  stateToHumanReadable(state: MessageListState): any {
+    return {
+      ...state,
+      messagePages: state.messagePages.map(messagePage => {
+        return {
+          ...messagePage,
+          messages: messagePage.messages.toArray().map(([msgId, message]) => {
+            return [
+              msgId,
+              typeof message.id !== 'string'
+                ? {
+                    messageId: message.id,
+                    messsage: (message as Type.Message).text,
+                  }
+                : {
+                    messageId: message.id,
+                    timestamp: (message as {
+                      id: string
+                      ts: number
+                    }).ts,
+                  },
+            ]
+          }),
+        }
+      }),
+    }
+  }
+}
+
+function calculatePageKey(
+  messages: MessagePage['messages'],
+  indexStart: number,
+  indexEnd: number
+): string {
+  const first = messages.first()?.id
+  const last = messages.last()?.id
+  if (!first && !last && indexStart === 0 && indexEnd === 0) {
+    throw new Error('calculatePageKey: non unique page key of 0')
+  } else {
+    return `page-${first}-${last}-${indexStart}-${indexEnd}`
+  }
+}
+
+async function getMessagesFromIndex(
+  accountId: number,
+  chatId: number,
+  indexStart: number,
+  indexEnd: number,
+  flags = C.DC_GCM_ADDDAYMARKER
+): Promise<[number | string, Type.Message | { id: string; ts: number }][]> {
+  const allMessageListItems = (
+    await BackendRemote.rpc.getMessageListItems(accountId, chatId, flags)
+  ).slice(indexStart, indexEnd + 1)
+
+  const messageIds = allMessageListItems
+    .map(m => (m.kind === 'message' ? m.msg_id : C.DC_MSG_ID_LAST_SPECIAL))
+    .filter(msgId => msgId !== C.DC_MSG_ID_LAST_SPECIAL)
+
+  const messages = await BackendRemote.rpc.getMessages(accountId, messageIds)
+
+  return allMessageListItems.map(m => [
+    m.kind === 'message' ? m.msg_id : `d${m.timestamp}`,
+    m.kind === 'message'
+      ? messages[m.msg_id]
+      : { id: `d${m.timestamp}`, ts: m.timestamp },
+  ])
+}

--- a/src/renderer/stores/messagelist.ts
+++ b/src/renderer/stores/messagelist.ts
@@ -129,12 +129,6 @@ async function messagePagesFromMessageIndexes(
   return messagePages
 }
 
-// select chat
-// and unselect chat
-// and mute need to be done outside of this
-// and sendMessage
-// and onEventChatModified
-
 export function useMessageList(accountId: number, chatId: number) {
   let store = useMemo(() => {
     const store = new MessageListStore(accountId, chatId)

--- a/src/renderer/stores/messagelist.ts
+++ b/src/renderer/stores/messagelist.ts
@@ -1,7 +1,6 @@
 import { Store } from './store'
 import { ActionEmitter, KeybindAction } from '../keybindings'
 import { C } from '@deltachat/jsonrpc-client'
-import { OrderedMap } from 'immutable'
 import { BackendRemote, onDCEvent, Type } from '../backend-com'
 import { selectedAccountId } from '../ScreenController'
 import { T } from '@deltachat/jsonrpc-client'
@@ -16,134 +15,38 @@ import { useDebouncedCallback } from 'use-debounce'
 
 const PAGE_SIZE = 11
 
-export interface MessagePage {
-  pageKey: string
-  messages: OrderedMap<
-    number | string,
-    Type.Message | { id: string; ts: number }
-  >
-}
-
 interface MessageListState {
   // chat: Type.FullChat | null
   messageListItems: T.MessageListItem[]
-  messagePages: MessagePage[]
+  messageCache: { [msgId: number]: T.Message }
   newestFetchedMessageListItemIndex: number
   oldestFetchedMessageListItemIndex: number
   viewState: ChatViewState
   jumpToMessageStack: number[]
-  countFetchedMessages: number
 }
 
 const defaultState = () =>
   ({
     messageListItems: [],
-    messagePages: [],
+    messageCache: {},
     newestFetchedMessageListItemIndex: -1,
     oldestFetchedMessageListItemIndex: -1,
     viewState: defaultChatViewState(),
     jumpToMessageStack: [],
-    countFetchedMessages: 0,
   } as MessageListState)
 
-async function messagePageFromMessageIndexes(
-  accountId: number,
-  chatId: number,
-  indexStart: number,
-  indexEnd: number
-): Promise<MessagePage> {
-  const rawMessages = await getMessagesFromIndex(
-    accountId,
-    chatId,
-    indexStart,
-    indexEnd
-  )
-
-  if (rawMessages.length === 0) {
-    throw new Error(
-      'messagePageFromMessageIndexes: _messages.length equals zero. This should not happen'
-    )
-  }
-
-  // log.debug('messagePageFromMessageIndexes', rawMessages, indexEnd, indexStart)
-
-  if (rawMessages.length !== indexEnd - indexStart + 1) {
-    throw new Error(
-      "messagePageFromMessageIndexes: _messages.length doesn't equal indexEnd - indexStart + 1. This should not happen"
-    )
-  }
-
-  const messages = OrderedMap<
-    number | string,
-    Type.Message | { id: string; ts: number }
-  >().withMutations(messagePages => {
-    for (let i = 0; i < rawMessages.length; i++) {
-      const [messageId, message] = rawMessages[i]
-      messagePages.set(messageId, message)
-    }
-  })
-
-  // log.debug('messagePageFromMessageIndexes', messages)
-
-  const messagePage = {
-    pageKey: calculatePageKey(messages, indexStart, indexEnd),
-    messages,
-  }
-
-  return messagePage
-}
-
-async function messagePagesFromMessageIndexes(
-  accountId: number,
-  chatId: number,
-  indexStart: number,
-  indexEnd: number
-): Promise<MessagePage[]> {
-  const rawMessages = await getMessagesFromIndex(
-    accountId,
-    chatId,
-    indexStart,
-    indexEnd
-  )
-
-  const messagePages = []
-  while (rawMessages.length > 0) {
-    const pageMessages = rawMessages.splice(0, PAGE_SIZE)
-
-    const messages = OrderedMap<
-      number | string,
-      Type.Message | { id: string; ts: number }
-    >().withMutations(messagePages => {
-      for (let i = 0; i < pageMessages.length; i++) {
-        const [messageId, message] = pageMessages[i]
-        messagePages.set(messageId, message)
-      }
-    })
-
-    messagePages.push({
-      pageKey: calculatePageKey(messages, indexStart, indexEnd),
-      messages,
-    })
-  }
-
-  return messagePages
-}
-
 export function useMessageList(accountId: number, chatId: number) {
-  let store = useMemo(() => {
+  const store = useMemo(() => {
     const store = new MessageListStore(accountId, chatId)
     store.effect.loadChat()
     return store
   }, [accountId, chatId])
 
   useEffect(() => {
-    let cleanup = [
+    const cleanup = [
       onDCEvent(accountId, 'MsgDelivered', ({ chatId: eventChatId, msgId }) => {
         if (chatId === eventChatId) {
-          store.reducer.setMessageState({
-            messageId: msgId,
-            messageState: C.DC_STATE_OUT_DELIVERED,
-          })
+          store.reducer.setMessageState(msgId, C.DC_STATE_OUT_DELIVERED)
         }
       }),
       onDCEvent(accountId, 'IncomingMsg', ({ chatId: eventChatId }) => {
@@ -157,10 +60,7 @@ export function useMessageList(accountId: number, chatId: number) {
       }),
       onDCEvent(accountId, 'MsgRead', ({ chatId: eventChatId, msgId }) => {
         if (chatId === eventChatId) {
-          store.reducer.setMessageState({
-            messageId: msgId,
-            messageState: C.DC_STATE_OUT_MDN_RCVD,
-          })
+          store.reducer.setMessageState(msgId, C.DC_STATE_OUT_MDN_RCVD)
         }
       }),
       onDCEvent(accountId, 'MsgsChanged', ({ chatId: eventChatId, msgId }) => {
@@ -177,7 +77,7 @@ export function useMessageList(accountId: number, chatId: number) {
       }),
     ]
     return () => cleanup.forEach(off => off())
-  }, [accountId, chatId])
+  }, [accountId, chatId, store])
 
   const [state, setState] = useState(store.getState())
 
@@ -205,6 +105,10 @@ export function useMessageList(accountId: number, chatId: number) {
   return { store, state, fetchMoreTop, fetchMoreBottom }
 }
 
+function getView<T>(items: T[], start: number, end: number) {
+  return items.slice(start, end + 1)
+}
+
 class MessageListStore extends Store<MessageListState> {
   scheduler = new ChatStoreScheduler()
 
@@ -217,16 +121,15 @@ class MessageListStore extends Store<MessageListState> {
     super(defaultState())
   }
 
-  guardReducerTriesToAddDuplicatePageKey(pageKeyToAdd: string) {
-    const isDuplicatePageKey =
-      this.state.messagePages.findIndex(
-        messagePage => messagePage.pageKey === pageKeyToAdd
-      ) !== -1
-    if (isDuplicatePageKey) {
-      this.log.error('Duplicate page key')
-    }
-    return isDuplicatePageKey
+  get activeView() {
+    const items = [...this.state.messageListItems]
+    const start = this.state.oldestFetchedMessageListItemIndex
+    const end = this.state.newestFetchedMessageListItemIndex
+    const view = getView(items, start, end)
+    this.log.debug('get activeView', { end, start, view })
+    return view
   }
+
   reducer = {
     selectedChat: (payload: Partial<MessageListState>) => {
       this.setState(_ => {
@@ -240,7 +143,7 @@ class MessageListStore extends Store<MessageListState> {
     },
     refresh: (
       messageListItems: T.MessageListItem[],
-      messagePages: MessagePage[],
+      messageCache: MessageListState['messageCache'],
       newestFetchedMessageListItemIndex: number,
       oldestFetchedMessageListItemIndex: number
     ) => {
@@ -248,9 +151,8 @@ class MessageListStore extends Store<MessageListState> {
         const modifiedState: MessageListState = {
           ...state,
           messageListItems,
-          messagePages,
+          messageCache,
           viewState: ChatViewReducer.refresh(state.viewState),
-          countFetchedMessages: messageListItems.length,
           newestFetchedMessageListItemIndex,
           oldestFetchedMessageListItemIndex,
         }
@@ -268,76 +170,56 @@ class MessageListStore extends Store<MessageListState> {
     },
     appendMessagePageTop: (payload: {
       id: number
-      messagePage: MessagePage
-      countFetchedMessages: number
+      newMessageCacheItems: MessageListState['messageCache']
       oldestFetchedMessageListItemIndex: number
     }) => {
       this.setState(state => {
         const modifiedState: MessageListState = {
           ...state,
-          messagePages: [payload.messagePage, ...state.messagePages],
+          messageCache: {
+            ...state.messageCache,
+            ...payload.newMessageCacheItems,
+          },
           oldestFetchedMessageListItemIndex:
             payload.oldestFetchedMessageListItemIndex,
           viewState: ChatViewReducer.appendMessagePageTop(state.viewState),
-          countFetchedMessages: payload.countFetchedMessages,
-        }
-        if (
-          this.guardReducerTriesToAddDuplicatePageKey(
-            payload.messagePage.pageKey
-          )
-        ) {
-          return
         }
         return modifiedState
       }, 'appendMessagePageTop')
     },
     appendMessagePageBottom: (payload: {
-      messagePage: MessagePage
-      countFetchedMessages: number
+      newMessageCacheItems: MessageListState['messageCache']
       newestFetchedMessageIndex: number
     }) => {
       this.setState(state => {
         const modifiedState: MessageListState = {
           ...state,
-          messagePages: [...state.messagePages, payload.messagePage],
+          messageCache: {
+            ...state.messageCache,
+            ...payload.newMessageCacheItems,
+          },
           newestFetchedMessageListItemIndex: payload.newestFetchedMessageIndex,
           viewState: ChatViewReducer.appendMessagePageBottom(state.viewState),
-          countFetchedMessages: payload.countFetchedMessages,
         }
-        if (
-          this.guardReducerTriesToAddDuplicatePageKey(
-            payload.messagePage.pageKey
-          )
-        )
-          return
         return modifiedState
       }, 'appendMessagePageBottom')
     },
     fetchedIncomingMessages: (payload: {
       messageListItems: MessageListState['messageListItems']
       newestFetchedMessageIndex: number
-      messagePage: MessagePage
+      newMessageCacheItems: MessageListState['messageCache']
     }) => {
       this.setState(state => {
         const modifiedState: MessageListState = {
           ...state,
           messageListItems: payload.messageListItems,
-          messagePages: [...state.messagePages, payload.messagePage],
+          messageCache: {
+            ...state.messageCache,
+            ...payload.newMessageCacheItems,
+          },
           // newestFetchedMessageIndex: payload.newestFetchedMessageIndex,
           viewState: ChatViewReducer.fetchedIncomingMessages(state.viewState),
         }
-
-        if (
-          this.guardReducerTriesToAddDuplicatePageKey(
-            payload.messagePage.pageKey
-          )
-        ) {
-          throw new Error(
-            'We almost added the same page twice! We should prevent this in code duplicate pageKey: ' +
-              payload.messagePage.pageKey
-          )
-        }
-
         return modifiedState
       }, 'fetchedIncomingMessages')
     },
@@ -352,52 +234,26 @@ class MessageListStore extends Store<MessageListState> {
         return modifiedState
       }, 'unlockScroll')
     },
-    messageChanged: (payload: { messagesChanged: Type.Message[] }) => {
+    messageChanged: (message: Type.Message) => {
       this.setState(state => {
         const modifiedState: MessageListState = {
           ...state,
-          messagePages: state.messagePages.map(messagePage => {
-            let changed = false
-            const messages = messagePage.messages.withMutations(messages => {
-              for (const changedMessage of payload.messagesChanged) {
-                if (!messages.has(changedMessage.id)) continue
-                changed = true
-                messages.set(changedMessage.id, changedMessage)
-              }
-            })
-            if (changed === false) return messagePage
-            return {
-              ...messagePage,
-              messages,
-            }
-          }),
+          messageCache: { ...state.messageCache, [message.id]: message },
         }
         return modifiedState
       }, 'messageChanged')
     },
-    setMessageState: (payload: { messageId: number; messageState: number }) => {
-      const { messageId, messageState } = payload
+    setMessageState: (messageId: number, messageState: number) => {
       this.setState(state => {
         const modifiedState: MessageListState = {
           ...state,
-          messagePages: state.messagePages.map(messagePage => {
-            if (messagePage.messages.has(messageId)) {
-              const message = messagePage.messages.get(messageId)
-              if (message !== null && message !== undefined) {
-                const updatedMessages = messagePage.messages.set(messageId, {
-                  ...message,
-                  state: messageState,
-                })
-
-                return {
-                  ...messagePage,
-                  messages: updatedMessages,
-                }
-              }
-            }
-
-            return messagePage
-          }),
+          messageCache: {
+            ...state.messageCache,
+            [messageId]: {
+              ...state.messageCache[messageId],
+              state: messageState,
+            },
+          },
         }
         return modifiedState
       }, 'setMessageState')
@@ -455,7 +311,7 @@ class MessageListStore extends Store<MessageListState> {
 
         let oldestFetchedMessageListItemIndex = -1
         let newestFetchedMessageListItemIndex = -1
-        let messagePage: MessagePage | null = null
+        let messageCache: MessageListState['messageCache'] = {}
         if (messageListItems.length !== 0) {
           // mesageIds.length = 1767
           // oldestFetchedMessageListItemIndex = 1767 - 1 = 1766 - 10 = 1756
@@ -466,26 +322,21 @@ class MessageListStore extends Store<MessageListState> {
           )
           newestFetchedMessageListItemIndex = messageListItems.length - 1
 
-          messagePage = await messagePageFromMessageIndexes(
+          messageCache = await loadMessages(
             this.accountId,
-            this.chatId,
+            messageListItems,
             oldestFetchedMessageListItemIndex,
             newestFetchedMessageListItemIndex
           )
         }
 
         this.reducer.selectedChat({
-          messagePages: messagePage === null ? [] : [messagePage],
+          messageCache,
           messageListItems,
           oldestFetchedMessageListItemIndex,
           newestFetchedMessageListItemIndex,
           viewState: ChatViewReducer.selectChat(this.state.viewState),
         })
-        ActionEmitter.emitAction(
-          chat.archived
-            ? KeybindAction.ChatList_SwitchToArchiveView
-            : KeybindAction.ChatList_SwitchToNormalView
-        )
       },
       'selectChat'
     ),
@@ -495,12 +346,11 @@ class MessageListStore extends Store<MessageListState> {
         'scroll',
         async (
           msgId: number | undefined,
-          highlight?: boolean,
+          highlight = true,
           addMessageIdToStack?: undefined | number
         ) => {
           this.log.debug('jumpToMessage with messageId: ', msgId)
           const accountId = selectedAccountId()
-          highlight = highlight === false ? false : true
           // these methods were called in backend before
           // might be an issue if DeltaBackend.call has a significant delay
 
@@ -514,6 +364,7 @@ class MessageListStore extends Store<MessageListState> {
           let jumpToMessageStack: number[] = []
           let message: Type.Message | undefined = undefined
           if (msgId === undefined) {
+            // jump down
             const jumpToMessageStackLength = this.state.jumpToMessageStack
               .length
             if (jumpToMessageStackLength !== 0) {
@@ -530,8 +381,19 @@ class MessageListStore extends Store<MessageListState> {
               )
               chatId = message.chatId
             } else {
-              this.effect.loadChat()
-              return
+              const items = this.state.messageListItems
+                .map(m =>
+                  m.kind === 'message' ? m.msg_id : C.DC_MSG_ID_LAST_SPECIAL
+                )
+                .filter(msgId => msgId !== C.DC_MSG_ID_LAST_SPECIAL)
+              message = await BackendRemote.rpc.getMessage(
+                accountId,
+                items[items.length - 1]
+              )
+              chatId = message.chatId
+              jumpToMessageStack = []
+              jumpToMessageId = message.id
+              highlight = false
             }
           } else if (addMessageIdToStack === undefined) {
             // reset jumpToMessageStack
@@ -599,7 +461,7 @@ class MessageListStore extends Store<MessageListState> {
           // calculate page indexes, so that jumpToMessageId is in the middle of the page
           let oldestFetchedMessageListItemIndex = -1
           let newestFetchedMessageListItemIndex = -1
-          let messagePage: MessagePage | null = null
+          let messageCache: MessageListState['messageCache'] = {}
           const half_page_size = Math.ceil(PAGE_SIZE / 2)
           if (messageListItems.length !== 0) {
             oldestFetchedMessageListItemIndex = Math.max(
@@ -629,22 +491,16 @@ class MessageListStore extends Store<MessageListState> {
               )
             }
 
-            messagePage = await messagePageFromMessageIndexes(
+            messageCache = await loadMessages(
               accountId,
-              chatId,
+              messageListItems,
               oldestFetchedMessageListItemIndex,
               newestFetchedMessageListItemIndex
             )
           }
 
-          if (messagePage === null) {
-            throw new Error(
-              'jumpToMessage: messagePage is null, this should not happen'
-            )
-          }
-
           this.reducer.selectedChat({
-            messagePages: [messagePage],
+            messageCache,
             messageListItems,
             oldestFetchedMessageListItemIndex,
             newestFetchedMessageListItemIndex: newestFetchedMessageListItemIndex,
@@ -690,18 +546,17 @@ class MessageListStore extends Store<MessageListState> {
             return false
           }
 
-          const messagePage: MessagePage = await messagePageFromMessageIndexes(
+          const newMessageCacheItems = await loadMessages(
             this.accountId,
-            id,
+            state.messageListItems,
             oldestFetchedMessageListItemIndex,
             lastMessageIndexOnLastPage - 1
           )
 
           this.reducer.appendMessagePageTop({
             id,
-            messagePage,
+            newMessageCacheItems,
             oldestFetchedMessageListItemIndex,
-            countFetchedMessages: fetchedMessageListItems.length,
           })
           return true
         },
@@ -714,8 +569,6 @@ class MessageListStore extends Store<MessageListState> {
         'scroll',
         async () => {
           const state = this.state
-
-          const id = this.chatId
 
           const newestFetchedMessageListItemIndex =
             state.newestFetchedMessageListItemIndex + 1
@@ -747,17 +600,16 @@ class MessageListStore extends Store<MessageListState> {
             return false
           }
 
-          const messagePage: MessagePage = await messagePageFromMessageIndexes(
+          const newMessageCacheItems = await loadMessages(
             this.accountId,
-            this.chatId,
+            state.messageListItems,
             newestFetchedMessageListItemIndex,
             newNewestFetchedMessageListItemIndex
           )
 
           this.reducer.appendMessagePageBottom({
-            messagePage,
+            newMessageCacheItems,
             newestFetchedMessageIndex: newNewestFetchedMessageListItemIndex,
-            countFetchedMessages: fetchedMessageListItems.length,
           })
           return true
         },
@@ -789,16 +641,16 @@ class MessageListStore extends Store<MessageListState> {
             0
           )
 
-          const messagePages = await messagePagesFromMessageIndexes(
+          const messageCache = await loadMessages(
             this.accountId,
-            this.chatId,
+            messageListItems,
             oldestFetchedMessageListItemIndex,
             newestFetchedMessageListItemIndex
           )
 
           this.reducer.refresh(
             messageListItems,
-            messagePages,
+            messageCache,
             newestFetchedMessageListItemIndex,
             oldestFetchedMessageListItemIndex
           )
@@ -835,16 +687,17 @@ class MessageListStore extends Store<MessageListState> {
         this.reducer.setMessageListItems(messageListItems)
         return
       }
-      const messagePage = await messagePageFromMessageIndexes(
+
+      const newMessageCacheItems = await loadMessages(
         this.accountId,
-        this.chatId,
+        messageListItems,
         indexStart,
         indexEnd
       )
 
       this.reducer.fetchedIncomingMessages({
         messageListItems,
-        messagePage,
+        newMessageCacheItems,
         newestFetchedMessageIndex: indexEnd,
       })
     }, 'onEventIncomingMessage'),
@@ -864,9 +717,7 @@ class MessageListStore extends Store<MessageListState> {
               this.accountId,
               messageId
             )
-            this.reducer.messageChanged({
-              messagesChanged: [message],
-            })
+            this.reducer.messageChanged(message)
           } catch (error) {
             this.log.warn('failed to fetch message with id', messageId, error)
             // ignore not found and other errors
@@ -892,67 +743,22 @@ class MessageListStore extends Store<MessageListState> {
   stateToHumanReadable(state: MessageListState): any {
     return {
       ...state,
-      messagePages: state.messagePages.map(messagePage => {
-        return {
-          ...messagePage,
-          messages: messagePage.messages.toArray().map(([msgId, message]) => {
-            return [
-              msgId,
-              typeof message.id !== 'string'
-                ? {
-                    messageId: message.id,
-                    messsage: (message as Type.Message).text,
-                  }
-                : {
-                    messageId: message.id,
-                    timestamp: (message as {
-                      id: string
-                      ts: number
-                    }).ts,
-                  },
-            ]
-          }),
-        }
-      }),
     }
   }
 }
 
-function calculatePageKey(
-  messages: MessagePage['messages'],
-  indexStart: number,
-  indexEnd: number
-): string {
-  const first = messages.first()?.id
-  const last = messages.last()?.id
-  if (!first && !last && indexStart === 0 && indexEnd === 0) {
-    throw new Error('calculatePageKey: non unique page key of 0')
-  } else {
-    return `page-${first}-${last}-${indexStart}-${indexEnd}`
-  }
-}
-
-async function getMessagesFromIndex(
+async function loadMessages(
   accountId: number,
-  chatId: number,
-  indexStart: number,
-  indexEnd: number,
-  flags = C.DC_GCM_ADDDAYMARKER
-): Promise<[number | string, Type.Message | { id: string; ts: number }][]> {
-  const allMessageListItems = (
-    await BackendRemote.rpc.getMessageListItems(accountId, chatId, flags)
-  ).slice(indexStart, indexEnd + 1)
-
-  const messageIds = allMessageListItems
+  messageListItems: Type.MessageListItem[],
+  oldestFetchedMessageListItemIndex: number,
+  newestFetchedMessageListItemIndex: number
+) {
+  const view = getView(
+    messageListItems,
+    oldestFetchedMessageListItemIndex,
+    newestFetchedMessageListItemIndex
+  )
     .map(m => (m.kind === 'message' ? m.msg_id : C.DC_MSG_ID_LAST_SPECIAL))
     .filter(msgId => msgId !== C.DC_MSG_ID_LAST_SPECIAL)
-
-  const messages = await BackendRemote.rpc.getMessages(accountId, messageIds)
-
-  return allMessageListItems.map(m => [
-    m.kind === 'message' ? m.msg_id : `d${m.timestamp}`,
-    m.kind === 'message'
-      ? messages[m.msg_id]
-      : { id: `d${m.timestamp}`, ts: m.timestamp },
-  ])
+  return await BackendRemote.rpc.getMessages(accountId, view)
 }


### PR DESCRIPTION
- move message list to it's own store, that is thrown away and reacreated on selecting a chat,
so selecting a new chat auto fixes possible problems again,
also makes our code simpler
- fix go to bottom when clicking chat again