### PR TITLE
smaller video chat bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Update inApp help (11.4.2023)
 - improve confirm abort dialog for setup second device #3173
 
+### Fixed
+- do not save custom video chat provider if it only contains whitespaces
+
 <a id="1_36_1"></a>
 
 ## [1.36.1] - 2023-04-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 - do not save custom video chat provider if it only contains whitespaces
+- fix show error messages when starting a video chat
+- don't show video chat in attachment menu when the feature is turned off
 
 <a id="1_36_1"></a>
 

--- a/src/renderer/components/attachment/menuAttachment.tsx
+++ b/src/renderer/components/attachment/menuAttachment.tsx
@@ -13,6 +13,8 @@ import { MEDIA_EXTENSIONS } from '../../../shared/constants'
 
 import { sendCallInvitation } from '../helpers/ChatMethods'
 import { Type } from '../../backend-com'
+import { useStore } from '../../stores/store'
+import SettingsStoreInstance from '../../stores/settings'
 //function to populate Menu
 const MenuAttachmentItems = ({
   itemsArray,
@@ -44,6 +46,7 @@ const MenuAttachment = ({
 }) => {
   const tx = useTranslationFunction()
   const screenContext = useContext(ScreenContext)
+  const [settings] = useStore(SettingsStoreInstance)
   const addFilenameFile = async () => {
     //function for files
     const file = await runtime.showOpenFileDialog({
@@ -94,7 +97,7 @@ const MenuAttachment = ({
   }
   // item array used to populate menu
   const items = [
-    {
+    settings?.settings.webrtc_instance && {
       id: 0,
       icon: 'phone' as IconName,
       text: tx('videochat'),
@@ -115,7 +118,7 @@ const MenuAttachment = ({
       onClick: addFilenameFile.bind(null),
       attachment: 'attachment-files',
     },
-  ]
+  ].filter(item => !!item) as MenuAttachmentItemObject[]
 
   return (
     <div className='attachment-button'>

--- a/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
+++ b/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
@@ -131,7 +131,7 @@ export function EditVideochatInstanceDialog({
   }
   const onClickOk = () => {
     onClose()
-    onOk(configValue)
+    onOk(configValue.trim()) // the trim is here to not save custom provider if it only contains whitespaces
   }
   const onChangeRadio = (event: FormEvent<HTMLInputElement>) => {
     const currentRadioValue = event.currentTarget.value as RadioButtonValue

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -176,7 +176,9 @@ export async function sendCallInvitation(
     await joinCall(screenContext, messageId)
   } catch (error: todo) {
     log.error('failed send call invitation', error)
-    screenContext.openDialog(AlertDialog, { message: error.toString() })
+    screenContext.openDialog(AlertDialog, {
+      message: error?.message || error.toString(),
+    })
   }
 }
 


### PR DESCRIPTION
- do not save custom video chat provider if it only contains whitespaces
- sendCallInvitation: show error message instead of `[object Object]`
- don't show video chat in attachment menu when the feature is turned off
