### PR TITLE
webxdc add sendToChat api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Show thumbnail in chatlist summary of image, sticker and webxdc messages
+- add webxdc api `sendToChat` #3240
 
 ### Changed
 - exclude more unused files from installation package
@@ -18,6 +19,7 @@
 - add missing languages to supported languages in appx manifest
 - fix show verification state of chat in chatlist
 - fix make self contact not clickable in group member list
+- remove pasted images from temp folder #2927
 
 <a id="1_36_4"></a>
 

--- a/src/main/application-constants.ts
+++ b/src/main/application-constants.ts
@@ -1,6 +1,6 @@
 import appConfig from './application-config'
 import { dirname, join } from 'path'
-import { screen } from 'electron'
+import { app, screen } from 'electron'
 
 export function appIcon() {
   const iconFormat = process.platform === 'win32' ? '.ico' : '.png'
@@ -58,6 +58,12 @@ export function getAccountsPath() {
 
 export function getCustomThemesPath() {
   return join(getConfigPath(), 'custom-themes')
+}
+
+// this is used for temporary files (because core expects file paths, can not accept blobs directly yet)
+// used when sending file from webxdc and when pasting a file from clipboard
+export function getDraftTempDir() {
+  return join(app.getPath('temp'), 'chat.delta.desktop-draft')
 }
 
 export const supportedURISchemes = [

--- a/src/main/cleanup_temp_dir.ts
+++ b/src/main/cleanup_temp_dir.ts
@@ -1,0 +1,39 @@
+import { app } from 'electron'
+import { mkdir, readdir, rm, rmdir } from 'fs/promises'
+import { join } from 'path'
+import { getLogger } from '../shared/logger'
+import { getDraftTempDir } from './application-constants'
+
+const log = getLogger('main/cleanup_temp_dir')
+
+export async function cleanupDraftTempDir() {
+  try {
+    // ensure dir exists
+    await mkdir(getDraftTempDir(), { recursive: true })
+    const path = getDraftTempDir()
+    if (path.indexOf(app.getPath('temp')) === -1 || path.indexOf('..') !== -1) {
+      log.error(
+        'removeTempFile was called with a path that is outside of the temp dir: ',
+        path
+      )
+      throw new Error('Path is outside of the temp folder')
+    }
+
+    const files = await readdir(path)
+    log.debug(
+      `found old ${files.length} temporary draft files, trying to delete them now`
+    )
+    const promises = []
+    for (const file in files) {
+      log.debug('delete', join(getDraftTempDir(), file))
+      promises.push(rm(join(getDraftTempDir(), file)))
+    }
+
+    await Promise.all(promises)
+
+    // delete dir at the end
+    await rmdir(path)
+  } catch (error) {
+    log.error('Cleanup of old temp files failed: ', error)
+  }
+}

--- a/src/main/cleanup_temp_dir.ts
+++ b/src/main/cleanup_temp_dir.ts
@@ -20,16 +20,18 @@ export async function cleanupDraftTempDir() {
     }
 
     const files = await readdir(path)
-    log.debug(
-      `found old ${files.length} temporary draft files, trying to delete them now`
-    )
-    const promises = []
-    for (const file in files) {
-      log.debug('delete', join(getDraftTempDir(), file))
-      promises.push(rm(join(getDraftTempDir(), file)))
+    if (files.length !== 0) {
+        log.debug(
+          `found old ${files.length} temporary draft files, trying to delete them now`
+        )
+        const promises = []
+        for (const file in files) {
+          log.debug('delete', join(getDraftTempDir(), file))
+          promises.push(rm(join(getDraftTempDir(), file)))
+        }
+    
+        await Promise.all(promises)
     }
-
-    await Promise.all(promises)
 
     // delete dir at the end
     await rmdir(path)

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -400,7 +400,7 @@ If you think that's a bug and you need that permission, then please open an issu
     })
 
     ipcMain.handle(
-      'webxdc.sendFileToChat',
+      'webxdc.sendToChat',
       (
         event,
         file: { file_name: string; file_content: string } | null,
@@ -411,12 +411,12 @@ If you think that's a bug and you need that permission, then please open an issu
         )
         if (!key) {
           log.error(
-            'webxdc.sendFileToChat failed, app not found in list of open ones'
+            'webxdc.sendToChat failed, app not found in list of open ones'
           )
           return
         }
         // forward to main window
-        main_window?.webContents.send('webxdc.sendFileToChat', file, text)
+        main_window?.webContents.send('webxdc.sendToChat', file, text)
         main_window?.focus()
         open_apps[key].win.destroy()
       }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -105,6 +105,7 @@ import { updateTrayIcon, hideDeltaChat, showDeltaChat } from './tray'
 import './notifications'
 import { acceptThemeCLI } from './themes'
 import { webxdcStartUpCleanup } from './deltachat/webxdc'
+import { cleanupDraftTempDir } from './cleanup_temp_dir'
 
 app.ipcReady = false
 app.isQuitting = false
@@ -159,11 +160,7 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
   cleanupLogFolder().catch(err =>
     log.error('Cleanup of old logfiles failed: ', err)
   )
-
-  // cleanupDraftTempDir
-  rm(getDraftTempDir(), { recursive: true }).catch(err =>
-    log.error('Cleanup of old temp files failed: ', err)
-  )
+  cleanupDraftTempDir()
 }
 
 ;(app as EventEmitter).once('ipcReady', () => {
@@ -217,10 +214,7 @@ export function quit(e?: Electron.Event) {
   // does stop io and other things
   ipc_shutdown_function && ipc_shutdown_function()
 
-  // cleanupDraftTempDir
-  rm(getDraftTempDir(), { recursive: true }).catch(err =>
-    log.error('Cleanup of old temp files failed: ', err)
-  )
+  cleanupDraftTempDir()
 
   function doQuit() {
     log.info('Quitting now. Bye.')

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import type { EventEmitter } from 'events'
 import contextMenu from './electron-context-menu'
 import { findOutIfWeAreRunningAsAppx } from './isAppx'
 import { getHelpMenu } from './help_menu'
+import { rm } from 'fs/promises'
 
 // Hardening: prohibit all DNS queries, except for Mapbox
 // (see src/renderer/components/map/MapComponent.tsx)
@@ -63,6 +64,7 @@ import {
   getLogsPath,
   getAccountsPath,
   getCustomThemesPath,
+  getDraftTempDir,
 } from './application-constants'
 mkdirSync(getConfigPath(), { recursive: true })
 mkdirSync(getLogsPath(), { recursive: true })
@@ -157,6 +159,11 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
   cleanupLogFolder().catch(err =>
     log.error('Cleanup of old logfiles failed: ', err)
   )
+
+  // cleanupDraftTempDir
+  rm(getDraftTempDir(), { recursive: true }).catch(err =>
+    log.error('Cleanup of old temp files failed: ', err)
+  )
 }
 
 ;(app as EventEmitter).once('ipcReady', () => {
@@ -209,6 +216,11 @@ export function quit(e?: Electron.Event) {
 
   // does stop io and other things
   ipc_shutdown_function && ipc_shutdown_function()
+
+  // cleanupDraftTempDir
+  rm(getDraftTempDir(), { recursive: true }).catch(err =>
+    log.error('Cleanup of old temp files failed: ', err)
+  )
 
   function doQuit() {
     log.info('Quitting now. Bye.')

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -189,8 +189,8 @@ export async function init(cwd: string, logHandler: LogHandler) {
   ipcMain.handle('app.writeClipboardToTempFile', () =>
     writeClipboardToTempFile()
   )
-  ipcMain.handle('app.writeTempFile', (_ev, name, content) =>
-    writeTempFile(name, content)
+  ipcMain.handle('app.writeTempFileFromBase64', (_ev, name, content) =>
+    writeTempFileFromBase64(name, content)
   )
   ipcMain.handle('app.removeTempFile', (_ev, path) => removeTempFile(path))
 
@@ -281,11 +281,11 @@ async function writeClipboardToTempFile(): Promise<string> {
   return pathToFile
 }
 
-async function writeTempFile(name: string, content: string): Promise<string> {
+async function writeTempFileFromBase64(name: string, content: string): Promise<string> {
   await mkdir(join(rawApp.getPath('temp'), 'draft/'), { recursive: true })
   const pathToFile = join(rawApp.getPath('temp'), 'draft/', name)
   log.debug(`Writing base64 encoded file ${pathToFile}`)
-  await writeFile(pathToFile, Buffer.from(content, 'utf8'), 'binary')
+  await writeFile(pathToFile, Buffer.from(content, 'base64'), 'binary')
   return pathToFile
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,4 +1,4 @@
-import { copyFile, mkdir, rm } from 'fs/promises'
+import { copyFile, writeFile, mkdir, rm } from 'fs/promises'
 import {
   app as rawApp,
   clipboard,
@@ -22,7 +22,6 @@ import { platform } from 'os'
 import { existsSync } from 'fs'
 import { set_has_unread, updateTrayIcon } from './tray'
 import mimeTypes from 'mime-types'
-import { writeFile } from 'fs/promises'
 import { openHtmlEmailWindow } from './windows/html_email'
 
 const log = getLogger('main/ipc')
@@ -190,6 +189,10 @@ export async function init(cwd: string, logHandler: LogHandler) {
   ipcMain.handle('app.writeClipboardToTempFile', () =>
     writeClipboardToTempFile()
   )
+  ipcMain.handle('app.writeTempFile', (_ev, name, content) =>
+    writeTempFile(name, content)
+  )
+  ipcMain.handle('app.removeTempFile', (_ev, path) => removeTempFile(path))
 
   ipcMain.handle('electron.shell.openExternal', (_ev, url) =>
     shell.openExternal(url)
@@ -258,6 +261,7 @@ export async function init(cwd: string, logHandler: LogHandler) {
 }
 
 async function writeClipboardToTempFile(): Promise<string> {
+  await mkdir(join(rawApp.getPath('temp'), 'draft/'), { recursive: true })
   const formats = clipboard.availableFormats().sort()
   log.debug('Clipboard available formats:', formats)
   if (formats.length <= 0) {
@@ -265,6 +269,7 @@ async function writeClipboardToTempFile(): Promise<string> {
   }
   const pathToFile = join(
     rawApp.getPath('temp'),
+    'draft',
     `paste.${mimeTypes.extension(formats[0]) || 'bin'}`
   )
   const buf =
@@ -274,4 +279,26 @@ async function writeClipboardToTempFile(): Promise<string> {
   log.debug(`Writing clipboard ${formats[0]} to file ${pathToFile}`)
   await writeFile(pathToFile, buf, 'binary')
   return pathToFile
+}
+
+async function writeTempFile(name: string, content: string): Promise<string> {
+  await mkdir(join(rawApp.getPath('temp'), 'draft/'), { recursive: true })
+  const pathToFile = join(rawApp.getPath('temp'), 'draft/', name)
+  log.debug(`Writing base64 encoded file ${pathToFile}`)
+  await writeFile(pathToFile, Buffer.from(content, 'utf8'), 'binary')
+  return pathToFile
+}
+
+async function removeTempFile(path: string) {
+  if (
+    path.indexOf(rawApp.getPath('temp')) === -1 ||
+    path.indexOf('..') !== -1
+  ) {
+    log.error(
+      'removeTempFile was called with a path that is outside of the temp dir: ',
+      path
+    )
+    throw new Error('Path is outside of the temp folder')
+  }
+  await rm(path)
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -281,7 +281,10 @@ async function writeClipboardToTempFile(): Promise<string> {
   return pathToFile
 }
 
-async function writeTempFileFromBase64(name: string, content: string): Promise<string> {
+async function writeTempFileFromBase64(
+  name: string,
+  content: string
+): Promise<string> {
   await mkdir(join(rawApp.getPath('temp'), 'draft/'), { recursive: true })
   const pathToFile = join(rawApp.getPath('temp'), 'draft/', name)
   log.debug(`Writing base64 encoded file ${pathToFile}`)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -8,7 +8,7 @@ import {
   shell,
 } from 'electron'
 import { getLogger } from '../shared/logger'
-import { getLogsPath } from './application-constants'
+import { getDraftTempDir, getLogsPath } from './application-constants'
 import { LogHandler } from './log-handler'
 import { ExtendedAppMainProcess } from './types'
 import * as mainWindow from './windows/main'
@@ -261,15 +261,14 @@ export async function init(cwd: string, logHandler: LogHandler) {
 }
 
 async function writeClipboardToTempFile(): Promise<string> {
-  await mkdir(join(rawApp.getPath('temp'), 'draft/'), { recursive: true })
+  await mkdir(getDraftTempDir(), { recursive: true })
   const formats = clipboard.availableFormats().sort()
   log.debug('Clipboard available formats:', formats)
   if (formats.length <= 0) {
     throw new Error('No files to write')
   }
   const pathToFile = join(
-    rawApp.getPath('temp'),
-    'draft',
+    getDraftTempDir(),
     `paste.${mimeTypes.extension(formats[0]) || 'bin'}`
   )
   const buf =
@@ -285,8 +284,8 @@ async function writeTempFileFromBase64(
   name: string,
   content: string
 ): Promise<string> {
-  await mkdir(join(rawApp.getPath('temp'), 'draft/'), { recursive: true })
-  const pathToFile = join(rawApp.getPath('temp'), 'draft/', name)
+  await mkdir(getDraftTempDir(), { recursive: true })
+  const pathToFile = join(getDraftTempDir(), name)
   log.debug(`Writing base64 encoded file ${pathToFile}`)
   await writeFile(pathToFile, Buffer.from(content, 'base64'), 'binary')
   return pathToFile

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -20,6 +20,7 @@ import { debouncedUpdateBadgeCounter } from './system-integration/badge-counter'
 import { updateDeviceChats } from './deviceMessages'
 import { runtime } from './runtime'
 import { DcEventType } from '@deltachat/jsonrpc-client'
+import WebxdcSaveToChatDialog from './components/dialogs/WebxdcSaveToChatDialog'
 
 const log = getLogger('renderer/ScreenController')
 
@@ -161,6 +162,12 @@ export default class ScreenController extends Component {
     }
 
     runtime.onOpenQrUrl = processOpenQrUrl
+    runtime.onWebxdcSendFile = (file, text) => {
+      ;(this.openDialog as OpenDialogFunctionType)(WebxdcSaveToChatDialog, {
+        messageText: text,
+        file,
+      })
+    }
 
     this.startup().then(() => {
       runtime.emitUIFullyReady()

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -20,7 +20,7 @@ import { debouncedUpdateBadgeCounter } from './system-integration/badge-counter'
 import { updateDeviceChats } from './deviceMessages'
 import { runtime } from './runtime'
 import { DcEventType } from '@deltachat/jsonrpc-client'
-import WebxdcSaveToChatDialog from './components/dialogs/WebxdcSaveToChatDialog'
+import WebxdcSaveToChatDialog from './components/dialogs/WebxdcSendToChatDialog'
 
 const log = getLogger('renderer/ScreenController')
 
@@ -162,7 +162,7 @@ export default class ScreenController extends Component {
     }
 
     runtime.onOpenQrUrl = processOpenQrUrl
-    runtime.onWebxdcSendFile = (file, text) => {
+    runtime.onWebxcSendToChat = (file, text) => {
       ;(this.openDialog as OpenDialogFunctionType)(WebxdcSaveToChatDialog, {
         messageText: text,
         file,

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -61,7 +61,7 @@ const Composer = forwardRef<
     draftState: DraftObject
     removeQuote: () => void
     updateDraftText: (text: string, InputChatId: number) => void
-    addFileToDraft: (file: string) => void
+    addFileToDraft: (file: string) => Promise<void>
     removeFile: () => void
     clearDraft: () => void
   }
@@ -211,7 +211,9 @@ const Composer = forwardRef<
     try {
       // Write clipboard to file then attach it to the draft
       const path = await runtime.writeClipboardToTempFile()
-      addFileToDraft(path)
+      await addFileToDraft(path)
+      // delete file again after it was sucessfuly added
+      await runtime.removeTempFile(path)
     } catch (err) {
       log.error('Failed to paste file.', err)
     }
@@ -350,7 +352,7 @@ export function useDraft(
   draftState: DraftObject
   removeQuote: () => void
   updateDraftText: (text: string, InputChatId: number) => void
-  addFileToDraft: (file: string) => void
+  addFileToDraft: (file: string) => Promise<void>
   removeFile: () => void
   clearDraft: () => void
 } {
@@ -499,9 +501,9 @@ export function useDraft(
   }, [saveDraft])
 
   const addFileToDraft = useCallback(
-    (file: string) => {
+    async (file: string) => {
       draftRef.current.file = file
-      saveDraft()
+      return saveDraft()
     },
     [saveDraft]
   )

--- a/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
+++ b/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
@@ -33,7 +33,10 @@ export default function WebxdcSaveToChatDialog(props: {
   const onChatClick = async (chatId: number) => {
     let path = null
     if (file) {
-      path = await runtime.writeTempFileFromBase64(file.file_name, file.file_content)
+      path = await runtime.writeTempFileFromBase64(
+        file.file_name,
+        file.file_content
+      )
     }
     await saveToChatAction(chatId, messageText, path)
     if (path) {
@@ -51,7 +54,10 @@ export default function WebxdcSaveToChatDialog(props: {
   const noResults = chatListIds.length === 0 && queryStr !== ''
   return (
     <DeltaDialogBase isOpen={true} onClose={onClose} fixed>
-      <DeltaDialogHeader onClose={onClose} title={tx('chat_share_with_title')} />
+      <DeltaDialogHeader
+        onClose={onClose}
+        title={tx('chat_share_with_title')}
+      />
       <div
         className={classNames(
           Classes.DIALOG_BODY,

--- a/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
+++ b/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
@@ -1,0 +1,144 @@
+import React from 'react'
+import { Card, Classes } from '@blueprintjs/core'
+import { DeltaDialogBase, DeltaDialogHeader } from './DeltaDialog'
+import ChatListItem from '../chat/ChatListItem'
+import { PseudoListItemNoSearchResults } from '../helpers/PseudoListItem'
+import classNames from 'classnames'
+import { DialogProps } from './DialogController'
+
+import { C } from '@deltachat/jsonrpc-client'
+import { ChatListPart, useLogicVirtualChatList } from '../chat/ChatList'
+import AutoSizer from 'react-virtualized-auto-sizer'
+import { useChatList } from '../chat/ChatListHelpers'
+import { useThemeCssVar } from '../../ThemeManager'
+import { selectChat } from '../helpers/ChatMethods'
+import { BackendRemote } from '../../backend-com'
+import { selectedAccountId } from '../../ScreenController'
+import { runtime } from '../../runtime'
+
+export default function WebxdcSaveToChatDialog(props: {
+  messageText: string | null
+  file: { file_name: string; file_content: string } | null
+  onClose: DialogProps['onClose']
+}) {
+  const tx = window.static_translate
+  const { onClose, messageText, file } = props
+  const listFlags = C.DC_GCL_FOR_FORWARDING | C.DC_GCL_NO_SPECIALS
+  const { chatListIds, queryStr, setQueryStr } = useChatList(listFlags)
+  const { isChatLoaded, loadChats, chatCache } = useLogicVirtualChatList(
+    chatListIds,
+    listFlags
+  )
+
+  const onChatClick = async (chatId: number) => {
+    let path = null
+    if (file) {
+      path = await runtime.writeTempFile(file.file_name, file.file_content)
+    }
+    await saveToChatAction(chatId, messageText, path)
+    if (path) {
+      await runtime.removeTempFile(path)
+    }
+    onClose()
+  }
+
+  const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    setQueryStr(e.target.value)
+
+  const CHATLISTITEM_CHAT_HEIGHT =
+    Number(useThemeCssVar('--SPECIAL-chatlist-item-chat-height')) || 64
+
+  const noResults = chatListIds.length === 0 && queryStr !== ''
+  return (
+    <DeltaDialogBase isOpen={true} onClose={onClose} fixed>
+      <DeltaDialogHeader onClose={onClose} title={tx('webxdc_send_to_chat')} />
+      <div
+        className={classNames(
+          Classes.DIALOG_BODY,
+          'bp4-dialog-body-no-footer',
+          'mailto-dialog'
+        )}
+      >
+        <Card style={{ padding: '0px' }}>
+          <div className='select-chat-chat-list'>
+            <input
+              className='search-input'
+              onChange={onSearchChange}
+              value={queryStr}
+              placeholder={tx('contacts_enter_name_or_email')}
+              autoFocus
+              spellCheck={false}
+            />
+            {noResults && queryStr && (
+              <PseudoListItemNoSearchResults queryStr={queryStr} />
+            )}
+            <div style={noResults ? { height: '0px' } : {}} className='results'>
+              <AutoSizer>
+                {({ width, height }) => (
+                  <ChatListPart
+                    isRowLoaded={isChatLoaded}
+                    loadMoreRows={loadChats}
+                    rowCount={chatListIds.length}
+                    width={width}
+                    height={height}
+                    itemKey={index => 'key' + chatListIds[index]}
+                    itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                  >
+                    {({ index, style }) => {
+                      const chatId = chatListIds[index]
+                      return (
+                        <div style={style}>
+                          <ChatListItem
+                            chatListItem={chatCache[chatId] || undefined}
+                            onClick={onChatClick.bind(null, chatId)}
+                          />
+                        </div>
+                      )
+                    }}
+                  </ChatListPart>
+                )}
+              </AutoSizer>
+            </div>
+          </div>
+        </Card>
+      </div>
+    </DeltaDialogBase>
+  )
+}
+
+async function saveToChatAction(
+  chatId: number,
+  messageText: string | null,
+  file: string | null
+) {
+  const accountId = selectedAccountId()
+
+  const chat = await BackendRemote.rpc.getBasicChatInfo(accountId, chatId)
+  const draft = await BackendRemote.rpc.getDraft(accountId, chatId)
+
+  selectChat(chatId)
+
+  if (draft) {
+    // ask if the draft should be replaced
+    const continue_process = await new Promise((resolve, _reject) => {
+      window.__openDialog('ConfirmationDialog', {
+        message: window.static_translate('confirm_replace_draft', chat.name),
+        confirmLabel: window.static_translate('replace_draft'),
+        cb: resolve,
+      })
+    })
+    if (!continue_process) {
+      return
+    }
+  }
+
+  await BackendRemote.rpc.miscSetDraft(
+    accountId,
+    chatId,
+    messageText,
+    file,
+    null
+  )
+
+  window.__reloadDraft && window.__reloadDraft()
+}

--- a/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
+++ b/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
@@ -33,7 +33,7 @@ export default function WebxdcSaveToChatDialog(props: {
   const onChatClick = async (chatId: number) => {
     let path = null
     if (file) {
-      path = await runtime.writeTempFile(file.file_name, file.file_content)
+      path = await runtime.writeTempFileFromBase64(file.file_name, file.file_content)
     }
     await saveToChatAction(chatId, messageText, path)
     if (path) {

--- a/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
+++ b/src/renderer/components/dialogs/WebxdcSaveToChatDialog.tsx
@@ -51,7 +51,7 @@ export default function WebxdcSaveToChatDialog(props: {
   const noResults = chatListIds.length === 0 && queryStr !== ''
   return (
     <DeltaDialogBase isOpen={true} onClose={onClose} fixed>
-      <DeltaDialogHeader onClose={onClose} title={tx('webxdc_send_to_chat')} />
+      <DeltaDialogHeader onClose={onClose} title={tx('chat_share_with_title')} />
       <div
         className={classNames(
           Classes.DIALOG_BODY,

--- a/src/renderer/components/dialogs/WebxdcSendToChatDialog.tsx
+++ b/src/renderer/components/dialogs/WebxdcSendToChatDialog.tsx
@@ -38,7 +38,7 @@ export default function WebxdcSaveToChatDialog(props: {
         file.file_content
       )
     }
-    await saveToChatAction(chatId, messageText, path)
+    await sendToChatAction(chatId, messageText, path)
     if (path) {
       await runtime.removeTempFile(path)
     }
@@ -112,7 +112,7 @@ export default function WebxdcSaveToChatDialog(props: {
   )
 }
 
-async function saveToChatAction(
+async function sendToChatAction(
   chatId: number,
   messageText: string | null,
   file: string | null

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -132,7 +132,7 @@ interface Runtime {
     | ((kind: 'about' | 'keybindings' | 'settings') => void)
     | undefined
   onOpenQrUrl: ((url: string) => void) | undefined
-  onWebxdcSendFile:
+  onWebxcSendToChat:
     | ((
         file: { file_name: string; file_content: string } | null,
         text: string | null
@@ -147,7 +147,7 @@ class Browser implements Runtime {
     | ((kind: 'about' | 'keybindings' | 'settings') => void)
     | undefined
   onOpenQrUrl: ((url: string) => void) | undefined
-  onWebxdcSendFile:
+  onWebxcSendToChat:
     | ((
         file: { file_name: string; file_content: string } | null,
         text: string | null
@@ -319,7 +319,7 @@ class Browser implements Runtime {
   }
 }
 class Electron implements Runtime {
-  onWebxdcSendFile:
+  onWebxcSendToChat:
     | ((
         file: { file_name: string; file_content: string } | null,
         text: string | null
@@ -546,12 +546,12 @@ class Electron implements Runtime {
     ipcBackend.on('open-url', (_ev, url) => this.onOpenQrUrl?.(url))
     ipcBackend.on('open-url', (_ev, url) => this.onOpenQrUrl?.(url))
     ipcBackend.on(
-      'webxdc.sendFileToChat',
+      'webxdc.sendToChat',
       (
         _ev,
         file: { file_name: string; file_content: string } | null,
         text: string | null
-      ) => this.onWebxdcSendFile?.(file, text)
+      ) => this.onWebxcSendToChat?.(file, text)
     )
   }
   openHelpWindow(): void {

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -107,7 +107,7 @@ interface Runtime {
     cb: (data: { accountId: number; chatId: number; msgId: number }) => void
   ): void
   writeClipboardToTempFile(): Promise<string>
-  writeTempFile(name: string, content: string): Promise<string>
+  writeTempFileFromBase64(name: string, content: string): Promise<string>
   removeTempFile(path: string): Promise<void>
   getWebxdcDiskUsage(
     accountId: number
@@ -221,7 +221,7 @@ class Browser implements Runtime {
   async writeClipboardToTempFile(): Promise<string> {
     throw new Error('Method not implemented.')
   }
-  writeTempFile(_name: string, _content: string): Promise<string> {
+  writeTempFileFromBase64(_name: string, _content: string): Promise<string> {
     throw new Error('Method not implemented.')
   }
   removeTempFile(_name: string): Promise<void> {
@@ -401,8 +401,8 @@ class Electron implements Runtime {
   async writeClipboardToTempFile(): Promise<string> {
     return ipcBackend.invoke('app.writeClipboardToTempFile')
   }
-  writeTempFile(name: string, content: string): Promise<string> {
-    return ipcBackend.invoke('app.writeTempFile', name, content)
+  writeTempFileFromBase64(name: string, content: string): Promise<string> {
+    return ipcBackend.invoke('app.writeTempFileFromBase64', name, content)
   }
   removeTempFile(path: string): Promise<void> {
     return ipcBackend.invoke('app.removeTempFile', path)

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -107,6 +107,8 @@ interface Runtime {
     cb: (data: { accountId: number; chatId: number; msgId: number }) => void
   ): void
   writeClipboardToTempFile(): Promise<string>
+  writeTempFile(name: string, content: string): Promise<string>
+  removeTempFile(path: string): Promise<void>
   getWebxdcDiskUsage(
     accountId: number
   ): Promise<{
@@ -130,21 +132,34 @@ interface Runtime {
     | ((kind: 'about' | 'keybindings' | 'settings') => void)
     | undefined
   onOpenQrUrl: ((url: string) => void) | undefined
+  onWebxdcSendFile:
+    | ((
+        file: { file_name: string; file_content: string } | null,
+        text: string | null
+      ) => void)
+    | undefined
 }
 
 class Browser implements Runtime {
-  onOpenQrUrl: ((url: string) => void) | undefined
+  onChooseLanguage: ((locale: string) => Promise<void>) | undefined
+  onThemeUpdate: (() => void) | undefined
   onShowDialog:
     | ((kind: 'about' | 'keybindings' | 'settings') => void)
     | undefined
+  onOpenQrUrl: ((url: string) => void) | undefined
+  onWebxdcSendFile:
+    | ((
+        file: { file_name: string; file_content: string } | null,
+        text: string | null
+      ) => void)
+    | undefined
+
   emitUIFullyReady(): void {
     throw new Error('Method not implemented.')
   }
   onDragFileOut(_file: string): void {
     throw new Error('Method not implemented.')
   }
-  onThemeUpdate: (() => void) | undefined
-  onChooseLanguage: ((locale: string) => Promise<void>) | undefined
   emitUIReady(): void {
     throw new Error('Method not implemented.')
   }
@@ -204,6 +219,12 @@ class Browser implements Runtime {
     throw new Error('Method not implemented.')
   }
   async writeClipboardToTempFile(): Promise<string> {
+    throw new Error('Method not implemented.')
+  }
+  writeTempFile(_name: string, _content: string): Promise<string> {
+    throw new Error('Method not implemented.')
+  }
+  removeTempFile(_name: string): Promise<void> {
     throw new Error('Method not implemented.')
   }
   setNotificationCallback(
@@ -298,6 +319,12 @@ class Browser implements Runtime {
   }
 }
 class Electron implements Runtime {
+  onWebxdcSendFile:
+    | ((
+        file: { file_name: string; file_content: string } | null,
+        text: string | null
+      ) => void)
+    | undefined
   onOpenQrUrl: ((url: string) => void) | undefined
   onShowDialog:
     | ((kind: 'about' | 'keybindings' | 'settings') => void)
@@ -373,6 +400,12 @@ class Electron implements Runtime {
   }
   async writeClipboardToTempFile(): Promise<string> {
     return ipcBackend.invoke('app.writeClipboardToTempFile')
+  }
+  writeTempFile(name: string, content: string): Promise<string> {
+    return ipcBackend.invoke('app.writeTempFile', name, content)
+  }
+  removeTempFile(path: string): Promise<void> {
+    return ipcBackend.invoke('app.removeTempFile', path)
   }
   private notificationCallback: (data: {
     accountId: number
@@ -511,6 +544,15 @@ class Electron implements Runtime {
     )
     ipcBackend.on('showSettingsDialog', () => this.onShowDialog?.('settings'))
     ipcBackend.on('open-url', (_ev, url) => this.onOpenQrUrl?.(url))
+    ipcBackend.on('open-url', (_ev, url) => this.onOpenQrUrl?.(url))
+    ipcBackend.on(
+      'webxdc.sendFileToChat',
+      (
+        _ev,
+        file: { file_name: string; file_content: string } | null,
+        text: string | null
+      ) => this.onWebxdcSendFile?.(file, text)
+    )
   }
   openHelpWindow(): void {
     ipcBackend.send('help', window.localeData.locale)

--- a/static/webxdc-preload.js
+++ b/static/webxdc-preload.js
@@ -121,7 +121,7 @@
         }
       }
 
-      await ipcRenderer.invoke('webxdc.sendFileToChat', file, content.text)
+      await ipcRenderer.invoke('webxdc.sendToChat', file, content.text)
     },
   }
 

--- a/static/webxdc-preload.js
+++ b/static/webxdc-preload.js
@@ -59,7 +59,7 @@
     sendToChat: async content => {
       if (!content.file && !content.text) {
         return Promise.reject(
-          'Error from sendToChat: either file or text need to be set'
+          'Error from sendToChat: Invalid empty message, at least one of text or file should be provided'
         )
       }
       /** @type {(file: Blob) => Promise<string>} */

--- a/static/webxdc.d.ts
+++ b/static/webxdc.d.ts
@@ -9,6 +9,9 @@ type SendingStatusUpdate<T> = {
    * usually only one line of text is shown,
    * use this option sparingly to not spam the chat. */
   info?: string
+  /** optional, if the Webxdc creates a document, you can set this to the name of the document;
+   * do not set if the Webxdc does not create a document */
+  document?: string
   /** optional, short text, shown beside the icon;
    * it is recommended to use some aggregated value,
    * eg. "8 votes", "Highscore: 123" */
@@ -24,17 +27,38 @@ type ReceivedStatusUpdate<T> = {
   max_serial: number
   /** optional, short, informational message. */
   info?: string
+  /** optional, if the Webxdc creates a document, this is the name of the document;
+   * not set if the Webxdc does not create a document */
+  document?: string
   /** optional, short text, shown beside the webxdc's icon. */
   summary?: string
 }
 
+type XDCFile = {
+  /** name of the file */
+  name: string
+} & (
+  | {
+      /** blob, also accepts types that inherit Blob, like File */
+      blob: Blob
+    }
+  | {
+      /** base64 encoded file data */
+      base64: string
+    }
+  | {
+      /** text for textfile, will be encoded as utf8 */
+      plainText: string
+    }
+)
+
 type sendOptions =
   | {
-      file: File
+      file: XDCFile
       text?: string
     }
   | {
-      file?: File
+      file?: XDCFile
       text: string
     }
 
@@ -49,17 +73,18 @@ interface Webxdc<T> {
    * set a listener for new status updates.
    * The "serial" specifies the last serial that you know about (defaults to 0).
    * Note that own status updates, that you send with {@link sendUpdate}, also trigger this method
+   * @returns promise that resolves when the listener has processed all the update messages known at the time when `setUpdateListener` was called.
    * */
   setUpdateListener(
     cb: (statusUpdate: ReceivedStatusUpdate<T>) => void,
-    serial: number
+    serial?: number
   ): Promise<void>
   /**
-   * WARNING! This function is deprecated, see setUpdateListener().
+   * @deprecated See {@link setUpdateListener|`setUpdateListener()`}.
    */
   getAllUpdates(): Promise<ReceivedStatusUpdate<T>[]>
   /**
-   * Webxdcs are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
+   * Webxdc are usually shared in a chat and run independently on each peer. To get a shared status, the peers use sendUpdate() to send updates to each other.
    * @param update status update to send
    * @param description short, human-readable description what this update is about. this is shown eg. as a fallback text in an email program.
    */
@@ -82,4 +107,4 @@ declare global {
 }
 ////////// ANCHOR_END: global
 
-export { SendingStatusUpdate, ReceivedStatusUpdate, Webxdc }
+export { SendingStatusUpdate, ReceivedStatusUpdate, Webxdc, XDCFile }

--- a/static/webxdc.d.ts
+++ b/static/webxdc.d.ts
@@ -28,6 +28,16 @@ type ReceivedStatusUpdate<T> = {
   summary?: string
 }
 
+type sendOptions =
+  | {
+      file: File
+      text?: string
+    }
+  | {
+      file?: File
+      text: string
+    }
+
 interface Webxdc<T> {
   /** Returns the peer's own address.
    *  This is esp. useful if you want to differ between different peers - just send the address along with the payload,
@@ -54,6 +64,14 @@ interface Webxdc<T> {
    * @param description short, human-readable description what this update is about. this is shown eg. as a fallback text in an email program.
    */
   sendUpdate(update: SendingStatusUpdate<T>, description: string): void
+  /**
+   * Send a message with file, text or both to a chat.
+   * Asks user to what Chat to send the message to.
+   * Always exits the xdc, please save your app state before calling this function
+   * @param content
+   * @returns returns a promise that never resolves (because the xdc closes), but is rejected on error.
+   */
+  sendToChat(content: sendOptions): Promise<void>
 }
 
 ////////// ANCHOR: global


### PR DESCRIPTION
also clear clipboard image/file after core copies it (needs testing) (would close #2927)

- [x] test deletion of clipboard pasted images (does the feature still work, also does it work on windows/linux/Mac)
    - [X] works on Mac, seems like I just tested with an image that did not work even before.
    - [X] linux works too @adbenitez tested it
- [x] additionally clear temporary draft folder on startup and shutdown of DC, just to be extra safe
- [x] is there is translation string yet for the dialog header?
- [x] test if webxdc save to chat feature works on all platforms (for testing use https://github.com/webxdc/webxdc-test/pull/11)
  - [x] Linux
  - [X] Mac
  - [x] Windows
- [x] change to new iteration of the api https://github.com/webxdc/webxdc_docs/pull/45
- [x] update changelog

close #3241 
close #2927