### PR TITLE
improve jumbomoji logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@
 - update `emoji-mart` to version `5.5.2` (adds `@emoji-mart/data@1.1.2` & `@emoji-mart/react@1.1.1`)
 - emoji picker now closes automatically when selecting an emoji, press `shift` to select multiple emojis
 - escape key closes the emoji picker
+- removed dependency on `emoji-regex`
 
 ### Fixed
+- improve jumbomoji logic (that emoji only messages appear bigger), now works even with new emojis that are not in delta chat yet.
 - css: fix hover overflow on context menu corners
 
 ### Removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "deltachat-node": "^1.107.0",
         "emoji-js-clean": "^4.0.0",
         "emoji-mart": "5.5.2",
-        "emoji-regex": "^9.2.2",
         "error-stack-parser": "^2.0.7",
         "filesize": "^8.0.6",
         "immutable": "^4.0.0",
@@ -6328,7 +6327,8 @@
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -22724,7 +22724,8 @@
     "emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "end-of-stream": {
       "version": "1.4.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "deltachat-node": "^1.107.0",
     "emoji-js-clean": "^4.0.0",
     "emoji-mart": "5.5.2",
-    "emoji-regex": "^9.2.2",
     "error-stack-parser": "^2.0.7",
     "filesize": "^8.0.6",
     "immutable": "^4.0.0",

--- a/src/renderer/components/conversations/emoji.ts
+++ b/src/renderer/components/conversations/emoji.ts
@@ -2,15 +2,11 @@
 // We only really need the emoji data of this module
 import EmojiConvertor from 'emoji-js-clean'
 import { getLogger } from '../../../shared/logger'
-// @ts-ignore
-import emojiRegexRGI from 'emoji-regex/RGI_Emoji'
 
 const log = getLogger('renderer/emoji')
 
 const instance = new EmojiConvertor()
 instance.init_colons()
-
-export const emojiRegEx: RegExp = emojiRegexRGI()
 
 // taken from (new EmojiConvertor()).rx_colons
 const colonEmojiCodeRegExp = /:[a-zA-Z0-9-_+]+:(:skin-tone-[2-6]:)?/g
@@ -47,23 +43,50 @@ export function replaceColonsSafe(message: string) {
   }
 }
 
-export function getSizeClass(str: string) {
-  const conv = str.replace(/-/g, '').replace(emojiRegEx, '-')
-  if (conv.replace(/-/g, '').trim().length > 0) {
-    // has normal characters?
-    return ''
-  }
-  const emojiCount = conv.match(/-/g)?.length || 0
+// Emojis might be comprised of multiple sub emojis, search for "unicode graphemes" online to learn more
+// Thanks to https://stackoverflow.com/questions/10287887/get-grapheme-character-count-in-javascript-strings for pointing to `Intl.Segmenter`
+let getEmojiCount: (input: string) => number
+//@ts-ignore
+if (typeof Intl.Segmenter === 'function') {
+  //@ts-ignore
+  getEmojiCount = input => [...new Intl.Segmenter().segment(input)].length
+} else {
+  log.warn(
+    'Intl.Segmenter api is not availible, emoji counting will be less percise'
+  )
+  getEmojiCount = input => input.length
+}
 
-  if (emojiCount > 8) {
+// thanks to https://medium.com/reactnative/emojis-in-javascript-f693d0eb79fb for figuring this out.
+const emojiRegEx =
+  '(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])'
+const MAX_BIG_EMOJI_COUNT = 6
+const MAX_BYTE_SIZE_OF_EMOJI = 10 /* 10 is maybe already to generous? */
+const MAX_STRING_LENGTH_FOR_BIG_EMOJI =
+  MAX_BIG_EMOJI_COUNT * MAX_BYTE_SIZE_OF_EMOJI
+const emojiRegExTestLine = new RegExp(
+  `^${emojiRegEx}{1,${MAX_STRING_LENGTH_FOR_BIG_EMOJI}}$`
+)
+
+export function getSizeClass(str: string) {
+  // if string is small enough and only contains emojis
+  if (
+    str.length > MAX_STRING_LENGTH_FOR_BIG_EMOJI ||
+    !emojiRegExTestLine.test(str)
+  ) {
     return ''
-  } else if (emojiCount > 6) {
-    return 'small'
-  } else if (emojiCount > 4) {
-    return 'medium'
-  } else if (emojiCount > 2) {
-    return 'large'
   } else {
-    return 'jumbo'
+    const emojiCount = getEmojiCount(str)
+    if (emojiCount > 8) {
+      return ''
+    } else if (emojiCount > 6) {
+      return 'small'
+    } else if (emojiCount > 4) {
+      return 'medium'
+    } else if (emojiCount > 2) {
+      return 'large'
+    } else {
+      return 'jumbo'
+    }
   }
 }

--- a/src/renderer/components/message/MessageBody.tsx
+++ b/src/renderer/components/message/MessageBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
-import { getSizeClass, emojiRegEx, replaceColons } from '../conversations/emoji'
+import { getSizeClass, replaceColons } from '../conversations/emoji'
 import { message2React } from './MessageMarkdown'
 
 export default function MessageBody(props: {
@@ -11,12 +11,8 @@ export default function MessageBody(props: {
   const { text, disableJumbomoji, preview } = props
   // if text is only emojis and Jumbomoji is enabled
   const emojifiedText = trim(text.replace(/:[\w\d_\-+]*:/g, replaceColons))
-  if (
-    emojifiedText.length < 50 &&
-    !disableJumbomoji &&
-    emojifiedText.replace(emojiRegEx, '') === ''
-  ) {
-    const sizeClass = disableJumbomoji ? '' : getSizeClass(emojifiedText)
+  const sizeClass = disableJumbomoji ? '' : getSizeClass(emojifiedText)
+  if (sizeClass !== '') {
     return (
       <span className={classNames('emoji-container', sizeClass)}>
         {emojifiedText}


### PR DESCRIPTION
improve jumbomoji logic (that emoji only messages appear bigger), now works better with emoji that consist out of multiple sub-emojis like composite emojis (👪) and emojis with skin color (🧑🏾).

also removed dependency on `emoji-regex`, because it's now not needed anymore.

now works even with new emojis that are not in delta chat yet:
<img width="246" alt="Bildschirmfoto 2023-01-31 um 18 41 52" src="https://user-images.githubusercontent.com/18725968/215840653-bcec3410-d3cf-47e2-bd66-8a49b0be9655.png">
<img width="246" alt="Bildschirmfoto 2023-01-31 um 18 43 07" src="https://user-images.githubusercontent.com/18725968/215840793-48f73b0f-3e3d-4112-88a4-9f63e167b1e1.png">
