### PR TITLE
add option to save to file system to webxdc "send to chat"-dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - mark webxdc app context as secure #3413
 - Experimental: Related Chats
 - Developer option to disable IMAP IDLE #4803
+- add option to save to file system to webxdc "send to chat"-dialog
 
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.125.0`

--- a/scss/dialogs/_webxdc_send_to_chat.scss
+++ b/scss/dialogs/_webxdc_send_to_chat.scss
@@ -1,0 +1,26 @@
+.webxdc-send-to-chat-dialog {
+  background-color: var(--bp4DialogBgPrimary);
+
+  .select-chat-chat-list {
+    flex-grow: 1;
+
+    height: 100%;
+    $search-input-height: 32px;
+    $search-input-margin: 12px;
+
+    .search-input {
+      height: 32px;
+      margin: $search-input-margin;
+      width: calc(100% - #{$search-input-margin * 2});
+    }
+
+    div.results {
+      height: calc(100% - #{$search-input-height + $search-input-margin * 2});
+    }
+
+    .chat-list-item {
+      padding-right: 20px;
+      padding-left: 20px;
+    }
+  }
+}

--- a/scss/manifest.scss
+++ b/scss/manifest.scss
@@ -44,6 +44,7 @@
 @import 'dialogs/_ephermeral_message';
 @import 'dialogs/_qr-code';
 @import 'dialogs/multidevice/send_backup';
+@import 'dialogs/webxdc_send_to_chat.scss';
 
 // Login
 @import 'login/_login.scss';

--- a/src/renderer/components/dialogs/WebxdcSendToChatDialog.tsx
+++ b/src/renderer/components/dialogs/WebxdcSendToChatDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Card, Classes } from '@blueprintjs/core'
+import { Classes } from '@blueprintjs/core'
 import {
   DeltaDialogBase,
   DeltaDialogFooter,
@@ -52,7 +52,7 @@ export default function WebxdcSaveToChatDialog(props: {
 
   const onSaveClick = async () => {
     if (file) {
-      let tmp_file = await runtime.writeTempFileFromBase64(
+      const tmp_file = await runtime.writeTempFileFromBase64(
         file.file_name,
         file.file_content
       )

--- a/src/renderer/components/dialogs/WebxdcSendToChatDialog.tsx
+++ b/src/renderer/components/dialogs/WebxdcSendToChatDialog.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { Card, Classes } from '@blueprintjs/core'
-import { DeltaDialogBase, DeltaDialogHeader } from './DeltaDialog'
+import {
+  DeltaDialogBase,
+  DeltaDialogFooter,
+  DeltaDialogFooterActions,
+  DeltaDialogHeader,
+} from './DeltaDialog'
 import ChatListItem from '../chat/ChatListItem'
 import { PseudoListItemNoSearchResults } from '../helpers/PseudoListItem'
 import classNames from 'classnames'
@@ -45,6 +50,18 @@ export default function WebxdcSaveToChatDialog(props: {
     onClose()
   }
 
+  const onSaveClick = async () => {
+    if (file) {
+      let tmp_file = await runtime.writeTempFileFromBase64(
+        file.file_name,
+        file.file_content
+      )
+      onClose()
+      await runtime.downloadFile(tmp_file, file.file_name)
+      await runtime.removeTempFile(tmp_file)
+    }
+  }
+
   const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setQueryStr(e.target.value)
 
@@ -63,52 +80,59 @@ export default function WebxdcSaveToChatDialog(props: {
         className={classNames(
           Classes.DIALOG_BODY,
           'bp4-dialog-body-no-footer',
-          'mailto-dialog'
+          'webxdc-send-to-chat-dialog'
         )}
       >
-        <Card style={{ padding: '0px' }}>
-          <div className='select-chat-chat-list'>
-            <input
-              className='search-input'
-              onChange={onSearchChange}
-              value={queryStr}
-              placeholder={tx('contacts_enter_name_or_email')}
-              autoFocus
-              spellCheck={false}
-            />
-            {noResults && queryStr && (
-              <PseudoListItemNoSearchResults queryStr={queryStr} />
-            )}
-            <div style={noResults ? { height: '0px' } : {}} className='results'>
-              <AutoSizer>
-                {({ width, height }) => (
-                  <ChatListPart
-                    isRowLoaded={isChatLoaded}
-                    loadMoreRows={loadChats}
-                    rowCount={chatListIds.length}
-                    width={width}
-                    height={height}
-                    itemKey={index => 'key' + chatListIds[index]}
-                    itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                  >
-                    {({ index, style }) => {
-                      const chatId = chatListIds[index]
-                      return (
-                        <div style={style}>
-                          <ChatListItem
-                            chatListItem={chatCache[chatId] || undefined}
-                            onClick={onChatClick.bind(null, chatId)}
-                          />
-                        </div>
-                      )
-                    }}
-                  </ChatListPart>
-                )}
-              </AutoSizer>
-            </div>
+        <div className='select-chat-chat-list'>
+          <input
+            className='search-input'
+            onChange={onSearchChange}
+            value={queryStr}
+            placeholder={tx('contacts_enter_name_or_email')}
+            autoFocus
+            spellCheck={false}
+          />
+          {noResults && queryStr && (
+            <PseudoListItemNoSearchResults queryStr={queryStr} />
+          )}
+          <div style={noResults ? { height: '0px' } : {}} className='results'>
+            <AutoSizer>
+              {({ width, height }) => (
+                <ChatListPart
+                  isRowLoaded={isChatLoaded}
+                  loadMoreRows={loadChats}
+                  rowCount={chatListIds.length}
+                  width={width}
+                  height={height}
+                  itemKey={index => 'key' + chatListIds[index]}
+                  itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                >
+                  {({ index, style }) => {
+                    const chatId = chatListIds[index]
+                    return (
+                      <div style={style}>
+                        <ChatListItem
+                          chatListItem={chatCache[chatId] || undefined}
+                          onClick={onChatClick.bind(null, chatId)}
+                        />
+                      </div>
+                    )
+                  }}
+                </ChatListPart>
+              )}
+            </AutoSizer>
           </div>
-        </Card>
+        </div>
       </div>
+      <DeltaDialogFooter>
+        <DeltaDialogFooterActions style={{ justifyContent: 'start' }}>
+          {file && (
+            <p className={'delta-button bold primary'} onClick={onSaveClick}>
+              {tx('save_as')}
+            </p>
+          )}
+        </DeltaDialogFooterActions>
+      </DeltaDialogFooter>
     </DeltaDialogBase>
   )
 }


### PR DESCRIPTION
also removed unnecessary Card component and made a new css file for this dialog (don't just reuse all mailto styles), I think in the future it would make sense to give the "select chat from list with search" ui element it's own react component, then it makes more sense to just have one class for it because then we can be sure there really is only one variant of the element.

hide whitespaces for a clearer review experience.