### PR TITLE
Fix centering of username in settings view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - fix: context menu items could take up multiple lines
 - fix: retrieve bounds directly from window and check if null on resize or move event #3461
 - fix: initialise power monitor after electron signals readyness to avoid electron failing with SIGTRAP #3460
+- centering of username component in settings view #3467
 
 ### Added
 

--- a/scss/dialogs/_settings.scss
+++ b/scss/dialogs/_settings.scss
@@ -79,7 +79,6 @@
       border-radius: 100%;
       user-select: none;
       pointer-events: none;
-      margin-bottom: 20px;
     }
     span {
       line-height: 100px;

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -39,7 +39,7 @@ export default function SettingsProfile({
   )
   return (
     <>
-      <div className='profile-image-username' style={{ marginBottom: '10px' }}>
+      <div className='profile-image-username' style={{ marginBottom: '20px' }}>
         <div className='profile-image-selector'>
           {profileBlobUrl ? (
             <ClickForFullscreenAvatarWrapper filename={profileBlobUrl}>


### PR DESCRIPTION
Before:

![2023-11-02-164456_591x353_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/96fa6a7d-ae61-444b-b843-1baeb1527c3b)

After:

![2023-11-02-164435_594x429_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/04d8de62-4b7d-4511-afcc-bdedb1e94de4)