### PR TITLE
streamline headlines in profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - update deltachat-node and deltachat/jsonrpc-client to `v1.131.2`
 - Update inApp help (15.11.2023)
 - make help's "scroll to top" button less intrusive
+- streamline profile titles
 
 ### Fixed
 - macOS: prevent second instances when runing from terminal

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -244,9 +244,7 @@ function ViewGroupInner(props: {
       {!profileContact && (
         <>
           <DeltaDialogHeader
-            title={
-              !isBroadcast ? tx('tab_group') : tx('broadcast_list')
-            }
+            title={!isBroadcast ? tx('tab_group') : tx('broadcast_list')}
             onClickEdit={onClickEdit}
             showEditButton={!chatDisabled}
             showCloseButton={true}

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -245,7 +245,7 @@ function ViewGroupInner(props: {
         <>
           <DeltaDialogHeader
             title={
-              !isBroadcast ? tx('menu_edit_group') : tx('edit_broadcast_list')
+              !isBroadcast ? tx('tab_group') : tx('broadcast_list')
             }
             onClickEdit={onClickEdit}
             showEditButton={!chatDisabled}

--- a/src/renderer/components/dialogs/ViewProfile.tsx
+++ b/src/renderer/components/dialogs/ViewProfile.tsx
@@ -105,7 +105,7 @@ export default function ViewProfile(props: {
   return (
     <DeltaDialogBase isOpen={isOpen} onClose={onClose} fixed>
       <DeltaDialogHeader
-        title={tx('profile')}
+        title={tx('contact')}
         onClickEdit={onClickEdit}
         showEditButton={!(isDeviceChat || isSelfChat)}
         showCloseButton={true}


### PR DESCRIPTION
the headlines in profiles should just read what the "profile" is about - so "Contact", "Group", "Broadcast List" -
not that it is a "profile" (whatever that is from the view of the user).

also the 'Edit' prefix is not correct,
esp. confusing as there is a dialog that open the thing for editing.

these are the headlines that we're using also on android/ios, and that are used in similar ways also in similar app.

left=before / right=after:

<img width=250 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/c4b80a5c-cf08-4ce7-9d27-0db7d91ce8d3> &nbsp; &nbsp; <img width=250 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/75e1d86b-9340-4ec1-a2d1-f5c19510a9d1>
&nbsp;

<img width=250 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/81b37b11-c492-4892-bdda-15779c51cb2e> &nbsp; &nbsp; <img width=250 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/48ce3600-1014-4e09-be49-fb58b4d382a5>

(nb: it is correct that "tunis1000" does not have a green checkmark, i just used that to test breaking encryption)
