### PR TITLE
[wip] Add toggle to set "manual encryption mode"

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -41,6 +41,9 @@
   "search_in_chat": {
     "message": "Search in Chat"
   },
+  "manual_encryption_mode_settings":{
+    "message": "Manually set encryption per chat"
+  },
   "exit_search": {
     "message": "Exit Search"
   },

--- a/src/renderer/components/dialogs/Settings-Account.tsx
+++ b/src/renderer/components/dialogs/Settings-Account.tsx
@@ -73,6 +73,7 @@ export function SettingsAccountInner(onClose: () => void) {
         'mvbox_move',
         'only_fetch_mvbox',
         'e2ee_enabled',
+	'manual_encryption_mode',
         'mail_server',
         'mail_user',
         'mail_port',

--- a/src/renderer/components/dialogs/Settings-Encryption.tsx
+++ b/src/renderer/components/dialogs/Settings-Encryption.tsx
@@ -126,7 +126,7 @@ export default function SettingsEncryption({
       <div className='bp4-callout'>{tx('autocrypt_explain')}</div>
       {renderDeltaSwitch2({
         key: 'manual_encryption_mode',
-        label: tx('autocrypt_prefer_e2ee'),
+        label: tx('manual_encryption_mode_settings'),
       })}
     </>
   )

--- a/src/renderer/components/dialogs/Settings-Encryption.tsx
+++ b/src/renderer/components/dialogs/Settings-Encryption.tsx
@@ -124,6 +124,10 @@ export default function SettingsEncryption({
         {tx('autocrypt_send_asm_button')}
       </SettingsButton>
       <div className='bp4-callout'>{tx('autocrypt_explain')}</div>
+      {renderDeltaSwitch2({
+        key: 'manual_encryption_mode',
+        label: tx('autocrypt_prefer_e2ee'),
+      })}
     </>
   )
 }

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -12,6 +12,7 @@ export interface SettingsStoreState {
     sentbox_watch: string
     mvbox_move: string
     e2ee_enabled: string
+    manual_encryption_mode: string
     addr: string
     displayname: string
     selfstatus: string
@@ -33,6 +34,7 @@ const settingsKeys: Array<keyof SettingsStoreState['settings']> = [
   'sentbox_watch',
   'mvbox_move',
   'e2ee_enabled',
+  'manual_encryption_mode',
   'addr',
   'displayname',
   'selfstatus',


### PR DESCRIPTION
This PR enables users to choose the new config option "manual encryption mode", introduced in https://github.com/deltachat/deltachat-core-rust/pull/3767.