### PR TITLE
update electron from `v22.3.24` to version `v22.3.27`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - update `@deltachat/message_parser_wasm` to `0.8.0`, which adds linkification to links on more generic URI schemes.
 - Update translations (13.10.2023)
 - better search in chat design which shows more results (remove redundant chat info and combine both headers)
+- update electron from `v22.3.24` to version `v22.3.27`
 
 ### Fixed
 - fix clipboard not working in webxdc apps

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@typescript-eslint/parser": "^5.3.1",
         "chai": "^4.3.4",
         "chokidar": "^3.5.3",
-        "electron": "^22.3.24",
+        "electron": "^22.3.27",
         "electron-builder": "23.0.4",
         "electron-notarize": "^1.0.0",
         "esbuild": "^0.14.51",
@@ -2868,9 +2868,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "22.3.24",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.24.tgz",
-      "integrity": "sha512-wnGsShoRVk1Jmgr7h/jZK9bI5UwMF88sdQ5c8z2j2N8B9elhF/jKDFjwDXUrY1Y0xzAskOP0tYIDE+UbUM4byQ==",
+      "version": "22.3.27",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.27.tgz",
+      "integrity": "sha512-7Rht21vHqj4ZFRnKuZdFqZFsvMBCmDqmjetiMqPtF+TmTBiGne1mnstVXOA/SRGhN2Qy5gY5bznJKpiqogjM8A==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -9924,9 +9924,9 @@
       }
     },
     "electron": {
-      "version": "22.3.24",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.24.tgz",
-      "integrity": "sha512-wnGsShoRVk1Jmgr7h/jZK9bI5UwMF88sdQ5c8z2j2N8B9elhF/jKDFjwDXUrY1Y0xzAskOP0tYIDE+UbUM4byQ==",
+      "version": "22.3.27",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.27.tgz",
+      "integrity": "sha512-7Rht21vHqj4ZFRnKuZdFqZFsvMBCmDqmjetiMqPtF+TmTBiGne1mnstVXOA/SRGhN2Qy5gY5bznJKpiqogjM8A==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "@typescript-eslint/parser": "^5.3.1",
     "chai": "^4.3.4",
     "chokidar": "^3.5.3",
-    "electron": "^22.3.24",
+    "electron": "^22.3.27",
     "electron-builder": "23.0.4",
     "electron-notarize": "^1.0.0",
     "esbuild": "^0.14.51",


### PR DESCRIPTION
this is the last version of electron to still support windows 7