### PR TITLE
fix make self contact not clickable in group member list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix some emojis not getting larger in emoji only messages
 - add missing languages to supported languages in appx manifest
 - fix show verification state of chat in chatlist
+- fix make self contact not clickable in group member list
 
 <a id="1_36_4"></a>
 

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -279,6 +279,9 @@ function ViewGroupInner(props: {
                   contacts={chat.contacts}
                   showRemove={!chatDisabled}
                   onClick={contact => {
+                    if (contact.id === C.DC_CONTACT_ID_SELF) {
+                      return
+                    }
                     setProfileContact(contact)
                     setViewMode('profile')
                   }}


### PR DESCRIPTION
don't open view profile in the group member list when clicking on the self contact

partially addresses #3231
