### PR TITLE
remove outdated device messages

### DIFF
--- a/src/renderer/deviceMessages.ts
+++ b/src/renderer/deviceMessages.ts
@@ -1,24 +1,7 @@
 import { BackendRemote } from './backend-com'
 
 export async function updateDeviceChats(accountId: number) {
-  await BackendRemote.rpc.addDeviceMessage(
-    accountId,
-    'changelog-version-1.36.0-version1',
-    `What's new in 1.36.0?
-
-💻📱 Use Delta Chat on all your devices easily - just follow three simple steps at "Settings / Add Second Device" (experimental)
-✉️ Open HTML emails securely in internal sandboxed viewer
-✨ Many smaller bug fixes and general improvements
-
-Full Changelog: https://github.com/deltachat/deltachat-desktop/blob/master/CHANGELOG.md#1_36_0`
-  )
-
-  const tx = window.static_translate
-  await BackendRemote.rpc.addDeviceMessage(
-    accountId,
-    'changelog-version-1.36.0-audit',
-    tx('update_1_36_audit', 'https://delta.chat/en/2023-05-22-webxdc-security')
-  )
+  // const tx = window.static_translate
 
   await BackendRemote.rpc.addDeviceMessage(
     accountId,


### PR DESCRIPTION
also because translation for key `update_1_36_audit` was removed.

I keept the 1.38 device message that we stil have the template to modify for the 1.41 and 1.42 device messages.
