### PR TITLE
self contact now is displayed as saved messages chat in view profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Improved message search results
 - Update translations (18.05.2023)
 - add Romanian translation
+- better profile view for saved messages chat
 
 ### Fixed
 - fix some emojis not getting larger in emoji only messages

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -76,7 +76,8 @@ export default function ViewProfile(props: {
   const tx = window.static_translate
   const { openDialog } = useContext(ScreenContext)
   const [contact, setContact] = useState<Type.Contact>(props.contact)
-  const isDeviceMessage = contact.id === C.DC_CONTACT_ID_DEVICE
+  const isDeviceChat = contact.id === C.DC_CONTACT_ID_DEVICE
+  const isSelfChat = contact.id === C.DC_CONTACT_ID_SELF
 
   const onClickEdit = () => {
     openDialog(EditContactNameDialog, {
@@ -102,7 +103,7 @@ export default function ViewProfile(props: {
       <DeltaDialogHeader
         title={tx('menu_view_profile')}
         onClickEdit={onClickEdit}
-        showEditButton={!isDeviceMessage}
+        showEditButton={!(isDeviceChat || isSelfChat)}
         showCloseButton={true}
         onClose={onClose}
       />
@@ -128,7 +129,8 @@ export function ViewProfileInner({
     chatListIds,
     null
   )
-  const isDeviceMessage = contact.id === C.DC_CONTACT_ID_DEVICE
+  const isDeviceChat = contact.id === C.DC_CONTACT_ID_DEVICE
+  const isSelfChat = contact.id === C.DC_CONTACT_ID_SELF
 
   const tx = window.static_translate
 
@@ -149,6 +151,18 @@ export function ViewProfileInner({
 
   const screenContext = useContext(ScreenContext)
 
+  let displayNameLine = contact.displayName
+  let addressLine = contact.address
+  let statusText = contact.status
+
+  if (isDeviceChat) {
+    addressLine = tx('device_talk_subtitle')
+  } else if (isSelfChat) {
+    displayNameLine = tx('saved_messages')
+    addressLine = tx('chat_self_talk_subtitle')
+    statusText = tx('saved_messages_explain')
+  }
+
   return (
     <>
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -160,44 +174,44 @@ export function ViewProfileInner({
             <div className='profile-info-name-container'>
               <div>
                 <p className='group-name'>
-                  {contact.displayName}
+                  {displayNameLine}
                   {/* {isVerified && <InlineVerifiedIcon />} */}
                 </p>
               </div>
-              <div className='address'>
-                {isDeviceMessage ? tx('device_talk_subtitle') : contact.address}
-              </div>
+              <div className='address'>{addressLine}</div>
             </div>
           </div>
-          <div className='contact-attributes'>
-            {contact.isVerified && !contact.verifierAddr && (
-              <div>
-                <InlineVerifiedIcon />
-                {tx('verified')}
-              </div>
-            )}
-            {contact.isVerified && contact.verifierAddr && (
-              <div
-                className='clickable'
-                onClick={() =>
-                  contact.verifierId &&
-                  openViewProfileDialog(screenContext, contact.verifierId)
-                }
-              >
-                <InlineVerifiedIcon />
-                {tx('verified_by', contact.verifierAddr)}
-              </div>
-            )}
-            {contact.lastSeen !== 0 && (
-              <div>
-                <img
-                  className='material-icon'
-                  src='../images/icons/schedule.svg'
-                />
-                <LastSeen timestamp={contact.lastSeen} />
-              </div>
-            )}
-          </div>
+          {!isSelfChat && (
+            <div className='contact-attributes'>
+              {contact.isVerified && !contact.verifierAddr && (
+                <div>
+                  <InlineVerifiedIcon />
+                  {tx('verified')}
+                </div>
+              )}
+              {contact.isVerified && contact.verifierAddr && (
+                <div
+                  className='clickable'
+                  onClick={() =>
+                    contact.verifierId &&
+                    openViewProfileDialog(screenContext, contact.verifierId)
+                  }
+                >
+                  <InlineVerifiedIcon />
+                  {tx('verified_by', contact.verifierAddr)}
+                </div>
+              )}
+              {contact.lastSeen !== 0 && (
+                <div>
+                  <img
+                    className='material-icon'
+                    src='../images/icons/schedule.svg'
+                  />
+                  <LastSeen timestamp={contact.lastSeen} />
+                </div>
+              )}
+            </div>
+          )}
           <div
             style={{
               display: 'flex',
@@ -205,7 +219,7 @@ export function ViewProfileInner({
               justifyContent: 'center',
             }}
           >
-            {!isDeviceMessage && (
+            {!isDeviceChat && (
               <button
                 aria-label={tx('send_message')}
                 onClick={onSendMessage}
@@ -216,7 +230,7 @@ export function ViewProfileInner({
               </button>
             )}
           </div>
-          {contact.status != '' && (
+          {statusText != '' && (
             <>
               <DeltaDialogContentTextSeparator
                 text={tx('pref_default_status_label')}
@@ -229,13 +243,13 @@ export function ViewProfileInner({
                     closeProfileDialog: onClose,
                   }}
                 >
-                  <MessageBody text={contact.status} />
+                  <MessageBody text={statusText} />
                 </MessagesDisplayContext.Provider>
               </div>
             </>
           )}
         </div>
-        {!isDeviceMessage && (
+        {!(isDeviceChat || isSelfChat) && (
           <>
             <DeltaDialogContentTextSeparator
               text={tx('profile_shared_chats')}

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -129,6 +129,7 @@ export function ViewProfileInner({
     chatListIds,
     null
   )
+  const [selfChatAvatar, setSelfChatAvatar] = useState<string | null>(null)
   const isDeviceChat = contact.id === C.DC_CONTACT_ID_DEVICE
   const isSelfChat = contact.id === C.DC_CONTACT_ID_SELF
 
@@ -145,6 +146,22 @@ export function ViewProfileInner({
     )
     onChatClick(dmChatId)
   }
+
+  useEffect(() => {
+    if (isSelfChat) {
+      ;(async () => {
+        const chatid = await BackendRemote.rpc.createChatByContactId(
+          accountId,
+          C.DC_CONTACT_ID_SELF
+        )
+        const { profileImage } = await BackendRemote.rpc.getBasicChatInfo(
+          accountId,
+          chatid
+        )
+        setSelfChatAvatar(profileImage)
+      })()
+    }
+  }, [accountId, isSelfChat])
 
   const CHATLISTITEM_CHAT_HEIGHT =
     Number(useThemeCssVar('--SPECIAL-chatlist-item-chat-height')) || 64
@@ -168,8 +185,16 @@ export function ViewProfileInner({
       <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
         <div>
           <div className='profile-info-container'>
-            <ClickForFullscreenAvatarWrapper filename={contact.profileImage}>
-              <ProfileInfoAvatar contact={contact} />
+            <ClickForFullscreenAvatarWrapper
+              filename={isSelfChat ? selfChatAvatar : contact.profileImage}
+            >
+              {isSelfChat ? (
+                <ProfileInfoAvatar
+                  contact={{ ...contact, profileImage: selfChatAvatar }}
+                />
+              ) : (
+                <ProfileInfoAvatar contact={contact} />
+              )}
             </ClickForFullscreenAvatarWrapper>
             <div className='profile-info-name-container'>
               <div>


### PR DESCRIPTION
See https://github.com/deltachat/deltachat-desktop/issues/3231#issuecomment-1557225606


~~The image might be harder to get, because is the saved messages chat avatar and not the avatar of the self contact.~~
See comments beneath r10s had a trick to get it, works, but not the prettiest or most efficient code, I know some alternative routes but they are not prettier, just a bit more efficient (runtime, not coding/maintenance) - like passing down the profile url in react properties, now that there is only one way to get to the dialog (since #3235) and that place already has the picture, but then one extra property or a cloned component just for saving 2 jsonrpc calls and 5 lines of code for this small edge case?

<img width="409" alt="Bildschirmfoto 2023-05-30 um 21 40 36" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/9dd3b457-cd81-4fb2-b415-b165bc74925c">
