### PR TITLE
lowercase `enableRelatedChats` settings key

### DIFF
--- a/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
+++ b/src/renderer/components/dialogs/Settings-ExperimentalFeatures.tsx
@@ -80,7 +80,7 @@ export function SettingsExperimentalFeatures({
         description: tx('chat_audit_log_description'),
       })}
       {renderDTSettingSwitch({
-        key: 'EnableRelatedChats',
+        key: 'enableRelatedChats',
         label: tx('group_related_chats'),
       })}
       {renderDTSettingSwitch({

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -142,7 +142,7 @@ function ViewGroupInner(props: {
   const tx = useTranslationFunction()
   const [settings] = useSettingsStore()
   const isRelatedChatsEnabled =
-    settings?.desktopSettings.EnableRelatedChats || false
+    settings?.desktopSettings.enableRelatedChats || false
 
   const [chatListIds, setChatListIds] = useState<number[]>([])
 

--- a/src/shared/shared-types.d.ts
+++ b/src/shared/shared-types.d.ts
@@ -69,7 +69,7 @@ export interface DesktopSettingsType {
   HTMLEmailAskForRemoteLoadingConfirmation: boolean
   /** always loads remote content without asking, for non contact requests  */
   HTMLEmailAlwaysLoadRemoteContent: boolean
-  EnableRelatedChats: boolean
+  enableRelatedChats: boolean
 }
 
 export interface RC_Config {

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -29,6 +29,6 @@ export function getDefaultState(): DesktopSettingsType {
     enableWebxdcDevTools: false,
     HTMLEmailAskForRemoteLoadingConfirmation: true,
     HTMLEmailAlwaysLoadRemoteContent: false,
-    EnableRelatedChats: false,
+    enableRelatedChats: false,
   }
 }


### PR DESCRIPTION
we can only do this without migration because there is no release with this feature yet.

This pr is only about naming consistency.