### PR TITLE
fix `null` account name when leaving the field empty bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - fix wording of autocrypt setup messages
 - fix wording of menu entries and dialog titles
 - fix window store installation (remove unknown language code from supported languages)
+- fix `null` account name when leaving the field empty bug
 
 ### Added
 

--- a/src/renderer/components/dialogs/Settings-Profile.tsx
+++ b/src/renderer/components/dialogs/Settings-Profile.tsx
@@ -178,7 +178,10 @@ export function SettingsEditProfileDialogInner({
       'selfavatar',
       profilePicture ? profilePicture : null
     )
-    SettingsStoreInstance.effect.setCoreSetting('displayname', displayname)
+    SettingsStoreInstance.effect.setCoreSetting(
+      'displayname',
+      displayname || ''
+    )
     SettingsStoreInstance.effect.setCoreSetting('selfstatus', selfstatus || '')
     onClose()
   }


### PR DESCRIPTION
Basically leaving the profile name empty resulted in the name `"null"` being chosen.

Also there is another bug where the name was not updated because this happens in while passing to jsonrpc and the settings cache just stores what you set, maybe it should reload the affected config key instead, but that's another issue/task.