### PR TITLE
simon/webxdc titlebar menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- fix: show webxdc titlebar also on mac -> make show sourcecode link accessible on macOS
 
 <a id="1_40_0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## [Unreleased][unreleased]
 
 ### Added
+- add: "always on top" option to webxdc titlebar menu.
 
 ### Changed
 
 ### Fixed
 - fix: show webxdc titlebar also on mac -> make show sourcecode link accessible on macOS
+- fix: hide devtool option in webxdc titlebar menu when it is not enabled.
+- fix: remove reload options that don't work from webxdc titlebar menu.
 
 <a id="1_40_0"></a>
 

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -4,7 +4,13 @@ import SplitOut from './splitout'
 import { getLogger } from '../../shared/logger'
 const log = getLogger('main/deltachat/webxdc')
 import Mime from 'mime-types'
-import { Menu, ProtocolResponse, nativeImage, shell } from 'electron'
+import {
+  Menu,
+  ProtocolResponse,
+  nativeImage,
+  shell,
+  MenuItemConstructorOptions,
+} from 'electron'
 import { join } from 'path'
 import { readdir, stat, rmdir, writeFile, readFile } from 'fs/promises'
 import { getConfigPath, htmlDistDir } from '../application-constants'
@@ -254,7 +260,41 @@ export default class DCWebxdc extends SplitOut {
                 },
               ],
             },
-            { role: 'viewMenu' },
+            {
+              label: tx('global_menu_view_desktop'),
+              submenu: [
+                ...(DesktopSettings.state.enableWebxdcDevTools
+                  ? [
+                      {
+                        label: tx('global_menu_view_developer_tools_desktop'),
+                        role: 'toggleDevTools',
+                      } as MenuItemConstructorOptions,
+                    ]
+                  : []),
+                { type: 'separator' },
+                { role: 'resetZoom' },
+                { role: 'zoomIn' },
+                { role: 'zoomOut' },
+                { type: 'separator' },
+                {
+                  label: tx('global_menu_view_floatontop_desktop'),
+                  type: 'checkbox',
+                  checked: webxdc_windows.isAlwaysOnTop(),
+                  click: () => {
+                    webxdc_windows.setAlwaysOnTop(
+                      !webxdc_windows.isAlwaysOnTop()
+                    )
+                    if (platform() !== 'darwin') {
+                      webxdc_windows.setMenu(makeMenu())
+                    } else {
+                      // change to webxdc menu
+                      Menu.setApplicationMenu(makeMenu())
+                    }
+                  },
+                },
+                { role: 'togglefullscreen' },
+              ],
+            },
             {
               label: tx('menu_help'),
               submenu: [
@@ -283,7 +323,7 @@ export default class DCWebxdc extends SplitOut {
 
         webxdc_windows.on('focus', () => {
           if (process.platform === 'darwin') {
-            // change back to webxdc menu
+            // change to webxdc menu
             Menu.setApplicationMenu(makeMenu())
           }
         })

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -13,6 +13,7 @@ import { refreshTrayContextMenu } from '../tray'
 import { join } from 'path'
 import { DesktopSettings } from '../desktop_settings'
 import { Session } from 'electron/main'
+import { refresh as refreshTitleMenu } from '../menu'
 const log = getLogger('main/mainWindow')
 
 export let window: (BrowserWindow & { hidden?: boolean }) | null = null
@@ -96,6 +97,7 @@ export function init(options: { hidden: boolean }) {
   window.on('focus', () => {
     main_window.hidden = false
     refreshTrayContextMenu()
+    refreshTitleMenu()
   })
 
   const allowed_web_permissions = [


### PR DESCRIPTION
- fix: show webxdc titlebar also on mac -> make show sourcecode link accessible on macOS
- fix: hide devtool option in webxdc titlebar menu when it is not enabled.
