### PR TITLE
fix unblock contact did not update the chatlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - fix default welcome screen height so all buttons fit scrollbar is hidden
+- fix unblock contact did not update the chatlist
 
 <a id="1_34_1"></a>
 

--- a/src/renderer/backend-com.ts
+++ b/src/renderer/backend-com.ts
@@ -98,6 +98,16 @@ export namespace EffectfulBackendActions {
     clearNotificationsForChat(accountId, chatId)
     window.__refetchChatlist && window.__refetchChatlist()
   }
+
+  export async function blockContact(accountId: number, contactId: number) {
+    await BackendRemote.rpc.blockContact(accountId, contactId)
+    window.__refetchChatlist && window.__refetchChatlist()
+  }
+
+  export async function unBlockContact(accountId: number, contactId: number) {
+    await BackendRemote.rpc.unblockContact(accountId, contactId)
+    window.__refetchChatlist && window.__refetchChatlist()
+  }
 }
 
 type ContextEvents = { ALL: (event: DcEvent) => void } & {

--- a/src/renderer/components/dialogs/UnblockContacts.tsx
+++ b/src/renderer/components/dialogs/UnblockContacts.tsx
@@ -5,7 +5,12 @@ import { ContactList2 } from '../contact/ContactList'
 import { ScreenContext } from '../../contexts'
 import { DialogProps } from './DialogController'
 import debounce from 'debounce'
-import { BackendRemote, onDCEvent, Type } from '../../backend-com'
+import {
+  BackendRemote,
+  EffectfulBackendActions,
+  onDCEvent,
+  Type,
+} from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 
 export default function UnblockContacts(props: {
@@ -36,7 +41,7 @@ export default function UnblockContacts(props: {
       message: tx('ask_unblock_contact'),
       confirmLabel: tx('menu_unblock_contact'),
       cb: (yes: boolean) =>
-        yes && BackendRemote.rpc.unblockContact(accountId, id),
+        yes && EffectfulBackendActions.unBlockContact(accountId, id),
     })
   }
 

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -112,10 +112,9 @@ export function openBlockFirstContactOfChatDialog(
       isConfirmDanger: true,
       cb: (yes: boolean) =>
         yes &&
-        BackendRemote.rpc.blockContact(accountId, dmChatContact).then(() => {
-          unselectChat()
-          window.__refetchChatlist && window.__refetchChatlist()
-        }),
+        EffectfulBackendActions.blockContact(accountId, dmChatContact).then(
+          unselectChat
+        ),
     })
   }
 }


### PR DESCRIPTION
also move all use of the `window.__refetchChatlist` - hack to EffectfulBackendActions. that we can get an overview of what events need to be added to core
