### PR TITLE
update timestamps and reconnect after resuming after sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - fix show verification state of chat in chatlist
 - fix make self contact not clickable in group member list
 - remove pasted images from temp folder #2927
+- update timestamps and reconnect after resuming after sleep
 
 <a id="1_36_4"></a>
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -289,3 +289,5 @@ ipcMain.handle('restart_app', async _ev => {
   app.relaunch()
   app.quit()
 })
+
+import './resume_from_sleep'

--- a/src/main/resume_from_sleep.ts
+++ b/src/main/resume_from_sleep.ts
@@ -1,0 +1,10 @@
+import { powerMonitor } from 'electron'
+import { window } from './windows/main'
+
+function onResumeFromSleep() {
+  window?.webContents.send('onResumeFromSleep')
+}
+
+powerMonitor.on('resume', onResumeFromSleep)
+powerMonitor.on('unlock-screen', onResumeFromSleep)
+powerMonitor.on('user-did-become-active', onResumeFromSleep)

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -21,6 +21,8 @@ import { updateDeviceChats } from './deviceMessages'
 import { runtime } from './runtime'
 import { DcEventType } from '@deltachat/jsonrpc-client'
 import WebxdcSaveToChatDialog from './components/dialogs/WebxdcSendToChatDialog'
+import { updateTimestamps } from './components/conversations/Timestamp'
+import { debounce } from 'debounce'
 
 const log = getLogger('renderer/ScreenController')
 
@@ -168,6 +170,13 @@ export default class ScreenController extends Component {
         file,
       })
     }
+    runtime.onResumeFromSleep = debounce(() => {
+      log.info('onResumeFromSleep')
+      // update timestamps
+      updateTimestamps()
+      // call maybe network
+      BackendRemote.rpc.maybeNetwork()
+    }, 1000)
 
     this.startup().then(() => {
       runtime.emitUIFullyReady()

--- a/src/renderer/components/conversations/Timestamp.tsx
+++ b/src/renderer/components/conversations/Timestamp.tsx
@@ -14,7 +14,7 @@ const updateRefs: { [key: string]: () => void } = {}
 // to prevent same key on same timestamp
 let deduplicationCounter = 0
 
-function updateTimestamps() {
+export function updateTimestamps() {
   if (document.hidden) {
     log.debug('updateTS: canceled page not visible')
     return

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -138,9 +138,11 @@ interface Runtime {
         text: string | null
       ) => void)
     | undefined
+  onResumeFromSleep: (() => void) | undefined
 }
 
 class Browser implements Runtime {
+  onResumeFromSleep: (() => void) | undefined
   onChooseLanguage: ((locale: string) => Promise<void>) | undefined
   onThemeUpdate: (() => void) | undefined
   onShowDialog:
@@ -319,6 +321,7 @@ class Browser implements Runtime {
   }
 }
 class Electron implements Runtime {
+  onResumeFromSleep: (() => void) | undefined
   onWebxcSendToChat:
     | ((
         file: { file_name: string; file_content: string } | null,
@@ -553,6 +556,7 @@ class Electron implements Runtime {
         text: string | null
       ) => this.onWebxcSendToChat?.(file, text)
     )
+    ipcBackend.on('onResumeFromSleep', () => this.onResumeFromSleep?.())
   }
   openHelpWindow(): void {
     ipcBackend.send('help', window.localeData.locale)


### PR DESCRIPTION
In my experience timestamps did not update reliable when resuming from standby before. Also sometimes it did not automatically reconnect after resuming after standby.

This pr listens for resume and unlock events and then updates timestamp and calls maybe_network.
