### PR TITLE
prepare 1.38.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+<a id="1_38_1"></a>
+
+## [1.38.1] - 2023-06-23
+
 ### Changed
 - don't close webxdc on `sendToChat()`
 - Update translations (22.06.2023)
@@ -2051,7 +2055,9 @@ This section is only relevant to contributors.
 
 **Historical Note 2** We removed the older changelog, you can look at the git history to get it. (version numbers made hallmark crazy)
 
-[unreleased]: https://github.com/deltachat/deltachat-desktop/compare/v1.38.0...HEAD
+[unreleased]: https://github.com/deltachat/deltachat-desktop/compare/v1.38.1...HEAD
+
+[1.38.1]: https://github.com/deltachat/deltachat-desktop/compare/v1.38.0...v1.38.1
 
 [1.38.0]: https://github.com/deltachat/deltachat-desktop/compare/v1.37.1...v1.38.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deltachat-desktop",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "deltachat-desktop",
-      "version": "1.38.0",
+      "version": "1.38.1",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deltachat-desktop",
-  "version": "1.38.0",
+  "version": "1.38.1",
   "description": "Desktop Application for delta.chat",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
this release is mainly needed because it fixes the qr scanning bug on linux #3279 