### PR TITLE
first prototype of highlight qr codes in fullscreen image view

### DIFF
--- a/bin/build-frontend-ts.mjs
+++ b/bin/build-frontend-ts.mjs
@@ -52,6 +52,10 @@ async function bundle(production, minify = false) {
     'node_modules/@deltachat/message_parser_wasm/message_parser_wasm_bg.wasm',
     'html-dist/message_parser_wasm_bg.wasm'
   )
+  await copyFile(
+    'node_modules/quircs-wasm/quircs_wasm_bg.wasm',
+    'html-dist/quircs_wasm_bg.wasm'
+  )
 }
 
 let wasmPlugin = {

--- a/images/qrhighlight-off.svg
+++ b/images/qrhighlight-off.svg
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24px"
+   height="24px"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1620"
+   sodipodi:docname="qrhighlight-off.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1622"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="14.296316"
+     inkscape:cx="18.955932"
+     inkscape:cy="16.227956"
+     inkscape:window-width="1344"
+     inkscape:window-height="430"
+     inkscape:window-x="51"
+     inkscape:window-y="328"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g8543" />
+  <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title1602">Icons/Download/download-24</title>
+  <desc
+     id="desc1604">Created with Sketch.</desc>
+  <defs
+     id="defs1608">
+    <path
+       d="M19,9 L15,9 L15,3 L9,3 L9,9 L5,9 L12,16 L19,9 Z M5,18 L5,20 L19,20 L19,18 L5,18 Z"
+       id="path-1" />
+    <rect
+       id="path-3"
+       x="0"
+       y="0"
+       width="24"
+       height="24" />
+  </defs>
+  <g
+     id="g4290"
+     transform="matrix(1.5731895,0,0,1.5731895,19.865947,27.731895)"
+     style="stroke:#000000;stroke-opacity:1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -10,-15 v 4 h 4 v -4 h -4"
+       id="path2603" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -4,-15 v 4 h 4 v -4 h -4"
+       id="path2603-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -10,-9 v 4 h 4 v -4 h -4"
+       id="path2603-3-9" />
+    <rect
+       style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3521"
+       width="0.50000018"
+       height="0.49999988"
+       x="-8.25"
+       y="-13.25" />
+    <rect
+       style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3521-8"
+       width="0.50000018"
+       height="0.49999988"
+       x="-8.25"
+       y="-7.25" />
+    <rect
+       style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3521-4"
+       width="0.50000018"
+       height="0.49999988"
+       x="-2.25"
+       y="-13.25" />
+  </g>
+  <g
+     id="g4596"
+     transform="matrix(1.5491525,0,0,1.5491525,-3.359322,27.623729)">
+    <g
+       id="g4297"
+       transform="translate(15)"
+       style="display:none;stroke:#000000;stroke-opacity:1">
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2"
+         width="0.50000018"
+         height="0.49999988"
+         x="-4.25"
+         y="-5.25" />
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2-9"
+         width="0.50000018"
+         height="0.49999988"
+         x="-2.25"
+         y="-5.25" />
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2-9-3"
+         width="0.50000018"
+         height="0.49999988"
+         x="-3.25"
+         y="-6.25" />
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2-9-3-9"
+         width="0.50000018"
+         height="0.49999988"
+         x="-1.25"
+         y="-6.25" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 0,-4.5 V -9 h -4 v 2 h 2 v -2 h 2 z"
+         id="path3908"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g8543"
+       transform="matrix(1,0,0,-1,-0.13545746,-11.837353)"
+       style="stroke-width:1.16192563;stroke-dasharray:none">
+      <path
+         id="path6749"
+         style="font-variation-settings:'wght' 800;fill:none;stroke:#000000;stroke-width:1.16192563;stroke-linecap:round;stroke-linejoin:round;paint-order:markers stroke fill;stroke-dasharray:none"
+         d="m 11.681985,-5.3664961 c 0,-0.740079 1.068629,-1.3400315 2.386849,-1.3400316 1.31822,10e-8 2.386849,0.5999526 2.386849,1.3400316"
+         sodipodi:nodetypes="csc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1.16193;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 12.577082,-6.4268161 11.883142,-7.422574"
+         id="path6994"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1.16193;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="m 15.749088,-6.6525786 0.69394,-0.9506054"
+         id="path6996"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1.16193;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+         d="m 14.027456,-6.7591934 -0.03022,-1.6296097"
+         id="path6998"
+         sodipodi:nodetypes="cc" />
+      <path
+         style="fill:none;stroke:#000000;stroke-width:1.16193;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+         d="M 12.424456,-6.6525786 11.730516,-7.603184"
+         id="path11521"
+         sodipodi:nodetypes="cc" />
+    </g>
+  </g>
+  <metadata
+     id="metadata8561">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:title>Icons/Download/download-24</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/images/qrhighlight-on.svg
+++ b/images/qrhighlight-on.svg
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24px"
+   height="24px"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1620"
+   sodipodi:docname="qrhighlight-on.svg"
+   inkscape:version="1.2.2 (b0a84865, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1622"
+     pagecolor="#505050"
+     bordercolor="#ffffff"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#505050"
+     showgrid="false"
+     inkscape:zoom="5.9158504"
+     inkscape:cx="-13.353955"
+     inkscape:cy="16.058553"
+     inkscape:window-width="1344"
+     inkscape:window-height="430"
+     inkscape:window-x="51"
+     inkscape:window-y="300"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g14626" />
+  <!-- Generator: Sketch 50.2 (55047) - http://www.bohemiancoding.com/sketch -->
+  <title
+     id="title1602">Icons/Download/download-24</title>
+  <desc
+     id="desc1604">Created with Sketch.</desc>
+  <defs
+     id="defs1608">
+    <path
+       d="M19,9 L15,9 L15,3 L9,3 L9,9 L5,9 L12,16 L19,9 Z M5,18 L5,20 L19,20 L19,18 L5,18 Z"
+       id="path-1" />
+    <rect
+       id="path-3"
+       x="0"
+       y="0"
+       width="24"
+       height="24" />
+  </defs>
+  <g
+     id="g4290"
+     transform="matrix(1.5731895,0,0,1.5731895,19.865947,27.731895)"
+     style="stroke:#000000;stroke-opacity:1">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -10,-15 v 4 h 4 v -4 h -4"
+       id="path2603" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -4,-15 v 4 h 4 v -4 h -4"
+       id="path2603-3" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m -10,-9 v 4 h 4 v -4 h -4"
+       id="path2603-3-9" />
+    <rect
+       style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3521"
+       width="0.50000018"
+       height="0.49999988"
+       x="-8.25"
+       y="-13.25" />
+    <rect
+       style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3521-8"
+       width="0.50000018"
+       height="0.49999988"
+       x="-8.25"
+       y="-7.25" />
+    <rect
+       style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect3521-4"
+       width="0.50000018"
+       height="0.49999988"
+       x="-2.25"
+       y="-13.25" />
+  </g>
+  <g
+     id="g4596"
+     transform="matrix(1.5491525,0,0,1.5491525,-3.359322,27.623729)">
+    <g
+       id="g4297"
+       transform="translate(15)"
+       style="display:none;stroke:#000000;stroke-opacity:1">
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2"
+         width="0.50000018"
+         height="0.49999988"
+         x="-4.25"
+         y="-5.25" />
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2-9"
+         width="0.50000018"
+         height="0.49999988"
+         x="-2.25"
+         y="-5.25" />
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2-9-3"
+         width="0.50000018"
+         height="0.49999988"
+         x="-3.25"
+         y="-6.25" />
+      <rect
+         style="fill:none;fill-opacity:0.395147;stroke:#000000;stroke-width:0.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="rect3521-8-2-9-3-9"
+         width="0.50000018"
+         height="0.49999988"
+         x="-1.25"
+         y="-6.25" />
+      <path
+         style="display:inline;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 0,-4.5 V -9 h -4 v 2 h 2 v -2 h 2 z"
+         id="path3908"
+         sodipodi:nodetypes="cccccccc" />
+    </g>
+    <g
+       id="g14626"
+       transform="matrix(1.3366208,0,0,1.3029059,-5.2965025,1.2750737)">
+      <g
+         id="g15446"
+         transform="matrix(0.91154218,0,0,0.91154218,1.2444984,-0.52514919)">
+        <ellipse
+           style="font-variation-settings:'wght' 800;fill:none;stroke:#000000;stroke-width:0.763569;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           id="path6749"
+           cx="14.068834"
+           cy="-5.3664961"
+           rx="2.3868492"
+           ry="1.3400316" />
+        <ellipse
+           style="font-variation-settings:'wght' 800;fill:none;stroke:#000000;stroke-width:0.599198;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1;paint-order:markers stroke fill"
+           id="path6773"
+           cx="14.080344"
+           cy="-5.331193"
+           rx="0.33675766"
+           ry="0.17860094" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.763569;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="m 12.577082,-6.4268161 -0.423025,-0.634538"
+           id="path6994" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.763569;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+           d="m 15.568478,-6.4268161 0.423025,-0.634538"
+           id="path6996" />
+        <path
+           style="fill:none;stroke:#000000;stroke-width:0.763569;stroke-linecap:round;stroke-linejoin:miter;stroke-dasharray:none;stroke-opacity:1"
+           d="m 14.027456,-6.7591934 -0.03022,-1.0877799"
+           id="path6998" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "mime-types": "^2.1.31",
         "moment": "^2.29.2",
         "path-browserify": "^1.0.1",
+        "quircs-wasm": "^0.1.1",
         "rc": "^1.2.8",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -6203,6 +6204,11 @@
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
+    "node_modules/quircs-wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/quircs-wasm/-/quircs-wasm-0.1.1.tgz",
+      "integrity": "sha512-m2B0+SCOLSUImjvRFA4xSU/USIUcibB7Vj9ol7ylnZImOdQu5BTZb5FBE4ueyOyftp+lWhSMpc9tGMOYgzzeYg=="
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -12316,6 +12322,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
+    },
+    "quircs-wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/quircs-wasm/-/quircs-wasm-0.1.1.tgz",
+      "integrity": "sha512-m2B0+SCOLSUImjvRFA4xSU/USIUcibB7Vj9ol7ylnZImOdQu5BTZb5FBE4ueyOyftp+lWhSMpc9tGMOYgzzeYg=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "mime-types": "^2.1.31",
     "moment": "^2.29.2",
     "path-browserify": "^1.0.1",
