### PR TITLE
update `@deltachat/message_parser_wasm` to `0.6.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 
 ### Changed
+- update `@deltachat/message_parser_wasm` to `0.6.0`, which fixes 2 bugs:
+ - Fixed problem of IPv6 links being detected as punycode
+ - Fixed the bug of brackets being parsed as part of the email address
 
 ### Fixed
 - fix missing translation string in setup second device progress dialog

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@blueprintjs/core": "^4.1.2",
         "@deltachat/jsonrpc-client": "^1.119.0",
-        "@deltachat/message_parser_wasm": "^0.5.1",
+        "@deltachat/message_parser_wasm": "^0.6.0",
         "@deltachat/react-qr-reader": "^4.0.0",
         "@emoji-mart/data": "1.1.2",
         "@emoji-mart/react": "1.1.1",
@@ -174,9 +174,9 @@
       }
     },
     "node_modules/@deltachat/message_parser_wasm": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.5.1.tgz",
-      "integrity": "sha512-1BtV26EGmv7vR4C5B9qL5APjX7MeGFSlx3udFG4RkfCr5WroRvASfybFJ3OUcgho8jmIoV5m9de9+RhEW4fqUA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.6.0.tgz",
+      "integrity": "sha512-Fqzu8FwShJ8RFhdNg78umWItjSQsdmw05rpo62GU43PPiKPIAft+HBUKPIw7ziYz50RXUe4F+P4D/RwB/dZUjA=="
     },
     "node_modules/@deltachat/react-qr-reader": {
       "version": "4.0.0",
@@ -7846,9 +7846,9 @@
       }
     },
     "@deltachat/message_parser_wasm": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.5.1.tgz",
-      "integrity": "sha512-1BtV26EGmv7vR4C5B9qL5APjX7MeGFSlx3udFG4RkfCr5WroRvASfybFJ3OUcgho8jmIoV5m9de9+RhEW4fqUA=="
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@deltachat/message_parser_wasm/-/message_parser_wasm-0.6.0.tgz",
+      "integrity": "sha512-Fqzu8FwShJ8RFhdNg78umWItjSQsdmw05rpo62GU43PPiKPIAft+HBUKPIw7ziYz50RXUe4F+P4D/RwB/dZUjA=="
     },
     "@deltachat/react-qr-reader": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "dependencies": {
     "@blueprintjs/core": "^4.1.2",
     "@deltachat/jsonrpc-client": "^1.119.0",
-    "@deltachat/message_parser_wasm": "^0.5.1",
+    "@deltachat/message_parser_wasm": "^0.6.0",
     "@deltachat/react-qr-reader": "^4.0.0",
     "@emoji-mart/data": "1.1.2",
     "@emoji-mart/react": "1.1.1",


### PR DESCRIPTION
which fixes 2 bugs:
 - Fixed problem of IPv6 links being detected as punycode
 - Fixed the bug of brackets being parsed as part of the email address
