### PR TITLE
css: fix hover overflow on context menu corners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- css: fix hover overflow on context menu corners
 
 ### Removed
 

--- a/scss/misc/_context_menu.scss
+++ b/scss/misc/_context_menu.scss
@@ -32,6 +32,7 @@
   width: var(--local-menu-width);
 
   border-radius: 3px;
+  overflow: hidden;
 
   box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.1), 0 2px 4px rgba(16, 22, 26, 0.2),
     0 8px 24px rgba(16, 22, 26, 0.2);


### PR DESCRIPTION
the context menu has rounded corners, before this pr the corners got pointy on hovering.
before:
<img width="144" alt="Bildschirmfoto 2023-01-31 um 22 09 40" src="https://user-images.githubusercontent.com/18725968/215884156-3ffc82b5-63a5-40cc-b999-10d364e55908.png">
after:
<img width="144" alt="Bildschirmfoto 2023-01-31 um 22 09 15" src="https://user-images.githubusercontent.com/18725968/215884243-15b6b6ec-bf65-4d30-af4a-a966293f8e22.png">

\#consistency