### PR TITLE
handle webxdc info messages differently than normal system messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - reduce notifications when many messages are received at once.
 - update deltachat-node and deltachat/jsonrpc-client to `v1.99.0`
 - jump down button: show different icon (one arrow), when jumping to message in jump to message list
+- add webxdc's icon to webxdc info messages
 
 ### Fixed
 
@@ -28,6 +29,7 @@
 - Fix notifications when showNotificationContent was disabled
 - fix unread count on scroll down button
 - make recently seen dot in navbar disappear automatically #2926
+- only webxdc info messages jump to parent message on click now
 
 ## [1.33.0] - 2022-10-16
 

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -441,13 +441,11 @@
   }
 
   &.webxdc-info > .bubble {
-    border-radius: 20px;
-    background-color: rgb(0 0 0 / 29%);
-    padding: 7px 7px;
+    padding: 7px 8px;
     img {
       height: 18px;
       width: 18px;
-      margin: 0px 5px;
+      margin-right: 5px;
       border-radius: 7%; // webxdc border radius
       vertical-align: bottom;
       background-color: black;

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -445,7 +445,7 @@
     img {
       height: 18px;
       width: 18px;
-      margin-right: 5px;
+      margin-inline-end: 5px;
       border-radius: 7%; // webxdc border radius
       vertical-align: bottom;
       background-color: black;

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -440,6 +440,20 @@
     }
   }
 
+  &.webxdc-info > .bubble {
+    border-radius: 20px;
+    background-color: rgb(0 0 0 / 29%);
+    padding: 7px 7px;
+    img {
+      height: 18px;
+      width: 18px;
+      margin: 0px 5px;
+      border-radius: 7%; // webxdc border radius
+      vertical-align: bottom;
+      background-color: black;
+    }
+  }
+
   &.big > .bubble {
     max-width: 550px;
     font-size: 1rem;

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -289,12 +289,16 @@ const Message = (props: {
 
   // Info Message
   if (message.isInfo) {
+    const isWebxdcInfo = message.systemMessageType === 'WebxdcInfoMessage'
+
     return (
       <div
         className='info-message'
         onContextMenu={showMenu}
         onClick={() => {
-          message.parentId && jumpToMessage(message.parentId, true, message.id)
+          isWebxdcInfo &&
+            message.parentId &&
+            jumpToMessage(message.parentId, true, message.id)
         }}
       >
         <div className='bubble'>

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -293,7 +293,7 @@ const Message = (props: {
 
     return (
       <div
-        className='info-message'
+        className={'info-message' + (isWebxdcInfo ? ' webxdc-info' : '')}
         onContextMenu={showMenu}
         onClick={() => {
           isWebxdcInfo &&
@@ -302,7 +302,25 @@ const Message = (props: {
         }}
       >
         <div className='bubble'>
+          {isWebxdcInfo && message.parentId && (
+            <img
+              src={runtime.getWebxdcIconURL(
+                selectedAccountId(),
+                message.parentId
+              )}
+              onClick={() => openWebxdc(message.id)}
+            />
+          )}
           {text}
+          {isWebxdcInfo && message.parentId && (
+            <img
+              src={runtime.getWebxdcIconURL(
+                selectedAccountId(),
+                message.parentId
+              )}
+              onClick={() => openWebxdc(message.id)}
+            />
+          )}
           {direction === 'outgoing' &&
             (status === 'sending' || status === 'error') && (
               <div

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -312,15 +312,6 @@ const Message = (props: {
             />
           )}
           {text}
-          {isWebxdcInfo && message.parentId && (
-            <img
-              src={runtime.getWebxdcIconURL(
-                selectedAccountId(),
-                message.parentId
-              )}
-              onClick={() => openWebxdc(message.id)}
-            />
-          )}
           {direction === 'outgoing' &&
             (status === 'sending' || status === 'error') && (
               <div


### PR DESCRIPTION
- don't jump to parent on non webxdc messages closes #2933
- different style for webxdc info messages + show webxdc icon closes #2989
- default info style, only one icon and adjust padding
