### PR TITLE
fix webxdc: allow `self` and `blob:` in `connect-src` in CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Changed
 
 ### Fixed
-
+- fix webxdc: allow `self` and `blob:` in `connect-src` in CSP
 
 <a id="1_34_0"></a>
 

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -36,7 +36,7 @@ const CSP =
   style-src 'self' 'unsafe-inline' blob: ;\
   font-src 'self' data: blob: ;\
   script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: ;\
-  connect-src data: ;\
+  connect-src 'self' data: blob: ;\
   img-src 'self' data: blob: ;"
 
 export default class DCWebxdc extends SplitOut {


### PR DESCRIPTION
fixes #3027