### PR TITLE
Do not show redundant read-only message when in device messages chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - update `@deltachat/message_parser_wasm` to `0.9.0`, which fixes a bug with BotCommandSuggestion parsing
 - update `electron` from `v26.4.2` to version `v26.6.0`
 - update deltachat-node and deltachat/jsonrpc-client to `v1.131.3`
+- Do not show redundant read-only message when in device messages chat #3532
 
 ### Fixed
 - fix: files search not case-insensitive

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -27,6 +27,8 @@ import { confirmDialog } from '../message/messageFunctions'
 import { ProtectionBrokenDialog } from '../dialogs/ProtectionStatusDialog'
 import { T } from '@deltachat/jsonrpc-client'
 import { Viewtype } from '@deltachat/jsonrpc-client/dist/generated/types'
+import DisabledMessageInput from './DisabledMessageInput'
+import { DisabledChatReasons } from './useIsChatDisabled'
 
 const log = getLogger('renderer/composer')
 
@@ -58,7 +60,7 @@ const Composer = forwardRef<
   any,
   {
     isDisabled: boolean
-    disabledReason: string
+    disabledReason?: DisabledChatReasons
     isContactRequest: boolean
     isProtectionBroken: boolean
     selectedChat: Type.FullChat
@@ -303,15 +305,7 @@ const Composer = forwardRef<
       </div>
     )
   } else if (isDisabled) {
-    if (disabledReason) {
-      return (
-        <div ref={ref} className='composer composer--disabled-message-input'>
-          {tx(disabledReason)}
-        </div>
-      )
-    } else {
-      return <span />
-    }
+    return <DisabledMessageInput ref={ref} reason={disabledReason} />
   } else {
     return (
       <div className='composer' ref={ref}>

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -20,7 +20,6 @@ const DisabledMessageInput = forwardRef<any, Props>(
         case DisabledChatReasons.DEADDROP:
           return tx('messaging_disabled_deaddrop')
         case DisabledChatReasons.UNKNOWN:
-          return tx('messaging_disabled_unknown')
         default:
           return tx('messaging_disabled_unknown')
       }

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -1,0 +1,47 @@
+import React, { forwardRef, useMemo } from 'react'
+
+import { useTranslationFunction } from '../../contexts'
+import { DisabledChatReasons } from './useIsChatDisabled'
+
+type Props = {
+  reason?: DisabledChatReasons
+}
+
+const DisabledMessageInput = forwardRef<any, Props>(
+  ({ reason }: Props, ref) => {
+    const tx = useTranslationFunction()
+
+    const reasonMessage = useMemo(() => {
+      switch (reason) {
+        case DisabledChatReasons.MAILING_LIST:
+          return tx('messaging_disabled_mailing_list')
+        case DisabledChatReasons.NOT_IN_GROUP:
+          return tx('messaging_disabled_not_in_group')
+        case DisabledChatReasons.DEADDROP:
+          return tx('messaging_disabled_deaddrop')
+        case DisabledChatReasons.UNKNOWN:
+          return tx('messaging_disabled_unknown')
+        default:
+          return tx('messaging_disabled_unknown')
+      }
+    }, [reason, tx])
+
+    // If no reason was given we return no component
+    if (!reason) {
+      return null
+    }
+
+    // If we're in the device message chat we also do not want to show anything
+    if (reason === DisabledChatReasons.DEVICE_CHAT) {
+      return null
+    }
+
+    return (
+      <div ref={ref} className='composer composer--disabled-message-input'>
+        {reasonMessage}
+      </div>
+    )
+  }
+)
+
+export default DisabledMessageInput

--- a/src/renderer/components/composer/useIsChatDisabled.ts
+++ b/src/renderer/components/composer/useIsChatDisabled.ts
@@ -20,7 +20,7 @@ export default function useIsChatDisabled(
 
   if (chat.isContactRequest) {
     return [true, DisabledChatReasons.DEADDROP]
-  } else if (chat.isDeviceChat === true) {
+  } else if (chat.isDeviceChat) {
     return [true, DisabledChatReasons.DEVICE_CHAT]
   } else if (chat.chatType === C.DC_CHAT_TYPE_MAILINGLIST) {
     return [true, DisabledChatReasons.MAILING_LIST]

--- a/src/renderer/components/composer/useIsChatDisabled.ts
+++ b/src/renderer/components/composer/useIsChatDisabled.ts
@@ -1,0 +1,32 @@
+import { T, C } from '@deltachat/jsonrpc-client'
+
+export enum DisabledChatReasons {
+  DEADDROP,
+  DEVICE_CHAT,
+  MAILING_LIST,
+  NOT_IN_GROUP,
+  UNKNOWN,
+}
+
+export default function useIsChatDisabled(
+  chat: Pick<
+    T.FullChat,
+    'isContactRequest' | 'isDeviceChat' | 'chatType' | 'selfInGroup' | 'canSend'
+  >
+): [isDisabled: boolean, disabledReason?: DisabledChatReasons] {
+  if (chat.canSend) {
+    return [false, undefined]
+  }
+
+  if (chat.isContactRequest) {
+    return [true, DisabledChatReasons.DEADDROP]
+  } else if (chat.isDeviceChat === true) {
+    return [true, DisabledChatReasons.DEVICE_CHAT]
+  } else if (chat.chatType === C.DC_CHAT_TYPE_MAILINGLIST) {
+    return [true, DisabledChatReasons.MAILING_LIST]
+  } else if (chat.chatType === C.DC_CHAT_TYPE_GROUP && !chat.selfInGroup) {
+    return [true, DisabledChatReasons.NOT_IN_GROUP]
+  }
+
+  return [true, DisabledChatReasons.UNKNOWN]
+}

--- a/src/renderer/components/message/MessageListAndComposer.tsx
+++ b/src/renderer/components/message/MessageListAndComposer.tsx
@@ -1,4 +1,7 @@
 import React, { useRef, useContext, useEffect } from 'react'
+import { Viewtype } from '@deltachat/jsonrpc-client/dist/generated/types'
+import { join, parse } from 'path'
+
 import Composer, { useDraft } from '../composer/Composer'
 import { getLogger } from '../../../shared/logger'
 import MessageList from './MessageList'
@@ -6,14 +9,11 @@ import { ScreenContext } from '../../contexts'
 import { ChatStoreStateWithChatSet } from '../../stores/chat'
 import ComposerMessageInput from '../composer/ComposerMessageInput'
 import { DesktopSettingsType } from '../../../shared/shared-types'
-import { join, parse } from 'path'
 import { runtime } from '../../runtime'
 import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
 import { useSettingsStore } from '../../stores/settings'
-import { Type } from '../../backend-com'
-import { C } from '@deltachat/jsonrpc-client'
 import { sendMessage } from '../helpers/ChatMethods'
-import { Viewtype } from '@deltachat/jsonrpc-client/dist/generated/types'
+import useIsChatDisabled from '../composer/useIsChatDisabled'
 
 const log = getLogger('renderer/MessageListAndComposer')
 
@@ -220,7 +220,7 @@ export default function MessageListAndComposer({
     }
   }, [])
 
-  const [disabled, disabledReason] = isChatReadonly(chatStore.chat)
+  const [isDisabled, disabledReason] = useIsChatDisabled(chatStore.chat)
 
   const settingsStore = useSettingsStore()[0]
   const style = settingsStore
@@ -243,7 +243,7 @@ export default function MessageListAndComposer({
       <Composer
         ref={refComposer}
         selectedChat={chatStore.chat}
-        isDisabled={disabled}
+        isDisabled={isDisabled}
         disabledReason={disabledReason}
         isContactRequest={chatStore.chat.isContactRequest}
         isProtectionBroken={chatStore.chat.isProtectionBroken}
@@ -257,27 +257,4 @@ export default function MessageListAndComposer({
       />
     </div>
   )
-}
-
-export function isChatReadonly(
-  chat: Pick<
-    Type.FullChat,
-    'isContactRequest' | 'isDeviceChat' | 'chatType' | 'selfInGroup' | 'canSend'
-  >
-): [isDisabled: boolean, disabledReason: string] {
-  if (chat.canSend) {
-    return [false, '']
-  } else {
-    if (chat.isContactRequest) {
-      return [true, 'messaging_disabled_deaddrop']
-    } else if (chat.isDeviceChat === true) {
-      return [true, 'messaging_disabled_device_chat']
-    } else if (chat.chatType === C.DC_CHAT_TYPE_MAILINGLIST) {
-      return [true, 'messaging_disabled_mailing_list']
-    } else if (chat.chatType === C.DC_CHAT_TYPE_GROUP && !chat.selfInGroup) {
-      return [true, 'messaging_disabled_not_in_group']
-    } else {
-      return [true, 'UNKNOWN DISABLED REASON']
-    }
-  }
 }


### PR DESCRIPTION
This PR hides the composer view including it's little message when being in the read-only "Device Message" chat as it didn't add much information for the user.

Also, I've done a mini-refactoring, moving this logic into own component and hook files.

Closes https://github.com/deltachat/deltachat-desktop/issues/3511