### PR TITLE
log error when webxdc status update send fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - update deltachat-node and deltachat/jsonrpc-client to `v1.131.8`
   - more fixes for mail.163.com
 
+### Fixed
+- log error when webxdc status update send fails
+
 <a id="1_42_1"></a>
 
 ## [1.42.1] - 2023-11-23

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -520,12 +520,17 @@ If you think that's a bug and you need that permission, then please open an issu
         return
       }
       const { accountId, msgId } = open_apps[key]
-      return await this.rpc.sendWebxdcStatusUpdate(
-        accountId,
-        msgId,
-        update,
-        description
-      )
+      try {
+        return await this.rpc.sendWebxdcStatusUpdate(
+          accountId,
+          msgId,
+          update,
+          description
+        )
+      } catch (error) {
+        log.error('webxdc.sendUpdate failed:', error)
+        throw error
+      }
     })
 
     ipcMain.handle(


### PR DESCRIPTION
Used to find this bug that is triggered when you send 2 status updates at the same time or closely together:
<img width="307" alt="Bildschirmfoto 2023-12-02 um 15 32 35" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/970f7752-6b4e-4670-a50a-dbb4e0c47b52">

I think it is fixed in the next core update, so I'm doing a pr to upgrade core next: #3580