### PR TITLE
always show copy link when right clicking a link in a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - fix show error messages when starting a video chat
 - don't show video chat in attachment menu when the feature is turned off
 - fix "Always Load Remote Images" should be hidden for contact requests #3180
+- always show copy link when right clicking a link in a message #3184
 
 <a id="1_36_1"></a>
 

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -145,7 +145,9 @@ function buildContextMenu(
     throw new Error('cannot show context menu for undefined message')
   }
 
-  const isLink = clickTarget && !clickTarget.getAttribute('x-not-a-link')
+  const isLink = Boolean(
+    clickTarget && !clickTarget.getAttribute('x-not-a-link')
+  )
   const email = clickTarget?.getAttribute('x-target-email')
   const link: string =
     clickTarget?.getAttribute('x-target-url') || clickTarget?.href || ''
@@ -174,11 +176,6 @@ function buildContextMenu(
         runtime.writeClipboardText(selectedText as string)
       },
     }
-  } else if (link !== '' && isLink) {
-    copy_item = {
-      label: tx('menu_copy_link_to_clipboard'),
-      action: () => runtime.writeClipboardText(link),
-    }
   } else if (email) {
     copy_item = {
       label: tx('menu_copy_email_to_clipboard'),
@@ -205,6 +202,13 @@ function buildContextMenu(
         label: tx('reply_privately'),
         action: privateReply.bind(null, message),
       },
+    // copy link
+    link !== '' &&
+      isLink && {
+        label: tx('menu_copy_link_to_clipboard'),
+        action: () => runtime.writeClipboardText(link),
+      },
+    // copy item (selection or all text)
     text !== '' && copy_item,
     // Copy image
     showCopyImage && {


### PR DESCRIPTION
closes #3184
<img width="378" alt="Bildschirmfoto 2023-04-14 um 01 08 56" src="https://user-images.githubusercontent.com/18725968/231902010-7930db93-53eb-4811-9e72-daaf4964bec5.png">
