### PR TITLE
fix: only allow one instance of `sendToChat()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - fix: if systemPreferences.askForMediaAccess is not available, then don't call it (broke qr scan under linux (and maybe also under windows, was not tested))
+- fix: only allow one instance of `sendToChat()` (the old one is now replaced by the new one) #3281
 
 <a id="1_38_0"></a>
 

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -47,6 +47,7 @@ export default class ScreenController extends Component {
   onShowKeybindings: any
   onShowSettings: any
   selectedAccountId: number | undefined
+  openSendToDialogId?: number
 
   constructor(public props: {}) {
     super(props)
@@ -165,10 +166,17 @@ export default class ScreenController extends Component {
 
     runtime.onOpenQrUrl = processOpenQrUrl
     runtime.onWebxcSendToChat = (file, text) => {
-      ;(this.openDialog as OpenDialogFunctionType)(WebxdcSaveToChatDialog, {
-        messageText: text,
-        file,
-      })
+      if (this.openSendToDialogId) {
+        this.closeDialog(this.openSendToDialogId)
+        this.openSendToDialogId = undefined
+      }
+      this.openSendToDialogId = (this.openDialog as OpenDialogFunctionType)(
+        WebxdcSaveToChatDialog,
+        {
+          messageText: text,
+          file,
+        }
+      )
     }
     runtime.onResumeFromSleep = debounce(() => {
       log.info('onResumeFromSleep')


### PR DESCRIPTION
the old dialog is replaced by the new one

closes #3281
