### PR TITLE
make sure verified icon is shown everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - fix window store installation (remove unknown language code from supported languages)
 - fix emojis in some html emails (force charset utf-8)
 - fix `null` account name when leaving the field empty bug
-- fix text truncation so verified icon is always shown on ViewGroup, ViewProfile and on ChatlistItem
+- fix text truncation so verified icon is always shown on ViewGroup, ViewProfile, ContactListItems and on ChatlistItem
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - fix window store installation (remove unknown language code from supported languages)
 - fix emojis in some html emails (force charset utf-8)
 - fix `null` account name when leaving the field empty bug
-- fix text truncation so verified icon is always shown on ViewGroup and on ViewProfile
+- fix text truncation so verified icon is always shown on ViewGroup, ViewProfile and on ChatlistItem
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - fix window store installation (remove unknown language code from supported languages)
 - fix emojis in some html emails (force charset utf-8)
 - fix `null` account name when leaving the field empty bug
+- fix text truncation so verified icon is always shown on ViewGroup and on ViewProfile
 
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 - fix window store installation (remove unknown language code from supported languages)
 - fix emojis in some html emails (force charset utf-8)
 - fix `null` account name when leaving the field empty bug
-- fix text truncation so verified icon is always shown on ViewGroup, ViewProfile, ContactListItems and on ChatlistItem
+- fix text truncation so verified icon is always shown on ViewGroup, ViewProfile, ContactListItems, Navbar and on ChatlistItem
 
 
 ### Removed

--- a/scss/_icons.scss
+++ b/scss/_icons.scss
@@ -35,8 +35,6 @@ img.verified-icon {
   // about 1 white space's width
   margin-inline-start: 0.3em;
   vertical-align: middle;
-  // move it up a little bit so it looks more centered
-  transform: translate(0px, -0.07em);
 }
 
 img.material-icon {

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -38,6 +38,12 @@
         font-size: medium;
         & > span {
           user-select: none;
+          display: inline-flex;
+          max-width: 100%;
+          .truncated {
+            text-overflow: ellipsis;
+            overflow: hidden;
+          }
         }
       }
 

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -45,7 +45,7 @@
             overflow: hidden;
           }
           .verified-icon {
-            margin-inline-start: 0.2em;
+            margin-inline-start: 0.3em;
             margin-inline-end: 0.1em;
           }
         }

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -44,6 +44,10 @@
             text-overflow: ellipsis;
             overflow: hidden;
           }
+          .verified-icon {
+            margin-inline-start: 0.2em;
+            margin-inline-end: 0.1em;
+          }
         }
       }
 

