### PR TITLE
fix autocrypt setup message strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fix: retrieve bounds directly from window and check if null on resize or move event #3461
 - fix: initialise power monitor after electron signals readyness to avoid electron failing with SIGTRAP #3460
 - centering of username component in settings view #3467
+- fix wording of autocrypt setup messages
 
 ### Added
 

--- a/src/renderer/components/dialogs/EnterAutocryptSetupMessage.tsx
+++ b/src/renderer/components/dialogs/EnterAutocryptSetupMessage.tsx
@@ -109,7 +109,7 @@ export default function EnterAutocryptSetupMessage({
     if (result === false) {
       userFeedback({
         type: 'error',
-        text: tx('autocrypt_incorrect_desktop'),
+        text: tx('autocrypt_bad_setup_code'),
       })
       return
     }
@@ -148,7 +148,7 @@ export default function EnterAutocryptSetupMessage({
   return (
     <DeltaDialog
       isOpen={isOpen}
-      title={tx('autocrypt_key_transfer_desktop')}
+      title={tx('autocrypt_continue_transfer_title')}
       onClose={onClose}
     >
       {body}

--- a/src/renderer/components/dialogs/Settings-Encryption.tsx
+++ b/src/renderer/components/dialogs/Settings-Encryption.tsx
@@ -23,7 +23,7 @@ export function KeyViewPanel({
     <React.Fragment>
       <div>
         <Card>
-          <Callout>{tx('show_key_transfer_message_desktop')}</Callout>
+          <Callout>{tx('autocrypt_send_asm_explain_after')}</Callout>
           <div>
             <InputTransferKey
               autocryptkey={autocryptKey.split('-')}
@@ -49,7 +49,7 @@ function InitiatePanel({ onClick }: { onClick: todo }) {
   return (
     <div className={Classes.DIALOG_BODY}>
       <Card>
-        <Callout>{tx('initiate_key_transfer_desktop')}</Callout>
+        <Callout>{tx('autocrypt_send_asm_explain_before')}</Callout>
         <p
           className='delta-button bold'
           style={{ float: 'right', marginTop: '20px' }}
@@ -95,7 +95,7 @@ export function SendAutocryptSetupMessage({
   return (
     <DeltaDialog
       isOpen={isOpen}
-      title={tx('autocrypt_key_transfer_desktop')}
+      title={tx('autocrypt_send_asm_title')}
       onClose={onClose}
     >
       {body}


### PR DESCRIPTION
some autocrypt-setup strings were duplicated,
and the ones desktop was using were partly too short
or do not follow autocrypt ux as not talking about "keys".

also, this adds unneeded load for translators.

this pr switches to using the same strings as on android/ios;
once merged, the duplicated strings can be removed from transifex.