### PR TITLE
feat: add "related chats" to group profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - mark webxdc app context as secure #3413
+- Experimental: Related Chats
 
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.123.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Added
 - Show video chat instance URLs as subtitles #3369
+- Add similar chats to group profile #3379
 
 ### Changed
 - Offer to copy non-HTTP links to the clipboard instead of trying to open them in webxdc source code link and inside of html emails.

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -73,5 +73,8 @@
   },
   "desktop_offer_copy_non_web_link_to_clipboard": {
     "message": "The link \"%1$d\" can not be opened in the web browser. Do you want to copy the link to the clipboard instead?"
+  },
+  "group_related_chats": {
+    "message": "Related Chats"
   }
 }

--- a/scss/dialogs/_group-styles.scss
+++ b/scss/dialogs/_group-styles.scss
@@ -46,6 +46,11 @@ div.group-member-contact-list-wrapper {
   margin-right: -20px;
 }
 
+div.group-related-chats-list-wrapper {
+  margin-left: -20px;
+  margin-bottom: -20px;
+}
+
 div.group-image-wrapper {
   position: relative;
   div.group-image-edit-button {

--- a/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
+++ b/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
@@ -73,6 +73,10 @@ export function SettingsExperimentalFeatures({
         label: tx('menu_chat_audit_log'),
       })}
       {renderDTSettingSwitch({
+        key: 'EnableRelatedChats',
+        label: tx('group_related_chats'),
+      })}
+      {renderDTSettingSwitch({
         key: 'experimentalEnableMarkdownInMessages',
         label: 'Render Markdown in Messages',
       })}

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -265,9 +265,7 @@ function ViewGroupInner(props: {
                   {groupName} {chat.isProtected && <InlineVerifiedIcon />}
                 </p>
               </div>
-              <div className='group-separator'>
-                {tx('profile_shared_chats')}
-              </div>
+              <div className='group-separator'>{tx('group_related_chats')}</div>
               <div style={{ marginLeft: '-20px' }}>
                 <ChatListPart
                   isRowLoaded={isChatLoaded}

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -144,9 +144,9 @@ function ViewGroupInner(props: {
 
   useEffect(() => {
     BackendRemote.rpc
-      .getSimilarChatlistEntries(selectedAccountId(), chat.id)
-      .then(entries => {
-        setChatListIds(entries.map(item => item[0]))
+      .getSimilarChatIds(selectedAccountId(), chat.id)
+      .then(chatIds => {
+        setChatListIds(chatIds)
       })
   }, [chat.id])
 

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -266,7 +266,7 @@ function ViewGroupInner(props: {
                 </p>
               </div>
               <div className='group-separator'>{tx('group_related_chats')}</div>
-              <div style={{ marginLeft: '-20px' }}>
+              <div className='group-related-chats-list-wrapper'>
                 <ChatListPart
                   isRowLoaded={isChatLoaded}
                   loadMoreRows={loadChats}

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -69,6 +69,7 @@ export interface DesktopSettingsType {
   HTMLEmailAskForRemoteLoadingConfirmation: boolean
   /** always loads remote content without asking, for non contact requests  */
   HTMLEmailAlwaysLoadRemoteContent: boolean
+  EnableRelatedChats: boolean
 }
 
 export interface RC_Config {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -29,5 +29,6 @@ export function getDefaultState(): DesktopSettingsType {
     enableWebxdcDevTools: false,
     HTMLEmailAskForRemoteLoadingConfirmation: true,
     HTMLEmailAlwaysLoadRemoteContent: false,
+    EnableRelatedChats: false,
   }
 }


### PR DESCRIPTION
This is using experimental core API https://github.com/deltachat/deltachat-core-rust/pull/4649

For merging:
- [x] Adapt to new API once the core is updated https://github.com/deltachat/deltachat-core-rust/pull/4693
- [x] Rename from "Shared Chats" into "Related Chats" in the group profile and add a translation string
- [x] Hide by default and add a new experimental setting to enable it