### PR TITLE
Ask for name/photo for accounts created through QR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
+- new dialog to change profile name/photo pops up after logging with a QR-Code
 
 ### Changed
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -61,5 +61,11 @@
   },
   "save_sticker": {
     "message": "Save Sticker"
+  },
+  "later": {
+    "message": "Later"
+  },
+  "settings_can_change_later": {
+    "message": "You can change it later in the settings"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -64,8 +64,5 @@
   },
   "later": {
     "message": "Later"
-  },
-  "settings_can_change_later": {
-    "message": "You can change it later in the settings"
   }
 }

--- a/src/renderer/components/dialogs/DeltaDialog.tsx
+++ b/src/renderer/components/dialogs/DeltaDialog.tsx
@@ -375,13 +375,20 @@ export function DeltaDialogOkCancelFooter({
   onCancel,
   onOk,
   disableOK,
+  cancelLabel,
+  confirmLabel,
 }: {
   onCancel: () => any
   onOk: () => any
   disableOK?: boolean
+  cancelLabel?: string
+  confirmLabel?: string
 }) {
   const tx = window.static_translate
   disableOK = disableOK === true ? true : false
+
+  cancelLabel = cancelLabel || tx('cancel')
+  confirmLabel = confirmLabel || tx('ok')
 
   return (
     <DeltaDialogFooter>
@@ -391,7 +398,7 @@ export function DeltaDialogOkCancelFooter({
           style={{ marginRight: '10px' }}
           onClick={onCancel}
         >
-          {tx('cancel')}
+          {cancelLabel}
         </p>
         <p
           //className={ 'delta-button bold primary' + disableOK ? " disabled" : "" }
@@ -403,7 +410,7 @@ export function DeltaDialogOkCancelFooter({
           )}
           onClick={onOk}
         >
-          {tx('ok')}
+          {confirmLabel}
         </p>
       </DeltaDialogFooterActions>
     </DeltaDialogFooter>

--- a/src/renderer/components/dialogs/DialogController.tsx
+++ b/src/renderer/components/dialogs/DialogController.tsx
@@ -56,7 +56,6 @@ export type DialogProps = {
   onClose: () => void
   userFeedback: todo
   key: string
-  title: todo
   openDialog: todo
   closeDialog: todo
   [key: string]: any

--- a/src/renderer/components/dialogs/DialogController.tsx
+++ b/src/renderer/components/dialogs/DialogController.tsx
@@ -56,6 +56,7 @@ export type DialogProps = {
   onClose: () => void
   userFeedback: todo
   key: string
+  title: todo
   openDialog: todo
   closeDialog: todo
   [key: string]: any

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -291,7 +291,7 @@ export function SettingsProfileDialog({
   isOpen: DialogProps['isOpen']
   onClose: DialogProps['onClose']
   settingsStore: SettingsStoreState
-  title?: DialogProps['title']
+  title?: string
   cancelLabel?: string
   confirmLabel?: string
   simpleSetup?: boolean

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -123,12 +123,14 @@ export function ProfileImageSelector({
   color,
   profilePicture,
   setProfilePicture,
+  hideDeleteButton = false,
 }: {
   displayName: string
   addr: string
   color: string
   profilePicture: string | null
   setProfilePicture: (path: string) => void
+  hideDeleteButton?: boolean
 }) {
   const tx = window.static_translate
 
@@ -167,14 +169,16 @@ export function ProfileImageSelector({
         >
           {tx('profile_image_select')}
         </button>
-        <button
-          aria-label={tx('profile_image_delete')}
-          onClick={onClickRemovePicture}
-          className={'delta-button-round'}
-          disabled={!profilePicture}
-        >
-          {tx('profile_image_delete')}
-        </button>
+        {!hideDeleteButton ? (
+          <button
+            aria-label={tx('profile_image_delete')}
+            onClick={onClickRemovePicture}
+            className={'delta-button-round'}
+            disabled={!profilePicture}
+          >
+            {tx('profile_image_delete')}
+          </button>
+        ) : null}
       </>
     </div>
   )
@@ -232,6 +236,7 @@ export function SettingsEditProfileDialogInner({
               color={settingsStore.selfContact.color}
               profilePicture={profilePicture}
               setProfilePicture={setProfilePicture}
+              hideDeleteButton={simpleSetup}
             />
           </div>
           <DeltaInput

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -186,13 +186,13 @@ export function SettingsEditProfileDialogInner({
   settingsStore,
   cancelLabel,
   confirmLabel,
-  simpleSetup = false,
+  firstSetup = false,
 }: {
   onClose: DialogProps['onClose']
   settingsStore: SettingsStoreState
   cancelLabel?: string
   confirmLabel?: string
-  simpleSetup?: boolean
+  firstSetup?: boolean
 }) {
   const tx = useTranslationFunction()
   const [displayname, setDisplayname] = useState(
@@ -247,8 +247,14 @@ export function SettingsEditProfileDialogInner({
               setDisplayname(event.target.value)
             }}
           />
-          {simpleSetup ? <span>{tx('settings_can_change_later')}</span> : null}
-          {simpleSetup ? null : (
+          {firstSetup ? (
+            <p className='bp4-callout'>
+              {tx('qraccount_success_enter_name', [
+                settingsStore.selfContact.address,
+              ])}
+            </p>
+          ) : null}
+          {firstSetup ? null : (
             <DeltaTextarea
               key='status'
               id='status'
@@ -281,7 +287,7 @@ export function SettingsProfileDialog({
   title,
   cancelLabel,
   confirmLabel,
-  simpleSetup = false,
+  firstSetup = false,
 }: {
   isOpen: DialogProps['isOpen']
   onClose: DialogProps['onClose']
@@ -289,7 +295,7 @@ export function SettingsProfileDialog({
   title?: string
   cancelLabel?: string
   confirmLabel?: string
-  simpleSetup?: boolean
+  firstSetup?: boolean
 }) {
   const tx = useTranslationFunction()
   title = title || tx('pref_edit_profile')
@@ -309,7 +315,7 @@ export function SettingsProfileDialog({
         onClose,
         cancelLabel,
         confirmLabel,
-        simpleSetup,
+        firstSetup,
       })}
     </DeltaDialogBase>
   )

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -183,9 +183,15 @@ export function ProfileImageSelector({
 export function SettingsEditProfileDialogInner({
   onClose,
   settingsStore,
+  cancelLabel,
+  confirmLabel,
+  simpleSetup = false,
 }: {
   onClose: DialogProps['onClose']
   settingsStore: SettingsStoreState
+  cancelLabel?: string
+  confirmLabel?: string
+  simpleSetup?: boolean
 }) {
   const tx = useTranslationFunction()
   const [displayname, setDisplayname] = useState(
@@ -240,21 +246,30 @@ export function SettingsEditProfileDialogInner({
               setDisplayname(event.target.value)
             }}
           />
-          <DeltaTextarea
-            key='status'
-            id='status'
-            placeholder={tx('pref_default_status_label')}
-            value={selfstatus}
-            onChange={(
-              event: React.FormEvent<HTMLElement> &
-                React.ChangeEvent<HTMLTextAreaElement>
-            ) => {
-              setSelfstatus(event.target.value)
-            }}
-          />
+          {simpleSetup ? (
+            <span>You can change that later in the settings</span>
+          ) : (
+            <DeltaTextarea
+              key='status'
+              id='status'
+              placeholder={tx('pref_default_status_label')}
+              value={selfstatus}
+              onChange={(
+                event: React.FormEvent<HTMLElement> &
+                  React.ChangeEvent<HTMLTextAreaElement>
+              ) => {
+                setSelfstatus(event.target.value)
+              }}
+            />
+          )}
         </Card>
       </DeltaDialogBody>
-      <DeltaDialogOkCancelFooter onCancel={onCancel} onOk={onOk} />
+      <DeltaDialogOkCancelFooter
+        cancelLabel={cancelLabel}
+        confirmLabel={confirmLabel}
+        onCancel={onCancel}
+        onOk={onOk}
+      />
     </>
   )
 }
@@ -263,12 +278,21 @@ export function SettingsProfileDialog({
   onClose,
   isOpen,
   settingsStore,
+  title,
+  cancelLabel,
+  confirmLabel,
+  simpleSetup = false,
 }: {
   isOpen: DialogProps['isOpen']
   onClose: DialogProps['onClose']
   settingsStore: SettingsStoreState
+  title?: DialogProps['title']
+  cancelLabel?: string
+  confirmLabel?: string
+  simpleSetup?: boolean
 }) {
   const tx = useTranslationFunction()
+  title = title || tx('pref_edit_profile')
   return (
     <DeltaDialogBase
       onClose={onClose}
@@ -279,10 +303,13 @@ export function SettingsProfileDialog({
         width: '500px',
       }}
     >
-      <DeltaDialogHeader title={tx('pref_edit_profile')} />
+      <DeltaDialogHeader title={title} />
       {SettingsEditProfileDialogInner({
         settingsStore,
         onClose,
+        cancelLabel,
+        confirmLabel,
+        simpleSetup,
       })}
     </DeltaDialogBase>
   )

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -123,7 +123,6 @@ export function ProfileImageSelector({
   color,
   profilePicture,
   setProfilePicture,
-  hideDeleteButton = false,
 }: {
   displayName: string
   addr: string
@@ -169,16 +168,14 @@ export function ProfileImageSelector({
         >
           {tx('profile_image_select')}
         </button>
-        {!hideDeleteButton ? (
-          <button
-            aria-label={tx('profile_image_delete')}
-            onClick={onClickRemovePicture}
-            className={'delta-button-round'}
-            disabled={!profilePicture}
-          >
-            {tx('profile_image_delete')}
-          </button>
-        ) : null}
+        <button
+          aria-label={tx('profile_image_delete')}
+          onClick={onClickRemovePicture}
+          className={'delta-button-round'}
+          disabled={!profilePicture}
+        >
+          {tx('profile_image_delete')}
+        </button>
       </>
     </div>
   )
@@ -236,7 +233,6 @@ export function SettingsEditProfileDialogInner({
               color={settingsStore.selfContact.color}
               profilePicture={profilePicture}
               setProfilePicture={setProfilePicture}
-              hideDeleteButton={simpleSetup}
             />
           </div>
           <DeltaInput
@@ -251,9 +247,8 @@ export function SettingsEditProfileDialogInner({
               setDisplayname(event.target.value)
             }}
           />
-          {simpleSetup ? (
-            <span>You can change that later in the settings</span>
-          ) : (
+          {simpleSetup ? <span>{tx('settings_can_change_later')}</span> : null}
+          {simpleSetup ? null : (
             <DeltaTextarea
               key='status'
               id='status'

--- a/src/renderer/components/helpers/OpenQrUrl.tsx
+++ b/src/renderer/components/helpers/OpenQrUrl.tsx
@@ -231,6 +231,7 @@ export default async function processOpenQrUrl(
         window.__openDialog(ConfigureProgressDialog, {
           credentials: {},
           onSuccess: () => {
+            window.__askForName = true
             window.__changeScreen(Screens.Main)
             callback()
           },

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -118,7 +118,7 @@ export default function MainScreen() {
       title: 'Account setup',
       confirmLabel: tx('ok'),
       cancelLabel: tx('later'),
-      simpleSetup: true,
+      firstSetup: true,
     })
   }
 

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -116,8 +116,8 @@ export default function MainScreen() {
     screenContext.openDialog(SettingsProfileDialog, {
       settingsStore,
       title: 'Account setup',
-      confirmLabel: 'ok',
-      cancelLabel: 'later',
+      confirmLabel: tx('ok'),
+      cancelLabel: tx('later'),
       simpleSetup: true,
     })
   }

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -41,6 +41,7 @@ import Sidebar, { SidebarState } from '../Sidebar'
 import SettingsStoreInstance, { useSettingsStore } from '../../stores/settings'
 import { Type } from '../../backend-com'
 import { InlineVerifiedIcon } from '../VerifiedIcon'
+import { SettingsProfileDialog } from '../dialogs/Settings-Profile'
 
 const log = getLogger('renderer/main-screen')
 
@@ -109,6 +110,17 @@ export default function MainScreen() {
 
   const tx = useTranslationFunction()
   const settingsStore = useSettingsStore()[0]
+
+  if (settingsStore && window.__askForName) {
+    window.__askForName = false
+    screenContext.openDialog(SettingsProfileDialog, {
+      settingsStore,
+      title: 'Account setup',
+      confirmLabel: 'ok',
+      cancelLabel: 'later',
+      simpleSetup: true,
+    })
+  }
 
   const searchRef = useRef<HTMLInputElement>(null)
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -36,6 +36,7 @@ declare global {
     __chatStore: any
     __refetchChatlist: undefined | (() => void)
     __welcome_qr: undefined | string
+    __askForName: boolean
     __internal_jump_to_message:
       | undefined
       | ((


### PR DESCRIPTION
* new property on window __askForName if it is set to true first time the MainScreen opens the SettingsProfileDialog pops up for user to change their name, add photo
* SettingsProfileDialog accepts custom title, confirmLabel, cancelLabel and passes it down

fixes #3036