### PR TITLE
temporarily remove donate link to make app store release possible again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 - fix default welcome screen height so all buttons fit scrollbar is hidden
 - fix unblock contact did not update the chatlist
 
+### Removed
+- temporarily remove donate link to make app store release possible again
+
 <a id="1_34_1"></a>
 
 ## [1.34.1] - 2022-12-22

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -246,13 +246,15 @@ export default function Settings(props: DialogProps) {
                 >
                   {tx('pref_experimental_features')}
                 </SettingsIconButton>
+                {/* 
                 <SettingsIconButton
                   iconName='favorite'
                   onClick={() => runtime.openLink(donationUrl)}
                   isLink
                 >
                   {tx('pref_donate')}
-                </SettingsIconButton>
+                </SettingsIconButton> 
+                */}
               </Card>
             </DeltaDialogBody>
           </>

--- a/src/renderer/components/dialogs/Settings.tsx
+++ b/src/renderer/components/dialogs/Settings.tsx
@@ -21,8 +21,8 @@ import SettingsStoreInstance, {
   SettingsStoreState,
   useSettingsStore,
 } from '../../stores/settings'
-import { runtime } from '../../runtime'
-import { donationUrl } from '../../../shared/constants'
+// import { runtime } from '../../runtime'
+// import { donationUrl } from '../../../shared/constants'
 
 export function flipDeltaBoolean(value: string) {
   return value === '1' ? '0' : '1'


### PR DESCRIPTION
unfortunatly electron builder is still too bugged to give me a way
 to figgure out what kind of build we are in at runtime - I can't event plant a target specific file into the output reliably :facepalm:

I guess we'll migrate to electron forge soon...
