### PR TITLE
message-parse summary text in chatlist item summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
-- message-parse summary text in chatlist item summary #3476
+- Introduce text formatting for chatlist item summary (use message-parser) #3476
 
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.132.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- message-parse summary text in chatlist item summary #3476
+
 ### Changed
 - update deltachat-node and deltachat/jsonrpc-client to `v1.132.1`
 - Use native watch mode and CSS modules of esbuild #3571

--- a/src/renderer/components/chat/ChatListItem.tsx
+++ b/src/renderer/components/chat/ChatListItem.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames'
 import { T, C } from '@deltachat/jsonrpc-client'
 
 import Timestamp from '../conversations/Timestamp'
-import MessageBody from '../message/MessageBody'
 import { Avatar } from '../Avatar'
 import { BackendRemote, Type } from '../../backend-com'
 import { mapCoreMsgStatus2String } from '../helpers/MapMsgStatus'
@@ -12,6 +11,7 @@ import { useContextMenuWithActiveState } from '../ContextMenu'
 import { selectedAccountId } from '../../ScreenController'
 import { InlineVerifiedIcon } from '../VerifiedIcon'
 import { runtime } from '../../runtime'
+import { message2React } from '../message/MessageMarkdown'
 
 const log = getLogger('renderer/chatlist/item')
 
@@ -110,9 +110,7 @@ function Message({
             src={runtime.getWebxdcIconURL(selectedAccountId(), lastMessageId)}
           />
         )}
-        <div>
-          <MessageBody text={summaryText2 || ''} disableJumbomoji preview />
-        </div>
+        <div>{message2React(summaryText2 || '', true)}</div>
       </div>
       {isContactRequest && (
         <div className='label'>
@@ -218,7 +216,7 @@ function ChatListItemError({
         </div>
         <div className='chat-list-item-message'>
           <div className='text' title={chatListItem.error}>
-            <MessageBody text={chatListItem.error} disableJumbomoji preview />
+            {chatListItem.error}
           </div>
         </div>
       </div>

--- a/src/renderer/components/message/MessageBody.tsx
+++ b/src/renderer/components/message/MessageBody.tsx
@@ -3,15 +3,10 @@ import classNames from 'classnames'
 import { getSizeClass, replaceColons } from '../conversations/emoji'
 import { message2React } from './MessageMarkdown'
 
-export default function MessageBody(props: {
-  text: string
-  disableJumbomoji?: boolean
-  preview?: boolean
-}): JSX.Element {
-  const { text, disableJumbomoji, preview } = props
+export default function MessageBody({ text }: { text: string }): JSX.Element {
   // if text is only emojis and Jumbomoji is enabled
   const emojifiedText = trim(text.replace(/:[\w\d_\-+]*:/g, replaceColons))
-  const sizeClass = disableJumbomoji ? '' : getSizeClass(emojifiedText)
+  const sizeClass = getSizeClass(emojifiedText)
   if (sizeClass !== '') {
     return (
       <span className={classNames('emoji-container', sizeClass)}>
@@ -19,8 +14,7 @@ export default function MessageBody(props: {
       </span>
     )
   }
-  if (preview) return <>{emojifiedText}</>
-  return message2React(emojifiedText)
+  return message2React(emojifiedText, false)
 }
 const trimRegex = /^[\s\uFEFF\xA0\n\t]+|[\s\uFEFF\xA0\n\t]+$/g
 

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -103,10 +103,59 @@ function renderElement(elm: ParsedElement, key?: number): JSX.Element {
   }
 }
 
-export function message2React(message: string): JSX.Element {
+/** render in preview mode for ChatListItem summary, not interactive but looks rendered */
+function renderElementPreview(elm: ParsedElement, key?: number): JSX.Element {
+  switch (elm.t) {
+    case 'CodeBlock':
+    case 'InlineCode':
+      return (
+        <code className='mm-inline-code' key={key}>
+          {elm.c.content}
+        </code>
+      )
+
+    case 'StrikeThrough':
+      return <s key={key}>{elm.c.map(renderElement)}</s>
+
+    case 'Italics':
+      return <i key={key}>{elm.c.map(renderElement)}</i>
+
+    case 'Bold':
+      return <b key={key}>{elm.c.map(renderElement)}</b>
+
+    case 'Link':
+      return <span key={key}>{elm.c.destination.target}</span>
+
+    case 'LabeledLink':
+      return (
+        <>
+          <span key={key}>{elm.c.label.map(renderElement)}</span>{' '}
+        </>
+      )
+
+    case 'Linebreak':
+      return <span key={key}>{''}</span>
+
+    case 'Tag':
+    case 'EmailAddress':
+    case 'BotCommandSuggestion':
+    case 'Text':
+      return <span key={key}>{elm.c}</span>
+    default:
+      //@ts-ignore
+      log.error(`type ${elm.t} not known/implemented yet`, elm)
+      return (
+        <span key={key} style={{ color: 'red' }}>
+          {JSON.stringify(elm)}
+        </span>
+      )
+  }
+}
+
+export function message2React(message: string, preview: boolean): JSX.Element {
   try {
     const elements = parseMessage(message)
-    return <>{elements.map(renderElement)}</>
+    return <>{elements.map(preview ? renderElementPreview : renderElement)}</>
   } catch (error) {
     log.error('parseMessage failed:', { input: message, error })
     return <>{message}</>

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -103,7 +103,8 @@ function renderElement(elm: ParsedElement, key?: number): JSX.Element {
   }
 }
 
-/** render in preview mode for ChatListItem summary, not interactive but looks rendered */
+/** render in preview mode for ChatListItem summary,
+ *  not interactive (links can not be clicked) just looks more similar to the message in the chatview/message-list */
 function renderElementPreview(elm: ParsedElement, key?: number): JSX.Element {
   switch (elm.t) {
     case 'CodeBlock':


### PR DESCRIPTION
also simplify MessageBody component

closes #3476

preview:

| markdown disabled (default) | markdown enabled |
|------------------------------| -------------------|
|<img alt="Bildschirmfoto 2024-01-01 um 06 21 58" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/7e64748b-efa9-4cca-a6e9-6560b3500a6d"> | ![image](https://github.com/deltachat/deltachat-desktop/assets/18725968/969e9f58-b2e2-4232-8112-073ff5a7fb59)|