### PR TITLE
Hardening: prohibit all DNS queries

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,14 @@ import contextMenu from './electron-context-menu'
 import { findOutIfWeAreRunningAsAppx } from './isAppx'
 import { getHelpMenu } from './help_menu'
 
+// Hardening: prohibit all DNS queries, except for Mapbox
+// (see src/renderer/components/map/MapComponent.tsx)
+// The `~NOTFOUND` string is here:
+// https://chromium.googlesource.com/chromium/src/+/6459548ee396bbe1104978b01e19fcb1bb68d0e5/net/dns/mapped_host_resolver.cc#46
+const hostRules = 'MAP * ~NOTFOUND, EXCLUDE *.mapbox.com'
+rawApp.commandLine.appendSwitch('host-resolver-rules', hostRules)
+rawApp.commandLine.appendSwitch('host-rules', hostRules)
+
 if (rc['version'] === true || rc['v'] === true) {
   /* ignore-console-log */
   console.info(VERSION)


### PR DESCRIPTION
(except for Mapbox)