### PR TITLE
show previous dialog in CreateChat if any

### DIFF
--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -54,10 +54,26 @@ export default function CreateChat(props: {
   isOpen: DialogProps['isOpen']
   onClose: DialogProps['onClose']
 }) {
-  const { isOpen, onClose } = props
+  const isOpen = props.isOpen
   const tx = useTranslationFunction()
   const { userFeedback } = useContext(ScreenContext)
-  const [viewMode, setViewMode] = useState('main')
+  const [viewModeStack, setViewModeStack] = useState(['main'])
+  const [_openDialogsNumber, setOpenDialogsNumber] = useState(1)
+
+  const setViewMode = (mode: string) => {
+    setViewModeStack(viewModeStack.concat(mode))
+    setOpenDialogsNumber(viewModeStack.length + 1)
+  }
+
+  const onClose = () => {
+    if (viewModeStack.length === 1) {
+      props.onClose()
+    } else {
+      viewModeStack.pop()
+      setViewModeStack(viewModeStack)
+      setOpenDialogsNumber(viewModeStack.length)
+    }
+  }
 
   const [{ contacts, queryStrIsValidEmail }, updateContacts] = useContactsNew(
     C.DC_GCL_ADD_SELF,
@@ -134,6 +150,8 @@ export default function CreateChat(props: {
       />
     )
   }
+
+  const viewMode = viewModeStack[viewModeStack.length - 1]
 
   return (
     <DeltaDialogBase isOpen={isOpen} onClose={onClose} fixed>

--- a/src/renderer/components/dialogs/DialogController.tsx
+++ b/src/renderer/components/dialogs/DialogController.tsx
@@ -75,10 +75,12 @@ export default class DialogController extends React.Component<
     }
   }
 > {
+  public dialogsStack: number[]
   constructor(props: any) {
     super(props)
 
     this.state = { dialogs: {} }
+    this.dialogsStack = []
     this.openDialog = this.openDialog.bind(this)
     this.closeDialog = this.closeDialog.bind(this)
     this.hasOpenDialogs = this.hasOpenDialogs.bind(this)
@@ -121,6 +123,7 @@ export default class DialogController extends React.Component<
         },
       }
     })
+    this.dialogsStack.push(id)
     return id
   }
 
@@ -131,6 +134,7 @@ export default class DialogController extends React.Component<
       log.debug(`Close dialog with id: ${id}`)
       return { ...prevState, dialogs }
     })
+    this.dialogsStack.pop()
   }
 
   render() {


### PR DESCRIPTION
This tries to address #2268
Currently, it is only implemented for CreateChat dialog. Please comment on my solution. If it's good, I could think of a universal way of doing so for all such these situations.

Currently clicking outside the dialog, goes back to previous dialog. I think this is not good and should rather close every thing. Please comment on this one, too.