### PR TITLE
only fetch the entry of chatlist that we need, not the whole list

### DIFF
--- a/src/renderer/components/chat/ChatListHelpers.tsx
+++ b/src/renderer/components/chat/ChatListHelpers.tsx
@@ -67,7 +67,9 @@ export function useChatList(
   const [listFlags, setListFlags] = useState(_listFlags)
   const [queryStr, setQueryStr] = useState<string | undefined>(_queryStr)
   const [queryContactId, setQueryContactId] = useState(_queryContactId)
-  const [chatListEntries, setChatListEntries] = useState<[number, number][]>([])
+  const [chatListEntries, setChatListEntries] = useState<
+    [number, number | null][]
+  >([])
 
   const debouncedGetChatListEntries = useMemo(
     () =>

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -25,8 +25,7 @@ export default function ForwardMessage(props: {
   const listFlags = C.DC_GCL_FOR_FORWARDING | C.DC_GCL_NO_SPECIALS
   const { chatListIds, queryStr, setQueryStr } = useChatList(listFlags)
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
-    chatListIds,
-    listFlags
+    chatListIds
   )
 
   const onChatClick = async (chatid: number) => {

--- a/src/renderer/components/dialogs/MailtoDialog.tsx
+++ b/src/renderer/components/dialogs/MailtoDialog.tsx
@@ -24,8 +24,7 @@ export default function MailtoDialog(props: {
   const listFlags = C.DC_GCL_FOR_FORWARDING | C.DC_GCL_NO_SPECIALS
   const { chatListIds, queryStr, setQueryStr } = useChatList(listFlags)
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
-    chatListIds,
-    listFlags
+    chatListIds
   )
 
   const onChatClick = async (chatId: number) => {

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -144,8 +144,7 @@ export function ViewProfileInner({
   const accountId = selectedAccountId()
   const { chatListIds } = useChatList(null, '', contact.id)
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
-    chatListIds,
-    null
+    chatListIds
   )
   const isDeviceMessage = contact.id === C.DC_CONTACT_ID_DEVICE
 


### PR DESCRIPTION
depends on https://github.com/deltachat/deltachat-core-rust/pull/3929

In my subjective testing this helped reducing message replay time (after backup) import on desktop by 13-19%. backup import is a good stress test for this because it calls this code-path often.

## TODO
- [ ] maybe add tests?