### PR TITLE
view profile part of i3468

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
 - move tray icon option to Appearance
 - show prettier linter warnings through eslint #3463
 - move "Forward" and "Reply" close together in the message menu
+- for the "introduced by" line, only use verifier_id (no ContactObject.is_verified)
+- show verification icon in title of view profile if verified dm chat exists.
 - update dependencies
   - update minimum nodejs version from `16` to `18`
   - update `electron` from `v22.3.24` to version `v26.4.2`

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -468,7 +468,6 @@ export function AddMemberInnerDialog({
         nameAndAddr: '',
         isBlocked: false,
         isVerified: false,
-        verifierAddr: null,
         verifierId: null,
         wasSeenRecently: false,
       }

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -177,7 +177,7 @@ export function ViewProfileInner({
   useEffect(() => {
     ;(async () => {
       if (contact.verifierId === null) {
-        setVerifier({ label: tx('verified') })
+        setVerifier(null)
       } else if (contact.verifierId === C.DC_CONTACT_ID_SELF) {
         setVerifier({ label: tx('verified_by_you') })
       } else {
@@ -249,7 +249,7 @@ export function ViewProfileInner({
           </div>
           {!isSelfChat && (
             <div className='contact-attributes'>
-              {contact.isVerified && verifier && (
+              {verifier && (
                 <div
                   className={verifier.action && 'clickable'}
                   onClick={verifier.action}

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -9,7 +9,7 @@ import {
 } from './DeltaDialog'
 import ChatListItem from '../chat/ChatListItem'
 import { useChatList } from '../chat/ChatListHelpers'
-import { C } from '@deltachat/jsonrpc-client'
+import { C, T } from '@deltachat/jsonrpc-client'
 import {
   MessagesDisplayContext,
   ScreenContext,
@@ -141,6 +141,8 @@ export function ViewProfileInner({
     label: string
     action?: () => void
   }>(null)
+  const [contactDMChat, setContactDMChat] = useState<null | T.BasicChat>(null)
+
   const isDeviceChat = contact.id === C.DC_CONTACT_ID_DEVICE
   const isSelfChat = contact.id === C.DC_CONTACT_ID_SELF
 
@@ -157,6 +159,22 @@ export function ViewProfileInner({
     )
     onChatClick(dmChatId)
   }
+
+  useEffect(() => {
+    ;(async () => {
+      const chatId = await BackendRemote.rpc.getChatIdByContactId(
+        accountId,
+        contact.id
+      )
+      if (chatId) {
+        setContactDMChat(
+          await BackendRemote.rpc.getBasicChatInfo(accountId, chatId)
+        )
+      } else {
+        setContactDMChat(null)
+      }
+    })()
+  }, [accountId, contact.id])
 
   useEffect(() => {
     if (isSelfChat) {
@@ -241,7 +259,7 @@ export function ViewProfileInner({
               <div>
                 <p className='group-name'>
                   {displayNameLine}
-                  {/* {isVerified && <InlineVerifiedIcon />} */}
+                  {contactDMChat?.isProtected && <InlineVerifiedIcon />}
                 </p>
               </div>
               <div className='address'>{addressLine}</div>


### PR DESCRIPTION
- for the "introduced by" line, only use verifier_id (no ContactObject.is_verified)
- show verification icon in title of view profile if verified dm chat exists.

This does the view profile part of #3468.

This pr depends on https://github.com/deltachat/deltachat-core-rust/pull/4918
