### PR TITLE
Initialise power monitor after electron signals readyness to fix SIGTRAP issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - improve video message - wide enough to show controls
 - gallery: fix scroll to top when switching tabs
 - fix: context menu items could take up multiple lines
+- fix: initialise power monitor after electron signals readyness to avoid electron failing with SIGTRAP
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@
 - improve video message - wide enough to show controls
 - gallery: fix scroll to top when switching tabs
 - fix: context menu items could take up multiple lines
-- fix: initialise power monitor after electron signals readyness to avoid electron failing with SIGTRAP
+- fix: initialise power monitor after electron signals readyness to avoid electron failing with SIGTRAP #3460
 
 ### Added
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -183,6 +183,7 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
   )
   cleanupDraftTempDir()
 
+  // NOTE: Make sure to use `powerMonitor` only when electron signals it is ready
   initialisePowerMonitor()
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,7 @@ import type { EventEmitter } from 'events'
 import contextMenu from './electron-context-menu'
 import { findOutIfWeAreRunningAsAppx } from './isAppx'
 import { getHelpMenu } from './help_menu'
+import { initialisePowerMonitor } from './resume_from_sleep'
 
 // Hardening: prohibit all DNS queries, except for Mapbox
 // (see src/renderer/components/map/MapComponent.tsx)
@@ -181,6 +182,8 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
     log.error('Cleanup of old logfiles failed: ', err)
   )
   cleanupDraftTempDir()
+
+  initialisePowerMonitor()
 }
 
 ;(app as EventEmitter).once('ipcReady', () => {
@@ -313,5 +316,3 @@ ipcMain.handle('restart_app', async _ev => {
   app.relaunch()
   app.quit()
 })
-
-import './resume_from_sleep'

--- a/src/main/resume_from_sleep.ts
+++ b/src/main/resume_from_sleep.ts
@@ -5,6 +5,8 @@ function onResumeFromSleep() {
   window?.webContents.send('onResumeFromSleep')
 }
 
-powerMonitor.on('resume', onResumeFromSleep)
-powerMonitor.on('unlock-screen', onResumeFromSleep)
-powerMonitor.on('user-did-become-active', onResumeFromSleep)
+export function initialisePowerMonitor() {
+  powerMonitor.on('resume', onResumeFromSleep)
+  powerMonitor.on('unlock-screen', onResumeFromSleep)
+  powerMonitor.on('user-did-become-active', onResumeFromSleep)
+}


### PR DESCRIPTION
This PR fixes a race condition causing electron to directly crash returning `SIGTRAP`. Apparently we can not use electrons `powerMonitor` before the `onReady` event got fired.

Related PR: https://github.com/deltachat/deltachat-desktop/pull/3381

Closes: #3459 