--- a/scss/contact/_contact.scss
+++ b/scss/contact/_contact.scss
@@ -18,15 +18,21 @@
     // height: 54px;
     margin-left: 10px;
     .chat-list & {
-      width: calc(100% - 84px);
+      width: calc(100% - 37px);
     }
     .display-name {
       font-weight: bold;
       margin-bottom: 0px;
       margin-top: 3px;
       white-space: nowrap;
-      overflow: hidden;
-      text-overflow: ellipsis;
+
+      display: inline-flex;
+      max-width: 100%;
+      align-items: center;
+      .truncated {
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
     }
     .email {
       color: var(--contactEmailColor);

--- a/scss/dialogs/_group-styles.scss
+++ b/scss/dialogs/_group-styles.scss
@@ -16,6 +16,7 @@ p.group-name {
   p.trucated-name {
     text-overflow: ellipsis;
     overflow: hidden;
+    margin-bottom: 0;
   }
 }
 

--- a/scss/dialogs/_group-styles.scss
+++ b/scss/dialogs/_group-styles.scss
@@ -11,6 +11,14 @@ input.group-name-input {
   user-select: text;
 }
 
+p.group-name {
+  display: flex;
+  p.trucated-name {
+    text-overflow: ellipsis;
+    overflow: hidden;
+  }
+}
+
 input.group-name-input {
   border-bottom: solid;
   border-color: var(--loginInputFocusColor);

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -3,8 +3,12 @@
     font-size: medium;
     font-weight: bold;
     cursor: pointer;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    display: flex;
+   
+    .truncated {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
 
     .chat_property_icons {
       display: inline-block;

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -4,7 +4,7 @@
     font-weight: bold;
     cursor: pointer;
     display: flex;
-   
+
     .truncated {
       overflow: hidden;
       text-overflow: ellipsis;

--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -14,6 +14,7 @@
     text-overflow: ellipsis;
     font-size: 18px;
     font-weight: bold;
+    overflow: hidden;
   }
 
   .bp4-align-left {

--- a/scss/misc/_avatar.scss
+++ b/scss/misc/_avatar.scss
@@ -8,11 +8,14 @@
   display: inline-block;
   font-weight: normal;
 
+  height: var(--local-avatar-size);
+  width: var(--local-avatar-size);
+  margin: var(--local-avatar-vertical-margin) 0;
+
   div.content,
   img.content {
     height: var(--local-avatar-size);
     width: var(--local-avatar-size);
-    margin: var(--local-avatar-vertical-margin) 0;
     border-radius: 100%;
     pointer-events: none;
   }
@@ -37,7 +40,6 @@
 
       height: var(--local-avatar-size);
       width: var(--local-avatar-size);
-      margin: var(--local-avatar-vertical-margin) 0;
 
       background-color: var(--recently-seen-indicator-color);
       mask: url('../images/avatar/online-avatar-dot.svg') no-repeat center;

--- a/src/renderer/components/chat/ChatListItem.tsx
+++ b/src/renderer/components/chat/ChatListItem.tsx
@@ -39,7 +39,7 @@ function Header({
     <div className='header'>
       <div className='name'>
         <span>
-          {name}
+          <span className="truncated">{name}</span>
           {isProtected && <InlineVerifiedIcon />}
         </span>
       </div>

--- a/src/renderer/components/chat/ChatListItem.tsx
+++ b/src/renderer/components/chat/ChatListItem.tsx
@@ -39,7 +39,7 @@ function Header({
     <div className='header'>
       <div className='name'>
         <span>
-          <span className="truncated">{name}</span>
+          <span className='truncated'>{name}</span>
           {isProtected && <InlineVerifiedIcon />}
         </span>
       </div>
@@ -385,7 +385,7 @@ export const ChatListItemMessageResult = React.memo<{
         <div className='header'>
           <div className='name'>
             <span>
-              {msr.chatName}
+              <span className='truncated'>{msr.chatName}</span>
               {msr.isChatProtected && <InlineVerifiedIcon />}
             </span>
           </div>

--- a/src/renderer/components/contact/Contact.tsx
+++ b/src/renderer/components/contact/Contact.tsx
@@ -10,7 +10,7 @@ function ContactName(
   return (
     <div className='contact-name'>
       <div className='display-name'>
-        {displayName}
+        <span className='truncated'>{displayName}</span>
         {isVerified && <InlineVerifiedIcon />}
       </div>
       <div className='email'>{address}</div>

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -265,7 +265,8 @@ function ViewGroupInner(props: {
                   />
                 </ClickForFullscreenAvatarWrapper>
                 <p className='group-name' style={{ marginLeft: '17px' }}>
-                  {groupName} {chat.isProtected && <InlineVerifiedIcon />}
+                  <p className='trucated-name'>{groupName}</p>
+                  {chat.isProtected && <InlineVerifiedIcon />}
                 </p>
               </div>
               {isRelatedChatsEnabled && (

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -241,7 +241,7 @@ export function ViewProfileInner({
             <div className='profile-info-name-container'>
               <div>
                 <p className='group-name'>
-                  {displayNameLine}
+                  <p className='trucated-name'>{displayNameLine}</p>
                   {contact.isProfileVerified && <InlineVerifiedIcon />}
                 </p>
               </div>

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -288,7 +288,7 @@ export default function MainScreen() {
                 />
                 <div style={{ marginLeft: '7px', overflow: 'hidden' }}>
                   <div className='navbar-chat-name'>
-                    <div className='truncated'>{selectedChat.chat.name}</div>                  
+                    <div className='truncated'>{selectedChat.chat.name}</div>
                     <div className='chat_property_icons'>
                       {selectedChat.chat.isProtected && <InlineVerifiedIcon />}
                       {selectedChat.chat.ephemeralTimer !== 0 && (

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -288,7 +288,7 @@ export default function MainScreen() {
                 />
                 <div style={{ marginLeft: '7px', overflow: 'hidden' }}>
                   <div className='navbar-chat-name'>
-                    {selectedChat.chat.name}
+                    <div className='truncated'>{selectedChat.chat.name}</div>                  
                     <div className='chat_property_icons'>
                       {selectedChat.chat.isProtected && <InlineVerifiedIcon />}
                       {selectedChat.chat.ephemeralTimer !== 0 && (


### PR DESCRIPTION
- fix truncation so verified icon is always shown on ViewGroup and on ViewProfile
- always show verified icon in chatlist items
- fix trucation on contact list items
- fix truncation in navbar
- fix centering of verified icon
- improve spaceing in chatlistitems also trucate name in chatname in message search results
- more spacing
- center avatars
- css fixes

closes #3498

removes multiline display of display/group name in view group/profile, I couldn't get it to look good, maybe some other css wizard wants to try.