### PR TITLE
Fix edit button in a contact's profile not shown when selected from a group member list(fix #3267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix: text is now smaller in the unread badge on the top of the jump down button(#3068)
 - fix: links in quoted texts should not be clickable (#3290)
 - fix: remove unsupported language code, this broke the installation from the ms store on windows #3292
+- fix: show edit button if a contact's profile is shown from group view(#3267)
 
 <a id="1_38_1"></a>
 

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -79,7 +79,6 @@ export default function ViewGroup(props: {
   isBroadcast: boolean
 }) {
   const { isOpen, onClose, isBroadcast } = props
-  const [viewMode, setViewMode] = useState('main')
 
   const chat = useChat(props.chat)
 
@@ -93,13 +92,7 @@ export default function ViewGroup(props: {
         height: 'calc(100vh - 50px)',
       }}
     >
-      <ViewGroupInner
-        viewMode={viewMode}
-        setViewMode={setViewMode}
-        onClose={onClose}
-        chat={chat}
-        isBroadcast={isBroadcast}
-      />
+      <ViewGroupInner onClose={onClose} chat={chat} isBroadcast={isBroadcast} />
     </DeltaDialogBase>
   )
 }
@@ -135,14 +128,12 @@ export const useGroup = (chat: Type.FullChat) => {
 }
 
 function ViewGroupInner(props: {
-  viewMode: string
-  setViewMode: (newViewMode: string) => void
   onClose: DialogProps['onClose']
   chat: Type.FullChat
   isBroadcast: boolean
 }) {
   const { openDialog } = useContext(ScreenContext)
-  const { viewMode, setViewMode, onClose, chat, isBroadcast } = props
+  const { onClose, chat, isBroadcast } = props
   const tx = useTranslationFunction()
 
   const chatDisabled = !chat.canSend
@@ -216,15 +207,9 @@ function ViewGroupInner(props: {
     null
   )
 
-  if (viewMode === 'profile' && !profileContact) {
-    log.error(
-      '[ViewGroup] viewMode is profile but profileContact is null. Showing the main view instead'
-    )
-  }
-
   return (
     <>
-      {(viewMode === 'main' || (viewMode === 'profile' && !profileContact)) && (
+      {!profileContact && (
         <>
           <DeltaDialogHeader
             title={
@@ -288,7 +273,6 @@ function ViewGroupInner(props: {
                       return
                     }
                     setProfileContact(contact)
-                    setViewMode('profile')
                   }}
                   onRemoveClick={showRemoveGroupMemberConfirmationDialog}
                 />
@@ -297,10 +281,10 @@ function ViewGroupInner(props: {
           </div>
         </>
       )}
-      {viewMode === 'profile' && profileContact && (
+      {profileContact && (
         <ViewProfile
           isOpen
-          onBack={() => setViewMode('main')}
+          onBack={() => setProfileContact(null)}
           onClose={onClose}
           contact={profileContact}
         />

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -15,7 +15,7 @@ import {
   PseudoListItemAddMember,
 } from '../helpers/PseudoListItem'
 import { DialogProps } from './DialogController'
-import { ViewProfileInner } from './ViewProfile'
+import ViewProfile from './ViewProfile'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
 import { useState, useContext, useEffect, useCallback, useMemo } from 'react'
 import React from 'react'
@@ -216,10 +216,14 @@ function ViewGroupInner(props: {
   const [profileContact, setProfileContact] = useState<Type.Contact | null>(
     null
   )
+  
+  if (viewMode === 'profile' && !profileContact) {
+    console.error('[ViewGroup] viewMode is profile but profileContact is null. Showing the main view instead')
+  }
 
   return (
     <>
-      {viewMode === 'main' && (
+      {(viewMode === 'main' || (viewMode === "profile" && !profileContact)) && (
         <>
           <DeltaDialogHeader
             title={
@@ -292,23 +296,12 @@ function ViewGroupInner(props: {
           </div>
         </>
       )}
-      {viewMode === 'profile' && (
-        <>
-          <DeltaDialogHeader
-            title={tx('menu_view_profile')}
-            showBackButton={true}
-            onClickBack={() => setViewMode('main')}
-            showCloseButton={true}
-            onClose={onClose}
-          />
-          <DeltaDialogBody noFooter>
-            <DeltaDialogContent noPadding>
-              {profileContact && (
-                <ViewProfileInner contact={profileContact} onClose={onClose} />
-              )}
-            </DeltaDialogContent>
-          </DeltaDialogBody>
-        </>
+      {(viewMode === 'profile' && profileContact) && (
+        <ViewProfile
+          isOpen
+          onClose={onClose}
+          contact={profileContact}
+        />
       )}
     </>
   )

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -217,7 +217,7 @@ function ViewGroupInner(props: {
   )
 
   if (viewMode === 'profile' && !profileContact) {
-    console.error(
+    log.error(
       '[ViewGroup] viewMode is profile but profileContact is null. Showing the main view instead'
     )
   }

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -300,7 +300,8 @@ function ViewGroupInner(props: {
       {viewMode === 'profile' && profileContact && (
         <ViewProfile
           isOpen
-          onClose={() => setViewMode('main')}
+          onBack={() => setViewMode('main')}
+          onClose={onClose}
           contact={profileContact}
         />
       )}

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -216,14 +216,16 @@ function ViewGroupInner(props: {
   const [profileContact, setProfileContact] = useState<Type.Contact | null>(
     null
   )
-  
+
   if (viewMode === 'profile' && !profileContact) {
-    console.error('[ViewGroup] viewMode is profile but profileContact is null. Showing the main view instead')
+    console.error(
+      '[ViewGroup] viewMode is profile but profileContact is null. Showing the main view instead'
+    )
   }
 
   return (
     <>
-      {(viewMode === 'main' || (viewMode === "profile" && !profileContact)) && (
+      {(viewMode === 'main' || (viewMode === 'profile' && !profileContact)) && (
         <>
           <DeltaDialogHeader
             title={
@@ -296,12 +298,8 @@ function ViewGroupInner(props: {
           </div>
         </>
       )}
-      {(viewMode === 'profile' && profileContact) && (
-        <ViewProfile
-          isOpen
-          onClose={onClose}
-          contact={profileContact}
-        />
+      {viewMode === 'profile' && profileContact && (
+        <ViewProfile isOpen onClose={onClose} contact={profileContact} />
       )}
     </>
   )

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -4,7 +4,6 @@ import {
   DeltaDialogBase,
   DeltaDialogHeader,
   DeltaDialogBody,
-  DeltaDialogContent,
   DeltaDialogOkCancelFooter,
 } from './DeltaDialog'
 import { useContactSearch, AddMemberInnerDialog } from './CreateChat'

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -298,7 +298,11 @@ function ViewGroupInner(props: {
         </>
       )}
       {viewMode === 'profile' && profileContact && (
-        <ViewProfile isOpen onClose={onClose} contact={profileContact} />
+        <ViewProfile
+          isOpen
+          onClose={() => setViewMode('main')}
+          contact={profileContact}
+        />
       )}
     </>
   )

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -69,8 +69,9 @@ export default function ViewProfile(props: {
   isOpen: boolean
   onClose: () => void
   contact: Type.Contact
+  onBack?: () => void
 }) {
-  const { isOpen, onClose } = props
+  const { isOpen, onClose, onBack } = props
 
   const accountId = selectedAccountId()
   const tx = window.static_translate
@@ -106,6 +107,8 @@ export default function ViewProfile(props: {
         showEditButton={!(isDeviceChat || isSelfChat)}
         showCloseButton={true}
         onClose={onClose}
+        showBackButton={Boolean(onBack)}
+        onClickBack={onBack}
       />
       <DeltaDialogBody noFooter>
         <DeltaDialogContent noPadding>


### PR DESCRIPTION
This uses `ViewProfile` component to show someone's profile when they are selected from group member list. This fixes #3267 

Note: currently, when the X button is pressed in the user's profile which is shown this way, the entire dialogue is closed. Should it show the previous dialogue instead which is the group member list?