### PR TITLE
Retrieve bounds directly from window and check if null on move or resize event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - improve video message - wide enough to show controls
 - gallery: fix scroll to top when switching tabs
 - fix: context menu items could take up multiple lines
+- fix: retrieve bounds directly from window and check if null on resize or move event #3461
 
 ### Added
 

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -78,8 +78,11 @@ export function init(options: { hidden: boolean }) {
     e.preventDefault()
   })
 
-  const saveBounds = debounce((e: any) => {
-    DesktopSettings.update({ bounds: e.sender.getBounds() })
+  const saveBounds = debounce(() => {
+    const bounds = window?.getBounds()
+    if (bounds) {
+      DesktopSettings.update({ bounds })
+    }
   }, 1000)
 
   window.on('move', saveBounds)


### PR DESCRIPTION
This fixes an issue where `sender` is not given on the event object on `resize` or `move` events, causing an error where the bounds can not be updated.

Since this issue didn't seem to come up before, I assume this is due to my special Linux setup (no desktop, only using X11 + i3)? Might be an edge case, however, this PR changes the update method to a) make sure it retrieved the bounds b) which are now taken directly from the `window` instance.

Closes: https://github.com/deltachat/deltachat-desktop/issues/3462