### PR TITLE
always display html emails in black text on white background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- always display html emails in black text on white background by default, fixes white text on white background when the OS was in dark theme mode
+
 <a id="1_36_2"></a>
 
 ## [1.36.2] - 2023-04-14

--- a/src/main/windows/html_email.ts
+++ b/src/main/windows/html_email.ts
@@ -311,6 +311,10 @@ function makeBrowserView(allow_remote_content: boolean, html_content: string) {
   })
 
   sandboxedView.webContents.loadURL('email://index.html')
+  sandboxedView.webContents.insertCSS(`:root {
+      color: black;
+      background-color: white;
+    }`)
 
   sandboxedView.webContents.on(
     'will-navigate',


### PR DESCRIPTION
by default, fixes white text on white background when the OS was in dark theme mode
