### PR TITLE
make sure, we always use the same path

### DIFF
--- a/src/main/cleanup_temp_dir.ts
+++ b/src/main/cleanup_temp_dir.ts
@@ -21,16 +21,16 @@ export async function cleanupDraftTempDir() {
 
     const files = await readdir(path)
     if (files.length !== 0) {
-        log.debug(
-          `found old ${files.length} temporary draft files, trying to delete them now`
-        )
-        const promises = []
-        for (const file in files) {
-          log.debug('delete', join(path, file))
-          promises.push(rm(join(path, file)))
-        }
-    
-        await Promise.all(promises)
+      log.debug(
+        `found old ${files.length} temporary draft files, trying to delete them now`
+      )
+      const promises = []
+      for (const file in files) {
+        log.debug('delete', join(path, file))
+        promises.push(rm(join(path, file)))
+      }
+
+      await Promise.all(promises)
     }
 
     // delete dir at the end

--- a/src/main/cleanup_temp_dir.ts
+++ b/src/main/cleanup_temp_dir.ts
@@ -9,8 +9,8 @@ const log = getLogger('main/cleanup_temp_dir')
 export async function cleanupDraftTempDir() {
   try {
     // ensure dir exists
-    await mkdir(getDraftTempDir(), { recursive: true })
     const path = getDraftTempDir()
+    await mkdir(path, { recursive: true })
     if (path.indexOf(app.getPath('temp')) === -1 || path.indexOf('..') !== -1) {
       log.error(
         'removeTempFile was called with a path that is outside of the temp dir: ',
@@ -26,8 +26,8 @@ export async function cleanupDraftTempDir() {
         )
         const promises = []
         for (const file in files) {
-          log.debug('delete', join(getDraftTempDir(), file))
-          promises.push(rm(join(getDraftTempDir(), file)))
+          log.debug('delete', join(path, file))
+          promises.push(rm(join(path, file)))
         }
     
         await Promise.all(promises)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,6 @@ import type { EventEmitter } from 'events'
 import contextMenu from './electron-context-menu'
 import { findOutIfWeAreRunningAsAppx } from './isAppx'
 import { getHelpMenu } from './help_menu'
-import { rm } from 'fs/promises'
 
 // Hardening: prohibit all DNS queries, except for Mapbox
 // (see src/renderer/components/map/MapComponent.tsx)
@@ -64,7 +63,6 @@ import {
   getLogsPath,
   getAccountsPath,
   getCustomThemesPath,
-  getDraftTempDir,
 } from './application-constants'
 mkdirSync(getConfigPath(), { recursive: true })
 mkdirSync(getLogsPath(), { recursive: true })


### PR DESCRIPTION
even if it seems unprobable that the temp dir ever changes during the function running,
it is better style not to mix `getDraftTempDir()` and `path` randomly and also underlines the gist better.

came over this during review of https://github.com/deltachat/deltachat-desktop/pull/3240