### PR TITLE
remove messageid from chatlistentry

### DIFF
--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -530,6 +530,8 @@ export function useLogicVirtualChatList(chatListIds: number[]) {
           ...state,
           [chatId]: LoadStatus.LOADED,
         }))
+        // sleep a while to reduce overall calls
+        await new Promise((res) => setTimeout(res, 150))
       } catch (error) {
         log.warn('error loading chatlistitem', error)
       }

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -543,19 +543,21 @@ export function useLogicVirtualChatList(chatListIds: number[]) {
 
     return ({
       chatId,
-    }: Extract<
-      DcEvent,
-      {
-        type:
-          | 'MsgRead'
-          | 'MsgDelivered'
-          | 'MsgFailed'
-          | 'IncomingMsg'
-          | 'ChatModified'
-          | 'MsgsChanged'
-          | 'MsgsNoticed'
-      }
-    >) => {
+    }:
+      | Extract<
+          DcEvent,
+          {
+            type:
+              | 'MsgRead'
+              | 'MsgDelivered'
+              | 'MsgFailed'
+              | 'IncomingMsg'
+              | 'ChatModified'
+              | 'MsgsChanged'
+              | 'MsgsNoticed'
+          }
+        >
+      | { chatId: number; type: 'onContactChanged' }) => {
       if (chatId === C.DC_CHAT_ID_TRASH) {
         return
       }
@@ -586,16 +588,14 @@ export function useLogicVirtualChatList(chatListIds: number[]) {
           null,
           contactId
         )
-        const inCurrentCache = Object.keys(chatCacheRef.current).map(v =>
-          Number(v)
-        )
-        const toBeRefreshed = chatListItems.filter(
-          chatId => inCurrentCache.indexOf(chatId) !== -1
-        )
-        // other function already has debouncing so just use it
-        toBeRefreshed.forEach(chatId =>
-          onChatListItemChanged({ chatId, type: 'ChatModified' })
-        )
+        for (let i = 0; i < chatListItems.length; i++) {
+          const chatId = chatListItems[i]
+          // check if chat is already loaded and we need to refresh it
+          if (typeof chatCacheRef.current[chatId] !== 'undefined') {
+            // other function already has debouncing so just use it
+            onChatListItemChanged({ chatId, type: 'onContactChanged' })
+          }
+        }
       }
     },
     [accountId]

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -592,11 +592,10 @@ export function useLogicVirtualChatList(chatListIds: number[]) {
         const toBeRefreshed = chatListItems.filter(
           chatId => inCurrentCache.indexOf(chatId) !== -1
         )
-        const chats = await BackendRemote.rpc.getChatlistItemsByEntries(
-          accountId,
-          toBeRefreshed
+        // other function already has debouncing so just use it
+        toBeRefreshed.forEach(chatId =>
+          onChatListItemChanged({ chatId, type: 'ChatModified' })
         )
-        setChatCache(cache => ({ ...cache, ...chats }))
       }
     },
     [accountId]

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -505,16 +505,7 @@ export function useLogicVirtualChatList(chatListIds: number[]) {
 
   const onChatListItemChanged = useMemo(() => {
     let debouncingChatlistItemRequests: { [chatid: number]: number } = {}
-    let cleanup_timeout: any | null = null
     const updateChatListItem = async (chatId: number) => {
-      if (cleanup_timeout === null) {
-        // clean up debouncingChatlistItemRequests every half minute,
-        // so if there should ever be an error it auto recovers
-        cleanup_timeout = setTimeout(() => {
-          debouncingChatlistItemRequests = {}
-          cleanup_timeout = null
-        }, 30000)
-      }
       debouncingChatlistItemRequests[chatId] = 1
       try {
         setChatLoading(state => ({

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -629,13 +629,6 @@ export function useLogicVirtualChatList(chatListIds: number[]) {
     }
   }, [onChatListItemChanged, accountId])
 
-  // effects
-
-  useEffect(() => {
-    // force refresh of inital data
-    loadChats(0, Math.min(chatListIds.length, 10))
-  }, [chatListIds]) // eslint-disable-line react-hooks/exhaustive-deps
-
   return { isChatLoaded, loadChats, chatCache }
 }
 
@@ -660,6 +653,19 @@ function useLogicChatPart(
         : setListFlags(0),
     [showArchivedChats, queryStr, setListFlags]
   )
+
+  // for example user switched to search or to archived chats
+  // so force refresh of inital data
+  const shouldReload = useRef(false)
+  useEffect(() => {
+    shouldReload.current = true
+  }, [showArchivedChats, queryStr]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (shouldReload.current) {
+      shouldReload.current = false
+      loadChats(0, Math.min(chatListIds.length, 20))
+    }
+  }, [chatListIds]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return { chatListIds, isChatLoaded, loadChats, chatCache }
 }

--- a/src/renderer/components/chat/ChatListHelpers.tsx
+++ b/src/renderer/components/chat/ChatListHelpers.tsx
@@ -67,9 +67,7 @@ export function useChatList(
   const [listFlags, setListFlags] = useState(_listFlags)
   const [queryStr, setQueryStr] = useState<string | undefined>(_queryStr)
   const [queryContactId, setQueryContactId] = useState(_queryContactId)
-  const [chatListEntries, setChatListEntries] = useState<
-    [number, number | null][]
-  >([])
+  const [chatListEntries, setChatListEntries] = useState<number[]>([])
 
   const debouncedGetChatListEntries = useMemo(
     () =>

--- a/src/renderer/components/chat/ChatListHelpers.tsx
+++ b/src/renderer/components/chat/ChatListHelpers.tsx
@@ -67,7 +67,9 @@ export function useChatList(
   const [listFlags, setListFlags] = useState(_listFlags)
   const [queryStr, setQueryStr] = useState<string | undefined>(_queryStr)
   const [queryContactId, setQueryContactId] = useState(_queryContactId)
-  const [chatListEntries, setChatListEntries] = useState<[number, number][]>([])
+  const [chatListEntries, setChatListEntries] = useState<
+    [number, number | null][]
+  >([])
 
   const debouncedGetChatListEntries = useMemo(
     () =>

--- a/src/renderer/components/chat/ChatListItemRow.tsx
+++ b/src/renderer/components/chat/ChatListItemRow.tsx
@@ -6,11 +6,24 @@ import ChatListItem, {
 import { areEqual } from 'react-window'
 import { ContactListItem } from '../contact/ContactListItem'
 import { jumpToMessage, openViewProfileDialog } from '../helpers/ChatMethods'
+import { Type } from '../../backend-com'
 
 export const ChatListItemRowChat = React.memo<{
   index: number
-  data: todo
-  style: todo
+  data: {
+    selectedChatId: number | null
+    chatListIds: number[]
+    chatCache: {
+      [id: number]: Type.ChatListItemFetchResult
+    }
+    onChatClick: (chatId: number) => void
+    openContextMenu: (
+      event: React.MouseEvent<any, MouseEvent>,
+      chatListItem: Type.ChatListItemFetchResult,
+      selectedChatId: number | null
+    ) => void
+  }
+  style: React.CSSProperties
 }>(({ index, data, style }) => {
   const {
     selectedChatId,
@@ -19,7 +32,7 @@ export const ChatListItemRowChat = React.memo<{
     onChatClick,
     openContextMenu,
   } = data
-  const [chatId] = chatListIds[index]
+  const chatId = chatListIds[index]
   return (
     <div style={style}>
       <ChatListItem

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -90,7 +90,7 @@ export default function ForwardMessage(props: {
                     itemHeight={CHATLISTITEM_CHAT_HEIGHT}
                   >
                     {({ index, style }) => {
-                      const [chatId] = chatListIds[index]
+                      const chatId = chatListIds[index]
                       return (
                         <div style={style}>
                           <ChatListItem

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -26,8 +26,7 @@ export default function ForwardMessage(props: {
   const listFlags = C.DC_GCL_FOR_FORWARDING | C.DC_GCL_NO_SPECIALS
   const { chatListIds, queryStr, setQueryStr } = useChatList(listFlags)
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
-    chatListIds,
-    listFlags
+    chatListIds
   )
 
   const onChatClick = async (chatId: number) => {

--- a/src/renderer/components/dialogs/MailtoDialog.tsx
+++ b/src/renderer/components/dialogs/MailtoDialog.tsx
@@ -78,7 +78,7 @@ export default function MailtoDialog(props: {
                     itemHeight={CHATLISTITEM_CHAT_HEIGHT}
                   >
                     {({ index, style }) => {
-                      const [chatId] = chatListIds[index]
+                      const chatId = chatListIds[index]
                       return (
                         <div style={style}>
                           <ChatListItem

--- a/src/renderer/components/dialogs/MailtoDialog.tsx
+++ b/src/renderer/components/dialogs/MailtoDialog.tsx
@@ -24,8 +24,7 @@ export default function MailtoDialog(props: {
   const listFlags = C.DC_GCL_FOR_FORWARDING | C.DC_GCL_NO_SPECIALS
   const { chatListIds, queryStr, setQueryStr } = useChatList(listFlags)
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
-    chatListIds,
-    listFlags
+    chatListIds
   )
 
   const onChatClick = async (chatId: number) => {

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -237,7 +237,7 @@ export function ViewProfileInner({
                     itemHeight={CHATLISTITEM_CHAT_HEIGHT}
                   >
                     {({ index, style }) => {
-                      const [chatId] = chatListIds[index]
+                      const chatId = chatListIds[index]
                       return (
                         <div style={style}>
                           <ChatListItem

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -144,8 +144,7 @@ export function ViewProfileInner({
   const accountId = selectedAccountId()
   const { chatListIds } = useChatList(null, '', contact.id)
   const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
-    chatListIds,
-    null
+    chatListIds
   )
   const isDeviceMessage = contact.id === C.DC_CONTACT_ID_DEVICE
 


### PR DESCRIPTION
depends on https://github.com/deltachat/deltachat-core-rust/pull/3931

This makes the code simpler and prevents races due to desktop caching the message id of chatlistEntries.

EDIT: I investigated a bit more about the speed, still somewhat subjective, but this is what I think I understand: scrolling/initial-load is a **little bit slower** (because it has more sql queries), but updating (tested with backup import) might be a bit faster because less stuff is transferred and requested, but the sql call to get the last message is still there and it's unique (only asking for one message), so if sqlite does caching then it might have been a bit faster before.
But the upside to this change is still that there are:
- **fewer edge cases** (races where draft/msg does not exist anymore but desktop still requests a chatlist item with that message)
- and now there is one central place that we can optimise (all in core)

## More results from profiling ui code

#### Scrolling
332ms-398ms to 468ms-482ms Scripting, but also rendering and painting increase, so might be a thing with react?

„npm run build4production“ with this pr is around 270ms Scripting. so we should always make sure that we’re with this command when building for packaging, because it really makes a difference (react dev script is on, unless built with this command)

#### Startup of ui:
Before 626, 640, 687
After 630, 640, 669
-> no meaningful change


## Progress
This pr got a big bigger as I started optimising while using a backup import as "benchmark", I stoped the time until a full backup replay and with #3077 I tracked jsonrpc call count. While doing this I discovered a few bugs I indroduced, but also the core bug that slowed down backup import the most: it was spamming the contactChanged event: https://github.com/deltachat/deltachat-core-rust/pull/3938

- [x] rebase this pr onto master once the new archived design pr is merged

### Discovered bugs

- [ ] Contact recently seen change does not update chatlistitem?

#### Bug technically also on master:
Bugs that also exists on master, but are hidden by the unconditional reload of first 10 chats when order changes.
https://github.com/deltachat/deltachat-desktop/blob/b8d15c753c43f4fd5f99c86e746af3c34a76c2fd/src/renderer/components/chat/ChatList.tsx#L642-L645

- [ ] deleting last message does not update chatlistitem
- [ ] Pinning a chat does not update it’s chatlistitem, but muting does
- [ ] Incoming message does not update archived chats unread counter (missing core event https://github.com/deltachat/deltachat-core-rust/issues/3940)
- [X] chatlist is full of placeholders when switching to and back from archived chats 
