### PR TITLE
fix: if systemPreferences.askForMediaAccess is not available, then don't call it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+
+### Fixed
+- fix: if systemPreferences.askForMediaAccess is not available, then don't call it (broke qr scan under linux (and maybe also under windows, was not tested))
+
 <a id="1_38_0"></a>
 
 ## [1.38.0] - 2023-06-19

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -131,17 +131,17 @@ export function init(options: { hidden: boolean }) {
     }
   }
   window.webContents.session.setPermissionCheckHandler((_wc, permission) => {
-    if (permission === 'camera') {
+    if (systemPreferences.getMediaAccessStatus && permission === 'camera') {
       return systemPreferences.getMediaAccessStatus('camera') === 'granted'
     }
-    // if (permission === "microphone") {
+    // if (systemPreferences.getMediaAccessStatus && permission === "microphone") {
     //   return systemPreferences.getMediaAccessStatus("microphone") === "granted"
     // }
     return permission_handler(permission as any)
   })
   window.webContents.session.setPermissionRequestHandler(
     (_wc, permission, callback) => {
-      if (permission === 'media') {
+      if (systemPreferences.askForMediaAccess && permission === 'media') {
         systemPreferences.askForMediaAccess('camera').then(callback)
       } else {
         callback(permission_handler(permission))


### PR DESCRIPTION
(broke qr scan under linux (and maybe also under windows, was not tested))

fixes #3279