### PR TITLE
add: `webxdc_custom.desktopDragFileOut` api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- add: `webxdc_custom.desktopDragFileOut` api
 
 ### Fixed
 - fix: clicking start on an already open webxdc app now opens it again even when it was minimised #3294

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -15,6 +15,7 @@ import { tx } from '../load-translations'
 import { DcOpenWebxdcParameters } from '../../shared/shared-types'
 import { DesktopSettings } from '../desktop_settings'
 import { window as main_window } from '../windows/main'
+import { writeTempFileFromBase64 } from '../ipc'
 
 const open_apps: {
   [instanceId: string]: {
@@ -172,7 +173,8 @@ export default class DCWebxdc extends SplitOut {
                   mimeType,
                   data: Buffer.from(
                     `window.parent.webxdc_internal.setup("${selfAddr}","${displayName}")
-                  window.webxdc = window.parent.webxdc`
+                  window.webxdc = window.parent.webxdc
+                  window.webxdc_custom = window.parent.webxdc_custom`
                   ),
                 })
               } else {
@@ -429,6 +431,30 @@ If you think that's a bug and you need that permission, then please open an issu
     ipcMain.handle('close-all-webxdc', () => {
       this._closeAll()
     })
+
+    ipcMain.handle(
+      'webxdc:custom:drag-file-out',
+      async (
+        event,
+        file_name: string,
+        base64_content: string,
+        icon_data_url?: string
+      ) => {
+        const path = await writeTempFileFromBase64(file_name, base64_content)
+        let icon: string | Electron.NativeImage = join(
+          __dirname,
+          '../../../images/electron-file-drag-out.png'
+        )
+        if (icon_data_url) {
+          icon = nativeImage.createFromDataURL(icon_data_url)
+        }
+        // if xdc extract icon?
+        event.sender.startDrag({
+          file: path,
+          icon,
+        })
+      }
+    )
 
     ipcMain.handle(
       'webxdc:status-update',

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -280,7 +280,7 @@ async function writeClipboardToTempFile(): Promise<string> {
   return pathToFile
 }
 
-async function writeTempFileFromBase64(
+export async function writeTempFileFromBase64(
   name: string,
   content: string
 ): Promise<string> {

--- a/static/webxdc-preload.js
+++ b/static/webxdc-preload.js
@@ -250,4 +250,21 @@
       frame.contentWindow.window.addEventListener('keydown', keydown_handler)
     else console.log('attaching F12 handler failed, frame not found')
   }
+
+  contextBridge.exposeInMainWorld('webxdc_custom', {
+    /**
+     *
+     * @param {string} file_name
+     * @param {string} base64_content
+     * @param {string} icon_data_url
+     */
+    desktopDragFileOut: (file_name, base64_content, icon_data_url) => {
+      ipcRenderer.invoke(
+        'webxdc:custom:drag-file-out',
+        file_name,
+        base64_content,
+        icon_data_url
+      )
+    },
+  })
 })()

--- a/static/webxdc-preload.js
+++ b/static/webxdc-preload.js
@@ -256,7 +256,7 @@
      *
      * @param {string} file_name
      * @param {string} base64_content
-     * @param {string} icon_data_url
+     * @param {string | undefined} icon_data_url
      */
     desktopDragFileOut: (file_name, base64_content, icon_data_url) => {
       ipcRenderer.invoke(


### PR DESCRIPTION
this is an api that we added to make the UX of the "store" webxdc nicer on desktop, it allows for drag and drop sending.
It is not yet "official" or really documented as it is just for this one app.

- https://github.com/webxdc/store/pull/197