### PR TITLE
Ask for passphrase when exporting backup(closes #2636)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - fix: links in quoted texts should not be clickable (#3290)
 - fix: remove unsupported language code, this broke the installation from the ms store on windows #3292
 
+### Changed
+
+- Ask passphrase for exporting backup.
+
 <a id="1_38_1"></a>
 
 ## [1.38.1] - 2023-06-23

--- a/src/renderer/components/dialogs/DialogController.tsx
+++ b/src/renderer/components/dialogs/DialogController.tsx
@@ -17,6 +17,7 @@ import MuteChat from './MuteChat'
 import QrCode from './QrCode'
 import DisappearingMessages from './DisappearingMessages'
 import ChatAuditLogDialog from './ChatAuditLogDialog'
+import TextDialog from './TextDialog'
 import { getLogger } from '../../../shared/logger'
 
 export const allDialogs: { [key: string]: any } = {
@@ -38,6 +39,7 @@ export const allDialogs: { [key: string]: any } = {
   DisappearingMessages,
   ChatAuditLogDialog,
   QrCode,
+  TextDialog,
 }
 
 export type DialogId = keyof typeof allDialogs | string

--- a/src/renderer/components/dialogs/Settings-Backup.tsx
+++ b/src/renderer/components/dialogs/Settings-Backup.tsx
@@ -51,14 +51,10 @@ function onBackupExport() {
   const closeDialog = window.__closeDialog
   const userFeedback = window.__userFeedback
 
-  openDialog('ConfirmationDialog', {
+  openDialog('TextDialog', {
     message: tx('pref_backup_export_explain'),
-    yesIsPrimary: true,
-    confirmLabel: tx('ok'),
-    cb: async (yes: boolean) => {
-      if (!yes) {
-        return
-      }
+    placeholder: tx('passphrase'),
+    onOk: async (passphrase: string) => {
       const opts: OpenDialogOptions = {
         title: tx('export_backup_desktop'),
         defaultPath: runtime.getAppPath('downloads'),
@@ -83,7 +79,7 @@ function onBackupExport() {
 
       const dialog_number = openDialog(ExportProgressDialog)
       try {
-        await BackendRemote.rpc.exportBackup(accountId, destination, null)
+        await BackendRemote.rpc.exportBackup(accountId, destination, passphrase)
       } catch (error) {
         // TODO/QUESTION - how are errors shown to user?
         log.error('backup-export failed:', error)

--- a/src/renderer/components/dialogs/Settings-Backup.tsx
+++ b/src/renderer/components/dialogs/Settings-Backup.tsx
@@ -54,6 +54,7 @@ function onBackupExport() {
   openDialog('TextDialog', {
     message: tx('pref_backup_export_explain'),
     placeholder: tx('passphrase'),
+    type: 'password',
     onOk: async (passphrase: string) => {
       const opts: OpenDialogOptions = {
         title: tx('export_backup_desktop'),

--- a/src/renderer/components/dialogs/TextDialog.tsx
+++ b/src/renderer/components/dialogs/TextDialog.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react'
+import { DeltaInput } from '../Login-Styles'
+import { DialogProps } from './DialogController'
+import { Card, Elevation } from '@blueprintjs/core'
+import {
+  DeltaDialogBase,
+  DeltaDialogHeader,
+  DeltaDialogBody,
+  DeltaDialogContent,
+  DeltaDialogOkCancelFooter,
+} from './DeltaDialog'
+import { useTranslationFunction } from '../../contexts'
+
+type TextDialogProps = {
+  defaultValue?: string
+  description?: string
+  onOk: (value: string) => void
+  onCancel?: () => void
+}
+
+export default function TextDialog({
+  isOpen,
+  onClose,
+  onOk,
+  onCancel,
+  defaultValue,
+  description,
+}: DialogProps & TextDialogProps) {
+  const [value, setValue] = useState(defaultValue || '')
+  const tx = useTranslationFunction()
+
+  const onClickCancel = () => {
+    onClose()
+    onCancel && onCancel()
+  }
+  const onClickOk = () => {
+    onClose()
+    onOk(value)
+  }
+  return (
+    <DeltaDialogBase
+      onClose={onClose}
+      isOpen={isOpen}
+      canOutsideClickClose={false}
+      style={{
+        top: '15vh',
+        width: '500px',
+        maxHeight: '70vh',
+        height: 'auto',
+      }}
+      fixed
+    >
+      <DeltaDialogHeader title={tx('menu_edit_name')} />
+      <DeltaDialogBody>
+        <Card elevation={Elevation.ONE}>
+          {description && (
+            <DeltaDialogContent>
+              <p>{description}</p>
+            </DeltaDialogContent>
+          )}
+
+          <DeltaInput
+            key='contactname'
+            id='contactname'
+            placeholder={tx('name_desktop')}
+            value={value}
+            onChange={(
+              event: React.FormEvent<HTMLElement> &
+                React.ChangeEvent<HTMLInputElement>
+            ) => {
+              setValue(event.target.value)
+            }}
+          />
+        </Card>
+      </DeltaDialogBody>
+      <DeltaDialogOkCancelFooter onCancel={onClickCancel} onOk={onClickOk} />
+    </DeltaDialogBase>
+  )
+}

--- a/src/renderer/components/dialogs/TextDialog.tsx
+++ b/src/renderer/components/dialogs/TextDialog.tsx
@@ -13,9 +13,10 @@ import { useTranslationFunction } from '../../contexts'
 
 type TextDialogProps = {
   defaultValue?: string
-  description?: string
+  message?: string
   onOk: (value: string) => void
   onCancel?: () => void
+  placeholder?: string
 }
 
 export default function TextDialog({
@@ -24,7 +25,8 @@ export default function TextDialog({
   onOk,
   onCancel,
   defaultValue,
-  description,
+  placeholder,
+  message,
 }: DialogProps & TextDialogProps) {
   const [value, setValue] = useState(defaultValue || '')
   const tx = useTranslationFunction()
@@ -53,16 +55,16 @@ export default function TextDialog({
       <DeltaDialogHeader title={tx('menu_edit_name')} />
       <DeltaDialogBody>
         <Card elevation={Elevation.ONE}>
-          {description && (
+          {message && (
             <DeltaDialogContent>
-              <p>{description}</p>
+              <p>{message}</p>
             </DeltaDialogContent>
           )}
 
           <DeltaInput
             key='contactname'
             id='contactname'
-            placeholder={tx('name_desktop')}
+            placeholder={placeholder}
             value={value}
             onChange={(
               event: React.FormEvent<HTMLElement> &

--- a/src/renderer/components/dialogs/TextDialog.tsx
+++ b/src/renderer/components/dialogs/TextDialog.tsx
@@ -16,7 +16,8 @@ type TextDialogProps = {
   message?: string
   onOk: (value: string) => void
   onCancel?: () => void
-  placeholder?: string
+  placeholder?: string,
+  type?: string
 }
 
 export default function TextDialog({
@@ -26,6 +27,7 @@ export default function TextDialog({
   onCancel,
   defaultValue,
   placeholder,
+  type,
   message,
 }: DialogProps & TextDialogProps) {
   const [value, setValue] = useState(defaultValue || '')
@@ -66,6 +68,7 @@ export default function TextDialog({
             id='contactname'
             placeholder={placeholder}
             value={value}
+            type={type}
             onChange={(
               event: React.FormEvent<HTMLElement> &
                 React.ChangeEvent<HTMLInputElement>

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -86,6 +86,7 @@ export default function ViewProfile(props: {
       onOk: async (value: string) => {
         await BackendRemote.rpc.changeContactName(accountId, contact.id, value)
       },
+      placeholder: tx('name_desktop'),
     })
   }
 

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -28,6 +28,7 @@ import { BackendRemote, onDCEvent, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import moment from 'moment'
 import { InlineVerifiedIcon } from '../VerifiedIcon'
+import TextDialog from './TextDialog'
 
 function LastSeen({ timestamp }: { timestamp: number }) {
   const tx = useTranslationFunction()
@@ -80,14 +81,10 @@ export default function ViewProfile(props: {
   const isSelfChat = contact.id === C.DC_CONTACT_ID_SELF
 
   const onClickEdit = () => {
-    openDialog(EditContactNameDialog, {
-      contactName: contact.name,
-      onOk: async (contactName: string) => {
-        await BackendRemote.rpc.changeContactName(
-          accountId,
-          contact.id,
-          contactName
-        )
+    openDialog(TextDialog, {
+      defaultValue: contact.name,
+      onOk: async (value: string) => {
+        await BackendRemote.rpc.changeContactName(accountId, contact.id, value)
       },
     })
   }
@@ -310,58 +307,5 @@ export function ViewProfileInner({
         )}
       </div>
     </>
-  )
-}
-
-export function EditContactNameDialog({
-  isOpen,
-  onClose,
-  onOk,
-  onCancel,
-  contactName: initialGroupName,
-}: DialogProps) {
-  const [contactName, setContactName] = useState(initialGroupName)
-  const tx = useTranslationFunction()
-
-  const onClickCancel = () => {
-    onClose()
-    onCancel && onCancel()
-  }
-  const onClickOk = () => {
-    onClose()
-    onOk(contactName)
-  }
-  return (
-    <DeltaDialogBase
-      onClose={onClose}
-      isOpen={isOpen}
-      canOutsideClickClose={false}
-      style={{
-        top: '15vh',
-        width: '500px',
-        maxHeight: '70vh',
-        height: 'auto',
-      }}
-      fixed
-    >
-      <DeltaDialogHeader title={tx('menu_edit_name')} />
-      <DeltaDialogBody>
-        <Card elevation={Elevation.ONE}>
-          <DeltaInput
-            key='contactname'
-            id='contactname'
-            placeholder={tx('name_desktop')}
-            value={contactName}
-            onChange={(
-              event: React.FormEvent<HTMLElement> &
-                React.ChangeEvent<HTMLInputElement>
-            ) => {
-              setContactName(event.target.value)
-            }}
-          />
-        </Card>
-      </DeltaDialogBody>
-      <DeltaDialogOkCancelFooter onCancel={onClickCancel} onOk={onClickOk} />
-    </DeltaDialogBase>
   )
 }


### PR DESCRIPTION
This PR:

 - Adds a new dialog: TextDialog
 - Removes ViewProfile's edit contact dialog and replaces it with TextDialog instead
 - Uses TextDialog to ask for passphrase when exporting backup
 - Closes #2636 

It's a draft because:
 - The `pref_backup_export_explain` string must be changed.
 - A `passphrase` string must be added. This is used as a placeholder for TextDialog's text input