### PR TITLE
style: add dark theme for help and webxdc wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.123.0`
+- add a dark theme for the "Help" and the webxdc loading screen
 
 ### Fixed
 - fix clipboard not working in webxdc apps

--- a/static/help/help.css
+++ b/static/help/help.css
@@ -3,7 +3,12 @@
 html {
   font-family: Roboto, Apple Color Emoji, NotoEmoji, Helvetica Neue, Arial,
     Helvetica, NotoMono, sans-serif !important;
-  background-color: white;
+  color-scheme: dark light;
+}
+@media (prefers-color-scheme: light) {
+  html {
+    background-color: white;
+  }
 }
 
 .back-btn {

--- a/static/webxdc_wrapper.html
+++ b/static/webxdc_wrapper.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="color-scheme" content="dark light">
     <style>
       html,
       body {


### PR DESCRIPTION
With webxdc it affects the "loading" stage.

I tested both light and dark mode for both the help page and the webxdc. Both look ok.