### PR TITLE
Silently fail when notifications are not supported by OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@
 - Helper method to easily use confirmation dialogs #3601
 - Refactor using new `useConfirmationDialog` hook #3602
 
+### Fixed
+- Silently fail when notifications are not supported by OS #3613
+
 <a id="1_42_2"></a>
 
 ## [1.42.2] - 2023-12-02


### PR DESCRIPTION
My OS does not support notifications so my console is spammed with "No handler found for notifications.clear" logs. This is clearly an edge-case but annoying for development.

This PR reduces the noise and adds a no-op handler to all notifications-related IPC events to silently "fail".