### PR TITLE
better error handling when messages fail to load from db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - update deltachat-node and deltachat/jsonrpc-client to `v1.109.0`
 
 ### Fixed
+- better error handling when messages fail to load from db
 
 ### Removed
 - remove unused direct dependency on babel: `@babel/core`, `@babel/preset-env` and `@babel/preset-react`

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -712,7 +712,7 @@ function useContactAndMessageLogic(
 
   // Message ----------------
   const [messageCache, setMessageCache] = useState<{
-    [id: number]: T.MessageSearchResult
+    [id: number]: T.MessageSearchResult | undefined
   }>({})
   const [messageLoadState, setMessageLoading] = useState<{
     [id: number]: undefined | LoadStatus.FETCHING | LoadStatus.LOADED

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -264,11 +264,11 @@ function buildContextMenu(
   ]
 }
 
-const Message = (props: {
+export default function Message(props: {
   message: Type.Message
   conversationType: ConversationType
   /* onRetrySend */
-}) => {
+}) {
   const { message, conversationType } = props
   const { id, viewType, text, hasLocation, isSetupmessage, hasHtml } = message
   const direction = getDirection(message)
@@ -501,8 +501,6 @@ const Message = (props: {
     </div>
   )
 }
-
-export default Message
 
 export const Quote = ({
   quote,

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -429,7 +429,7 @@ export const MessageListInner = React.memo(
     oldestFetchedMessageIndex: number
     messageListItems: T.MessageListItem[]
     activeView: T.MessageListItem[]
-    messageCache: { [msgId: number]: T.Message }
+    messageCache: { [msgId: number]: T.MessageLoadResult | undefined }
     messageListRef: React.MutableRefObject<HTMLDivElement | null>
     chatStore: ChatStoreStateWithChatSet
     loaded: boolean
@@ -502,17 +502,30 @@ export const MessageListInner = React.memo(
 
             if (messageId.kind === 'message') {
               const message = messageCache[messageId.msg_id]
-              if (message) {
+              if (message?.variant === 'message') {
                 return (
                   <MessageWrapper
                     key={messageId.msg_id}
                     key2={`${messageId.msg_id}`}
-                    message={message as T.Message}
+                    message={message}
                     conversationType={conversationType}
                     unreadMessageInViewIntersectionObserver={
                       unreadMessageInViewIntersectionObserver
                     }
                   />
+                )
+              } else if (message?.variant === 'loadingError') {
+                return (
+                  <div className='info-message' id={String(messageId.msg_id)}>
+                    <div
+                      className='bubble'
+                      style={{
+                        backgroundColor: 'rgba(55,0,0,0.5)',
+                      }}
+                    >
+                      loading message {messageId.msg_id} failed: {message.error}
+                    </div>
+                  </div>
                 )
               } else {
                 // setTimeout tells it to call method in next event loop iteration, so after rendering
@@ -523,11 +536,10 @@ export const MessageListInner = React.memo(
                     <div
                       className='bubble'
                       style={{
-                        textTransform: 'capitalize',
                         backgroundColor: 'rgba(55,0,0,0.5)',
                       }}
                     >
-                      loading message {messageId.msg_id}
+                      Loading Message {messageId.msg_id}
                     </div>
                   </div>
                 )

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -14,7 +14,7 @@ type RenderMessageProps = {
   unreadMessageInViewIntersectionObserver: React.MutableRefObject<IntersectionObserver | null>
 }
 
-export const MessageWrapper = (props: RenderMessageProps) => {
+export function MessageWrapper(props: RenderMessageProps) {
   const state = props.message.state
   const shouldInViewObserve =
     state === C.DC_STATE_IN_FRESH || state === C.DC_STATE_IN_NOTICED

--- a/src/renderer/stores/messagelist.ts
+++ b/src/renderer/stores/messagelist.ts
@@ -19,7 +19,7 @@ const PAGE_SIZE = 11
 interface MessageListState {
   // chat: Type.FullChat | null
   messageListItems: T.MessageListItem[]
-  messageCache: { [msgId: number]: T.Message }
+  messageCache: { [msgId: number]: T.MessageLoadResult|undefined }
   newestFetchedMessageListItemIndex: number
   oldestFetchedMessageListItemIndex: number
   viewState: ChatViewState
@@ -239,10 +239,11 @@ class MessageListStore extends Store<MessageListState> {
       }, 'unlockScroll')
     },
     messageChanged: (message: Type.Message) => {
+      const messageLoadResult:Type.MessageLoadResult = {variant: 'message', ...message}
       this.setState(state => {
         const modifiedState: MessageListState = {
           ...state,
-          messageCache: { ...state.messageCache, [message.id]: message },
+          messageCache: { ...state.messageCache, [message.id]: messageLoadResult },
         }
         return modifiedState
       }, 'messageChanged')
@@ -256,7 +257,7 @@ class MessageListStore extends Store<MessageListState> {
             [messageId]: {
               ...state.messageCache[messageId],
               state: messageState,
-            },
+            } as Type.MessageLoadResult,
           },
         }
         return modifiedState


### PR DESCRIPTION
uses new MessageLoadResult type, so requires core with https://github.com/deltachat/deltachat-core-rust/pull/4038 merged

- simplify daymarkers in chataudit dialog code
- define the undefined case in the types of message caches (this make typescript catch more mistakes)


impact on desktop:
now instead of getting multiple messages that fail to load (the whole batch ~10 messages), now only the actual one faulty message fails to load, and now it also shows the error inline:
<img width="628" alt="Bildschirmfoto 2023-02-14 um 17 28 58" src="https://user-images.githubusercontent.com/18725968/218809032-7487f35c-5b76-4955-bfbd-4ef6ff92390e.png">


also closes #3054
also closes #3123