### PR TITLE
don't close webxdc on `sendToChat()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+### Changed
+- don't close webxdc on `sendToChat()`
 
 ### Fixed
 - fix: if systemPreferences.askForMediaAccess is not available, then don't call it (broke qr scan under linux (and maybe also under windows, was not tested))

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -418,7 +418,6 @@ If you think that's a bug and you need that permission, then please open an issu
         // forward to main window
         main_window?.webContents.send('webxdc.sendToChat', file, text)
         main_window?.focus()
-        open_apps[key].win.destroy()
       }
     )
 


### PR DESCRIPTION
closes #3271, closes #3269
