### PR TITLE
improve jump down button behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - fix webxdc: allow `self` and `blob:` in `connect-src` in CSP
 - indentation in update device message
 - fix "no messages" blinking up for a second when loading a chat
+- hide unread count on jump down button if you are at the bottom, fixes #3033
 
 <a id="1_34_0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- show jump down button earlier when scrolling up
 
 ### Fixed
 - fix webxdc: allow `self` and `blob:` in `connect-src` in CSP

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -405,7 +405,7 @@ export default function MessageList({
           unreadMessageInViewIntersectionObserver
         }
       />
-      {(showJumpDownButton === true || countUnreadMessages > 0) && (
+      {showJumpDownButton && (
         <JumpDownButton
           countUnreadMessages={countUnreadMessages}
           jumpToMessage={jumpToMessage}

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -208,11 +208,9 @@ export default function MessageList({
 
       const isNewestMessageLoaded =
         newestFetchedMessageListItemIndex === messageListItems.length - 1
-      const onePageAwayFromNewestMessageTreshold =
-        messageListRef.current.clientHeight / 3
       const newShowJumpDownButton =
         !isNewestMessageLoaded ||
-        distanceToBottom >= onePageAwayFromNewestMessageTreshold
+        distanceToBottom >= 10 /* 10 is close enough to 0 */
       if (newShowJumpDownButton != showJumpDownButton) {
         setShowJumpDownButton(newShowJumpDownButton)
       }


### PR DESCRIPTION
- don't show unread count if you are at the bottom fixes #3033
- show jump down button earlier when scrolling up
