### PR TITLE
fix some emojis not getting larger in emoji only messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+
+### Fixed
+- fix some emojis not getting larger in emoji only messages
+
 <a id="1_36_4"></a>
 
 ## [1.36.4] - 2023-04-21

--- a/src/renderer/components/conversations/emoji.ts
+++ b/src/renderer/components/conversations/emoji.ts
@@ -57,9 +57,9 @@ if (typeof Intl.Segmenter === 'function') {
   getEmojiCount = input => input.length
 }
 
+const variantSelectors = '[\ufe00-\ufe0f]'
 // thanks to https://medium.com/reactnative/emojis-in-javascript-f693d0eb79fb for figuring this out.
-const emojiRegEx =
-  '(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])'
+const emojiRegEx = `(?:(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|[\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|[\ud83c[\ude32-\ude3a]|[\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])${variantSelectors}?)`
 const MAX_BIG_EMOJI_COUNT = 6
 const MAX_BYTE_SIZE_OF_EMOJI = 10 /* 10 is maybe already to generous? */
 const MAX_STRING_LENGTH_FOR_BIG_EMOJI =


### PR DESCRIPTION
the issue was caused by a Variation Selector char at the end that was not accounted for.

closes #3211

|before |after|
|-------|-----|
|<img width="117" alt="Bildschirmfoto 2023-04-22 um 18 09 34" src="https://user-images.githubusercontent.com/18725968/233796165-d6f3d260-091e-41f1-9201-f30600faac07.png"> |<img width="117" alt="Bildschirmfoto 2023-04-22 um 18 34 49" src="https://user-images.githubusercontent.com/18725968/233796167-8b5f420b-c4e8-49fe-becd-8a32f0cc0f6f.png"> |
