### PR TITLE
fix crash caused by dragging file attachment from draft

### DIFF
--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -195,14 +195,15 @@ export function DraftAttachment({
       </audio>
     )
   } else {
-    const { fileName, fileBytes, fileMime } = attachment
+    const { file, fileName, fileBytes, fileMime } = attachment
     const extension = getExtension(attachment)
+
     return (
       <div className={classNames('message-attachment-generic')}>
         <div
           className='file-icon'
           draggable='true'
-          onDragStart={ev => fileName && dragAttachmentOut(fileName, ev)}
+          onDragStart={ev => file && dragAttachmentOut(file, ev)}
           title={fileMime || 'null'}
         >
           {extension ? (


### PR DESCRIPTION
Fixes #3210 

Notes:

- `dragAttachmentOut` - which eventually calls [this electron api](https://www.electronjs.org/docs/latest/api/web-contents#contentsstartdragitem) - (implicitly) expects an absolute file path. The original issue was caused by providing `fileName` to this function, which is not a proper path in general. This PR uses the `file` field of the draft object, which represents the absolute path of the relevant file. This resembles the [implementation for dragging out media attachments](https://github.com/deltachat/deltachat-desktop/blob/a713ef666e782dd81231631dadc230ddf67e1d3d/src/renderer/components/attachment/mediaAttachment.tsx#L233)

---

Preview:

![3210-drag-file-attachment-from-draft](https://github.com/deltachat/deltachat-desktop/assets/18542095/5ce01676-31df-4a16-8029-ff9d2ba3c090)
