### PR TITLE
webxdc: allow `data:` in `connect-src` in CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - fix jump to message from gallery
+- webxdc: allow `data:` in `connect-src` in CSP
 
 ## [1.33.2] - 2022-16-09 - Testrelease
 

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -36,6 +36,7 @@ const CSP =
   style-src 'self' 'unsafe-inline' blob: ;\
   font-src 'self' data: blob: ;\
   script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: ;\
+  connect-src data: ;\
   img-src 'self' data: blob: ;"
 
 export default class DCWebxdc extends SplitOut {


### PR DESCRIPTION
this fixes the checklist webxdc app
