### PR TITLE
prevent double context menu on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+- prevent double context menu on macOS
 - fix setting color chat background color #2659
 - Fix that results of search in chat are not ordered by newest first
 - Fix messagelist overscrolling #2956 

--- a/scss/misc/_context_menu.scss
+++ b/scss/misc/_context_menu.scss
@@ -17,6 +17,10 @@
   // &.active {
   //   background-color: rgba(0, 0, 0, 0.3);
   // }
+
+  // prevent double context menu on macOS
+  // (when using touchpad it sometimes selects the text in the context menu, and then show a native context menu on top)
+  user-select: none;
 }
 
 .dc-context-menu {


### PR DESCRIPTION
when using touchpad it sometimes selects the text in the context menu, and then show a native context menu on top

the solution is to preventing text selection in the context menu
