### PR TITLE
fix(css): remove `display: flex` from chatlist item text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- Show thumbnail in chatlist summary of image, sticker and webxdc messages
+
 ### Changed
 - exclude more unused files from installation package
 - update deltachat-node and deltachat/jsonrpc-client to `v1.115.0`

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -63,6 +63,7 @@
       margin-top: 3px;
 
       & > .text {
+        display: flex;
         align-items: center;
         max-width: calc(100% - 18px);
         height: 1.3em;
@@ -179,6 +180,7 @@
     .chat-list-item-message {
       margin-top: 0;
       .text {
+        display: inline-block;
         max-width: fit-content;
       }
     }


### PR DESCRIPTION
Otherwise `<b>` highlight in the search result
does not have the space separating it from the rest of the text.

Bug screenshot:
![1](https://github.com/deltachat/deltachat-desktop/assets/18373967/b1d1f6ea-3f23-409e-9ac7-4ec867dca33b)
