### PR TITLE
Add confirmDialog and confirmForwardMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 ### Changed
-- forward message dialog now has a title and a confirmation dialog before forwarding
+- forward message dialog now has a title and a confirmation dialog and chat preview before forwarding
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+
+### Changed
+- forward message dialog now has a title and a confirmation dialog before forwarding
+
+### Fixed
+
 <a id="1_34_1"></a>
 
 ## [1.34.1] - 2022-12-22

--- a/scss/dialogs/_forward-message.scss
+++ b/scss/dialogs/_forward-message.scss
@@ -1,7 +1,15 @@
+$side-padding: 20px;
+
+.forward-message-account-input {
+    padding-right: $side-padding;
+    padding-left: $side-padding;
+    padding-bottom: $side-padding;
+}
+
 .forward-message-list-chat-list {
   height: 100%;
   .chat-list-item {
-    padding-right: 20px;
-    padding-left: 20px;
+    padding-right: $side-padding;
+    padding-left: $side-padding;
   }
 }

--- a/scss/dialogs/_forward-message.scss
+++ b/scss/dialogs/_forward-message.scss
@@ -1,9 +1,13 @@
 $side-padding: 20px;
 
 .forward-message-account-input {
-    padding-right: $side-padding;
-    padding-left: $side-padding;
-    padding-bottom: $side-padding;
+  padding-right: $side-padding;
+  padding-left: $side-padding;
+  padding-bottom: $side-padding;
+
+  .search-input {
+    width: 100%;
+  }
 }
 
 .forward-message-list-chat-list {

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -13,7 +13,7 @@ import { useChatList } from '../chat/ChatListHelpers'
 import { useThemeCssVar } from '../../ThemeManager'
 import { BackendRemote } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
-import { selectChat } from '../helpers/ChatMethods'
+import { forwardMessage, selectChat } from '../helpers/ChatMethods'
 import { confirmForwardMessage } from '../message/messageFunctions'
 
 export default function ForwardMessage(props: {
@@ -35,10 +35,12 @@ export default function ForwardMessage(props: {
     onClose()
     if (!chat.isSelfTalk) {
       selectChat(chat.id)
-    }
-    const yes = await confirmForwardMessage(accountId, message, chat)
-    if (!yes) {
-      selectChat(message.chatId)
+      const yes = await confirmForwardMessage(accountId, message, chat)
+      if (!yes) {
+        selectChat(message.chatId)
+      }
+    } else {
+      await forwardMessage(accountId, message.id, chat.id)
     }
   }
   const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -33,9 +33,12 @@ export default function ForwardMessage(props: {
   const onChatClick = async (chatId: number) => {
     const chat = await BackendRemote.rpc.getFullChatById(accountId, chatId)
     onClose()
-    const yes = await confirmForwardMessage(accountId, message, chat)
-    if (yes && !chat.isSelfTalk) {
+    if (!chat.isSelfTalk) {
       selectChat(chat.id)
+    }
+    const yes = await confirmForwardMessage(accountId, message, chat)
+    if (!yes) {
+      selectChat(message.chatId)
     }
   }
   const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>

--- a/src/renderer/components/dialogs/ForwardMessage.tsx
+++ b/src/renderer/components/dialogs/ForwardMessage.tsx
@@ -48,9 +48,10 @@ export default function ForwardMessage(props: {
     Number(useThemeCssVar('--SPECIAL-chatlist-item-chat-height')) || 64
   return (
     <DeltaDialogBase isOpen={isOpen} onClose={onClose} fixed>
-      <DeltaDialogHeader onClose={onClose}
-        title={tx('forward_to')}>
-      </DeltaDialogHeader>
+      <DeltaDialogHeader
+        onClose={onClose}
+        title={tx('forward_to')}
+      ></DeltaDialogHeader>
       <div
         className={classNames(
           Classes.DIALOG_BODY,
@@ -58,12 +59,12 @@ export default function ForwardMessage(props: {
         )}
       >
         <Card style={{ padding: '0px' }}>
-          <div className="forward-message-account-input">
+          <div className='forward-message-account-input'>
             <input
               className='search-input'
               onChange={onSearchChange}
               value={queryStr}
-              placeholder={tx('contacts_enter_name_or_email')}
+              placeholder={tx('search')}
               autoFocus
               spellCheck={false}
             />

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -252,12 +252,12 @@ export async function sendMessage(chatId: number, message: sendMessageParams) {
   chatStore.effect.jumpToMessage(id, false)
 }
 
-export async function forwardMessage(
+export function forwardMessage(
   accountId: number,
   messageId: number,
   chatId: number
 ) {
-  await BackendRemote.rpc.forwardMessages(accountId, [messageId], chatId)
+  return BackendRemote.rpc.forwardMessages(accountId, [messageId], chatId)
 }
 
 export const deleteMessage = (messageId: number) => {

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -252,7 +252,11 @@ export async function sendMessage(chatId: number, message: sendMessageParams) {
   chatStore.effect.jumpToMessage(id, false)
 }
 
-export async function forwardMessage(accountId: number, messageId: number, chatId: number) {
+export async function forwardMessage(
+  accountId: number,
+  messageId: number,
+  chatId: number
+) {
   await BackendRemote.rpc.forwardMessages(accountId, [messageId], chatId)
 }
 

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -252,6 +252,10 @@ export async function sendMessage(chatId: number, message: sendMessageParams) {
   chatStore.effect.jumpToMessage(id, false)
 }
 
+export async function forwardMessage(accountId: number, messageId: number, chatId: number) {
+  await BackendRemote.rpc.forwardMessages(accountId, [messageId], chatId)
+}
+
 export const deleteMessage = (messageId: number) => {
   BackendRemote.rpc.deleteMessages(selectedAccountId(), [messageId])
 }

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -1,7 +1,7 @@
 import {
   onDownload,
   openAttachmentInShell,
-  forwardMessage,
+  openForwardDialog,
   openMessageInfo,
   setQuoteInDraft,
   privateReply,
@@ -244,7 +244,7 @@ function buildContextMenu(
     // Forward message
     {
       label: tx('menu_forward'),
-      action: forwardMessage.bind(null, message),
+      action: openForwardDialog.bind(null, message),
     },
     // Message details
     {

--- a/src/renderer/components/message/messageFunctions.ts
+++ b/src/renderer/components/message/messageFunctions.ts
@@ -1,7 +1,7 @@
 import { getLogger } from '../../../shared/logger'
 const log = getLogger('render/msgFunctions')
 import { runtime } from '../../runtime'
-import { deleteMessage, selectChat } from '../helpers/ChatMethods'
+import { forwardMessage, deleteMessage, selectChat } from '../helpers/ChatMethods'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { internalOpenWebxdc } from '../../system-integration/webxdc'
@@ -29,8 +29,29 @@ export function openAttachmentInShell(msg: Type.Message) {
   }
 }
 
-export function forwardMessage(message: Type.Message) {
+export function openForwardDialog(message: Type.Message) {
   window.__openDialog('ForwardMessage', { message })
+}
+
+export function confirmDialog(message: string, confirmLabel: string) {
+  return new Promise((res, _rej) => {
+    window.__openDialog('ConfirmationDialog', {
+      message,
+      confirmLabel,
+      cb: (yes: boolean) => {
+        res(yes)
+      }
+    })
+  })
+}
+
+export async function confirmForwardMessage(accountId: number, message: Type.Message, chat: Type.FullChat) {
+  const tx = window.static_translate
+  const yes = await confirmDialog(tx('ask_forward', [chat.name]), tx('forward'))
+  if (yes) {
+    await forwardMessage(accountId, message.id, chat.id)
+  }
+  return yes
 }
 
 export function confirmDeleteMessage(msg: Type.Message) {

--- a/src/renderer/components/message/messageFunctions.ts
+++ b/src/renderer/components/message/messageFunctions.ts
@@ -1,7 +1,11 @@
 import { getLogger } from '../../../shared/logger'
 const log = getLogger('render/msgFunctions')
 import { runtime } from '../../runtime'
-import { forwardMessage, deleteMessage, selectChat } from '../helpers/ChatMethods'
+import {
+  forwardMessage,
+  deleteMessage,
+  selectChat,
+} from '../helpers/ChatMethods'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { internalOpenWebxdc } from '../../system-integration/webxdc'
@@ -40,12 +44,16 @@ export function confirmDialog(message: string, confirmLabel: string) {
       confirmLabel,
       cb: (yes: boolean) => {
         res(yes)
-      }
+      },
     })
   })
 }
 
-export async function confirmForwardMessage(accountId: number, message: Type.Message, chat: Type.FullChat) {
+export async function confirmForwardMessage(
+  accountId: number,
+  message: Type.Message,
+  chat: Type.FullChat
+) {
   const tx = window.static_translate
   const yes = await confirmDialog(tx('ask_forward', [chat.name]), tx('forward'))
   if (yes) {


### PR DESCRIPTION
* new function to open a confirmation dialog confirmDialog returns a promise so you don't have to use callback and can call other things after confirm popup is closed
* ForwardMessage dialog now has a title and a confirmation box before you forward the mesage

closes #3006