### PR TITLE
add confirm dialog to webxdc send to chat closes #3269

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Changed
+- Added confirmation dialog to `webxdc.sendToChat` api #3269
+
 <a id="1_37_1"></a>
 
 ## [1.37.1] - 2023-06-14


### PR DESCRIPTION
Personally I'm still not convinced, IMO we should just tell app devs to implement a confirmation dialog themselves.
<img width="380" alt="Bildschirmfoto 2023-06-16 um 13 19 51" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/9db9be2c-08a4-45f8-9193-f96313af84a1">

translations need to be pulled before releasing this. also this is a system dialog, the electron icon will be the DC logo on Mac, on other OS the dialogs will look different.

closes #3269