### PR TITLE
help gets a nicer "scroll to top"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.131.2`
 - Update inApp help (15.11.2023)
+- make help's "scroll to top" button less intrusive
 
 ### Fixed
 - macOS: prevent second instances when runing from terminal

--- a/src/main/windows/help.ts
+++ b/src/main/windows/help.ts
@@ -91,6 +91,7 @@ export async function openHelpWindow(locale: string) {
     const body = document.getElementsByTagName('body')[0];
     const back_btn = document.createElement('button');
     back_btn.className = 'back-btn';
+    back_btn.style = "opacity: 0.9; border: 0; border-radius: 5px"
     back_btn.onclick = (ev) => {document.body.scrollTop = 0; document.documentElement.scrollTop = 0;};
     back_btn.innerText = '↑ ${tx('menu_scroll_to_top')}';
     body.append(back_btn);

--- a/src/main/windows/help.ts
+++ b/src/main/windows/help.ts
@@ -91,7 +91,6 @@ export async function openHelpWindow(locale: string) {
     const body = document.getElementsByTagName('body')[0];
     const back_btn = document.createElement('button');
     back_btn.className = 'back-btn';
-    back_btn.style = "opacity: 0.9; border: 0; border-radius: 5px"
     back_btn.onclick = (ev) => {document.body.scrollTop = 0; document.documentElement.scrollTop = 0;};
     back_btn.innerText = '↑ ${tx('menu_scroll_to_top')}';
     body.append(back_btn);

--- a/static/help/help.css
+++ b/static/help/help.css
@@ -15,6 +15,9 @@ html {
   position: fixed;
   bottom: 8px;
   right: 8px;
+  opacity: 0.9;
+  border: 0;
+  border-radius: 5px
 }
 
 body {


### PR DESCRIPTION
now, that the in-app help becomes more into view, the "scroll to top" button, looking like a foreign object, get more into focus.

this pr styles the button in a more decent way, better fitting to overall look of the app. it just sets opacity, so in dark mode, things should still be fine (in case we add dark mode to the help)

before / after:

<img width=330 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/cce98433-8a35-4fa5-8dee-bf3ced9e9776> &nbsp; <img width=330 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/6a39650a-e892-4381-9371-36d86ea12030>

(a shorter wording as just "Top" or "Content" may be another improvement - or only use an arrow, similar to what we're doing to scroll down in chat - but that is another effort and discussion, translation etc. - so this pr is just unconditional improvement of the current state :) 