### PR TITLE
fix: clicking start on an already open webxdc app now opens it again even when it was minimised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+
+### Fixed
+- fix: clicking start on an already open webxdc app now opens it again even when it was minimised #3294
+
 <a id="1_38_1"></a>
 
 ## [1.38.1] - 2023-06-23

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -81,7 +81,11 @@ export default class DCWebxdc extends SplitOut {
             'webxdc instance for this app is already open, trying to focus it',
             { msg_id }
           )
-          open_apps[`${accountId}.${msg_id}`].win.focus()
+          const window = open_apps[`${accountId}.${msg_id}`].win
+          if (window.isMinimized()) {
+            window.restore()
+          }
+          window.focus()
           return
         }
 


### PR DESCRIPTION
fixes #3294
