### PR TITLE
top evil blueprint

### DIFF
--- a/bin/topEvil.sh
+++ b/bin/topEvil.sh
@@ -3,12 +3,29 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )/.."
 
 echo "Top-Evil TypeScript"
 
-res=$( grep -r "^import.*electron" src/main/deltachat --color=always )
-echo "🤔 Using Electron inside of the deltachat controller: $( echo "$res" | wc -l )"
+res=$( grep -r "^import.*blueprint" src --color=always )
+echo "🤔 Using Blueprint code: $( echo "$res" | wc -l )"
 echo "-----------------------------------------------------"
 echo "$res"
 
-res=$( grep -r "require(" src/main --color=always )
-echo "🤔 Requires in main Process: $( echo "$res" | wc -l )"
+res=$( grep -r "bp4-" src --color=always )
+echo "🤔 Using Blueprint css classes: $( echo "$res" | wc -l )"
 echo "-----------------------------------------------------"
 echo "$res"
+
+echo "Top-Evil SCSS"
+
+res=$( grep -r ".bp4-" scss --color=always )
+echo "🤔 Using Blueprint in css: $( echo "$res" | wc -l )"
+echo "-----------------------------------------------------"
+echo "$res"
+
+# res=$( grep -r "^import.*electron" src/main/deltachat --color=always )
+# echo "🤔 Using Electron inside of the deltachat controller: $( echo "$res" | wc -l )"
+# echo "-----------------------------------------------------"
+# echo "$res"
+
+# res=$( grep -r "require(" src/main --color=always )
+# echo "🤔 Requires in main Process: $( echo "$res" | wc -l )"
+# echo "-----------------------------------------------------"
+# echo "$res"

--- a/bin/topEvil.sh
+++ b/bin/topEvil.sh
@@ -5,11 +5,13 @@ echo "Top-Evil TypeScript"
 
 res=$( grep -r "^import.*blueprint" src --color=always )
 echo "🤔 Using Blueprint code: $( echo "$res" | wc -l )"
+code=$( echo "$res" | wc -l )
 echo "-----------------------------------------------------"
 echo "$res"
 
 res=$( grep -r "bp4-" src --color=always )
 echo "🤔 Using Blueprint css classes: $( echo "$res" | wc -l )"
+classes=$( echo "$res" | wc -l )
 echo "-----------------------------------------------------"
 echo "$res"
 
@@ -17,8 +19,12 @@ echo "Top-Evil SCSS"
 
 res=$( grep -r ".bp4-" scss --color=always )
 echo "🤔 Using Blueprint in css: $( echo "$res" | wc -l )"
+scss=$( echo "$res" | wc -l )
 echo "-----------------------------------------------------"
 echo "$res"
+
+echo "🤔Result🤔"
+echo "CODE: $code | CLASSES: $classes | SCSS: $scss"
 
 # res=$( grep -r "^import.*electron" src/main/deltachat --color=always )
 # echo "🤔 Using Electron inside of the deltachat controller: $( echo "$res" | wc -l )"


### PR DESCRIPTION
The new game is to remove our dependency blueprintjs, `./bin/topEvil.sh` is our trusty companion on this 
endevour: it show us where blueprint is still used.

```
🤔Result🤔
CODE:       33 | CLASSES:       35 | SCSS:      119
```

The goal is to get all 3 numbers down, idealy down to 0, bit by bit.




- change top evil goal to blueprintjs
- top evil summary
