### PR TITLE
Improve layout and fix unknown locale of `DisabledMessageInput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - fix: files search not case-insensitive
 - fix: bug in emoji detection for jumbomoji #3508
+- Improve layout and fix unknown locale of DisabledMessageInput #3537
 
 <a id="1_41_2"></a>
 

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -1,17 +1,18 @@
 .composer {
   background-color: var(--composerBg);
   border-left: 1px solid rgba(16, 22, 26, 0.1);
+
   &.composer--disabled-message-input {
     --composerHeight: 40px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
     text-align: center;
-    padding: calc((var(--composerHeight) - 16px) / 2);
     height: var(--composerHeight);
+    padding: 3px;
     color: #999;
     overflow: hidden;
-
-    @media only screen and (max-width: 830px) {
-      padding: 0px 3px;
-    }
   }
 
   &.contact-request {

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -305,7 +305,7 @@ const Composer = forwardRef<
       </div>
     )
   } else if (isDisabled) {
-    return <DisabledMessageInput ref={ref} reason={disabledReason} />
+    return <DisabledMessageInput reason={disabledReason} />
   } else {
     return (
       <div className='composer' ref={ref}>

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -21,7 +21,7 @@ const DisabledMessageInput = ({ reason }: Props) => {
       case DisabledChatReasons.DEVICE_CHAT:
         return tx('messaging_disabled_device_chat')
       case DisabledChatReasons.UNKNOWN:
-        // Unknown cases are likely to be caused by a bug somewhere else,
+        // Unknown cases are likely to be caused by a new case introduced by a new core update that is not yet handled here,
         // but we don't want to crash the UI
         return 'messaging_disabled_unknown'
       default:

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -18,8 +18,6 @@ const DisabledMessageInput = ({ reason }: Props) => {
         return tx('messaging_disabled_not_in_group')
       case DisabledChatReasons.DEADDROP:
         return tx('messaging_disabled_deaddrop')
-      case DisabledChatReasons.UNKNOWN:
-        return 'UNKNOWN_DISABLED_CHAT_REASON'
     }
   }, [reason, tx])
 

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo } from 'react'
+import React, { useMemo } from 'react'
 
 import { useTranslationFunction } from '../../contexts'
 import { DisabledChatReasons } from './useIsChatDisabled'
@@ -7,40 +7,37 @@ type Props = {
   reason?: DisabledChatReasons
 }
 
-const DisabledMessageInput = forwardRef<any, Props>(
-  ({ reason }: Props, ref) => {
-    const tx = useTranslationFunction()
+const DisabledMessageInput = ({ reason }: Props) => {
+  const tx = useTranslationFunction()
 
-    const reasonMessage = useMemo(() => {
-      switch (reason) {
-        case DisabledChatReasons.MAILING_LIST:
-          return tx('messaging_disabled_mailing_list')
-        case DisabledChatReasons.NOT_IN_GROUP:
-          return tx('messaging_disabled_not_in_group')
-        case DisabledChatReasons.DEADDROP:
-          return tx('messaging_disabled_deaddrop')
-        case DisabledChatReasons.UNKNOWN:
-        default:
-          return tx('messaging_disabled_unknown')
-      }
-    }, [reason, tx])
-
-    // If no reason was given we return no component
-    if (!reason) {
-      return null
+  const reasonMessage = useMemo(() => {
+    switch (reason) {
+      case DisabledChatReasons.MAILING_LIST:
+        return tx('messaging_disabled_mailing_list')
+      case DisabledChatReasons.NOT_IN_GROUP:
+        return tx('messaging_disabled_not_in_group')
+      case DisabledChatReasons.DEADDROP:
+        return tx('messaging_disabled_deaddrop')
+      case DisabledChatReasons.UNKNOWN:
+        return 'UNKNOWN_DISABLED_CHAT_REASON'
     }
+  }, [reason, tx])
 
-    // If we're in the device message chat we also do not want to show anything
-    if (reason === DisabledChatReasons.DEVICE_CHAT) {
-      return null
-    }
-
-    return (
-      <div ref={ref} className='composer composer--disabled-message-input'>
-        {reasonMessage}
-      </div>
-    )
+  // If no reason was given we return no component
+  if (!reason) {
+    return null
   }
-)
+
+  // If we're in the device message chat we also do not want to show anything
+  if (reason === DisabledChatReasons.DEVICE_CHAT) {
+    return null
+  }
+
+  return (
+    <div className='composer composer--disabled-message-input'>
+      {reasonMessage}
+    </div>
+  )
+}
 
 export default DisabledMessageInput

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -18,8 +18,10 @@ const DisabledMessageInput = ({ reason }: Props) => {
         return tx('messaging_disabled_not_in_group')
       case DisabledChatReasons.DEADDROP:
         return tx('messaging_disabled_deaddrop')
-      case DisabledChatReasons.UNKNOWN:
-        throw new Error('Invalid read-only chat status')
+      case DisabledChatReasons.DEVICE_CHAT:
+        return tx('messaging_disabled_device_chat')
+      default:
+        throw new Error('Unknown read-only chat status')
     }
   }, [reason, tx])
 

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -21,6 +21,8 @@ const DisabledMessageInput = ({ reason }: Props) => {
       case DisabledChatReasons.DEVICE_CHAT:
         return tx('messaging_disabled_device_chat')
       case DisabledChatReasons.UNKNOWN:
+        // Unknown cases are likely to be caused by a bug somewhere else,
+        // but we don't want to crash the UI
         return 'messaging_disabled_unknown'
       default:
         throw new Error('Invalid read-only chat status')

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -18,6 +18,8 @@ const DisabledMessageInput = ({ reason }: Props) => {
         return tx('messaging_disabled_not_in_group')
       case DisabledChatReasons.DEADDROP:
         return tx('messaging_disabled_deaddrop')
+      case DisabledChatReasons.UNKNOWN:
+        return 'UNKNOWN_DISABLED_CHAT_REASON'
     }
   }, [reason, tx])
 

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -19,7 +19,7 @@ const DisabledMessageInput = ({ reason }: Props) => {
       case DisabledChatReasons.DEADDROP:
         return tx('messaging_disabled_deaddrop')
       case DisabledChatReasons.UNKNOWN:
-        return 'UNKNOWN_DISABLED_CHAT_REASON'
+        throw new Error('Invalid read-only chat status')
     }
   }, [reason, tx])
 

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -20,8 +20,10 @@ const DisabledMessageInput = ({ reason }: Props) => {
         return tx('messaging_disabled_deaddrop')
       case DisabledChatReasons.DEVICE_CHAT:
         return tx('messaging_disabled_device_chat')
+      case DisabledChatReasons.UNKNOWN:
+        return 'messaging_disabled_unknown'
       default:
-        throw new Error('Unknown read-only chat status')
+        throw new Error('Invalid read-only chat status')
     }
   }, [reason, tx])
 
@@ -30,7 +32,7 @@ const DisabledMessageInput = ({ reason }: Props) => {
     return null
   }
 
-  // If we're in the device message chat we also do not want to show anything
+  // If we're in the "device message" chat we also do not want to show anything
   if (reason === DisabledChatReasons.DEVICE_CHAT) {
     return null
   }

--- a/src/renderer/components/composer/useIsChatDisabled.ts
+++ b/src/renderer/components/composer/useIsChatDisabled.ts
@@ -5,6 +5,7 @@ export enum DisabledChatReasons {
   DEVICE_CHAT,
   MAILING_LIST,
   NOT_IN_GROUP,
+  UNKNOWN,
 }
 
 export default function useIsChatDisabled(
@@ -27,7 +28,5 @@ export default function useIsChatDisabled(
     return [true, DisabledChatReasons.NOT_IN_GROUP]
   }
 
-  throw new Error(
-    'Could not determine read-only state of chat due to invalid chat information'
-  )
+  return [true, DisabledChatReasons.UNKNOWN]
 }

--- a/src/renderer/components/composer/useIsChatDisabled.ts
+++ b/src/renderer/components/composer/useIsChatDisabled.ts
@@ -5,7 +5,6 @@ export enum DisabledChatReasons {
   DEVICE_CHAT,
   MAILING_LIST,
   NOT_IN_GROUP,
-  UNKNOWN,
 }
 
 export default function useIsChatDisabled(
@@ -28,5 +27,7 @@ export default function useIsChatDisabled(
     return [true, DisabledChatReasons.NOT_IN_GROUP]
   }
 
-  return [true, DisabledChatReasons.UNKNOWN]
+  throw new Error(
+    'Could not determine read-only state of chat due to invalid chat information'
+  )
 }


### PR DESCRIPTION
Follow up PR from https://github.com/deltachat/deltachat-desktop/pull/3532

**Minor fixes:**

* Fix warning for using an unknown translation by just returning an debug string (this is at least how it was in the version before)
* Remove `useRef` as it doesn't really have a use in this scenario

**Layout fix:**

CSS: Center text always, also in narrow window sizes, independent of padding

Before:

![2023-11-16-202352_678x76_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/571c637f-3be9-48f8-b032-4793ea156b06)

After:

![2023-11-16-202413_682x64_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/a3c3c609-0d7c-4895-9471-4388c7f0bf89)
