### PR TITLE
fix "message not found in cache" bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - set `ITSAppUsesNonExemptEncryption` to `false` for mac
 
 ### Fixed
+- fix "message not found in cache" bug #3039
 - fix webxdc: allow `self` and `blob:` in `connect-src` in CSP
 - indentation in update device message
 - fix "no messages" blinking up for a second when loading a chat

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -434,7 +434,7 @@ export const MessageListInner = React.memo(
     chatStore: ChatStoreStateWithChatSet
     loaded: boolean
     unreadMessageInViewIntersectionObserver: React.MutableRefObject<IntersectionObserver | null>
-    loadMissingMessages:() => Promise<void>
+    loadMissingMessages: () => Promise<void>
   }) => {
     const {
       onScroll,
@@ -445,7 +445,7 @@ export const MessageListInner = React.memo(
       chatStore,
       loaded,
       unreadMessageInViewIntersectionObserver,
-      loadMissingMessages
+      loadMissingMessages,
     } = props
 
     if (!chatStore.chat.id) {

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -94,7 +94,7 @@ export default function MessageList({
   const {
     store: {
       scheduler,
-      effect: { jumpToMessage },
+      effect: { jumpToMessage, loadMissingMessages },
       reducer: { unlockScroll, clearJumpStack },
       activeView,
     },
@@ -402,6 +402,7 @@ export default function MessageList({
         unreadMessageInViewIntersectionObserver={
           unreadMessageInViewIntersectionObserver
         }
+        loadMissingMessages={loadMissingMessages}
       />
       {showJumpDownButton && (
         <JumpDownButton
@@ -433,6 +434,7 @@ export const MessageListInner = React.memo(
     chatStore: ChatStoreStateWithChatSet
     loaded: boolean
     unreadMessageInViewIntersectionObserver: React.MutableRefObject<IntersectionObserver | null>
+    loadMissingMessages:() => Promise<void>
   }) => {
     const {
       onScroll,
@@ -443,6 +445,7 @@ export const MessageListInner = React.memo(
       chatStore,
       loaded,
       unreadMessageInViewIntersectionObserver,
+      loadMissingMessages
     } = props
 
     if (!chatStore.chat.id) {
@@ -512,6 +515,9 @@ export const MessageListInner = React.memo(
                   />
                 )
               } else {
+                // setTimeout tells it to call method in next event loop iteration, so after rendering
+                // it is debounced later so we can call it here multiple times and it's ok
+                setTimeout(loadMissingMessages)
                 return (
                   <div className='info-message' id={String(messageId.msg_id)}>
                     <div
@@ -521,8 +527,7 @@ export const MessageListInner = React.memo(
                         backgroundColor: 'rgba(55,0,0,0.5)',
                       }}
                     >
-                      message with id {messageId.msg_id} was not found in cache,
-                      this should not happen, please contact the developers
+                      loading message {messageId.msg_id}
                     </div>
                   </div>
                 )


### PR DESCRIPTION
closes #3039

The fix consists in calling a method to load all missing messages upon rendering a “message not found in cache” message in react, would not call it clean, but it is reliable in my tests