### PR TITLE
Control overflow of so text does not escape the code block nor message bubble.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - hide unread count on jump down button if you are at the bottom, fixes #3033
 - fix removing group avatar image #3038
 - fix chat title in navbar did not update correctly when it should change (disappearing messages & recently seen indicator) #3046
+- Control overflow of so text does not escape the code block nor message bubble, for the experimental message markdown mode.
 
 <a id="1_34_0"></a>
 

--- a/scss/message/_message-markdown.scss
+++ b/scss/message/_message-markdown.scss
@@ -4,6 +4,8 @@
   padding: 6px;
   border-radius: 8px;
   margin-bottom: 5px;
+  // overflow needs to be controlled so text does not escape the message bubble
+  overflow: scroll;
 }
 
 .mm-inline-code {


### PR DESCRIPTION
for the experimental message markdown mode