### PR TITLE
show at least a basic hint on "Welcome / Add Second Device"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## [1.39.0] - 2023-08-05
 ### Added
+- Guide user tapping "Welcome / Add Second Device" what to do on the other device
 - add: `webxdc_custom.desktopDragFileOut` api
 
 ### Changed

--- a/src/renderer/components/dialogs/ImportQrCode.tsx
+++ b/src/renderer/components/dialogs/ImportQrCode.tsx
@@ -3,9 +3,11 @@ import DeltaDialog from './DeltaDialog'
 import { QrCodeScanQrInner } from './QrCode'
 
 export default function ImportQrCode({
+  subtitle,
   onClose,
   isOpen,
 }: {
+  subtitle: string
   onClose: () => void
   isOpen: boolean
 }) {
@@ -18,7 +20,7 @@ export default function ImportQrCode({
       onClose={onClose}
       showCloseButton={false}
     >
-      <QrCodeScanQrInner onClose={onClose} />
+      <QrCodeScanQrInner subtitle={subtitle} onClose={onClose} />
     </DeltaDialog>
   )
 }

--- a/src/renderer/components/dialogs/QrCode.tsx
+++ b/src/renderer/components/dialogs/QrCode.tsx
@@ -188,7 +188,7 @@ export function QrCodeShowQrInner({
 }
 
 export function QrCodeScanQrInner(
-  props: PropsWithChildren<{
+  props: React.PropsWithChildren<{
     subtitle: string
     onClose: () => void
   }>

--- a/src/renderer/components/dialogs/QrCode.tsx
+++ b/src/renderer/components/dialogs/QrCode.tsx
@@ -68,7 +68,9 @@ export default function QrCode({
           onClose={onClose}
         />
       )}
-      {!showQrCode && <QrCodeScanQrInner onClose={onClose} />}
+      {!showQrCode && (
+        <QrCodeScanQrInner subtitle={tx('qrscan_hint')} onClose={onClose} />
+      )}
     </DeltaDialogBase>
   )
 }
@@ -185,13 +187,18 @@ export function QrCodeShowQrInner({
   )
 }
 
-export function QrCodeScanQrInner({ onClose }: { onClose: () => void }) {
+export function QrCodeScanQrInner(
+  props: PropsWithChildren<{
+    subtitle: string
+    onClose: () => void
+  }>
+) {
   const tx = window.static_translate
 
   const processingQrCode = useRef(false)
 
   const onDone = () => {
-    onClose()
+    props.onClose()
     processingQrCode.current = false
   }
 
@@ -279,7 +286,7 @@ export function QrCodeScanQrInner({ onClose }: { onClose: () => void }) {
               />
             </div>
             <div className='scan-qr-red-line' />
-            <p className='scan-qr-description'>{tx('qrscan_hint')}</p>
+            <p className='scan-qr-description'>{props.subtitle}</p>
           </div>
         </DeltaDialogContent>
       </DeltaDialogBody>
@@ -288,7 +295,7 @@ export function QrCodeScanQrInner({ onClose }: { onClose: () => void }) {
           <p className={'delta-button bold primary'} onClick={openMenu}>
             {tx('menu_more_options')}
           </p>
-          <p className={'delta-button bold primary'} onClick={onClose}>
+          <p className={'delta-button bold primary'} onClick={props.onClose}>
             {tx('close')}
           </p>
         </DeltaDialogFooterActions>

--- a/src/renderer/components/screens/WelcomeScreen.tsx
+++ b/src/renderer/components/screens/WelcomeScreen.tsx
@@ -114,7 +114,12 @@ export default function WelcomeScreen({
 }) {
   const tx = useTranslationFunction()
   const { openDialog } = useContext(ScreenContext)
-  const onClickScanQr = () => openDialog('ImportQrCode')
+  const onClickScanQr = () =>
+    openDialog('ImportQrCode', { subtitle: tx('qrscan_hint') })
+  const onClickSecondDevice = () =>
+    openDialog('ImportQrCode', {
+      subtitle: tx('multidevice_open_settings_on_other_device'),
+    })
   const [showBackButton, setShowBackButton] = useState(false)
 
   useEffect(() => {
@@ -184,7 +189,7 @@ export default function WelcomeScreen({
                   </button>
                   <button
                     className='delta-button-round secondary'
-                    onClick={onClickScanQr}
+                    onClick={onClickSecondDevice}
                   >
                     {tx('multidevice_receiver_title')}
                   </button>


### PR DESCRIPTION
the idea of the extra "Welcome / Add Second Device" button is to guide users installing Delta Chat on a second device without even being aware of the settings option on the other device.

without the hint to the other device,
the user has no idea, how to set up a second device or what to scan.

<img width="847" alt="Screenshot 2023-08-09 at 19 42 19" src="https://github.com/deltachat/deltachat-desktop/assets/9800740/837cb489-356c-492e-85c7-3c92c21d653c">

the dialog may be improved eg. also showing
`multidevice_same_network_hint` and `multidevice_experimental_hint`, however, that does not fit to the existing dialog - therefore, this pr fixes the very basic things only.

fixes https://github.com/deltachat/deltachat-desktop/issues/3178 together with #3349