### PR TITLE
Helper method to easily use confirmation dialogues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Refactor dialog logic and add additional helper methods #3512
 - Upgrade `filesize` dependency from `8.0.6` to `10.1.0`
 - Prefer light theme for the help and webxdc loading pages
+- Helper method to easily use confirmation dialogs #3601
 
 <a id="1_42_2"></a>
 

--- a/src/renderer/components/dialogs/ConfirmationDialog.tsx
+++ b/src/renderer/components/dialogs/ConfirmationDialog.tsx
@@ -12,7 +12,7 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../contexts/DialogContext'
 
-type Props = {
+export type Props = {
   message: string
   cancelLabel?: string
   confirmLabel?: string

--- a/src/renderer/hooks/useConfirmationDialog.ts
+++ b/src/renderer/hooks/useConfirmationDialog.ts
@@ -5,7 +5,7 @@ import ConfirmationDialog, {
   Props as ConfirmationDialogProps,
 } from '../components/dialogs/ConfirmationDialog'
 
-type UseConfirmationDialog = Pick<
+type OpenConfirmationDialog = Pick<
   ConfirmationDialogProps,
   | 'cancelLabel'
   | 'confirmLabel'
@@ -15,18 +15,21 @@ type UseConfirmationDialog = Pick<
   | 'noMargin'
 >
 
-export default function useConfirmationDialog(args: UseConfirmationDialog) {
+export default function useConfirmationDialog() {
   const { openDialog } = useDialog()
 
-  const openConfirmationDialog = useCallback(() => {
-    return new Promise(resolve => {
-      const onUserResult = (confirmed: boolean) => {
-        resolve(confirmed)
-      }
+  const openConfirmationDialog = useCallback(
+    (args: OpenConfirmationDialog) => {
+      return new Promise(resolve => {
+        const onUserResult = (confirmed: boolean) => {
+          resolve(confirmed)
+        }
 
-      openDialog(ConfirmationDialog, { cb: onUserResult, ...args })
-    })
-  }, [openDialog, args])
+        openDialog(ConfirmationDialog, { cb: onUserResult, ...args })
+      })
+    },
+    [openDialog]
+  )
 
   return openConfirmationDialog
 }

--- a/src/renderer/hooks/useConfirmationDialog.ts
+++ b/src/renderer/hooks/useConfirmationDialog.ts
@@ -18,7 +18,7 @@ type OpenConfirmationDialog = Pick<
 export default function useConfirmationDialog() {
   const { openDialog } = useDialog()
 
-  const openConfirmationDialog = useCallback(
+  return useCallback(
     (args: OpenConfirmationDialog) => {
       return new Promise(resolve => {
         const onUserResult = (confirmed: boolean) => {
@@ -30,6 +30,4 @@ export default function useConfirmationDialog() {
     },
     [openDialog]
   )
-
-  return openConfirmationDialog
 }

--- a/src/renderer/hooks/useConfirmationDialog.ts
+++ b/src/renderer/hooks/useConfirmationDialog.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react'
+
+import useDialog from './useDialog'
+import ConfirmationDialog, {
+  Props as ConfirmationDialogProps,
+} from '../components/dialogs/ConfirmationDialog'
+
+type UseConfirmationDialog = Pick<
+  ConfirmationDialogProps,
+  | 'cancelLabel'
+  | 'confirmLabel'
+  | 'header'
+  | 'isConfirmDanger'
+  | 'message'
+  | 'noMargin'
+>
+
+export default function useConfirmationDialog(args: UseConfirmationDialog) {
+  const { openDialog } = useDialog()
+
+  const openConfirmationDialog = useCallback(() => {
+    return new Promise(resolve => {
+      const onUserResult = (confirmed: boolean) => {
+        resolve(confirmed)
+      }
+
+      openDialog(ConfirmationDialog, { cb: onUserResult, ...args })
+    })
+  }, [openDialog, args])
+
+  return openConfirmationDialog
+}


### PR DESCRIPTION
```typescript
const openConfirmationDialog = useConfirmationDialog()

const confirmed = await openConfirmationDialog({
  message: '...',
})

if (confirmed) {
  // Do something
}
```

Closes: https://github.com/deltachat/deltachat-desktop/issues/3485