### PR TITLE
cleanup account switch screen event listeners

### DIFF
--- a/src/renderer/experimental.ts
+++ b/src/renderer/experimental.ts
@@ -38,6 +38,10 @@ These functions are highly experimental, use at your own risk.
     log.debug(new Error('a test error - should be logged to logfile'))
     throw new Error('a test error - should be catched and logged to logfile')
   }
+
+  getContextEmitters() {
+    return (BackendRemote as any).contextEmitters
+  }
 }
 
 export const exp = new Experimental()


### PR DESCRIPTION
- cleanup account switch screen incoming message event listeners
- also add function to get context emitters to `exp`


closes #2990