+    "quircs-wasm": "^0.1.1",
     "rc": "^1.2.8",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/scss/gallery/_attachment-view.scss
+++ b/scss/gallery/_attachment-view.scss
@@ -38,14 +38,33 @@
     padding: 5px;
 
     .download-btn {
-      height: 32px;
-      width: 32px;
-      display: inline-block;
-      vertical-align: text-bottom;
       @include color-svg(
         '../images/download.svg',
         var(--fullScreenMediaButtons)
       );
+    }
+
+    .qrhighlight-on-btn {
+      @include color-svg(
+        '../images/qrhighlight-on.svg',
+        var(--fullScreenMediaButtons)
+      );
+    }
+
+    .qrhighlight-off-btn {
+      @include color-svg(
+        '../images/qrhighlight-off.svg',
+        var(--fullScreenMediaButtons)
+      );
+    }
+
+    .download-btn,
+    .qrhighlight-on-btn,
+    .qrhighlight-off-btn {
+      height: 32px;
+      width: 32px;
+      display: inline-block;
+      vertical-align: text-bottom;
 
       &:hover {
         background-color: var(--fullScreenMediaButtons);
@@ -86,4 +105,35 @@
 
 .react-transform-wrapper {
   overflow: unset !important;
+}
+
+.attachment-overlay {
+  .qr-code-highlight-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    .qr-code-highlight-img-area {
+      position: absolute;
+
+      .qrcode-highlight {
+        border: 1.6px solid orange;
+        border-radius: 4px;
+        min-height: 10px;
+        min-width: 10px;
+
+        &:hover {
+          background-color: rgba(0, 0, 0, 0.25);
+          color: white;
+          border-width: 1.9px;
+        }
+
+        color: darkblue;
+        overflow: hidden;
+        position: absolute;
+      }
+    }
+  }
 }

--- a/src/renderer/components/dialogs/FullscreenMedia.tsx
+++ b/src/renderer/components/dialogs/FullscreenMedia.tsx
@@ -414,6 +414,23 @@ function QrCodeHighlight({
   const height = Math.abs(code.corners[3].y - code.corners[0].y) * scalingRatio
   const width = Math.abs(code.corners[2].x - code.corners[0].x) * scalingRatio
 
+  // const scalePoint = (point: { x: number; y: number }, factor:number) =>{
+  //   return { x: point.x *factor, y: point.y *factor }
+  // }
+
+  // function distance(
+  //   pointA: { x: number; y: number },
+  //   pointB: { x: number; y: number }
+  // ) {
+  //   var dx = pointA.x - pointB.x // delta x
+  //   var dy = pointA.y - pointB.y // delta y
+  //   var dist = Math.sqrt(dx * dx + dy * dy) // distance
+  //   return dist
+  // }
+
+  // const height = distance(scalePoint(code.corners[3], scalingRatio), scalePoint(code.corners[0], scalingRatio)) 
+  // const width = distance(scalePoint(code.corners[2], scalingRatio), scalePoint(code.corners[0], scalingRatio))
+
   const onClick = () => {
     if (code.data['content']) {
       processOpenQrUrl(
@@ -433,26 +450,41 @@ function QrCodeHighlight({
   ])
 
   return (
-    <div
-      className='qrcode-highlight'
-      style={{
-        borderColor,
-        translate: `${x}px ${y}px`,
-        height: `${height}px`,
-        width: `${width}px`,
-        cursor: isError ? 'default' : 'pointer',
-      }}
-      title={
-        code.data['error'] ||
-        String.fromCharCode.apply(null, code.data['content']?.payload)
-      }
-      onClick={onClick}
-      onContextMenu={code.data['content'] && menu}
-    >
-      {code.data['error']}
-      <br />
-      {JSON.stringify(code.corners)}
-      QRCODE {String.fromCharCode.apply(null, code.data['content']?.payload)}
-    </div>
+    <>
+      {code.corners.map((c, i) => (
+        <div
+          key={JSON.stringify(c)}
+          style={{
+            translate: `${c.x * scalingRatio}px ${c.y * scalingRatio}px`,
+            background: 'yellow',
+            position: 'absolute',
+          }}
+        >
+          {i}
+        </div>
+      ))}
+      <div
+        key={'highlight'}
+        className='qrcode-highlight'
+        style={{
+          borderColor,
+          translate: `${x}px ${y}px`,
+          height: `${height}px`,
+          width: `${width}px`,
+          cursor: isError ? 'default' : 'pointer',
+        }}
+        title={
+          code.data['error'] ||
+          String.fromCharCode.apply(null, code.data['content']?.payload)
+        }
+        onClick={onClick}
+        onContextMenu={code.data['content'] && menu}
+      >
+        {code.data['error']}
+        <br />
+        {JSON.stringify(code.corners)}
+        QRCODE {String.fromCharCode.apply(null, code.data['content']?.payload)}
+      </div>
+    </>
   )
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -5,7 +5,8 @@ import { printProcessLogLevelInfo } from '../shared/logger'
 
 import App from './App'
 import { runtime } from './runtime'
-import init from '@deltachat/message_parser_wasm'
+import initMessageParser from '@deltachat/message_parser_wasm'
+import initQuircs from 'quircs-wasm'
 import initSystemIntegration from './system-integration'
 
 async function main() {
@@ -13,7 +14,10 @@ async function main() {
   try {
     runtime.initialize()
     printProcessLogLevelInfo()
-    await init('./message_parser_wasm_bg.wasm')
+    await Promise.all([
+      initMessageParser('./message_parser_wasm_bg.wasm'),
+      initQuircs('./quircs_wasm_bg.wasm'),
+    ])
 
     initSystemIntegration()
 


### PR DESCRIPTION
- [x] icon button to toggle
- [ ] handle window resize (ideally only change scaling without looking for qrcodes again) - test in both directions height and width
- [ ] correct positioning -> still has bugs getting the correct scaling sometimes
- [ ] nice design
- [ ] context menu -> does not open, somehow the other context menu blocks it (maybe the pan library?? or react?)
- [x] click to open link
- [ ] if user opens internal link then close the fullscreen media view when user takes an action that justifies it. (join group, create new account and so on)
- [ ] for the enum in the wasm qr code scanner I might need it in another serde variant  representation, ts does not like the current one
- [ ] bonus: 3D perspective for qr code highlight
- [ ] better detection with other or hybrid (use 2 libs at the same time) library
- [ ] worker thread (don't block ui)