### PR TITLE
add context menu entry to resend self sent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - add: "always on top" option to webxdc titlebar menu.
+- add: context menu entry to resend webxdc messages
 
 ### Changed
 - remove jitsi as a default Video Chat instance, because they added a sign-in requirement #3366

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - add: "always on top" option to webxdc titlebar menu.
 - add: context menu entry to resend webxdc messages
+- add: context menu entry to resend self sent messages
 
 ### Changed
 - remove jitsi as a default Video Chat instance, because they added a sign-in requirement #3366

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -189,8 +189,7 @@ function buildContextMenu(
   const showAttachmentOptions = !!message.file && !message.isSetupmessage
   const showCopyImage = !!message.file && message.viewType === 'Image'
 
-  const showResend =
-    message.viewType === 'Webxdc' && message.sender.id === C.DC_CONTACT_ID_SELF
+  const showResend = message.sender.id === C.DC_CONTACT_ID_SELF
 
   return [
     // Reply

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -189,6 +189,9 @@ function buildContextMenu(
   const showAttachmentOptions = !!message.file && !message.isSetupmessage
   const showCopyImage = !!message.file && message.viewType === 'Image'
 
+  const showResend =
+    message.viewType === 'Webxdc' && message.sender.id === C.DC_CONTACT_ID_SELF
+
   return [
     // Reply
     !conversationType.isDeviceChat && {
@@ -251,6 +254,13 @@ function buildContextMenu(
       label: tx('menu_forward'),
       action: openForwardDialog.bind(null, message),
     },
+    // Resend Message
+    showResend && {
+      label: tx('resend'),
+      action: () => {
+        BackendRemote.rpc.resendMessages(selectedAccountId(), [message.id])
+      },
+    },
     // Message details
     {
       label: tx('menu_message_details'),
@@ -261,10 +271,6 @@ function buildContextMenu(
       label: tx('delete_message_desktop'),
       action: confirmDeleteMessage.bind(null, message),
     },
-    // showRetry && {
-    //   label:tx('retry_send'),
-    //   action: onRetrySend
-    // },
   ]
 }
 

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -13,7 +13,6 @@ import ChatStore, {
   ChatStoreStateWithChatSet,
 } from '../../stores/chat'
 import { C } from '@deltachat/jsonrpc-client'
-import type { ChatTypes } from 'deltachat-node'
 import moment from 'moment'
 
 import { getLogger } from '../../../shared/logger'
@@ -25,6 +24,12 @@ import { useMessageList } from '../../stores/messagelist'
 import { BackendRemote, onDCEvent } from '../../backend-com'
 import { debouncedUpdateBadgeCounter } from '../../system-integration/badge-counter'
 const log = getLogger('render/components/message/MessageList')
+
+type ChatTypes =
+  | C.DC_CHAT_TYPE_GROUP
+  | C.DC_CHAT_TYPE_MAILINGLIST
+  | C.DC_CHAT_TYPE_SINGLE
+  | C.DC_CHAT_TYPE_UNDEFINED
 
 const onWindowFocus = (accountId: number) => {
   log.debug('window focused')


### PR DESCRIPTION
closes #3259
depends on https://github.com/deltachat/deltachat-core-rust/pull/4567

- [x] make it possible to resend all self sent messages not only webxdc messages, that is the real current android behaviour