### PR TITLE
fix problem of infinite exceptions when it can't write to stdout(fixes #3323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix: When opening new chat dialogue, it's always focused(#3286)
 - fix: No draft is saved if the message contains only whitespace(#3220)
 - fix: webxdc CSP allow media from `blob:` and `data:`
+- fix: Fix problem of crashing Delta Chat when it can't write to standard output (#3323)
 
 <a id="1_38_1"></a>
 

--- a/src/main/log-handler.ts
+++ b/src/main/log-handler.ts
@@ -1,6 +1,12 @@
 import { createWriteStream } from 'fs'
 import { join } from 'path'
 import { getLogsPath } from './application-constants'
+import { stdout, stderr } from 'process'
+
+stdout.on('error', () => {})
+stderr.on('error', () => {})
+// ^ Without this, the app will run into infinite exceptions
+// when it can't write to stdout or stderr
 
 function logName() {
   const dir = getLogsPath()

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -3,9 +3,7 @@ import StackFrame from 'stackframe'
 import { RC_Config } from './shared-types'
 import { stdout } from 'process'
 
-
 stdout.on('error', () => {})
-
 
 const startTime = Date.now()
 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,6 +1,11 @@
 import errorStackParser from 'error-stack-parser'
 import StackFrame from 'stackframe'
 import { RC_Config } from './shared-types'
+import { stdout } from 'process'
+
+
+stdout.on('error', () => {})
+
 
 const startTime = Date.now()
 

--- a/src/shared/logger.ts
+++ b/src/shared/logger.ts
@@ -1,9 +1,6 @@
 import errorStackParser from 'error-stack-parser'
 import StackFrame from 'stackframe'
 import { RC_Config } from './shared-types'
-import { stdout } from 'process'
-
-stdout.on('error', () => {})
 
 const startTime = Date.now()
 


### PR DESCRIPTION
It seems on node v16, we haven't got `stdout.closed` to check it for being true. [that's for v18](https://nodejs.org/dist/latest-v18.x/docs/api/stream.html#writableclosed).

According to docs of v16, we've got [writable](https://nodejs.org/dist/latest-v16.x/docs/api/stream.html#writablewritable) but it is `true` when app is in background and the crash still happens. So this solution I've committed is the only one I've found working.

Fixes #3323 