### PR TITLE
fix `target=_blank` links in html emails don't work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - fix clipboard not working in webxdc apps
+- fix `target=_blank` links in html emails don't work #3408
 
 <a id="1_40_4"></a>
 


### PR DESCRIPTION
fixes #3408
