### PR TITLE
fix file deletion in draft

### DIFF
--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -538,6 +538,7 @@ export function useDraft(
 
   const removeFile = useCallback(() => {
     draftRef.current.file = ''
+    draftRef.current.viewType = 'Text'
     saveDraft()
   }, [saveDraft])
 


### PR DESCRIPTION
did not work because it removed the file, but not the viewtype and core does not allow saving a draft with a file/image viewtype but without a file.

fixes #3484

no changelog entry because the thing that broke it (send compressed images) is not released yet / is in the same version as this fix.