### PR TITLE
update `@deltachat/message_parser_wasm` to `0.5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.110.0`
+- update `@deltachat/message_parser_wasm` to `0.5.1` (`<delimited@emails>` and fix code blocks with emojis)
 
 ### Fixed
 - better error handling when messages fail to load from db in messagelist and gallery

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@blueprintjs/core": "^4.1.2",
         "@deltachat/jsonrpc-client": "^1.110.0",
-        "@deltachat/message_parser_wasm": "^0.4.0",
+        "@deltachat/message_parser_wasm": "^0.5.1",
         "@deltachat/react-qr-reader": "^4.0.0",
         "@emoji-mart/data": "1.1.2",
         "@emoji-mart/react": "1.1.1",
@@ -1977,9 +1977,9 @@
       }
     },
     "node_modules/@deltachat/message_parser_wasm": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.4.0.tgz",
-      "integrity": "sha512-lnFkj1nwYUU09Ee7udBkci61aUltv7TsgqhPmh812nvr18yw+/gYmZM9tvD8qPkGVU1tgbQ36Iruv+QWmLUFUw=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.5.1.tgz",
+      "integrity": "sha512-1BtV26EGmv7vR4C5B9qL5APjX7MeGFSlx3udFG4RkfCr5WroRvASfybFJ3OUcgho8jmIoV5m9de9+RhEW4fqUA=="
     },
     "node_modules/@deltachat/react-qr-reader": {
       "version": "4.0.0",
@@ -13759,9 +13759,9 @@
       }
     },
     "@deltachat/message_parser_wasm": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.4.0.tgz",
-      "integrity": "sha512-lnFkj1nwYUU09Ee7udBkci61aUltv7TsgqhPmh812nvr18yw+/gYmZM9tvD8qPkGVU1tgbQ36Iruv+QWmLUFUw=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.5.1.tgz",
+      "integrity": "sha512-1BtV26EGmv7vR4C5B9qL5APjX7MeGFSlx3udFG4RkfCr5WroRvASfybFJ3OUcgho8jmIoV5m9de9+RhEW4fqUA=="
     },
     "@deltachat/react-qr-reader": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "@blueprintjs/core": "^4.1.2",
     "@deltachat/jsonrpc-client": "^1.110.0",
-    "@deltachat/message_parser_wasm": "^0.4.0",
+    "@deltachat/message_parser_wasm": "^0.5.1",
     "@deltachat/react-qr-reader": "^4.0.0",
     "@emoji-mart/data": "1.1.2",
     "@emoji-mart/react": "1.1.1",


### PR DESCRIPTION
adds support for `<delimited@emails>` and fixes code blocks with emojis

delimited email addresses are a part of #2872