### PR TITLE
make font-style of info messages consistent with iOS and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 ### Changed
+- make font-style of info messages consistent with iOS and Android #3034
 
 ### Fixed
 - fix webxdc: allow `self` and `blob:` in `connect-src` in CSP

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -434,8 +434,6 @@
   .bubble {
     display: inline-block;
     text-align: center;
-    font-style: italic;
-    font-weight: bold;
     padding: 7px 14px;
     background-color: var(--infoMessageBubbleBg);
     border-radius: 10px;
@@ -443,6 +441,12 @@
     color: var(--infoMessageBubbleText);
     .status-icon.sending {
       background-color: var(--infoMessageBubbleText);
+    }
+  }
+
+  &.daymarker {
+    .bubble {
+      font-weight: bold;
     }
   }
 

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -623,7 +623,7 @@ export function DayMarker(props: { timestamp: number }) {
   const { timestamp } = props
   const tx = useTranslationFunction()
   return (
-    <div className='info-message'>
+    <div className='info-message daymarker'>
       <div className='bubble' style={{ textTransform: 'capitalize' }}>
         {moment.unix(timestamp).calendar(null, {
           sameDay: `[${tx('today')}]`,


### PR DESCRIPTION
closes #3034
