### PR TITLE
add global gallery / all-media view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - fix copy text inserts extra linebreaks
 - improve video message - wide enough to show controls
 - gallery: fix scroll to top when switching tabs
+- fix: context menu items could take up multiple lines
 
 <a id="1_40_4"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Experimental: Related Chats
 - Developer option to disable IMAP IDLE #4803
 - add option to save to file system to webxdc "send to chat"-dialog
+- add context menu option to delete media-messages from gallery
 
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.127.0`
@@ -32,11 +33,7 @@
 - open help, webxdc and html email windows with always on top flag, if main window has that flag. 
 - fix copy text inserts extra linebreaks
 - improve video message - wide enough to show controls
-
-
-### Fixed
-- fix clipboard not working in webxdc apps
-- fix scroll to top when switching tabs
+- gallery: fix scroll to top when switching tabs
 
 <a id="1_40_4"></a>
 
@@ -196,7 +193,6 @@ Also make opening devtools with F12 more reliable.
 - Show thumbnail in chatlist summary of image, sticker and webxdc messages
 - add webxdc api `sendToChat` #3240
 - add webxdc api `importFiles`
-- add context menu option to delete media-messages from gallery
 
 ### Changed
 - exclude more unused files from installation package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 
 ### Fixed
 - fix clipboard not working in webxdc apps
+- fix scroll to top when switching tabs
 
 <a id="1_40_4"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
+- Global Gallery
 - mark webxdc app context as secure #3413
 - Experimental: Related Chats
 - Developer option to disable IMAP IDLE #4803

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,7 @@ Also make opening devtools with F12 more reliable.
 - Show thumbnail in chatlist summary of image, sticker and webxdc messages
 - add webxdc api `sendToChat` #3240
 - add webxdc api `importFiles`
+- add context menu option to delete media-messages from gallery
 
 ### Changed
 - exclude more unused files from installation package

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@
 - fix copy text inserts extra linebreaks
 - improve video message - wide enough to show controls
 
+### Fixed
+- fix clipboard not working in webxdc apps
+
 <a id="1_40_4"></a>
 
 ## [1.40.4] - 2023-09-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Global Gallery
+- Show date when scrolling gallery
+- add option to view images and videos in the gallery cropped to grid or in their original aspect ratio
 - mark webxdc app context as secure #3413
 - Experimental: Related Chats
 - Developer option to disable IMAP IDLE #4803
@@ -30,6 +32,7 @@
 - open help, webxdc and html email windows with always on top flag, if main window has that flag. 
 - fix copy text inserts extra linebreaks
 - improve video message - wide enough to show controls
+
 
 ### Fixed
 - fix clipboard not working in webxdc apps

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -82,5 +82,11 @@
   },
   "group_related_chats": {
     "message": "Related Chats"
+  },
+  "gallery_image_aspect_ratio_keep": {
+    "message": "Image aspect ratio keep"
+  },
+  "gallery_image_aspect_ratio_grid": {
+    "message": "Image aspect ratio grid"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -83,10 +83,10 @@
   "group_related_chats": {
     "message": "Related Chats"
   },
-  "gallery_image_aspect_ratio_keep": {
-    "message": "Image aspect ratio keep"
+  "aspect_ratio_grid": {
+    "message": "Aspect Ratio Grid"
   },
-  "gallery_image_aspect_ratio_grid": {
-    "message": "Image aspect ratio grid"
+  "square_grid": {
+    "message": "Square Grid"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -88,5 +88,8 @@
   },
   "square_grid": {
     "message": "Square Grid"
+  },
+  "search_files": {
+    "message": "Search Files"
   }
 }

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -168,10 +168,11 @@
   display: flex;
   flex-direction: row;
   width: 300px;
-  margin: 5px 3px;
+  margin: 3.5px 3px;
 
   &:hover {
     background-color: var(--galleryWebxdcItem);
+    border-radius: calc(44px * 0.07); // same radius as webxdc icon
   }
 
   & > .icon {

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -71,6 +71,12 @@
       color: grey;
     }
   }
+
+  &.broken {
+    .name {
+      color: var(--colorDanger);
+    }
+  }
 }
 
 .media-attachment-generic {
@@ -145,6 +151,16 @@
       margin-top: 3px;
     }
   }
+
+  &.broken {
+    & > .file-icon {
+      cursor: unset;
+    }
+    .name,
+    .file-extension {
+      color: var(--colorDanger);
+    }
+  }
 }
 
 .media-attachment-webxdc {
@@ -193,6 +209,15 @@
       user-select: text;
       position: relative;
       word-break: break-all;
+    }
+  }
+
+  &.broken {
+    & > .icon {
+      background-color: var(--colorDanger);
+    }
+    .name {
+      color: var(--colorDanger);
     }
   }
 }

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -11,7 +11,7 @@
   padding: 2px;
 
   & > .attachment-content {
-    object-fit: cover;
+    object-fit: var(--gallery-image-object-fit);
     width: 100%;
     height: 100%;
     border-radius: 2px;

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -142,6 +142,12 @@
       user-select: text;
       position: relative;
       word-break: break-all;
+
+      .highlight {
+        background-color: yellow;
+        color: black;
+        border-radius: 1.8px;
+      }
     }
 
     & > .size {

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -66,11 +66,25 @@
       font-size: 17px;
       display: inline-block;
       font-weight: bold;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      max-width: calc(100% - 90px);
     }
     & > span.date {
       float: right;
       color: grey;
     }
+  }
+
+  audio {
+    width: 100%;
+  }
+  
+  // overwrite chromium user agent styles to make it look a tiny bit better
+  // but the real solution would be using a custom player
+  audio::-webkit-media-controls-panel, audio::-webkit-media-controls-enclosure {
+    background: transparent;
   }
 
   &.broken {

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -83,17 +83,19 @@
 .media-attachment-generic {
   display: flex;
   flex-direction: row;
-  width: 300px;
-  margin: 5px 3px;
+  width: 100%;
+  padding: 5px;
+
+  &:hover {
+    background: var(--galleryFileRowHover);
+    border-radius: 5px;
+  }
 
   & > .file-icon {
     background: url('../images/file-gradient.svg') no-repeat center;
-    height: 44px;
-    width: 56px;
-    margin-left: -13px;
-    margin-right: -14px;
-    margin-bottom: -4px;
-    cursor: pointer;
+    height: 49px;
+    $file-icon-width: 42px;
+    width: $file-icon-width;
 
     // So we can center the extension text inside this icon
     display: flex;
@@ -101,14 +103,14 @@
     align-items: center;
 
     & > .file-extension {
-      font-size: 10px;
+      font-size: 8px;
       line-height: 13px;
       letter-spacing: 0.1px;
       text-transform: uppercase;
 
       // Along with flow layout in parent item, centers text
       text-align: center;
-      width: 25px;
+      width: $file-icon-width;
       margin-left: auto;
       margin-right: auto;
 
@@ -122,41 +124,59 @@
     }
   }
 
-  & > .text-part {
+  align-items: center;
+  position: relative;
+
+  $size_width: 70px;
+  $date_width: 120px;
+
+  & > .name {
     flex-grow: 1;
-    margin-left: 8px;
-    // The width of the icon plus our 8px margin
-    max-width: calc(100% - 37px);
+    //width: calc(100% - $size_width - $date_width);
+  }
+  & > .size {
+    width: $size_width;
+    flex-shrink: 0;
+  }
+  & > .date {
+    width: $date_width;
+    flex-shrink: 0;
+  }
 
-    & > .name {
-      color: var(--messageAttachmentFileInfo);
-      font-size: 14px;
-      line-height: 18px;
-      font-weight: 300;
-      margin-top: 2px;
+  & > .name {
+    color: var(--messageAttachmentFileInfo);
+    font-size: 14px;
+    line-height: 18px;
 
-      // Handling really long filenames - cut them off
-      overflow-x: hidden;
-      display: inline-block;
-      white-space: pre-line;
-      user-select: text;
-      position: relative;
-      word-break: break-all;
+    // Handling really long filenames - cut them off
+    overflow-x: hidden;
+    display: inline-block;
+    white-space: pre-line;
+    user-select: text;
+    position: relative;
+    word-break: break-all;
 
-      .highlight {
-        background-color: var(--colorPrimary);
-        color: white;
-        border-radius: 1.8px;
-      }
+    .highlight {
+      background-color: var(--colorPrimary);
+      color: white;
+      border-radius: 1.8px;
     }
+  }
 
-    & > .size {
-      color: var(--messageAttachmentFileInfo);
-      font-size: 11px;
-      line-height: 16px;
-      letter-spacing: 0.3px;
-      margin-top: 3px;
-    }
+  & > .date {
+    color: var(--messageAttachmentFileInfo);
+    font-size: 14px;
+    line-height: 18px;
+    text-align: end;
+  }
+
+  & > .size {
+    color: var(--messageAttachmentFileInfo);
+    font-size: 11px;
+    line-height: 16px;
+    letter-spacing: 0.3px;
+    margin-top: 3px;
+    text-align: end;
   }
 
   &.broken {

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -5,15 +5,16 @@
   cursor: pointer;
 
   overflow: hidden;
+  height: 100%;
+  width: 100%;
+  border-radius: 2px;
+  padding: 2px;
 
   & > .attachment-content {
     object-fit: cover;
-    width: 120pt;
-    height: 120pt;
-
-    // The padding on the bottom of the bubble produces 4 extra pixels of space at the
-    //   bottom, so this doesn't match up with the padding numbers above.
-    margin-bottom: -4px;
+    width: 100%;
+    height: 100%;
+    border-radius: 2px;
 
     // redundant with attachment-container, but we get cursor flashing on move otherwise
     cursor: pointer;

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -206,7 +206,6 @@
     .summary {
       // Handling really long names - cut them off
       overflow-x: hidden;
-      white-space: pre-line;
       user-select: text;
       position: relative;
       word-break: break-all;

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -144,8 +144,8 @@
       word-break: break-all;
 
       .highlight {
-        background-color: yellow;
-        color: black;
+        background-color: var(--colorPrimary);
+        color: white;
         border-radius: 1.8px;
       }
     }

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -83,7 +83,7 @@
 .media-attachment-generic {
   display: flex;
   flex-direction: row;
-  width: 100%;
+  width: calc(100% - 5px);
   padding: 5px;
 
   &:hover {

--- a/scss/gallery/_media-attachment.scss
+++ b/scss/gallery/_media-attachment.scss
@@ -80,10 +80,11 @@
   audio {
     width: 100%;
   }
-  
+
   // overwrite chromium user agent styles to make it look a tiny bit better
   // but the real solution would be using a custom player
-  audio::-webkit-media-controls-panel, audio::-webkit-media-controls-enclosure {
+  audio::-webkit-media-controls-panel,
+  audio::-webkit-media-controls-enclosure {
     background: transparent;
   }
 

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -14,8 +14,9 @@ $tab-height: 46px;
     text-align: end;
     align-self: center;
     padding-right: 12px;
-    font-size: 22px;
-    font-weight: bold;
+    font-size: 18px;
+    color: var(--summary-text-color);
+    white-space: nowrap;
   }
 
   & .gallery {

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -20,7 +20,7 @@ $tab-height: 46px;
 
   & .gallery {
     height: calc(100vh - #{$tab-height} - #{$nav-bar-height});
-  
+
     & > .empty-screen {
       display: flex;
       padding: 10px 10px;

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -9,6 +9,15 @@ $tab-height: 46px;
   max-height: calc(100vh - 50px);
   overflow: hidden;
 
+  .big-date {
+    flex-grow: 1;
+    text-align: end;
+    align-self: center;
+    padding-right: 12px;
+    font-size: 22px;
+    font-weight: bold;
+  }
+
   & .gallery {
     height: calc(100vh - #{$tab-height} - #{$nav-bar-height});
 

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -20,17 +20,7 @@ $tab-height: 46px;
 
   & .gallery {
     height: calc(100vh - #{$tab-height} - #{$nav-bar-height});
-
-    & > .item-container {
-      // .item-container is still used by file view
-      display: flex;
-      flex-wrap: wrap;
-      padding: 10px 0px;
-      & > .item {
-        padding: 5px 5px 5px 5px;
-      }
-    }
-
+  
     & > .empty-screen {
       display: flex;
       padding: 10px 10px;

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -57,4 +57,13 @@ $tab-height: 46px;
   .bp4-tab-panel {
     margin-top: 0;
   }
+
+  .searchbar {
+    input {
+      border: none;
+      border-bottom: 1px solid grey;
+      background: transparent;
+      color: var(--textPrimary);
+    }
+  }
 }

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -12,12 +12,25 @@ $tab-height: 46px;
   & .gallery {
     height: calc(100vh - #{$tab-height} - #{$nav-bar-height});
 
-    & > .item-container {
+    & > .item-container { // still used by file view
       display: flex;
       flex-wrap: wrap;
       padding: 10px 0px;
       & > .item {
         padding: 5px 5px 5px 5px;
+      }
+    }
+
+    & > .empty-screen {
+      display: flex;
+      padding: 10px 10px;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      width: 100%;
+      & > .no-media-message {
+        font-size: 1.1rem;
+        text-align: center;
       }
     }
 
@@ -31,12 +44,6 @@ $tab-height: 46px;
         margin: 0;
       }
     }
-  }
-  .no-media-message {
-    font-size: 1.1rem;
-    text-align: center;
-    margin-top: 5rem;
-    margin-left: 0.5rem;
   }
 
   .bp4-tab-panel {

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -10,7 +10,6 @@ $tab-height: 46px;
   overflow: hidden;
 
   & .gallery {
-    overflow: scroll;
     height: calc(100vh - #{$tab-height} - #{$nav-bar-height});
 
     & > .item-container {

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -12,7 +12,8 @@ $tab-height: 46px;
   & .gallery {
     height: calc(100vh - #{$tab-height} - #{$nav-bar-height});
 
-    & > .item-container { // still used by file view
+    & > .item-container {
+      // .item-container is still used by file view
       display: flex;
       flex-wrap: wrap;
       padding: 10px 0px;
@@ -43,6 +44,13 @@ $tab-height: 46px;
         font-size: medium;
         margin: 0;
       }
+    }
+
+    &.gallery-image-object-fit_contain {
+      --gallery-image-object-fit: contain;
+    }
+    &.gallery-image-object-fit_cover {
+      --gallery-image-object-fit: cover;
     }
   }
 

--- a/scss/misc/_context_menu.scss
+++ b/scss/misc/_context_menu.scss
@@ -31,6 +31,7 @@
   .item {
     line-height: 20px;
     padding: 5px 12px;
+    white-space: nowrap;
 
     &:hover {
       background-color: var(--chatListItemBgHover);

--- a/src/renderer/components/Avatar.tsx
+++ b/src/renderer/components/Avatar.tsx
@@ -4,7 +4,9 @@ import { useContext } from 'react'
 import classNames from 'classnames'
 import { ScreenContext } from '../contexts'
 import { Type } from '../backend-com'
-import FullscreenMedia from './dialogs/FullscreenMedia'
+import FullscreenMedia, {
+  NeighboringMediaMode,
+} from './dialogs/FullscreenMedia'
 import { T } from '@deltachat/jsonrpc-client'
 
 export function QRAvatar() {
@@ -109,6 +111,7 @@ export function ClickForFullscreenAvatarWrapper(props: {
             fileMime: 'image/x',
             file: props.filename,
           } as T.Message,
+          neighboringMedia: NeighboringMediaMode.Off,
         })
       }}
       style={{

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -69,13 +69,25 @@ export default class Gallery extends Component<
     }
   }
 
+  reset(){
+    this.setState({
+      id: 'images',
+      msgTypes: MediaTabs.images.values,
+      element: ImageAttachment,
+      mediaMessageIds: [],
+      mediaLoadResult: {},
+    })
+  }
+
   componentDidMount() {
     this.onSelect(this.state.id)
   }
 
   componentDidUpdate(prevProps: mediaProps) {
     if (this.props.chatId !== prevProps.chatId) {
-      this.onSelect(this.state.id)
+      // reset
+      this.reset()
+      this.onSelect('images')
     }
   }
 
@@ -150,7 +162,10 @@ export default class Gallery extends Component<
             })}
           </ul>
           <div className='bp4-tab-panel' role='tabpanel'>
-            <div className='gallery'>
+            <div
+              className='gallery'
+              key={this.state.msgTypes.join('.') + String(this.props.chatId)}
+            >
               <div className='item-container'>
                 {mediaMessageIds.length < 1 ? (
                   <p className='no-media-message'>{emptyTabMessage}</p>

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -220,17 +220,13 @@ export default class Gallery extends Component<
 
     const filteredMediaMessageIds = mediaMessageIds.filter(id => {
       const result = mediaLoadResult[id]
-      if (
-        result.kind === 'message' &&
-        result.fileName?.indexOf(queryText) !== -1
-      ) {
-        return true
-      } else {
-        return false
-      }
+      return (
+        result.kind === 'message' && result.fileName?.indexOf(queryText) !== -1
+      )
     })
 
-    const showDateHeader = currentTab !== 'files' && currentTab !== 'webxdc_apps'
+    const showDateHeader =
+      currentTab !== 'files' && currentTab !== 'webxdc_apps'
 
     return (
       <div className='media-view'>

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -58,6 +58,7 @@ export default class Gallery extends Component<
     element: (props: GalleryAttachmentElementProps) => JSX.Element
     mediaMessageIds: number[]
     mediaLoadResult: Record<number, Type.MessageLoadResult>
+    loading: boolean
   }
 > {
   constructor(props: mediaProps) {
@@ -68,6 +69,7 @@ export default class Gallery extends Component<
       element: ImageAttachment,
       mediaMessageIds: [],
       mediaLoadResult: {},
+      loading: true,
     }
   }
 
@@ -78,6 +80,7 @@ export default class Gallery extends Component<
       element: ImageAttachment,
       mediaMessageIds: [],
       mediaLoadResult: {},
+      loading: true,
     })
   }
 
@@ -101,6 +104,7 @@ export default class Gallery extends Component<
     const newElement = MediaTabs[id].element
     const accountId = selectedAccountId()
     const chatId = this.props.chatId !== 'all' ? this.props.chatId : null
+    this.setState({ loading: true })
 
     BackendRemote.rpc
       .getChatMedia(accountId, chatId, msgTypes[0], msgTypes[1], null)
@@ -116,6 +120,7 @@ export default class Gallery extends Component<
           element: newElement,
           mediaMessageIds: media_ids,
           mediaLoadResult,
+          loading: false,
         })
         this.forceUpdate()
       })
@@ -140,7 +145,7 @@ export default class Gallery extends Component<
   }
 
   render() {
-    const { mediaMessageIds, mediaLoadResult, id } = this.state
+    const { mediaMessageIds, mediaLoadResult, id, loading } = this.state
     const tx = window.static_translate // static because dynamic isn't too important here
     const emptyTabMessage = this.emptyTabMessage(id)
 
@@ -174,14 +179,15 @@ export default class Gallery extends Component<
                     : undefined,
               }}
             >
-              <div className='item-container'>
-                {mediaMessageIds.length < 1 ? (
+              {mediaMessageIds.length < 1 && !loading && (
+                <div className='item-container'>
                   <p className='no-media-message'>{emptyTabMessage}</p>
-                ) : (
-                  ''
-                )}
-                {this.state.id === 'files' &&
-                  mediaMessageIds.map(msgId => {
+                </div>
+              )}
+
+              {this.state.id === 'files' && (
+                <div className='item-container'>
+                  {mediaMessageIds.map(msgId => {
                     const message = mediaLoadResult[msgId]
                     return (
                       <div className='item' key={msgId}>
@@ -192,7 +198,8 @@ export default class Gallery extends Component<
                       </div>
                     )
                   })}
-              </div>
+                </div>
+              )}
 
               {this.state.id !== 'files' && (
                 <AutoSizer>

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -283,17 +283,26 @@ export default class Gallery extends Component<
               )}
 
               {this.state.id === 'files' && (
-                <AutoSizer>
-                  {({ width, height }) => (
-                    <FileTable
-                      width={width}
-                      height={height}
-                      mediaLoadResult={mediaLoadResult}
-                      mediaMessageIds={filteredMediaMessageIds}
-                      queryText={queryText}
-                    ></FileTable>
+                <>
+                  <AutoSizer>
+                    {({ width, height }) => (
+                      <FileTable
+                        width={width}
+                        height={height}
+                        mediaLoadResult={mediaLoadResult}
+                        mediaMessageIds={filteredMediaMessageIds}
+                        queryText={queryText}
+                      ></FileTable>
+                    )}
+                  </AutoSizer>
+                  {filteredMediaMessageIds.length === 0 && (
+                    <div className='empty-screen'>
+                      <p className='no-media-message'>
+                        {tx('search_no_result_for_x', queryText)}
+                      </p>
+                    </div>
                   )}
-                </AutoSizer>
+                </>
               )}
               {/* TODO empty state for no search result on files, maybe including query text */}
 

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -15,16 +15,25 @@ import AutoSizer from 'react-virtualized-auto-sizer'
 import { FixedSizeGrid } from 'react-window'
 import SettingsStoreInstance, { SettingsStoreState } from '../stores/settings'
 import moment from 'moment'
+import FullscreenMedia, {
+  NeighboringMediaMode,
+} from './dialogs/FullscreenMedia'
 
 const log = getLogger('renderer/Gallery')
 
 type MediaTabKey = 'images' | 'video' | 'audio' | 'files' | 'webxdc_apps'
 
+type GalleryElement = (
+  props: GalleryAttachmentElementProps & {
+    openFullscreenMedia: (message: Type.Message) => void
+  }
+) => JSX.Element
+
 const MediaTabs: Readonly<
   {
     [key in MediaTabKey]: {
       values: Type.Viewtype[]
-      element: (props: GalleryAttachmentElementProps) => JSX.Element
+      element: GalleryElement
     }
   }
 > = {
@@ -57,7 +66,7 @@ export default class Gallery extends Component<
   {
     id: MediaTabKey
     msgTypes: Type.Viewtype[]
-    element: (props: GalleryAttachmentElementProps) => JSX.Element
+    element: GalleryElement
     mediaMessageIds: number[]
     mediaLoadResult: Record<number, Type.MessageLoadResult>
     loading: boolean
@@ -184,6 +193,16 @@ export default class Gallery extends Component<
           message.timestamp * 1000
         ).format('LL')
     }
+  }
+
+  openFullscreenMedia(message: Type.Message) {
+    window.__openDialog(FullscreenMedia, {
+      msg: message,
+      neighboringMedia:
+        this.props.chatId === 'all'
+          ? NeighboringMediaMode.Global
+          : NeighboringMediaMode.Chat,
+    })
   }
 
   render() {
@@ -354,6 +373,9 @@ export default class Gallery extends Component<
                               <this.state.element
                                 msgId={msgId}
                                 load_result={message}
+                                openFullscreenMedia={this.openFullscreenMedia.bind(
+                                  this
+                                )}
                               />
                             </div>
                           )

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -336,11 +336,8 @@ export default class Gallery extends Component<
                     if (this.state.id === 'webxdc_apps') {
                       itemHeight = 61
                     } else if (this.state.id === 'audio') {
-                      itemHeight = 88
+                      itemHeight = 94
                     }
-
-                    const border =
-                      this.state.id === 'audio' ? '1px solid black' : undefined
 
                     return (
                       <FixedSizeGrid
@@ -378,7 +375,7 @@ export default class Gallery extends Component<
                           }
                           return (
                             <div
-                              style={{ ...style, border }}
+                              style={{ ...style }}
                               className='item'
                               key={msgId}
                             >

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -214,9 +214,9 @@ export default class Gallery extends Component<
                       minWidth = 322
                     }
 
-                    const itemsPerRow = Math.floor(
+                    const itemsPerRow = Math.max(Math.floor(
                       widthWithoutScrollbar / minWidth
-                    )
+                    ), 1)
 
                     let itemWidth = widthWithoutScrollbar / itemsPerRow
 

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, Component } from 'react'
+import React, { ChangeEvent, Component, createRef } from 'react'
 import { ScreenContext } from '../contexts'
 import {
   AudioAttachment,
@@ -14,7 +14,7 @@ import { selectedAccountId } from '../ScreenController'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { FixedSizeGrid } from 'react-window'
 import SettingsStoreInstance, { SettingsStoreState } from '../stores/settings'
-import moment, { Moment } from 'moment'
+import moment from 'moment'
 
 const log = getLogger('renderer/Gallery')
 
@@ -63,9 +63,9 @@ export default class Gallery extends Component<
     loading: boolean
     queryText: string
     GalleryImageKeepAspectRatio?: boolean
-    dateMoment?: Moment
   }
 > {
+  dateHeader = createRef<HTMLDivElement>()
   constructor(props: mediaProps) {
     super(props)
     this.state = {
@@ -77,7 +77,6 @@ export default class Gallery extends Component<
       loading: true,
       queryText: '',
       GalleryImageKeepAspectRatio: false,
-      dateMoment: undefined,
     }
 
     this.settingsStoreListener = this.settingsStoreListener.bind(this)
@@ -92,7 +91,6 @@ export default class Gallery extends Component<
       mediaLoadResult: {},
       loading: true,
       queryText: '',
-      dateMoment: undefined,
     })
   }
 
@@ -152,7 +150,6 @@ export default class Gallery extends Component<
           mediaMessageIds: media_ids,
           mediaLoadResult,
           loading: false,
-          dateMoment: undefined,
         })
         this.forceUpdate()
       })
@@ -182,9 +179,10 @@ export default class Gallery extends Component<
 
   updateFirstVisibleMessage(message: Type.MessageLoadResult) {
     if (message.variant === 'message') {
-      this.setState({
-        dateMoment: moment(message.timestamp * 1000),
-      })
+      if (this.dateHeader.current)
+        this.dateHeader.current.innerText = moment(
+          message.timestamp * 1000
+        ).format('LL')
     }
   }
 
@@ -233,10 +231,8 @@ export default class Gallery extends Component<
                 </li>
               )
             })}
-            {showDateHeader && this.state.dateMoment && (
-              <div className='big-date'>
-                {this.state.dateMoment.format('LL')}
-              </div>
+            {showDateHeader && (
+              <div className='big-date' ref={this.dateHeader}></div>
             )}
           </ul>
           <div role='tabpanel'>

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -146,7 +146,7 @@ export default class Gallery extends Component<
 
     return (
       <div className='media-view'>
-        <div className='bp4-tabs' style={{ minWidth: 200 }}>
+        <div style={{ minWidth: 200 }}>
           <ul className='bp4-tab-list .modifier' role='tablist'>
             {Object.keys(MediaTabs).map(realId => {
               const id = realId as MediaTabKey
@@ -163,7 +163,7 @@ export default class Gallery extends Component<
               )
             })}
           </ul>
-          <div className='bp4-tab-panel' role='tabpanel'>
+          <div role='tabpanel'>
             <div
               className='gallery'
               key={this.state.msgTypes.join('.') + String(this.props.chatId)}

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -209,7 +209,7 @@ export default class Gallery extends Component<
                     let minWidth = 160
 
                     if (this.state.id === 'webxdc_apps') {
-                      minWidth = 300
+                      minWidth = 265
                     } else if (this.state.id === 'audio') {
                       minWidth = 322
                     }
@@ -227,14 +227,13 @@ export default class Gallery extends Component<
                     let itemHeight = itemWidth
 
                     if (this.state.id === 'webxdc_apps') {
-                      itemHeight = 64
+                      itemHeight = 61
                     } else if (this.state.id === 'audio') {
                       itemHeight = 88
                     }
 
                     const border =
-                      this.state.id === 'audio' ||
-                      this.state.id === 'webxdc_apps'
+                      this.state.id === 'audio'
                         ? '1px solid black'
                         : undefined
 

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -174,7 +174,7 @@ export default class Gallery extends Component<
                     : undefined,
               }}
             >
-              {!(this.state.id === 'images' || this.state.id === 'video') && (
+              {this.state.id === 'files' && (
                 <div className='item-container'>
                   {mediaMessageIds.length < 1 ? (
                     <p className='no-media-message'>{emptyTabMessage}</p>
@@ -195,23 +195,48 @@ export default class Gallery extends Component<
                 </div>
               )}
 
-              {(this.state.id === 'images' || this.state.id === 'video') && (
+              {this.state.id !== 'files' && (
                 <AutoSizer>
                   {({ width, height }) => {
-                    const size = 200 // TODO: calc this stuff
-                    const itemsPerRow = Math.floor(width / size)
+                    const widthWithoutScrollbar = width - 6
+
+                    let minWidth = 160
+
+                    if (this.state.id === 'webxdc_apps') {
+                      minWidth = 300
+                    }
+                    if (this.state.id === 'audio') {
+                      minWidth = 322
+                    }
+
+                    const itemsPerRow = Math.floor(
+                      widthWithoutScrollbar / minWidth
+                    )
+
+                    let itemWidth = widthWithoutScrollbar / itemsPerRow
+
                     const rowCount = Math.ceil(
                       mediaMessageIds.length / itemsPerRow
                     )
+
+                    let itemHeight = itemWidth
+
+                    if (this.state.id === 'webxdc_apps') {
+                      itemHeight = 64
+                    }
+                    if (this.state.id === 'audio') {
+                      itemHeight = 88
+                    }
 
                     return (
                       <FixedSizeGrid
                         width={width}
                         height={height}
-                        columnWidth={size}
-                        rowHeight={size}
+                        columnWidth={itemWidth}
+                        rowHeight={itemHeight}
                         columnCount={itemsPerRow}
                         rowCount={rowCount}
+                        
                       >
                         {({ columnIndex, rowIndex, style }) => {
                           const msgId =

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -209,7 +209,8 @@ export default class Gallery extends Component<
               }}
             >
               {mediaMessageIds.length < 1 && !loading && (
-                <div className='item-container'>
+                <div className='empty-screen'>
+                  {/* IDEA: when we have someone doing illustrations this would be a great place to add some */}
                   <p className='no-media-message'>{emptyTabMessage}</p>
                 </div>
               )}

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -31,7 +31,7 @@ const MediaTabs: Readonly<
   },
 }
 
-type mediaProps = { chatId: number }
+type mediaProps = { chatId: number | 'all' }
 
 export default class Gallery extends Component<
   mediaProps,
@@ -67,16 +67,11 @@ export default class Gallery extends Component<
       throw new Error('chat id missing')
     }
     const msgTypes = MediaTabs[id].values
-
     const accountId = selectedAccountId()
+    const chatId = this.props.chatId !== 'all' ? this.props.chatId : null
+
     BackendRemote.rpc
-      .getChatMedia(
-        accountId,
-        this.props.chatId,
-        msgTypes[0],
-        msgTypes[1],
-        null
-      )
+      .getChatMedia(accountId, chatId, msgTypes[0], msgTypes[1], null)
       .then(async media_ids => {
         // throws if some media is not found
         const all_media_fetch_results = await BackendRemote.rpc.getMessages(

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -304,7 +304,6 @@ export default class Gallery extends Component<
                   )}
                 </>
               )}
-              {/* TODO empty state for no search result on files, maybe including query text */}
 
               {this.state.id !== 'files' && (
                 <AutoSizer>

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -196,7 +196,7 @@ export default class Gallery extends Component<
           <div role='tabpanel'>
             {this.state.id === 'files' && (
               <input
-                type='text'
+                type='search'
                 placeholder='search files'
                 onChange={this.onChangeInput.bind(this)}
               />

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -174,14 +174,14 @@ export default class Gallery extends Component<
                     : undefined,
               }}
             >
-              {this.state.id === 'files' && (
-                <div className='item-container'>
-                  {mediaMessageIds.length < 1 ? (
-                    <p className='no-media-message'>{emptyTabMessage}</p>
-                  ) : (
-                    ''
-                  )}
-                  {mediaMessageIds.map(msgId => {
+              <div className='item-container'>
+                {mediaMessageIds.length < 1 ? (
+                  <p className='no-media-message'>{emptyTabMessage}</p>
+                ) : (
+                  ''
+                )}
+                {this.state.id === 'files' &&
+                  mediaMessageIds.map(msgId => {
                     const message = mediaLoadResult[msgId]
                     return (
                       <div className='item' key={msgId}>
@@ -192,8 +192,7 @@ export default class Gallery extends Component<
                       </div>
                     )
                   })}
-                </div>
-              )}
+              </div>
 
               {this.state.id !== 'files' && (
                 <AutoSizer>
@@ -204,8 +203,7 @@ export default class Gallery extends Component<
 
                     if (this.state.id === 'webxdc_apps') {
                       minWidth = 300
-                    }
-                    if (this.state.id === 'audio') {
+                    } else if (this.state.id === 'audio') {
                       minWidth = 322
                     }
 
@@ -223,10 +221,15 @@ export default class Gallery extends Component<
 
                     if (this.state.id === 'webxdc_apps') {
                       itemHeight = 64
-                    }
-                    if (this.state.id === 'audio') {
+                    } else if (this.state.id === 'audio') {
                       itemHeight = 88
                     }
+
+                    const border =
+                      this.state.id === 'audio' ||
+                      this.state.id === 'webxdc_apps'
+                        ? '1px solid black'
+                        : undefined
 
                     return (
                       <FixedSizeGrid
@@ -249,7 +252,7 @@ export default class Gallery extends Component<
                           }
                           return (
                             <div
-                              style={{ ...style, border: '1px solid black' }}
+                              style={{ ...style, border }}
                               className='item'
                               key={msgId}
                             >

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -236,7 +236,7 @@ export default class Gallery extends Component<
                         rowHeight={itemHeight}
                         columnCount={itemsPerRow}
                         rowCount={rowCount}
-                        
+                        overscanRowCount={10}
                       >
                         {({ columnIndex, rowIndex, style }) => {
                           const msgId =

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -260,11 +260,13 @@ export default class Gallery extends Component<
             {this.state.id === 'files' && (
               <>
                 <div style={{ flexGrow: 1 }}></div>
-                <input
-                  type='search'
-                  placeholder='search files'
-                  onChange={this.onChangeInput.bind(this)}
-                />
+                <div className='searchbar'>
+                  <input
+                    type='search'
+                    placeholder='search files'
+                    onChange={this.onChangeInput.bind(this)}
+                  />
+                </div>
               </>
             )}
           </ul>

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -1,6 +1,13 @@
 import React, { Component } from 'react'
 import { ScreenContext } from '../contexts'
-import MediaAttachment from './attachment/mediaAttachment'
+import {
+  AudioAttachment,
+  FileAttachment,
+  GalleryAttachmentElementProps,
+  ImageAttachment,
+  VideoAttachment,
+  WebxdcAttachment,
+} from './attachment/mediaAttachment'
 import { getLogger } from '../../shared/logger'
 import { BackendRemote, Type } from '../backend-com'
 import { selectedAccountId } from '../ScreenController'
@@ -11,23 +18,31 @@ type MediaTabKey = 'images' | 'video' | 'audio' | 'files' | 'webxdc_apps'
 
 const MediaTabs: Readonly<
   {
-    [key in MediaTabKey]: { values: Type.Viewtype[] }
+    [key in MediaTabKey]: {
+      values: Type.Viewtype[]
+      element: (props: GalleryAttachmentElementProps) => JSX.Element
+    }
   }
 > = {
   images: {
     values: ['Gif', 'Image'],
+    element: ImageAttachment,
   },
   video: {
     values: ['Video'],
+    element: VideoAttachment,
   },
   audio: {
     values: ['Audio', 'Voice'],
+    element: AudioAttachment,
   },
   files: {
     values: ['File'],
+    element: FileAttachment,
   },
   webxdc_apps: {
     values: ['Webxdc'],
+    element: WebxdcAttachment,
   },
 }
 
@@ -38,8 +53,9 @@ export default class Gallery extends Component<
   {
     id: MediaTabKey
     msgTypes: Type.Viewtype[]
-    medias: Type.Message[]
-    errors: { msgId: number; error: string }[]
+    element: (props: GalleryAttachmentElementProps) => JSX.Element
+    mediaMessageIds: number[]
+    mediaLoadResult: Record<number, Type.MessageLoadResult>
   }
 > {
   constructor(props: mediaProps) {
@@ -47,8 +63,9 @@ export default class Gallery extends Component<
     this.state = {
       id: 'images',
       msgTypes: MediaTabs.images.values,
-      medias: [],
-      errors: [],
+      element: ImageAttachment,
+      mediaMessageIds: [],
+      mediaLoadResult: {},
     }
   }
 
@@ -67,29 +84,25 @@ export default class Gallery extends Component<
       throw new Error('chat id missing')
     }
     const msgTypes = MediaTabs[id].values
+    const newElement = MediaTabs[id].element
     const accountId = selectedAccountId()
     const chatId = this.props.chatId !== 'all' ? this.props.chatId : null
 
     BackendRemote.rpc
       .getChatMedia(accountId, chatId, msgTypes[0], msgTypes[1], null)
       .then(async media_ids => {
-        // throws if some media is not found
-        const all_media_fetch_results = await BackendRemote.rpc.getMessages(
+        const mediaLoadResult = await BackendRemote.rpc.getMessages(
           accountId,
           media_ids
         )
-        const medias: Type.Message[] = []
-        const errors = []
-        for (const msgId of media_ids) {
-          const result = all_media_fetch_results[msgId]
-          if (result.kind === 'message') {
-            medias.push(result)
-          } else {
-            errors.push({ msgId, error: result.error })
-          }
-        }
-        log.errorWithoutStackTrace('messages failed to load:', errors)
-        this.setState({ id, msgTypes, medias, errors })
+        media_ids.reverse() // order newest up - if we need different ordering we need to do it in core
+        this.setState({
+          id,
+          msgTypes,
+          element: newElement,
+          mediaMessageIds: media_ids,
+          mediaLoadResult,
+        })
         this.forceUpdate()
       })
       .catch(log.error.bind(log))
@@ -113,7 +126,7 @@ export default class Gallery extends Component<
   }
 
   render() {
-    const { medias, id, errors } = this.state
+    const { mediaMessageIds, mediaLoadResult, id } = this.state
     const tx = window.static_translate // static because dynamic isn't too important here
     const emptyTabMessage = this.emptyTabMessage(id)
 
@@ -138,39 +151,20 @@ export default class Gallery extends Component<
           </ul>
           <div className='bp4-tab-panel' role='tabpanel'>
             <div className='gallery'>
-              {errors.length > 0 && (
-                <div className='loading-errors'>
-                  The following messages failed to load, please report these
-                  errors to the developers:
-                  <ul>
-                    {errors.map(error => (
-                      <li key={error.msgId}>
-                        {error.msgId} {'->'} {error.error}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              )}
-              <div
-                className='item-container'
-                style={{
-                  justifyContent: medias.length < 1 ? 'center' : undefined,
-                }}
-              >
-                {medias.length < 1 ? (
+              <div className='item-container'>
+                {mediaMessageIds.length < 1 ? (
                   <p className='no-media-message'>{emptyTabMessage}</p>
                 ) : (
                   ''
                 )}
-                {medias
-                  .sort((a, b) => b.sortTimestamp - a.sortTimestamp)
-                  .map(message => {
-                    return (
-                      <div className='item' key={message.id}>
-                        <MediaAttachment message={message} />
-                      </div>
-                    )
-                  })}
+                {mediaMessageIds.map(msgId => {
+                  const message = mediaLoadResult[msgId]
+                  return (
+                    <div className='item' key={msgId}>
+                      <this.state.element msgId={msgId} load_result={message} />
+                    </div>
+                  )
+                })}
               </div>
             </div>
           </div>

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -102,6 +102,11 @@ const Sidebar = React.memo(
       ActionEmitter.emitAction(KeybindAction.ChatList_SwitchToArchiveView)
     }
 
+    const onOpenGlobalGallery = () => {
+      setSidebarState('invisible')
+      ActionEmitter.emitAction(KeybindAction.GlobalGallery_Open)
+    }
+
     useEffect(() => {
       window.addEventListener('keyup', onEscapeKeyUp)
       return () => {
@@ -171,6 +176,13 @@ const Sidebar = React.memo(
             onClick={onOpenArchivedChats}
           >
             {tx('chat_archived_chats_title')}
+          </div>
+          <div
+            key='global_gallery'
+            className='sidebar-item'
+            onClick={onOpenGlobalGallery}
+          >
+            {tx('menu_all_media')}
           </div>
           <div key='settings' className='sidebar-item' onClick={onOpenSettings}>
             {tx('menu_settings')}

--- a/src/renderer/components/ThreeDotMenu.tsx
+++ b/src/renderer/components/ThreeDotMenu.tsx
@@ -116,9 +116,7 @@ export function useThreeDotMenu(
     menu = [
       {
         label: tx(
-          `gallery_image_aspect_ratio_${
-            GalleryImageKeepAspectRatio ? 'grid' : 'keep'
-          }`
+          GalleryImageKeepAspectRatio ? 'square_grid' : 'aspect_ratio_grid'
         ),
         action: async () => {
           await SettingsStoreInstance.effect.setDesktopSetting(

--- a/src/renderer/components/ThreeDotMenu.tsx
+++ b/src/renderer/components/ThreeDotMenu.tsx
@@ -112,16 +112,16 @@ export function useThreeDotMenu(
   }
 
   if (mode == 'gallery' && settingsStore?.desktopSettings) {
-    const { GalleryImageKeepAspectRatio } = settingsStore.desktopSettings
+    const { galleryImageKeepAspectRatio } = settingsStore.desktopSettings
     menu = [
       {
         label: tx(
-          GalleryImageKeepAspectRatio ? 'square_grid' : 'aspect_ratio_grid'
+          galleryImageKeepAspectRatio ? 'square_grid' : 'aspect_ratio_grid'
         ),
         action: async () => {
           await SettingsStoreInstance.effect.setDesktopSetting(
-            'GalleryImageKeepAspectRatio',
-            !GalleryImageKeepAspectRatio
+            'galleryImageKeepAspectRatio',
+            !galleryImageKeepAspectRatio
           )
         },
       },

--- a/src/renderer/components/ThreeDotMenu.tsx
+++ b/src/renderer/components/ThreeDotMenu.tsx
@@ -11,13 +11,16 @@ import {
   clearChat,
 } from './helpers/ChatMethods'
 import { ContextMenuItem } from './ContextMenu'
-import { useSettingsStore } from '../stores/settings'
+import SettingsStoreInstance, { useSettingsStore } from '../stores/settings'
 import { Type } from '../backend-com'
 import { ActionEmitter, KeybindAction } from '../keybindings'
 
-export function useThreeDotMenu(selectedChat: Type.FullChat | null) {
+export function useThreeDotMenu(
+  selectedChat: Type.FullChat | null,
+  mode: 'chat' | 'gallery' = 'chat'
+) {
   const screenContext = useContext(ScreenContext)
-  const settingsStore = useSettingsStore()[0]
+  const [settingsStore] = useSettingsStore()
   const tx = useTranslationFunction()
 
   let menu: (ContextMenuItem | false)[] = [false]
@@ -104,6 +107,25 @@ export function useThreeDotMenu(selectedChat: Type.FullChat | null) {
       {
         label: tx('menu_delete_chat'),
         action: onDeleteChat,
+      },
+    ]
+  }
+
+  if (mode == 'gallery' && settingsStore?.desktopSettings) {
+    const { GalleryImageKeepAspectRatio } = settingsStore.desktopSettings
+    menu = [
+      {
+        label: tx(
+          `gallery_image_aspect_ratio_${
+            GalleryImageKeepAspectRatio ? 'grid' : 'keep'
+          }`
+        ),
+        action: async () => {
+          await SettingsStoreInstance.effect.setDesktopSetting(
+            'GalleryImageKeepAspectRatio',
+            !GalleryImageKeepAspectRatio
+          )
+        },
       },
     ]
   }

--- a/src/renderer/components/ThreeDotMenu.tsx
+++ b/src/renderer/components/ThreeDotMenu.tsx
@@ -15,22 +15,6 @@ import { useSettingsStore } from '../stores/settings'
 import { Type } from '../backend-com'
 import { ActionEmitter, KeybindAction } from '../keybindings'
 
-export function DeltaMenuItem({
-  text,
-  onClick,
-}: {
-  text: string
-  onClick: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void
-}) {
-  return (
-    <li onClick={onClick}>
-      <a className='bp4-menu-item bp4-popover-dismiss'>
-        <div className='bp4-text-overflow-ellipsis bp4-fill'>{text}</div>
-      </a>
-    </li>
-  )
-}
-
 export function useThreeDotMenu(selectedChat: Type.FullChat | null) {
   const screenContext = useContext(ScreenContext)
   const settingsStore = useSettingsStore()[0]

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -147,7 +147,7 @@ export function ImageAttachment({
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
-  if (load_result.variant === 'loadingError') {
+  if (load_result.kind === 'loadingError') {
     const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
     return (
       <div
@@ -202,7 +202,7 @@ export function VideoAttachment({
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
-  if (load_result.variant === 'loadingError') {
+  if (load_result.kind === 'loadingError') {
     const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
     return (
       <div
@@ -259,7 +259,7 @@ export function AudioAttachment({
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
-  if (load_result.variant === 'loadingError') {
+  if (load_result.kind === 'loadingError') {
     const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
     return (
       <div
@@ -291,7 +291,7 @@ export function AudioAttachment({
           <div className='name'>
             {message?.overrideSenderName
               ? `~${message.overrideSenderName}`
-              : message?.sender.displayName}
+              : message?.sender?.displayName}
           </div>
           <Timestamp
             timestamp={message?.timestamp * 1000}
@@ -324,7 +324,7 @@ export function FileAttachmentRow({
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
-  if (load_result.variant === 'loadingError') {
+  if (load_result.kind === 'loadingError') {
     const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
     return (
       <div
@@ -422,7 +422,7 @@ export function WebxdcAttachment({
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
-  if (load_result.variant === 'loadingError') {
+  if (load_result.kind === 'loadingError') {
     const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
     return (
       <div

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -331,10 +331,10 @@ export function FileAttachmentRow({
         <div className='file-icon'>
           <div className='file-extension'>?</div>
         </div>
-        <div className='text-part'>
-          <div className='name'>{tx('attachment_failed_to_load')}</div>
-          <div className='size'>{'?'}</div>
-        </div>
+
+        <div className='name'>{tx('attachment_failed_to_load')}</div>
+        <div className='size'>{'?'}</div>
+        <div className='date'>{'?'}</div>
       </div>
     )
   } else {
@@ -343,7 +343,7 @@ export function FileAttachmentRow({
       screenContext,
       message
     )
-    const { fileName, fileBytes, fileMime, file } = message
+    const { fileName, fileBytes, fileMime, file, timestamp } = message
 
     const extension = getExtension(message)
     return (
@@ -368,15 +368,21 @@ export function FileAttachmentRow({
             </div>
           ) : null}
         </div>
-        <div className='text-part'>
-          <div className='name'>
-            {queryText && fileName
-              ? highlightQuery(fileName, queryText)
-              : fileName}
-          </div>
-          <div className='size'>
-            {fileBytes ? filesizeConverter(fileBytes) : '?'}
-          </div>
+
+        <div className='name'>
+          {queryText && fileName
+            ? highlightQuery(fileName, queryText)
+            : fileName}
+        </div>
+        <div className='size'>
+          {fileBytes ? filesizeConverter(fileBytes) : '?'}
+        </div>
+        <div className='date'>
+          <Timestamp
+            timestamp={timestamp * 1000}
+            module={''}
+            extended={false}
+          />
         </div>
       </div>
     )

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -183,6 +183,7 @@ export function ImageAttachment({
           <img
             className='attachment-content'
             src={runtime.transformBlobURL(file)}
+            loading="lazy"
           />
         )}
       </div>

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -92,9 +92,6 @@ const getMediaActions = (
       contextMenuFactory.bind(null, message, openDialog),
       openContextMenu
     ),
-    openFullscreenMedia: openDialog.bind(null, 'FullscreenMedia', {
-      msg: message,
-    }),
     downloadMedia: onDownload.bind(null, message),
     openInShell: openAttachmentInShell.bind(null, message),
   }
@@ -143,7 +140,10 @@ export type GalleryAttachmentElementProps = {
 export function ImageAttachment({
   msgId,
   load_result,
-}: GalleryAttachmentElementProps) {
+  openFullscreenMedia,
+}: GalleryAttachmentElementProps & {
+  openFullscreenMedia: (message: Type.Message) => void
+}) {
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
@@ -162,18 +162,20 @@ export function ImageAttachment({
     )
   } else {
     const message = load_result
-    const {
-      openContextMenu,
-      openFullscreenMedia,
-      openInShell,
-    } = getMediaActions(screenContext, message)
+    const { openContextMenu, openInShell } = getMediaActions(
+      screenContext,
+      message
+    )
     const { file, fileMime } = message
     const hasSupportedFormat = isImage(fileMime)
     const isBroken = !file || !hasSupportedFormat
+
     return (
       <div
         className={`media-attachment-media${isBroken ? ` broken` : ''}`}
-        onClick={isBroken ? openInShell : openFullscreenMedia}
+        onClick={
+          isBroken ? openInShell : openFullscreenMedia.bind(null, message)
+        }
         onContextMenu={openContextMenu}
       >
         {isBroken ? (
@@ -193,7 +195,10 @@ export function ImageAttachment({
 export function VideoAttachment({
   msgId,
   load_result,
-}: GalleryAttachmentElementProps) {
+  openFullscreenMedia,
+}: GalleryAttachmentElementProps & {
+  openFullscreenMedia: (message: Type.Message) => void
+}) {
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
@@ -214,7 +219,7 @@ export function VideoAttachment({
     const message = load_result
     const {
       openContextMenu,
-      openFullscreenMedia,
+
       openInShell,
     } = getMediaActions(screenContext, message)
     const { file, fileMime } = message
@@ -223,7 +228,9 @@ export function VideoAttachment({
     return (
       <div
         className={`media-attachment-media${isBroken ? ` broken` : ''}`}
-        onClick={isBroken ? openInShell : openFullscreenMedia}
+        onClick={
+          isBroken ? openInShell : openFullscreenMedia.bind(null, message)
+        }
         onContextMenu={openContextMenu}
       >
         {isBroken ? (

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -3,8 +3,9 @@ import {
   openAttachmentInShell,
   onDownload,
   openWebxdc,
+  confirmDeleteMessage,
 } from '../message/messageFunctions'
-import { ScreenContext } from '../../contexts'
+import { ScreenContext, unwrapContext } from '../../contexts'
 import {
   isImage,
   isVideo,
@@ -18,38 +19,14 @@ import { OpenDialogFunctionType } from '../dialogs/DialogController'
 import { runtime } from '../../runtime'
 
 import filesizeConverter from 'filesize'
-import { jumpToMessage } from '../helpers/ChatMethods'
+import { deleteMessage, jumpToMessage } from '../helpers/ChatMethods'
 import { getLogger } from '../../../shared/logger'
 import { truncateText } from '../../../shared/util'
 import { Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
+import ConfirmationDialog from '../dialogs/ConfirmationDialog'
 
 const log = getLogger('mediaAttachment')
-
-export default function MediaAttachment({
-  message,
-}: {
-  message: Type.Message
-}) {
-  if (!message.file) {
-    return null
-  }
-  switch (message.viewType) {
-    case 'Gif':
-    case 'Image':
-      return <ImageAttachment message={message} />
-    case 'Video':
-      return <VideoAttachment message={message} />
-    case 'Audio':
-    case 'Voice':
-      return <AudioAttachment message={message} />
-    case 'Webxdc':
-      return <WebxdcAttachment message={message} />
-    case 'File':
-    default:
-      return <FileAttachment message={message} />
-  }
-}
 
 const hideOpenInShellTypes: Type.Viewtype[] = [
   'Gif',
@@ -94,12 +71,23 @@ const contextMenuFactory = (
       label: tx('menu_message_details'),
       action: openDialog.bind(null, 'MessageDetail', { id: msgId }),
     },
+    {
+      label: tx('delete'),
+      action: () =>
+        openDialog(ConfirmationDialog, {
+          message: tx('ask_delete_message'),
+          confirmLabel: tx('delete'),
+          cb: (yes: boolean) => yes && deleteMessage(msgId),
+        }),
+    },
   ]
 }
 
 /** provides a quick link to comonly used functions to save a few duplicated lines  */
-const useMediaActions = (message: Type.Message) => {
-  const { openDialog, openContextMenu } = useContext(ScreenContext)
+const getMediaActions = (
+  { openDialog, openContextMenu }: unwrapContext<typeof ScreenContext>,
+  message: Type.Message
+) => {
   return {
     openContextMenu: makeContextMenu(
       contextMenuFactory.bind(null, message, openDialog),
@@ -111,6 +99,27 @@ const useMediaActions = (message: Type.Message) => {
     downloadMedia: onDownload.bind(null, message),
     openInShell: openAttachmentInShell.bind(null, message),
   }
+}
+
+function getBrokenMediaContextMenu(
+  { openContextMenu, openDialog }: unwrapContext<typeof ScreenContext>,
+  msgId: number
+) {
+  const tx = window.static_translate
+  return makeContextMenu(
+    [
+      {
+        label: tx('delete'),
+        action: () =>
+          openDialog(ConfirmationDialog, {
+            message: tx('ask_delete_message'),
+            confirmLabel: tx('delete'),
+            cb: (yes: boolean) => yes && deleteMessage(msgId),
+          }),
+      },
+    ],
+    openContextMenu
+  )
 }
 
 function squareBrokenMediaContent(
@@ -127,159 +136,310 @@ function squareBrokenMediaContent(
   )
 }
 
-function ImageAttachment({ message }: { message: Type.Message }) {
-  const { openContextMenu, openFullscreenMedia, openInShell } = useMediaActions(
-    message
-  )
-  const { file, fileMime } = message
-  const hasSupportedFormat = isImage(fileMime || '')
-  const isBroken = !file || !hasSupportedFormat
-  return (
-    <div
-      className={`media-attachment-media${isBroken ? ` broken` : ''}`}
-      onClick={isBroken ? openInShell : openFullscreenMedia}
-      onContextMenu={openContextMenu}
-    >
-      {isBroken ? (
-        squareBrokenMediaContent(hasSupportedFormat, fileMime || '')
-      ) : (
-        <img
-          className='attachment-content'
-          src={runtime.transformBlobURL(file)}
-        />
-      )}
-    </div>
-  )
+export type GalleryAttachmentElementProps = {
+  msgId: number
+  load_result: Type.MessageLoadResult
 }
 
-function VideoAttachment({ message }: { message: Type.Message }) {
-  const { openContextMenu, openFullscreenMedia, openInShell } = useMediaActions(
-    message
-  )
-  const { fileMime, file } = message
-  const hasSupportedFormat = isVideo(fileMime)
-  const isBroken = !file || !hasSupportedFormat
-  return (
-    <div
-      className={`media-attachment-media${isBroken ? ` broken` : ''}`}
-      onClick={isBroken ? openInShell : openFullscreenMedia}
-      onContextMenu={openContextMenu}
-    >
-      {isBroken ? (
-        squareBrokenMediaContent(hasSupportedFormat, fileMime)
-      ) : (
-        <>
-          <video
+export function ImageAttachment({
+  msgId,
+  load_result,
+}: GalleryAttachmentElementProps) {
+  const screenContext = useContext(ScreenContext)
+  const tx = window.static_translate
+
+  if (load_result.variant === 'loadingError') {
+    const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
+    return (
+      <div
+        className={'media-attachment-media broken'}
+        title={load_result.error}
+        onContextMenu={onContextMenu}
+      >
+        <div className='attachment-content'>
+          {tx('attachment_failed_to_load')}
+        </div>
+      </div>
+    )
+  } else {
+    const message = load_result
+    const {
+      openContextMenu,
+      openFullscreenMedia,
+      openInShell,
+    } = getMediaActions(screenContext, message)
+    const { file, fileMime } = message
+    const hasSupportedFormat = isImage(fileMime)
+    const isBroken = !file || !hasSupportedFormat
+    return (
+      <div
+        className={`media-attachment-media${isBroken ? ` broken` : ''}`}
+        onClick={isBroken ? openInShell : openFullscreenMedia}
+        onContextMenu={openContextMenu}
+      >
+        {isBroken ? (
+          squareBrokenMediaContent(hasSupportedFormat, fileMime)
+        ) : (
+          <img
             className='attachment-content'
             src={runtime.transformBlobURL(file)}
-            controls={false}
           />
-          <div className='video-play-btn'>
-            <div className='video-play-btn-icon' />
-          </div>
-        </>
-      )}
-    </div>
-  )
-}
-
-function AudioAttachment({ message }: { message: Type.Message }) {
-  const { openContextMenu } = useMediaActions(message)
-  const { fileMime, file } = message
-  const hasSupportedFormat = isAudio(fileMime)
-  return (
-    <div className='media-attachment-audio' onContextMenu={openContextMenu}>
-      <div className='heading'>
-        <div className='name'>{message?.sender.displayName}</div>
-        <Timestamp
-          timestamp={message?.timestamp * 1000}
-          extended
-          module='date'
-        />
+        )}
       </div>
-      {hasSupportedFormat ? (
-        <audio controls>
-          <source src={runtime.transformBlobURL(file || '')} />
-        </audio>
-      ) : (
-        <div>
-          {window.static_translate(
-            'cannot_display_unsuported_file_type',
-            fileMime || 'null'
-          )}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function FileAttachment({ message }: { message: Type.Message }) {
-  const { openContextMenu, openInShell } = useMediaActions(message)
-  const { fileName, fileBytes, fileMime, file } = message
-  const extension = getExtension(message)
-  return (
-    <div
-      className='media-attachment-generic'
-      role='button'
-      onClick={ev => {
-        ev.stopPropagation()
-        openInShell()
-      }}
-      onContextMenu={openContextMenu}
-    >
-      <div
-        className='file-icon'
-        draggable='true'
-        onDragStart={dragAttachmentOut.bind(null, file)}
-        title={fileMime || 'null'}
-      >
-        {extension ? (
-          <div className='file-extension'>
-            {fileMime === 'application/octet-stream' ? '' : extension}
-          </div>
-        ) : null}
-      </div>
-      <div className='text-part'>
-        <div className='name'>{fileName}</div>
-        <div className='size'>
-          {fileBytes ? filesizeConverter(fileBytes) : '?'}
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function WebxdcAttachment({ message }: { message: Type.Message }) {
-  const { openContextMenu } = useMediaActions(message)
-
-  if (!message.webxdcInfo) {
-    log.error('message.webxdcInfo is undefined, msgid:', message.id)
-    return FileAttachment({ message })
+    )
   }
+}
 
-  const { summary, name, document } = message.webxdcInfo
+export function VideoAttachment({
+  msgId,
+  load_result,
+}: GalleryAttachmentElementProps) {
+  const screenContext = useContext(ScreenContext)
+  const tx = window.static_translate
 
-  return (
-    <div
-      className='media-attachment-webxdc'
-      role='button'
-      onContextMenu={openContextMenu}
-      onClick={openWebxdc.bind(null, message.id)}
-    >
-      <img
-        className='icon'
-        src={runtime.getWebxdcIconURL(selectedAccountId(), message.id)}
-      />
-      <div className='text-part'>
-        <div
-          className='name'
-          title={`${document ? document + ' \n' : ''}${name}`}
-        >
-          {document && truncateText(document, 25) + ' - '}
-          {name}
+  if (load_result.variant === 'loadingError') {
+    const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
+    return (
+      <div
+        className={'media-attachment-media broken'}
+        title={load_result.error}
+        onContextMenu={onContextMenu}
+      >
+        <div className='attachment-content'>
+          {tx('attachment_failed_to_load')}
         </div>
-        <div className='summary'>{summary}</div>
       </div>
-    </div>
-  )
+    )
+  } else {
+    const message = load_result
+    const {
+      openContextMenu,
+      openFullscreenMedia,
+      openInShell,
+    } = getMediaActions(screenContext, message)
+    const { file, fileMime } = message
+    const hasSupportedFormat = isVideo(fileMime)
+    const isBroken = !file || !hasSupportedFormat
+    return (
+      <div
+        className={`media-attachment-media${isBroken ? ` broken` : ''}`}
+        onClick={isBroken ? openInShell : openFullscreenMedia}
+        onContextMenu={openContextMenu}
+      >
+        {isBroken ? (
+          squareBrokenMediaContent(hasSupportedFormat, fileMime || '')
+        ) : (
+          <>
+            <video
+              className='attachment-content'
+              src={runtime.transformBlobURL(file)}
+              controls={false}
+            />
+            <div className='video-play-btn'>
+              <div className='video-play-btn-icon' />
+            </div>
+          </>
+        )}
+      </div>
+    )
+  }
+}
+
+export function AudioAttachment({
+  msgId,
+  load_result,
+}: GalleryAttachmentElementProps) {
+  const screenContext = useContext(ScreenContext)
+  const tx = window.static_translate
+
+  if (load_result.variant === 'loadingError') {
+    const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
+    return (
+      <div
+        className={'media-attachment-audio broken'}
+        title={load_result.error}
+        onContextMenu={onContextMenu}
+      >
+        <div className='heading'>
+          <div className='name'>? Error ?</div>
+          <span className='date'>?</span>
+        </div>
+        <div className='attachment-content'>
+          {tx('attachment_failed_to_load')}
+        </div>
+      </div>
+    )
+  } else {
+    const message = load_result
+    const { openContextMenu } = getMediaActions(screenContext, message)
+    const { file, fileMime } = message
+    const hasSupportedFormat = isAudio(fileMime)
+    const isBroken = !file || !hasSupportedFormat
+    return (
+      <div
+        className={`media-attachment-audio${isBroken ? ` broken` : ''}`}
+        onContextMenu={openContextMenu}
+      >
+        <div className='heading'>
+          <div className='name'>{message?.sender.displayName}</div>
+          <Timestamp
+            timestamp={message?.timestamp * 1000}
+            extended
+            module='date'
+          />
+        </div>
+        {hasSupportedFormat ? (
+          <audio controls>
+            <source src={runtime.transformBlobURL(file || '')} />
+          </audio>
+        ) : (
+          <div>
+            {window.static_translate(
+              'cannot_display_unsuported_file_type',
+              fileMime || 'null'
+            )}
+          </div>
+        )}
+      </div>
+    )
+  }
+}
+
+export function FileAttachment({
+  msgId,
+  load_result,
+}: GalleryAttachmentElementProps) {
+  const screenContext = useContext(ScreenContext)
+  const tx = window.static_translate
+
+  if (load_result.variant === 'loadingError') {
+    const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
+    return (
+      <div
+        className={'media-attachment-generic broken'}
+        title={load_result.error}
+        onContextMenu={onContextMenu}
+      >
+        <div className='file-icon'>
+          <div className='file-extension'>?</div>
+        </div>
+        <div className='text-part'>
+          <div className='name'>{tx('attachment_failed_to_load')}</div>
+          <div className='size'>{'?'}</div>
+        </div>
+      </div>
+    )
+  } else {
+    const message = load_result
+    const { openContextMenu, openInShell } = getMediaActions(
+      screenContext,
+      message
+    )
+    const { fileName, fileBytes, fileMime, file } = message
+
+    const extension = getExtension(message)
+    return (
+      <div
+        className='media-attachment-generic'
+        role='button'
+        onClick={ev => {
+          ev.stopPropagation()
+          openInShell()
+        }}
+        onContextMenu={openContextMenu}
+      >
+        <div
+          className='file-icon'
+          draggable='true'
+          onDragStart={dragAttachmentOut.bind(null, file)}
+          title={fileMime || 'null'}
+        >
+          {extension ? (
+            <div className='file-extension'>
+              {fileMime === 'application/octet-stream' ? '' : extension}
+            </div>
+          ) : null}
+        </div>
+        <div className='text-part'>
+          <div className='name'>{fileName}</div>
+          <div className='size'>
+            {fileBytes ? filesizeConverter(fileBytes) : '?'}
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+export function WebxdcAttachment({
+  msgId,
+  load_result,
+}: GalleryAttachmentElementProps) {
+  const screenContext = useContext(ScreenContext)
+  const tx = window.static_translate
+
+  if (load_result.variant === 'loadingError') {
+    const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
+    return (
+      <div
+        className={'media-attachment-webxdc broken'}
+        title={load_result.error}
+        onContextMenu={onContextMenu}
+      >
+        <div className='icon'></div>
+        <div className='text-part'>
+          <div className='name'>{tx('attachment_failed_to_load')}</div>
+          <div className='summary'></div>
+        </div>
+      </div>
+    )
+  } else if (load_result.webxdcInfo == null) {
+    const onContextMenu = getBrokenMediaContextMenu(screenContext, msgId)
+    // webxdc info is not set, show different error
+    log.error('message.webxdcInfo is undefined, msgid:', msgId)
+    return (
+      <div
+        className='media-attachment-webxdc'
+        role='button'
+        onContextMenu={onContextMenu}
+      >
+        <img
+          className='icon'
+          src={runtime.getWebxdcIconURL(selectedAccountId(), msgId)}
+        />
+        <div className='text-part'>
+          <div className='name'>Error loading info</div>
+          <div className='summary'>
+            {'message.webxdcInfo is undefined, msgid:' + msgId}
+          </div>
+        </div>
+      </div>
+    )
+  } else {
+    const { openContextMenu } = getMediaActions(screenContext, load_result)
+    const { summary, name, document } = load_result.webxdcInfo
+    return (
+      <div
+        className='media-attachment-webxdc'
+        role='button'
+        onContextMenu={openContextMenu}
+        onClick={openWebxdc.bind(null, load_result.id)}
+      >
+        <img
+          className='icon'
+          src={runtime.getWebxdcIconURL(selectedAccountId(), load_result.id)}
+        />
+        <div className='text-part'>
+          <div
+            className='name'
+            title={`${document ? document + ' \n' : ''}${name}`}
+          >
+            {document && truncateText(document, 25) + ' - '}
+            {name}
+          </div>
+          <div className='summary'>{summary}</div>
+        </div>
+      </div>
+    )
+  }
 }

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -288,7 +288,11 @@ export function AudioAttachment({
         onContextMenu={openContextMenu}
       >
         <div className='heading'>
-          <div className='name'>{message?.sender.displayName}</div>
+          <div className='name'>
+            {message?.overrideSenderName
+              ? `~${message.overrideSenderName}`
+              : message?.sender.displayName}
+          </div>
           <Timestamp
             timestamp={message?.timestamp * 1000}
             extended

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -3,7 +3,6 @@ import {
   openAttachmentInShell,
   onDownload,
   openWebxdc,
-  confirmDeleteMessage,
 } from '../message/messageFunctions'
 import { ScreenContext, unwrapContext } from '../../contexts'
 import {
@@ -183,7 +182,7 @@ export function ImageAttachment({
           <img
             className='attachment-content'
             src={runtime.transformBlobURL(file)}
-            loading="lazy"
+            loading='lazy'
           />
         )}
       </div>
@@ -306,10 +305,11 @@ export function AudioAttachment({
   }
 }
 
-export function FileAttachment({
+export function FileAttachmentRow({
   msgId,
   load_result,
-}: GalleryAttachmentElementProps) {
+  queryText,
+}: GalleryAttachmentElementProps & { queryText?: string }) {
   const screenContext = useContext(ScreenContext)
   const tx = window.static_translate
 
@@ -362,7 +362,11 @@ export function FileAttachment({
           ) : null}
         </div>
         <div className='text-part'>
-          <div className='name'>{fileName}</div>
+          <div className='name'>
+            {queryText && fileName
+              ? highlightQuery(fileName, queryText)
+              : fileName}
+          </div>
           <div className='size'>
             {fileBytes ? filesizeConverter(fileBytes) : '?'}
           </div>
@@ -370,6 +374,28 @@ export function FileAttachment({
       </div>
     )
   }
+}
+
+const highlightQuery = (msg: string, query: string) => {
+  const pos_of_search_term = msg.toLowerCase().indexOf(query.toLowerCase())
+  if (pos_of_search_term == -1) return msg
+  const text = msg
+  const pos_of_search_term_in_text = pos_of_search_term
+
+  const before = text.slice(0, pos_of_search_term_in_text)
+  const search_term = text.slice(
+    pos_of_search_term_in_text,
+    pos_of_search_term_in_text + query.length
+  )
+  const after = text.slice(pos_of_search_term_in_text + query.length)
+
+  return (
+    <>
+      {before}
+      <span className='highlight'>{search_term}</span>
+      {after}
+    </>
+  )
 }
 
 export function WebxdcAttachment({

--- a/src/renderer/components/attachment/messageAttachment.tsx
+++ b/src/renderer/components/attachment/messageAttachment.tsx
@@ -17,6 +17,9 @@ import { getDirection } from '../../../shared/util'
 
 import filesizeConverter from 'filesize'
 import { Type } from '../../backend-com'
+import FullscreenMedia, {
+  NeighboringMediaMode,
+} from '../dialogs/FullscreenMedia'
 
 // const MINIMUM_IMG_HEIGHT = 150
 // const MAXIMUM_IMG_HEIGHT = 300
@@ -44,7 +47,10 @@ export default function Attachment({
     if (message.viewType === 'Sticker') return
     ev.stopPropagation()
     if (isDisplayableByFullscreenMedia(message.fileMime)) {
-      openDialog('FullscreenMedia', { msg: message })
+      openDialog(FullscreenMedia, {
+        msg: message,
+        neighboringMedia: NeighboringMediaMode.Chat,
+      })
     } else {
       openAttachmentInShell(message)
     }

--- a/src/renderer/components/dialogs/Edit-Group-Image.tsx
+++ b/src/renderer/components/dialogs/Edit-Group-Image.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 import { ScreenContext } from '../../contexts'
 import { Avatar } from '../Avatar'
 import { useContextMenu } from '../ContextMenu'
-import FullscreenMedia from './FullscreenMedia'
+import FullscreenMedia, { NeighboringMediaMode } from './FullscreenMedia'
 
 export const GroupImage = (props: {
   groupImage?: string | null
@@ -31,6 +31,7 @@ export const GroupImage = (props: {
         fileMime: 'image/x',
         file: groupImage,
       } as T.Message,
+      neighboringMedia: NeighboringMediaMode.Off,
     })
 
   const openContextMenu = useContextMenu([

--- a/src/renderer/components/dialogs/FullscreenMedia.tsx
+++ b/src/renderer/components/dialogs/FullscreenMedia.tsx
@@ -73,7 +73,9 @@ export default function FullscreenMedia(props: {
       onDCEvent(accountId, 'IncomingMsgBunch', debouncedUpdate),
       onDCEvent(accountId, 'MsgDeleted', debouncedUpdate),
     ]
-    return () => listeners.every(cleanup => cleanup())
+    return () => {
+      listeners.every(cleanup => cleanup())
+    }
   }, [props.msg, props.neighboringMedia, accountId])
 
   const { file, fileMime } = msg

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -156,7 +156,13 @@ export default function MainScreen() {
     searchChats('')
     setQueryChatId(null)
   })
-  const onClickThreeDotMenu = useThreeDotMenu(selectedChat.chat)
+  const onClickThreeDotMenu = useThreeDotMenu(
+    selectedChat.chat,
+    alternativeView === 'global-gallery' ||
+      selectedChat?.activeView === ChatView.Media
+      ? 'gallery'
+      : 'chat'
+  )
 
   if (!selectedChat) {
     log.error('selectedChat is undefined')
@@ -334,23 +340,23 @@ export default function MainScreen() {
                     />
                   )}
                 </span>
-                <span
-                  style={{
-                    marginLeft: 0,
-                    marginRight: '3px',
-                  }}
-                >
-                  <Button
-                    className='icon-rotated'
-                    minimal
-                    icon='more'
-                    id='three-dot-menu-button'
-                    aria-label={tx('main_menu')}
-                    onClick={onClickThreeDotMenu}
-                  />
-                </span>
               </>
             )}
+            <span
+              style={{
+                marginLeft: 0,
+                marginRight: '3px',
+              }}
+            >
+              <Button
+                className='icon-rotated'
+                minimal
+                icon='more'
+                id='three-dot-menu-button'
+                aria-label={tx('main_menu')}
+                onClick={onClickThreeDotMenu}
+              />
+            </span>
           </NavbarGroup>
         </Navbar>
       </div>

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -18,6 +18,7 @@ import {
   openViewProfileDialog,
   selectChat,
   setChatView,
+  unselectChat,
 } from '../helpers/ChatMethods'
 
 import {
@@ -61,6 +62,19 @@ export default function MainScreen() {
 
   const screenContext = useContext(ScreenContext)
   const selectedChat = useChatStore()
+
+  const [alternativeView, setAlternativeView] = useState<
+    null | 'global-gallery'
+  >(null)
+  useEffect(() => {
+    if (selectedChat.chat?.id) {
+      setAlternativeView(null)
+    }
+  }, [selectedChat.chat?.id])
+  useKeyBindingAction(KeybindAction.GlobalGallery_Open, () => {
+    unselectChat()
+    setAlternativeView('global-gallery')
+  })
 
   const onChatClick = (chatId: number) => {
     if (chatId === C.DC_CHAT_ID_ARCHIVED_LINK) return setShowArchivedChats(true)
@@ -168,6 +182,8 @@ export default function MainScreen() {
           </RecoverableCrashScreen>
         )
     }
+  } else if (alternativeView === 'global-gallery') {
+    MessageListView = <Gallery chatId={'all'} />
   } else {
     const style: React.CSSProperties = settingsStore
       ? getBackgroundImageStyle(settingsStore.desktopSettings)
@@ -234,6 +250,19 @@ export default function MainScreen() {
             )}
           </NavbarGroup>
           <NavbarGroup align={Alignment.RIGHT}>
+            {alternativeView === 'global-gallery' && (
+              <NavbarHeading
+                style={{
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  width: '100%',
+                }}
+                onClick={onTitleClick}
+              >
+                {tx('menu_all_media')}
+              </NavbarHeading>
+            )}
             {selectedChat.chat && (
               <NavbarHeading
                 style={{

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -18,6 +18,7 @@ export enum KeybindAction {
   KeybindingCheatSheet_Open = 'keybindinginfo:open',
   MessageList_PageUp = 'msglist:pageup',
   MessageList_PageDown = 'msglist:pagedown',
+  GlobalGallery_Open = 'globalgallery:open',
 
   // Actions that are not necessarily triggered by keybindings
   ChatList_SwitchToArchiveView = 'chatlist:switch-to-archive-view',

--- a/src/renderer/stores/store.ts
+++ b/src/renderer/stores/store.ts
@@ -6,10 +6,7 @@ export function useStore<T extends Store<any>>(
 ): [T extends Store<infer S> ? S : any, T['dispatch']] {
   const [state, setState] = useState(StoreInstance.getState())
 
-  useEffect(() => {
-    StoreInstance.subscribe(setState)
-    return () => StoreInstance.unsubscribe(setState)
-  }, [StoreInstance])
+  useEffect(() => StoreInstance.subscribe(setState), [StoreInstance])
   // TODO: better return an object to allow destructuring
   return [state, StoreInstance.dispatch.bind(StoreInstance)]
 }
@@ -69,7 +66,7 @@ export class Store<S> {
 
   unsubscribe(listener: (state: S) => void) {
     const index = this.listeners.indexOf(listener)
-    this.listeners.splice(index, 1)
+    if (index !== -1) this.listeners.splice(index, 1)
   }
 
   attachEffect(effect: (action: Action, state: S) => void) {

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -71,7 +71,7 @@ export interface DesktopSettingsType {
   HTMLEmailAlwaysLoadRemoteContent: boolean
   enableRelatedChats: boolean
   /** gallery image & video - keep aspect ratio (true) or cover (false) */
-  GalleryImageKeepAspectRatio: boolean
+  galleryImageKeepAspectRatio: boolean
 }
 
 export interface RC_Config {

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -70,6 +70,8 @@ export interface DesktopSettingsType {
   /** always loads remote content without asking, for non contact requests  */
   HTMLEmailAlwaysLoadRemoteContent: boolean
   enableRelatedChats: boolean
+  /** gallery image & video - keep aspect ratio (true) or cover (false) */
+  GalleryImageKeepAspectRatio: boolean
 }
 
 export interface RC_Config {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -30,6 +30,6 @@ export function getDefaultState(): DesktopSettingsType {
     HTMLEmailAskForRemoteLoadingConfirmation: true,
     HTMLEmailAlwaysLoadRemoteContent: false,
     enableRelatedChats: false,
-    GalleryImageKeepAspectRatio: false,
+    galleryImageKeepAspectRatio: false,
   }
 }

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -30,5 +30,6 @@ export function getDefaultState(): DesktopSettingsType {
     HTMLEmailAskForRemoteLoadingConfirmation: true,
     HTMLEmailAlwaysLoadRemoteContent: false,
     enableRelatedChats: false,
+    GalleryImageKeepAspectRatio: false,
   }
 }

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -181,6 +181,7 @@ $hover-contrast-change: 2%;
   --addMemberChipBackgroundColor: #{$bgSecondary};
   --searchInputBackgroundColor: #52768700;
   --galleryWebxdcItem: #{changeContrast($bgPrimary, 10%)};
+  --galleryFileRowHover: #{changeContrast($bgPrimary, 7%)};
   --recently-seen-indicator-color: #34c759;
 
   /* Emoji & Sticker picker overwrites */

--- a/themes/_themebase.scss
+++ b/themes/_themebase.scss
@@ -213,6 +213,10 @@ $hover-contrast-change: 2%;
   --delta-btn-tab-selected-bg: #{$colorPrimary};
   --delta-btn-tab-selected-text: #{$textPrimary};
 
+  /** generic reusable colors */
+  --summary-text-color: #{changeContrast($textPrimary, 33%)};
+  --textPrimary: #{$textPrimary};
+
   @if lightness($bgPrimary) < 50 {
     // dark theme
     --scrollbarThumb: #{rgba(white, $scrollbarTransparency)};


### PR DESCRIPTION
todo:
- [x] use virtual grid for performance, we already use react-window so I would say try it with 
https://react-window.vercel.app/#/api/FixedSizeGrid
- [x] overlay with date or date range of first visible picture.
- [x] scroll to top when switching tabs
- [x] filtering / searching for file names in the document tab
    - [x] prettier search bar (follow theming)
    - [x] empty screen when there are no results
- [x] turn documents tab into a table
- [x] integrate https://github.com/deltachat/deltachat-desktop/pull/3360 into this pr
- [ ] optional: make audio elements prettier
- ~~lazy loading list content and reloading when it changes (like chatlist, and evens: deletion, incoming, changed (like for when webxdc title changes(loosely related to also #3412)))~~ first experiments failed, see #3446 to pick this up again
- ~~Gallery tabs integrated into navbar~~ we need to further discuss this, first experiments with it speak against it.

closes #3161