### PR TITLE
Fix Gallery errors cannot be closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 
+ - Fixed error in Gallery cannot be closed(#3339)
 
 <a id="1_39_0"></a>
 

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -81,7 +81,7 @@ export default class Gallery extends Component<
       showErrors: true,
     }
     runtime.getDesktopSettings().then((settings: DesktopSettingsType) => {
-      let showErrorsSettings = settings.DontShowMissingFilesError
+      const showErrorsSettings = settings.DontShowMissingFilesError
       if (showErrorsSettings && showErrorsSettings[props.chatId]) {
         this.setState({ showErrors: false })
       }

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -46,8 +46,8 @@ type GalleryErrorsProps = {
 function GalleryErrors({ onClose, errors }: GalleryErrorsProps) {
   return (
     <div className='loading-errors' onClick={() => onClose(false)}>
-      The following messages failed to load, please report these
-      errors to the developers:
+      The following messages failed to load, please report these errors to the
+      developers:
       <ul>
         {errors.map(error => (
           <li key={error.msgId}>
@@ -58,7 +58,7 @@ function GalleryErrors({ onClose, errors }: GalleryErrorsProps) {
       <button onClick={() => onClose(false)}>Close</button>
       <button onClick={() => onClose(true)}>Close and Don't show again</button>
     </div>
-  );
+  )
 }
 
 export default class Gallery extends Component<
@@ -83,9 +83,9 @@ export default class Gallery extends Component<
     runtime.getDesktopSettings().then((settings: DesktopSettingsType) => {
       let showErrorsSettings = settings.DontShowMissingFilesError
       if (showErrorsSettings && showErrorsSettings[props.chatId]) {
-        this.setState({ showErrors: false });
+        this.setState({ showErrors: false })
       }
-    });
+    })
   }
 
   componentDidMount() {
@@ -180,19 +180,28 @@ export default class Gallery extends Component<
           <div className='bp4-tab-panel' role='tabpanel'>
             <div className='gallery'>
               {errors.length > 0 && showErrors && (
-                <GalleryErrors onClose={(neverShowAgain: boolean) => {
-                  this.setState({ showErrors: false });
-                  if (neverShowAgain) {
-                    runtime.getDesktopSettings().then((settings: DesktopSettingsType) => {
-                      let showErrorsSettings = settings.DontShowMissingFilesError
-                      if (!showErrorsSettings) {
-                        showErrorsSettings = {}
-                      }
-                      showErrorsSettings[this.props.chatId] = true
-                      SettingsStoreInstance.effect.setDesktopSetting("DontShowMissingFilesError", showErrorsSettings);
-                    });
-                  }
-                }} errors={errors} />
+                <GalleryErrors
+                  onClose={(neverShowAgain: boolean) => {
+                    this.setState({ showErrors: false })
+                    if (neverShowAgain) {
+                      runtime
+                        .getDesktopSettings()
+                        .then((settings: DesktopSettingsType) => {
+                          let showErrorsSettings =
+                            settings.DontShowMissingFilesError
+                          if (!showErrorsSettings) {
+                            showErrorsSettings = {}
+                          }
+                          showErrorsSettings[this.props.chatId] = true
+                          SettingsStoreInstance.effect.setDesktopSetting(
+                            'DontShowMissingFilesError',
+                            showErrorsSettings
+                          )
+                        })
+                    }
+                  }}
+                  errors={errors}
+                />
               )}
               <div
                 className='item-container'

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -133,10 +133,7 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         rc,
       })
     },
-    setDesktopSetting: async (
-      key: keyof DesktopSettingsType,
-      value: any
-    ) => {
+    setDesktopSetting: async (key: keyof DesktopSettingsType, value: any) => {
       try {
         await runtime.setDesktopSetting(key, value)
         this.reducer.setDesktopSetting(key, value)

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -135,7 +135,7 @@ class SettingsStore extends Store<SettingsStoreState | null> {
     },
     setDesktopSetting: async (
       key: keyof DesktopSettingsType,
-      value: string | number | boolean
+      value: any
     ) => {
       try {
         await runtime.setDesktopSetting(key, value)

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -69,6 +69,8 @@ export interface DesktopSettingsType {
   HTMLEmailAskForRemoteLoadingConfirmation: boolean
   /** always loads remote content without asking, for non contact requests  */
   HTMLEmailAlwaysLoadRemoteContent: boolean
+  /** Set true for a chat so that the missing files error in gallery won't be shown again **/
+  DontShowMissingFilesError?: { [chatId: number]: boolean }
 }
 
 export interface RC_Config {


### PR DESCRIPTION
This PR fixes #3339 

The error in Gallery when shown has two buttons to close the error, or to close it and never show it again for this chat. If the latter is chosen, a property in desktop settings is set to `true` for this chatId so it won't be shown for this chat ever again.