### PR TITLE
Automatically create verified group when all users are verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - open `mailto:` and `openpgp4fpr:` links from webxdc in deltachat #3355
 - show confirm dialogue when creating new chat after clicking mail address #3469
 - Ask for broadcast name when creating one
+- Automatically create verified group when all users are verified #3492
 
 ### Changed
 - add a dark theme for the "Help" and the webxdc loading screen
@@ -45,7 +46,6 @@
   - update deltachat-node and deltachat/jsonrpc-client to `v1.129.0`
   - update `@deltachat/message_parser_wasm` to `0.8.0`, which adds linkification to links on more generic URI schemes.
   - Removed `url-parse` dependency replacing it with modern APIs
-
 
 ### Fixed
 - fix clipboard not working in webxdc apps

--- a/src/renderer/components/contact/ContactList.tsx
+++ b/src/renderer/components/contact/ContactList.tsx
@@ -6,7 +6,7 @@ import { debounceWithInit } from '../chat/ChatListHelpers'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 
-export function ContactList2(props: {
+export function ContactList(props: {
   contacts: Type.Contact[]
   onClick?: (contact: Type.Contact) => void
   showCheckbox?: boolean

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -43,7 +43,7 @@ import { Avatar } from '../Avatar'
 import { AddMemberDialog } from './ViewGroup'
 import { ContactListItem } from '../contact/ContactListItem'
 import { useSettingsStore } from '../../stores/settings'
-import { BackendRemote, Type } from '../../backend-com'
+import { BackendRemote, onDCEvent, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { InlineVerifiedIcon } from '../VerifiedIcon'
 import ConfirmationDialog from './ConfirmationDialog'
@@ -90,6 +90,14 @@ function CreateChatMain(props: CreateChatMainProps) {
   )
   const [queryStr, onSearchChange, _, refreshContacts] = useContactSearch(
     updateContacts
+  )
+
+  useEffect(
+    () =>
+      onDCEvent(accountId, 'ContactsChanged', () => {
+        refreshContacts()
+      }),
+    [accountId, refreshContacts]
   )
 
   const chooseContact = async ({ id }: Type.Contact) => {

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -742,9 +742,9 @@ const AddMemberChip = (props: {
 }
 
 /**
- * Returns true if all contacts of a group are verified, otherwise returns false.
+ * Returns true if all contacts of a given list are verified, otherwise returns false.
  */
-async function isGroupVerified(
+export async function areMembersVerified(
   accountId: number,
   groupMembers: number[]
 ): Promise<boolean> {
@@ -767,7 +767,7 @@ const useCreateGroup = (
   const accountId = selectedAccountId()
 
   const createGroup = useCallback(async () => {
-    const isVerified = await isGroupVerified(accountId, groupMembers)
+    const isVerified = await areMembersVerified(accountId, groupMembers)
 
     const chatId = await BackendRemote.rpc.createGroupChat(
       accountId,

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -209,12 +209,11 @@ function CreateChatMain(props: CreateChatMainProps) {
 type CreateGroupProps = {
   setViewMode: (newViewMode: ViewMode) => void
   onClose: DialogProps['onClose']
-  isVerified?: boolean
 }
 
 function CreateGroup(props: CreateGroupProps) {
   const { openDialog } = useContext(ScreenContext)
-  const { setViewMode, onClose, isVerified } = props
+  const { setViewMode, onClose } = props
   const tx = useTranslationFunction()
   const accountId = selectedAccountId()
 
@@ -222,7 +221,6 @@ function CreateGroup(props: CreateGroupProps) {
   const [groupImage, onSetGroupImage, onUnsetGroupImage] = useGroupImage()
   const [groupMembers, removeGroupMember, addGroupMember] = useGroupMembers([1])
   const finishCreateGroup = useCreateGroup(
-    Boolean(isVerified),
     groupName,
     groupImage,
     groupMembers,
@@ -241,12 +239,8 @@ function CreateGroup(props: CreateGroupProps) {
   }, [accountId, groupMembers])
 
   const showAddMemberDialog = () => {
-    const listFlags = isVerified
-      ? C.DC_GCL_VERIFIED_ONLY | C.DC_GCL_ADD_SELF
-      : C.DC_GCL_ADD_SELF
-
     openDialog(AddMemberDialog, {
-      listFlags,
+      listFlags: C.DC_GCL_ADD_SELF,
       groupMembers,
       onOk: (members: number[]) => {
         members.forEach(contactId => addGroupMember({ id: contactId }))
@@ -742,7 +736,6 @@ const AddMemberChip = (props: {
 }
 
 const useCreateGroup = (
-  verified: boolean,
   groupName: string,
   groupImage: string | null | undefined,
   groupMembers: number[],
@@ -754,7 +747,8 @@ const useCreateGroup = (
     const chatId = await BackendRemote.rpc.createGroupChat(
       accountId,
       groupName,
-      verified
+      // @TODO: Automatically determine if group is verified
+      false
     )
 
     if (groupImage && groupImage !== '') {
@@ -768,7 +762,7 @@ const useCreateGroup = (
     }
 
     return chatId
-  }, [accountId, groupImage, groupMembers, groupName, verified])
+  }, [accountId, groupImage, groupMembers, groupName])
 
   return async () => {
     if (groupName === '') {

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -441,87 +441,6 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
   )
 }
 
-export function useContactSearch(
-  updateContacts: (searchString: string) => void
-) {
-  const [searchString, setSearchString] = useState('')
-
-  const updateSearch = (searchString: string) => {
-    setSearchString(searchString)
-    updateContacts(searchString)
-  }
-
-  const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>
-    updateSearch(e.target.value)
-
-  const refresh = () => updateContacts(searchString)
-
-  return [searchString, onSearchChange, updateSearch, refresh] as [
-    searchString: string,
-    onSearchChange: typeof onSearchChange,
-    updateSearch: typeof updateSearch,
-    refresh: typeof refresh
-  ]
-}
-
-export function useGroupImage(image?: string | null) {
-  const [groupImage, setGroupImage] = useState(image)
-  const tx = window.static_translate
-
-  const onSetGroupImage = async () => {
-    const file = await runtime.showOpenFileDialog({
-      title: tx('select_group_image_desktop'),
-      filters: [{ name: 'Images', extensions: ['jpg', 'png', 'gif'] }],
-      properties: ['openFile'],
-      defaultPath: runtime.getAppPath('pictures'),
-    })
-    if (file) {
-      setGroupImage(file)
-    }
-  }
-  const onUnsetGroupImage = () => setGroupImage('')
-
-  return [groupImage, onSetGroupImage, onUnsetGroupImage] as [
-    typeof groupImage,
-    typeof onSetGroupImage,
-    typeof onUnsetGroupImage
-  ]
-}
-
-export function useGroupMembers(initialMemebers: number[]) {
-  const [groupMembers, setGroupMembers] = useState(initialMemebers)
-
-  const removeGroupMember = ({ id }: Type.Contact | { id: number }) =>
-    id !== 1 &&
-    setGroupMembers(prevMembers => prevMembers.filter(gId => gId !== id))
-  const addGroupMember = ({ id }: Type.Contact | { id: number }) =>
-    setGroupMembers(prevMembers => [...prevMembers, id])
-  const addRemoveGroupMember = ({ id }: Type.Contact | { id: number }) => {
-    groupMembers.indexOf(id) !== -1
-      ? removeGroupMember({ id })
-      : addGroupMember({ id })
-  }
-  const addGroupMembers = (ids: number[]) => {
-    setGroupMembers(prevMembers => {
-      return [...prevMembers, ...ids]
-    })
-  }
-
-  return [
-    groupMembers,
-    removeGroupMember,
-    addGroupMember,
-    addRemoveGroupMember,
-    addGroupMembers,
-  ] as [
-    number[],
-    typeof removeGroupMember,
-    typeof addGroupMember,
-    typeof addRemoveGroupMember,
-    typeof addGroupMembers
-  ]
-}
-
 export const ChatSettingsSetNameAndProfileImage = ({
   groupImage,
   onSetGroupImage,
@@ -892,4 +811,85 @@ const useCreateBroadcast = (
     selectChat(bId)
   }
   return finishCreateBroadcast as typeof finishCreateBroadcast
+}
+
+export function useContactSearch(
+  updateContacts: (searchString: string) => void
+) {
+  const [searchString, setSearchString] = useState('')
+
+  const updateSearch = (searchString: string) => {
+    setSearchString(searchString)
+    updateContacts(searchString)
+  }
+
+  const onSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>
+    updateSearch(e.target.value)
+
+  const refresh = () => updateContacts(searchString)
+
+  return [searchString, onSearchChange, updateSearch, refresh] as [
+    searchString: string,
+    onSearchChange: typeof onSearchChange,
+    updateSearch: typeof updateSearch,
+    refresh: typeof refresh
+  ]
+}
+
+export function useGroupImage(image?: string | null) {
+  const [groupImage, setGroupImage] = useState(image)
+  const tx = window.static_translate
+
+  const onSetGroupImage = async () => {
+    const file = await runtime.showOpenFileDialog({
+      title: tx('select_group_image_desktop'),
+      filters: [{ name: 'Images', extensions: ['jpg', 'png', 'gif'] }],
+      properties: ['openFile'],
+      defaultPath: runtime.getAppPath('pictures'),
+    })
+    if (file) {
+      setGroupImage(file)
+    }
+  }
+  const onUnsetGroupImage = () => setGroupImage('')
+
+  return [groupImage, onSetGroupImage, onUnsetGroupImage] as [
+    typeof groupImage,
+    typeof onSetGroupImage,
+    typeof onUnsetGroupImage
+  ]
+}
+
+export function useGroupMembers(initialMemebers: number[]) {
+  const [groupMembers, setGroupMembers] = useState(initialMemebers)
+
+  const removeGroupMember = ({ id }: Type.Contact | { id: number }) =>
+    id !== 1 &&
+    setGroupMembers(prevMembers => prevMembers.filter(gId => gId !== id))
+  const addGroupMember = ({ id }: Type.Contact | { id: number }) =>
+    setGroupMembers(prevMembers => [...prevMembers, id])
+  const addRemoveGroupMember = ({ id }: Type.Contact | { id: number }) => {
+    groupMembers.indexOf(id) !== -1
+      ? removeGroupMember({ id })
+      : addGroupMember({ id })
+  }
+  const addGroupMembers = (ids: number[]) => {
+    setGroupMembers(prevMembers => {
+      return [...prevMembers, ...ids]
+    })
+  }
+
+  return [
+    groupMembers,
+    removeGroupMember,
+    addGroupMember,
+    addRemoveGroupMember,
+    addGroupMembers,
+  ] as [
+    number[],
+    typeof removeGroupMember,
+    typeof addGroupMember,
+    typeof addRemoveGroupMember,
+    typeof addGroupMembers
+  ]
 }

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -92,14 +92,6 @@ function CreateChatMain(props: CreateChatMainProps) {
     updateContacts
   )
 
-  useEffect(
-    () =>
-      onDCEvent(accountId, 'ContactsChanged', () => {
-        refreshContacts()
-      }),
-    [accountId, refreshContacts]
-  )
-
   const chooseContact = async ({ id }: Type.Contact) => {
     try {
       await createChatByContactIdAndSelectIt(id)
@@ -534,6 +526,7 @@ export function AddMemberInnerDialog({
 }) {
   const tx = window.static_translate
   const { openDialog } = useContext(ScreenContext)
+  const accountId = selectedAccountId()
 
   const contactIdsInGroup: number[] = [...searchContacts]
     .filter(([contactId, _contact]) => groupMembers.indexOf(contactId) !== -1)
@@ -544,7 +537,12 @@ export function AddMemberInnerDialog({
     C.DC_GCL_ADD_SELF,
     ''
   )
-  const [_, onSearchChangeNewContact] = useContactSearch(updateContacts)
+  const [
+    _searchString,
+    onSearchChangeNewContact,
+    _updateSearch,
+    refreshContacts,
+  ] = useContactSearch(updateContacts)
 
   const onSearchChangeValidation = (query: ChangeEvent<HTMLInputElement>) => {
     if (searchContacts.size === 0) {
@@ -552,6 +550,14 @@ export function AddMemberInnerDialog({
     }
     onSearchChange(query)
   }
+
+  useEffect(
+    () =>
+      onDCEvent(accountId, 'ContactsChanged', () => {
+        refreshContacts()
+      }),
+    [accountId, refreshContacts]
+  )
 
   const [contactsToDeleteOnCancel, setContactsToDeleteOnCancel] = useState<
     number[]
@@ -590,8 +596,6 @@ export function AddMemberInnerDialog({
   const createNewContact = useCallback(async () => {
     if (!queryStrIsValidEmail) return
 
-    const accountId = selectedAccountId()
-
     const contactId = await BackendRemote.rpc.createContact(
       accountId,
       queryStr.trim(),
@@ -603,7 +607,7 @@ export function AddMemberInnerDialog({
     onSearchChange({
       target: { value: '' },
     } as ChangeEvent<HTMLInputElement>)
-  }, [toggleMember, onSearchChange, queryStr, queryStrIsValidEmail])
+  }, [accountId, toggleMember, onSearchChange, queryStr, queryStrIsValidEmail])
 
   const _onOk = () => {
     if (contactIdsToAdd.length === 0) {

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -15,7 +15,7 @@ import { C } from '@deltachat/jsonrpc-client'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
 import {
   useContacts,
-  ContactList2,
+  ContactList,
   useContactsNew,
 } from '../contact/ContactList'
 import {
@@ -165,7 +165,7 @@ export default function CreateChat(props: {
             <Card>
               <div className='create-chat-contact-list-wrapper'>
                 {renderAddGroupIfNeeded()}
-                <ContactList2
+                <ContactList
                   contacts={contacts}
                   onClick={chooseContact}
                   onContactContextMenu={onContactContextMenu}
@@ -523,7 +523,7 @@ export function AddMemberInnerDialog({
             className='group-member-contact-list-wrapper'
             ref={contactListRef}
           >
-            <ContactList2
+            <ContactList
               contacts={Array.from(searchContacts.values())}
               onClick={() => {}}
               showCheckbox
@@ -700,7 +700,7 @@ function CreateGroupInner(props: {
               onClick={showAddMemberDialog}
               isBroadcast={false}
             />
-            <ContactList2
+            <ContactList
               contacts={groupContacts}
               onClick={() => {}}
               showRemove
@@ -849,7 +849,7 @@ function CreateBroadcastInner(props: {
               onClick={showAddMemberDialog}
               isBroadcast
             />
-            <ContactList2
+            <ContactList
               contacts={searchContacts.filter(
                 ({ id }) => broadcastRecipients.indexOf(id) !== -1
               )}

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -741,6 +741,23 @@ const AddMemberChip = (props: {
   )
 }
 
+/**
+ * Returns true if all contacts of a group are verified, otherwise returns false.
+ */
+async function isGroupVerified(
+  accountId: number,
+  groupMembers: number[]
+): Promise<boolean> {
+  const contacts = await BackendRemote.rpc.getContactsByIds(
+    accountId,
+    groupMembers
+  )
+
+  return !groupMembers.some(contactId => {
+    return !contacts[contactId].isVerified
+  })
+}
+
 const useCreateGroup = (
   groupName: string,
   groupImage: string | null | undefined,
@@ -750,11 +767,12 @@ const useCreateGroup = (
   const accountId = selectedAccountId()
 
   const createGroup = useCallback(async () => {
+    const isVerified = await isGroupVerified(accountId, groupMembers)
+
     const chatId = await BackendRemote.rpc.createGroupChat(
       accountId,
       groupName,
-      // @TODO: Automatically determine if group is verified
-      false
+      isVerified
     )
 
     if (groupImage && groupImage !== '') {

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -801,34 +801,30 @@ const useCreateGroup = (
 
 const useCreateBroadcast = (
   broadcastRecipients: number[],
-  name: string,
+  groupName: string,
   onClose: DialogProps['onClose']
 ) => {
-  const [broadcastId, setBroadcastId] = useState(-1)
   const accountId = selectedAccountId()
 
-  const lazilyCreateOrUpdateBroadcast = async (finishing: boolean) => {
-    let bId = broadcastId
-    if (bId === -1) {
-      bId = await BackendRemote.rpc.createBroadcastList(accountId)
-      setBroadcastId(bId)
-    }
-    if (finishing === true) {
-      for (const contactId of broadcastRecipients) {
-        if (contactId !== C.DC_CONTACT_ID_SELF) {
-          await BackendRemote.rpc.addContactToChat(accountId, bId, contactId)
-        }
+  const createBroadcastList = async () => {
+    const chatId = await BackendRemote.rpc.createBroadcastList(accountId)
+
+    for (const contactId of broadcastRecipients) {
+      if (contactId !== C.DC_CONTACT_ID_SELF) {
+        await BackendRemote.rpc.addContactToChat(accountId, chatId, contactId)
       }
-      await BackendRemote.rpc.setChatName(accountId, bId, name)
     }
-    return bId
+
+    await BackendRemote.rpc.setChatName(accountId, chatId, groupName)
+
+    return chatId
   }
-  const finishCreateBroadcast = async () => {
-    const bId = await lazilyCreateOrUpdateBroadcast(true)
+
+  return async () => {
+    const chatId = await createBroadcastList()
     onClose()
-    selectChat(bId)
+    selectChat(chatId)
   }
-  return finishCreateBroadcast as typeof finishCreateBroadcast
 }
 
 export function useContactSearch(

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -511,6 +511,7 @@ export function AddMemberInnerDialog({
   onSearchChange,
   queryStr,
   searchContacts,
+  refreshContacts,
   groupMembers,
   isBroadcast = false,
   isVerificationRequired = false,
@@ -520,6 +521,7 @@ export function AddMemberInnerDialog({
   onSearchChange: ReturnType<typeof useContactSearch>[1]
   queryStr: string
   searchContacts: Map<number, Type.Contact>
+  refreshContacts: () => void
   groupMembers: number[]
   isBroadcast: boolean
   isVerificationRequired: boolean
@@ -537,12 +539,7 @@ export function AddMemberInnerDialog({
     C.DC_GCL_ADD_SELF,
     ''
   )
-  const [
-    _searchString,
-    onSearchChangeNewContact,
-    _updateSearch,
-    refreshContacts,
-  ] = useContactSearch(updateContacts)
+  const [_, onSearchChangeNewContact] = useContactSearch(updateContacts)
 
   const onSearchChangeValidation = (query: ChangeEvent<HTMLInputElement>) => {
     if (searchContacts.size === 0) {

--- a/src/renderer/components/dialogs/CreateChat.tsx
+++ b/src/renderer/components/dialogs/CreateChat.tsx
@@ -38,6 +38,7 @@ import { GroupImage } from './Edit-Group-Image'
 import { DialogProps } from './DialogController'
 import { runtime } from '../../runtime'
 import {
+  areAllContactsVerified,
   createChatByContactIdAndSelectIt,
   selectChat,
 } from '../helpers/ChatMethods'
@@ -741,23 +742,6 @@ const AddMemberChip = (props: {
   )
 }
 
-/**
- * Returns true if all contacts of a given list are verified, otherwise returns false.
- */
-export async function areMembersVerified(
-  accountId: number,
-  groupMembers: number[]
-): Promise<boolean> {
-  const contacts = await BackendRemote.rpc.getContactsByIds(
-    accountId,
-    groupMembers
-  )
-
-  return !groupMembers.some(contactId => {
-    return !contacts[contactId].isVerified
-  })
-}
-
 const useCreateGroup = (
   groupName: string,
   groupImage: string | null | undefined,
@@ -767,7 +751,7 @@ const useCreateGroup = (
   const accountId = selectedAccountId()
 
   const createGroup = useCallback(async () => {
-    const isVerified = await areMembersVerified(accountId, groupMembers)
+    const isVerified = await areAllContactsVerified(accountId, groupMembers)
 
     const chatId = await BackendRemote.rpc.createGroupChat(
       accountId,

--- a/src/renderer/components/dialogs/ProtectionStatusDialog.tsx
+++ b/src/renderer/components/dialogs/ProtectionStatusDialog.tsx
@@ -1,4 +1,5 @@
-import React, { CSSProperties, useContext } from 'react'
+import React, { useContext } from 'react'
+
 import { BackendRemote } from '../../backend-com'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
 import { runtime } from '../../runtime'
@@ -8,13 +9,16 @@ import {
   DeltaDialogFooter,
   DeltaDialogFooterActions,
 } from './DeltaDialog'
-import type { DialogProps } from './DialogController'
 import QrCode from './QrCode'
 
-const WebLinks = {
-  Broken: 'https://staging.delta.chat/733/en/help#verificationbroken',
-  Enabled: 'https://staging.delta.chat/733/en/help#verifiedchats',
-}
+import type { DialogProps } from './DialogController'
+
+const VERIFICATION_BROKEN_URL =
+  'https://staging.delta.chat/733/en/help#verificationbroken'
+const VERIFICATION_ENABLED_URL =
+  'https://staging.delta.chat/733/en/help#verifiedchats'
+const VERIFICATION_REQUIRED_URL =
+  'https://staging.delta.chat/746/en/help#howtoe2ee'
 
 export function ProtectionBrokenDialog({
   name,
@@ -25,47 +29,88 @@ export function ProtectionBrokenDialog({
   const { openDialog } = useContext(ScreenContext)
   const accountId = selectedAccountId()
 
+  const onQRScan = async () => {
+    const [
+      qrCode,
+      qrCodeSVG,
+    ] = await BackendRemote.rpc.getChatSecurejoinQrCodeSvg(accountId, null)
+    onClose()
+    openDialog(QrCode, { selectScan: true, qrCode, qrCodeSVG })
+  }
+
+  const onLearnMore = () => {
+    runtime.openLink(VERIFICATION_BROKEN_URL)
+  }
+
   return (
     <SmallDialog isOpen={isOpen} onClose={onClose}>
       <div className='bp4-dialog-body-with-padding'>
-        <p
-          style={{
-            wordBreak: 'break-word',
-          }}
-        >
+        <p style={{ wordBreak: 'break-word' }}>
           {tx('chat_protection_broken_explanation', name)}
         </p>
       </div>
       <DeltaDialogFooter style={{ padding: '0px 20px 10px' }}>
-        <DeltaDialogFooterActions
-          style={{ justifyContent: 'space-between' } as CSSProperties}
-        >
+        <DeltaDialogFooterActions style={{ justifyContent: 'space-between' }}>
           <p
             className='delta-button bold primary'
-            onClick={() =>
-              runtime.openLink(WebLinks.Broken)
-            } /* TODO better link to inApp help at some point? */
+            onClick={onLearnMore}
             style={{ marginRight: '10px' }}
           >
             {tx('learn_more')}
           </p>
-          <p
-            className={`delta-button bold primary`}
-            onClick={async () => {
-              const [
-                qrCode,
-                qrCodeSVG,
-              ] = await BackendRemote.rpc.getChatSecurejoinQrCodeSvg(
-                accountId,
-                null
-              )
-              onClose()
-              openDialog(QrCode, { selectScan: true, qrCode, qrCodeSVG })
-            }}
-          >
+          <p className={`delta-button bold primary`} onClick={onQRScan}>
             {tx('qrscan_title')}
           </p>
-          <p className={`delta-button bold primary`} onClick={() => onClose()}>
+          <p className={`delta-button bold primary`} onClick={onClose}>
+            {tx('ok')}
+          </p>
+        </DeltaDialogFooterActions>
+      </DeltaDialogFooter>
+    </SmallDialog>
+  )
+}
+
+export function VerifiedContactsRequiredDialog({
+  isOpen,
+  onClose,
+}: DialogProps) {
+  const tx = useTranslationFunction()
+  const { openDialog } = useContext(ScreenContext)
+  const accountId = selectedAccountId()
+
+  const onQRScan = async () => {
+    const [
+      qrCode,
+      qrCodeSVG,
+    ] = await BackendRemote.rpc.getChatSecurejoinQrCodeSvg(accountId, null)
+    onClose()
+    openDialog(QrCode, { selectScan: true, qrCode, qrCodeSVG })
+  }
+
+  const onLearnMore = () => {
+    runtime.openLink(VERIFICATION_REQUIRED_URL)
+  }
+
+  return (
+    <SmallDialog isOpen={isOpen} onClose={onClose}>
+      <div className='bp4-dialog-body-with-padding'>
+        <p style={{ wordBreak: 'break-word' }}>
+          {tx('verified_contact_required_explain')}
+        </p>
+      </div>
+      <DeltaDialogFooter style={{ padding: '0px 20px 10px' }}>
+        <DeltaDialogFooterActions style={{ justifyContent: 'space-between' }}>
+          <p
+            className='delta-button bold primary'
+            onClick={onLearnMore}
+            style={{ marginRight: '10px' }}
+          >
+            {tx('learn_more')}
+          </p>
+          <p className={`delta-button bold primary`} onClick={onQRScan}>
+            {tx('qrscan_title')}
+          </p>
+          <p className={`delta-button bold primary`} onClick={onClose}>
             {tx('ok')}
           </p>
         </DeltaDialogFooterActions>
@@ -77,31 +122,27 @@ export function ProtectionBrokenDialog({
 export function ProtectionEnabledDialog({ isOpen, onClose }: DialogProps) {
   const tx = useTranslationFunction()
 
+  const onLearnMore = () => {
+    runtime.openLink(VERIFICATION_ENABLED_URL)
+  }
+
   return (
     <SmallDialog isOpen={isOpen} onClose={onClose}>
       <div className='bp4-dialog-body-with-padding'>
-        <p
-          style={{
-            wordBreak: 'break-word',
-          }}
-        >
+        <p style={{ wordBreak: 'break-word' }}>
           {tx('chat_protection_enabled_explanation')}
         </p>
       </div>
       <DeltaDialogFooter style={{ padding: '0px 20px 10px' }}>
-        <DeltaDialogFooterActions
-          style={{ justifyContent: 'space-between' } as CSSProperties}
-        >
+        <DeltaDialogFooterActions style={{ justifyContent: 'space-between' }}>
           <p
             className='delta-button bold primary'
-            onClick={() =>
-              runtime.openLink(WebLinks.Enabled)
-            } /* TODO better link to inApp help at some point? */
+            onClick={onLearnMore}
             style={{ marginRight: '10px' }}
           >
             {tx('learn_more')}
           </p>
-          <p className={`delta-button bold primary`} onClick={() => onClose()}>
+          <p className={`delta-button bold primary`} onClick={onClose}>
             {tx('ok')}
           </p>
         </DeltaDialogFooterActions>

--- a/src/renderer/components/dialogs/UnblockContacts.tsx
+++ b/src/renderer/components/dialogs/UnblockContacts.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from 'react'
 import DeltaDialog, { DeltaDialogBody, DeltaDialogContent } from './DeltaDialog'
 
-import { ContactList2 } from '../contact/ContactList'
+import { ContactList } from '../contact/ContactList'
 import { ScreenContext } from '../../contexts'
 import { DialogProps } from './DialogController'
 import debounce from 'debounce'
@@ -65,7 +65,7 @@ export default function UnblockContacts(props: {
                 backgroundColor: 'var(--bp4DialogBgPrimary)',
               }}
             >
-              <ContactList2
+              <ContactList
                 contacts={blockedContacts}
                 onClick={onUnblockContact}
               />

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -1,5 +1,13 @@
-import { C } from '@deltachat/jsonrpc-client'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+import { C, DcEventType } from '@deltachat/jsonrpc-client'
 import { Card, Classes, Elevation } from '@blueprintjs/core'
+
 import {
   DeltaDialogBase,
   DeltaDialogHeader,
@@ -20,8 +28,6 @@ import {
 import { DialogProps } from './DialogController'
 import ViewProfile from './ViewProfile'
 import { ScreenContext, useTranslationFunction } from '../../contexts'
-import { useState, useContext, useEffect, useCallback, useMemo } from 'react'
-import React from 'react'
 import {
   Avatar,
   avatarInitial,
@@ -33,7 +39,6 @@ import { getLogger } from '../../../shared/logger'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { modifyGroup } from '../helpers/ChatMethods'
-import { DcEventType } from '@deltachat/jsonrpc-client'
 import { InlineVerifiedIcon } from '../VerifiedIcon'
 import { useSettingsStore } from '../../stores/settings'
 
@@ -197,9 +202,7 @@ function ViewGroupInner(props: {
     })
   }
 
-  const listFlags = chat.isProtected
-    ? C.DC_GCL_VERIFIED_ONLY | C.DC_GCL_ADD_SELF
-    : C.DC_GCL_ADD_SELF
+  const listFlags = C.DC_GCL_ADD_SELF
 
   const showAddMemberDialog = () => {
     openDialog(AddMemberDialog, {

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -367,7 +367,9 @@ export function AddMemberDialog({
   isVerificationRequired?: boolean
 } & DialogProps) {
   const [searchContacts, updateSearchContacts] = useContactsMap(listFlags, '')
-  const [queryStr, onSearchChange] = useContactSearch(updateSearchContacts)
+  const [queryStr, onSearchChange, _, refreshContacts] = useContactSearch(
+    updateSearchContacts
+  )
   return (
     <DeltaDialogBase
       onClose={onClose}
@@ -391,6 +393,7 @@ export function AddMemberDialog({
         onSearchChange,
         queryStr,
         searchContacts,
+        refreshContacts,
         groupMembers,
         isBroadcast,
         isVerificationRequired,

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -15,13 +15,9 @@ import {
   DeltaDialogOkCancelFooter,
 } from './DeltaDialog'
 import ChatListItem from '../chat/ChatListItem'
-import {
-  useContactSearch,
-  AddMemberInnerDialog,
-  areMembersVerified,
-} from './CreateChat'
+import { useContactSearch, AddMemberInnerDialog } from './CreateChat'
 import { QrCodeShowQrInner } from './QrCode'
-import { selectChat } from '../helpers/ChatMethods'
+import { areAllContactsVerified, selectChat } from '../helpers/ChatMethods'
 import { useThemeCssVar } from '../../ThemeManager'
 import { ContactList, useContactsMap } from '../contact/ContactList'
 import { useLogicVirtualChatList, ChatListPart } from '../chat/ChatList'
@@ -130,7 +126,7 @@ export const useGroup = (chat: Type.FullChat) => {
 
     // We can only add verified contacts to a protected group
     if (chat.isProtected) {
-      const membersVerified = await areMembersVerified(
+      const membersVerified = await areAllContactsVerified(
         accountId,
         newGroupMembers
       )

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -11,7 +11,7 @@ import { useContactSearch, AddMemberInnerDialog } from './CreateChat'
 import { QrCodeShowQrInner } from './QrCode'
 import { selectChat } from '../helpers/ChatMethods'
 import { useThemeCssVar } from '../../ThemeManager'
-import { ContactList2, useContactsMap } from '../contact/ContactList'
+import { ContactList, useContactsMap } from '../contact/ContactList'
 import { useLogicVirtualChatList, ChatListPart } from '../chat/ChatList'
 import {
   PseudoListItemShowQrCode,
@@ -321,7 +321,7 @@ function ViewGroupInner(props: {
                     )}
                   </>
                 )}
-                <ContactList2
+                <ContactList
                   contacts={chat.contacts}
                   showRemove={!chatDisabled}
                   onClick={contact => {

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -1,6 +1,7 @@
+import { T, C } from '@deltachat/jsonrpc-client'
+
 import ChatStore, { ChatView } from '../../stores/chat'
 import { ScreenContext, unwrapContext } from '../../contexts'
-import { C } from '@deltachat/jsonrpc-client'
 import { getLogger } from '../../../shared/logger'
 import AlertDialog from '../dialogs/AlertDialog'
 import { BackendRemote, EffectfulBackendActions, Type } from '../../backend-com'
@@ -8,10 +9,8 @@ import { selectedAccountId } from '../../ScreenController'
 import ViewGroup from '../dialogs/ViewGroup'
 import ViewProfile from '../dialogs/ViewProfile'
 import ConfirmationDialog from '../dialogs/ConfirmationDialog'
-import { T } from '@deltachat/jsonrpc-client'
 import chatStore from '../../stores/chat'
 import { openLinkSafely } from './LinkConfirmation'
-import { areMembersVerified } from '../dialogs/CreateChat'
 
 const log = getLogger('renderer/message')
 
@@ -410,4 +409,21 @@ export async function createDraftMessage(chatId: number, messageText: string) {
   )
 
   window.__reloadDraft && window.__reloadDraft()
+}
+
+/**
+ * Returns true if all contacts of a given list are verified, otherwise false.
+ */
+export async function areAllContactsVerified(
+  accountId: number,
+  contactIds: number[]
+): Promise<boolean> {
+  const contacts = await BackendRemote.rpc.getContactsByIds(
+    accountId,
+    contactIds
+  )
+
+  return !contactIds.some(contactId => {
+    return !contacts[contactId].isVerified
+  })
 }

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -11,6 +11,7 @@ import ConfirmationDialog from '../dialogs/ConfirmationDialog'
 import { T } from '@deltachat/jsonrpc-client'
 import chatStore from '../../stores/chat'
 import { openLinkSafely } from './LinkConfirmation'
+import { areMembersVerified } from '../dialogs/CreateChat'
 
 const log = getLogger('renderer/message')
 
@@ -338,11 +339,14 @@ export async function modifyGroup(
 ) {
   const accountId = selectedAccountId()
   log.debug('action - modify group', { chatId, name, image, members })
-  await BackendRemote.rpc.setChatName(accountId, chatId, name)
+
   const chat = await BackendRemote.rpc.getFullChatById(accountId, chatId)
   if (!chat) {
     throw new Error('chat is undefined, this should not happen')
   }
+
+  await BackendRemote.rpc.setChatName(accountId, chatId, name)
+
   if (typeof image !== 'undefined' && chat.profileImage !== image) {
     await BackendRemote.rpc.setChatProfileImage(
       accountId,

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -262,7 +262,7 @@ export async function createChatByContactIdAndSelectIt(
 
   const chat = await BackendRemote.rpc.getFullChatById(accountId, chatId)
 
-  if (chat && chat.archived) {
+  if (chat.archived) {
     log.debug('chat was archived, unarchiving it')
     await BackendRemote.rpc.setChatVisibility(
       selectedAccountId(),
@@ -340,9 +340,6 @@ export async function modifyGroup(
   log.debug('action - modify group', { chatId, name, image, members })
 
   const chat = await BackendRemote.rpc.getFullChatById(accountId, chatId)
-  if (!chat) {
-    throw new Error('chat is undefined, this should not happen')
-  }
 
   await BackendRemote.rpc.setChatName(accountId, chatId, name)
 

--- a/src/renderer/stockStrings.ts
+++ b/src/renderer/stockStrings.ts
@@ -1,4 +1,5 @@
 import { C } from '@deltachat/jsonrpc-client'
+
 import { getLogger } from '../shared/logger'
 import { BackendRemote } from './backend-com'
 
@@ -8,6 +9,7 @@ export async function updateCoreStrings() {
   log.info('loading core translations')
   const tx = window.static_translate
   const strings: { [key: number]: string } = {}
+
   // TODO: Check if we need the uncommented core translations
   strings[C.DC_STR_NOMESSAGES] = tx('chat_no_messages')
   strings[C.DC_STR_SELF] = tx('self')
@@ -32,6 +34,7 @@ export async function updateCoreStrings() {
   strings[C.DC_STR_AC_SETUP_MSG_BODY] = tx('autocrypt_asm_general_body')
   strings[C.DC_STR_CANNOT_LOGIN] = tx('login_error_cannot_login')
   strings[C.DC_STR_DEVICE_MESSAGES] = tx('device_talk')
+  strings[C.DC_STR_NEW_GROUP_SEND_FIRST_MESSAGE] = tx('chat_new_group_hint')
   strings[C.DC_STR_SAVED_MESSAGES] = tx('saved_messages')
   strings[C.DC_STR_CONTACT_VERIFIED] = tx('contact_verified')
   strings[C.DC_STR_CONTACT_NOT_VERIFIED] = tx('contact_not_verified')
@@ -50,7 +53,6 @@ export async function updateCoreStrings() {
   strings[C.DC_STR_CONFIGURATION_FAILED] = tx('configuration_failed_with_error')
   strings[C.DC_STR_REPLY_NOUN] = tx('reply_noun')
   strings[C.DC_STR_FORWARDED] = tx('forwarded')
-
   //strings[C.DC_STR_MSGLOCATIONENABLED] = tx('')
   //strings[C.DC_STR_MSGLOCATIONDISABLED] = tx('')
   strings[C.DC_STR_LOCATION] = tx('location')
@@ -88,7 +90,6 @@ export async function updateCoreStrings() {
   strings[C.DC_STR_NOT_CONNECTED] = tx('connectivity_not_connected')
   strings[C.DC_STR_AEAP_ADDR_CHANGED] = tx('aeap_addr_changed')
   strings[C.DC_STR_AEAP_EXPLANATION_AND_LINK] = tx('aeap_explanation')
-
   strings[C.DC_STR_GROUP_NAME_CHANGED_BY_YOU] = tx('group_name_changed_by_you')
   strings[C.DC_STR_GROUP_NAME_CHANGED_BY_OTHER] = tx(
     'group_name_changed_by_other'
@@ -179,7 +180,6 @@ export async function updateCoreStrings() {
   strings[C.DC_STR_CHAT_PROTECTION_DISABLED] = tx(
     'chat_protection_broken_tap_to_learn_more'
   )
-
   strings[C.DC_STR_BACKUP_TRANSFER_QR] = tx('multidevice_qr_subtitle')
 
   await BackendRemote.rpc.setStockStrings(strings)

--- a/themes/dev_rocket.scss
+++ b/themes/dev_rocket.scss
@@ -367,9 +367,6 @@ div.group-image-wrapper div.group-image-edit-button {
 .contact-list-item#addmember > .contact > .avatar > .content,
 .contact-list-item#action-go-to-login > .contact > .avatar > .content,
 .contact-list-item#newgroup > .contact > .avatar > .content,
-.contact-list-item#newverifiedgroup > .contact > .avatar > .content {
-  color: white;
-}
 
 .chat-list .search-result-divider {
   background: transparent;

--- a/themes/dev_rocket.scss
+++ b/themes/dev_rocket.scss
@@ -364,9 +364,13 @@ div.group-image-wrapper div.group-image-edit-button {
   top: -4px;
 }
 
-.contact-list-item#addmember > .contact > .avatar > .content,
-.contact-list-item#action-go-to-login > .contact > .avatar > .content,
-.contact-list-item#newgroup > .contact > .avatar > .content,
+.contact-list-item#addmember,
+.contact-list-item#action-go-to-login,
+.contact-list-item#newgroup {
+  & > .contact > .avatar > .content {
+    color: white;
+  }
+}
 
 .chat-list .search-result-divider {
   background: transparent;

--- a/themes/minimal.scss
+++ b/themes/minimal.scss
@@ -379,8 +379,12 @@ div.group-image-wrapper div.group-image-edit-button {
   top: -4px;
 }
 
-.contact-list-item#addmember > .contact > .avatar >.content, .contact-list-item#action-go-to-login > .contact > .avatar >.content, .contact-list-item#newgroup > .contact > .avatar >.content,  .contact-list-item#newverifiedgroup > .contact > .avatar >.content {
-  color: white;
+.contact-list-item#addmember,
+.contact-list-item#action-go-to-login,
+.contact-list-item#newgroup {
+  & > .contact > .avatar > .content {
+    color: white;
+  }
 }
 
 .chat-list .search-result-divider {


### PR DESCRIPTION
This PR simplifies the UI by removing all options to manually create a verified group chat. The idea is to automatically do so if all selected group members are known to be verified.

If an unverified member is added to an verified group a dialogue will be displayed. 

https://github.com/deltachat/deltachat-desktop/assets/1822473/5dec1da8-8f00-4cdc-a9fa-002c6c2aba1d

This entails:

* [x] Remove "Create Verified Group" from "New Chat" screen
* [x] Remove "QR Invite Code" from "Create Group" screen
* [x] When only verified contacts are selected in "New Group" screen, automatically create a verified group - otherwise a normal group
* [x] Set new stock string `DC_STR_NEW_GROUP_SEND_FIRST_MESSAGE` to `chat_new_group_hint`
* [x] Remove verified/unverified filtering of contact lists when adding members
* [x] When tapping an unverified contact in a verified group, show an alert with the text `verified_contact_required_explain` and the answer `learn_more` / `qrscan_title` / `ok` with scan-qr - similar to what we're doing at https://github.com/deltachat/deltachat-desktop/pull/3328
* [x] Verified status changes automatically in "Add new member to group" dialogue (after QR was scanned)

Tracking issue: https://github.com/deltachat/deltachat-desktop/issues/3468