### PR TITLE
fix copy text inserts extra linebreaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fix webxdc title not updated in document title changes #3412
 - fix: remove duplicated search button on "search in chat" #3014
 - fix "Verified by" is shown weirdly for contacts that were verified directly #3421
+- fix copy text inserts extra linebreaks
 
 <a id="1_40_4"></a>
 

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -117,18 +117,6 @@
         cursor: default;
 
         margin-right: 10px;
-
-        .double-line-break {
-          height: 28px;
-        }
-
-        .line-break {
-          height: 0px;
-        }
-
-        .line-break + .line-break {
-          height: 14px;
-        }
       }
     }
 

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -81,7 +81,7 @@ function renderElement(elm: ParsedElement, key?: number): JSX.Element {
       return <BotCommandSuggestion key={key} suggestion={elm.c} />
 
     case 'Linebreak':
-      return <div key={key} className='line-break' />
+      return <span key={key}>{"\n"}</span>
 
     case 'Text':
       return <span key={key}>{elm.c}</span>

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -81,7 +81,7 @@ function renderElement(elm: ParsedElement, key?: number): JSX.Element {
       return <BotCommandSuggestion key={key} suggestion={elm.c} />
 
     case 'Linebreak':
-      return <span key={key}>{"\n"}</span>
+      return <span key={key}>{'\n'}</span>
 
     case 'Text':
       return <span key={key}>{elm.c}</span>


### PR DESCRIPTION
The extra linebreak class did not really do anything anyway.
(besides causing the bug)

Maybe there was an idea to compress multiple line breaks (over 3) into just 2-3 linebreaks / multiple empty lines,
but this should be done in the message-parser now if we need it.
