### PR TITLE
Improve position of verified icon in profile info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [Unreleased][unreleased]
 
 ### Added
-
 - ContextMenu now handles multiple sublevels #3116
   - ContextMenuItem has a subitems array
   - Hovering outside of the menu closes last opened sublevel
@@ -32,11 +31,11 @@
 - Remember file open dialog locations across the current session and do not persist last save location across sessions anymore #3615
 - Disable three-dot-menu when not applicable (map, other gallery tabs) #3523
 
-
 ### Fixed
 - Silently fail when notifications are not supported by OS #3613
 - Fix uncaught Exception when dismissing notifications on windows #3593
 - Introduce own React context for context menus & fix regression #3608
+- Improve position of verified icon in profile info #3627
 
 <a id="1_42_2"></a>
 

--- a/scss/dialogs/_group-styles.scss
+++ b/scss/dialogs/_group-styles.scss
@@ -1,28 +1,15 @@
-p.group-name,
 input.group-name-input {
-  margin-left: 0px;
-  margin-bottom: 0px;
-  font-size: x-large;
-  width: 100%;
-  border: 0;
-  height: auto;
   background-color: transparent;
-  color: var(--bp4MenuText);
-  user-select: text;
-}
-
-p.group-name {
-  display: flex;
-  p.trucated-name {
-    text-overflow: ellipsis;
-    overflow: hidden;
-    margin-bottom: 0;
-  }
-}
-
-input.group-name-input {
   border-bottom: solid;
   border-color: var(--loginInputFocusColor);
+  border: 0;
+  color: var(--bp4MenuText);
+  font-size: x-large;
+  height: auto;
+  margin-bottom: 0px;
+  margin-left: 0px;
+  user-select: text;
+  width: 100%;
 }
 
 .group-separator {
@@ -40,19 +27,8 @@ input.group-name-input {
   display: flex;
   margin-bottom: 20px;
 
-  .group-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    line-height: 1;
-  }
-
   .group-name-input-wrapper {
     margin-left: 17px;
-
-    input.group-name-input {
-      top: -7px;
-      position: relative;
-    }
 
     p.input-error {
       color: var(--colorDanger);

--- a/scss/dialogs/_group-styles.scss
+++ b/scss/dialogs/_group-styles.scss
@@ -1,13 +1,13 @@
 input.group-name-input {
   background-color: transparent;
+  border: 0;
   border-bottom: solid;
   border-color: var(--loginInputFocusColor);
-  border: 0;
   color: var(--bp4MenuText);
   font-size: x-large;
   height: auto;
-  margin-bottom: 0px;
-  margin-left: 0px;
+  margin-bottom: 0;
+  margin-left: 0;
   user-select: text;
   width: 100%;
 }

--- a/scss/dialogs/_view_profile.scss
+++ b/scss/dialogs/_view_profile.scss
@@ -1,36 +1,3 @@
-.profile-info-container {
-  display: flex;
-  width: calc(100% - 65px);
-
-  .avatar.large {
-    --local-avatar-vertical-margin: 0;
-  }
-
-  .profile-info-name-container {
-    margin: auto 0px auto 17px;
-    flex-grow: 1;
-    max-width: 80%;
-    input.name {
-      font-size: medium;
-      font-weight: bold;
-      background-color: transparent;
-      color: var(--globalText);
-    }
-    .group-name {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      line-height: 1;
-    }
-    .address {
-      color: #565656;
-      user-select: text;
-      margin-top: 0.25rem;
-      overflow: hidden;
-      text-overflow: ellipsis;
-    }
-  }
-}
-
 .status-text {
   padding: 15px 15px;
   color: var(--globalText);

--- a/src/renderer/components/Avatar.tsx
+++ b/src/renderer/components/Avatar.tsx
@@ -8,6 +8,8 @@ import FullscreenMedia, {
 } from './dialogs/FullscreenMedia'
 import useDialog from '../hooks/useDialog'
 
+import type { PropsWithChildren } from 'react'
+
 export function QRAvatar() {
   return (
     <div className='avatar'>
@@ -94,10 +96,11 @@ export function AvatarFromContact(
   )
 }
 
-export function ClickForFullscreenAvatarWrapper(props: {
-  filename: string | null
-  children: React.ReactNode
-}) {
+export function ClickForFullscreenAvatarWrapper(
+  props: PropsWithChildren<{
+    filename?: string
+  }>
+) {
   const { openDialog } = useDialog()
 
   return (

--- a/src/renderer/components/ProfileInfoHeader/index.tsx
+++ b/src/renderer/components/ProfileInfoHeader/index.tsx
@@ -11,7 +11,7 @@ type Props = {
   color?: string
   displayName: string
   isVerified: boolean
-  wasSeenRecently: boolean
+  wasSeenRecently?: boolean
 }
 
 export default function ProfileInfoHeader({
@@ -20,7 +20,7 @@ export default function ProfileInfoHeader({
   color,
   displayName,
   isVerified,
-  wasSeenRecently,
+  wasSeenRecently = false,
 }: Props) {
   return (
     <div className={styles.profileInfoHeader}>

--- a/src/renderer/components/ProfileInfoHeader/index.tsx
+++ b/src/renderer/components/ProfileInfoHeader/index.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import { Avatar, ClickForFullscreenAvatarWrapper } from '../Avatar'
+import { InlineVerifiedIcon } from '../VerifiedIcon'
+
+import styles from './styles.module.scss'
+
+type Props = {
+  address?: string
+  avatarPath?: string
+  color?: string
+  displayName: string
+  isVerified: boolean
+  wasSeenRecently: boolean
+}
+
+export default function ProfileInfoHeader({
+  address,
+  avatarPath,
+  color,
+  displayName,
+  isVerified,
+  wasSeenRecently,
+}: Props) {
+  return (
+    <div className={styles.profileInfoHeader}>
+      <ClickForFullscreenAvatarWrapper filename={avatarPath}>
+        <Avatar
+          displayName={displayName}
+          avatarPath={avatarPath}
+          color={color}
+          wasSeenRecently={wasSeenRecently}
+          large
+        />
+      </ClickForFullscreenAvatarWrapper>
+      <div className={styles.infoContainer}>
+        <p className={styles.displayName}>
+          {displayName}
+          <span className={styles.verifiedIconWrapper}>
+            {isVerified && <InlineVerifiedIcon />}
+          </span>
+        </p>
+        {address && <div className={styles.address}>{address}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/ProfileInfoHeader/styles.module.scss
+++ b/src/renderer/components/ProfileInfoHeader/styles.module.scss
@@ -9,6 +9,7 @@
   flex-wrap: nowrap;
   justify-content: center;
   margin-left: 17px;
+  word-break: break-word;
 }
 
 .displayName {

--- a/src/renderer/components/ProfileInfoHeader/styles.module.scss
+++ b/src/renderer/components/ProfileInfoHeader/styles.module.scss
@@ -1,0 +1,33 @@
+.profileInfoHeader {
+  display: flex;
+}
+
+.infoContainer {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  flex-wrap: nowrap;
+  justify-content: center;
+  margin-left: 17px;
+}
+
+.displayName {
+  color: var(--globalText);
+  font-size: x-large;
+  line-height: 1.25;
+  margin: 0;
+  user-select: text;
+}
+
+.address {
+  color: #565656;
+  margin-top: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  user-select: text;
+}
+
+.verifiedIconWrapper {
+  position: relative;
+  top: -2px;
+}

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -32,9 +32,9 @@ import useDialog from '../../hooks/useDialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useConfirmationDialog from '../../hooks/useConfirmationDialog'
 import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
+import ProfileInfoHeader from '../ProfileInfoHeader'
 
 import type { DialogProps } from '../../contexts/DialogContext'
-import ProfileInfoHeader from '../ProfileInfoHeader'
 
 const log = getLogger('renderer/ViewGroup')
 
@@ -249,7 +249,6 @@ function ViewGroupInner(
                 color={chat.color}
                 displayName={groupName}
                 isVerified={chat.isProtected}
-                wasSeenRecently={chat.wasSeenRecently}
               />
             </DialogContent>
             {isRelatedChatsEnabled && (

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { C, DcEventType } from '@deltachat/jsonrpc-client'
+import { dirname } from 'path'
 
 import ChatListItem from '../chat/ChatListItem'
 import { useContactSearch, AddMemberInnerDialog } from './CreateChat'
@@ -13,18 +14,13 @@ import {
   PseudoListItemAddMember,
 } from '../helpers/PseudoListItem'
 import ViewProfile from './ViewProfile'
-import {
-  Avatar,
-  avatarInitial,
-  ClickForFullscreenAvatarWrapper,
-} from '../Avatar'
+import { avatarInitial } from '../Avatar'
 import { runtime } from '../../runtime'
 import { DeltaInput } from '../Login-Styles'
 import { getLogger } from '../../../shared/logger'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { modifyGroup } from '../helpers/ChatMethods'
-import { InlineVerifiedIcon } from '../VerifiedIcon'
 import { useSettingsStore } from '../../stores/settings'
 import Dialog, {
   DialogBody,
@@ -35,10 +31,10 @@ import Dialog, {
 import useDialog from '../../hooks/useDialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useConfirmationDialog from '../../hooks/useConfirmationDialog'
+import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
 
 import type { DialogProps } from '../../contexts/DialogContext'
-import { dirname } from 'path'
-import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
+import ProfileInfoHeader from '../ProfileInfoHeader'
 
 const log = getLogger('renderer/ViewGroup')
 
@@ -247,22 +243,14 @@ function ViewGroupInner(
             onClose={onClose}
           />
           <DialogBody>
-            <DialogContent>
-              <div className='group-settings-container'>
-                <ClickForFullscreenAvatarWrapper filename={groupImage}>
-                  <Avatar
-                    displayName={groupName}
-                    avatarPath={groupImage}
-                    color={chat.color}
-                    wasSeenRecently={chat.wasSeenRecently}
-                    large
-                  />
-                </ClickForFullscreenAvatarWrapper>
-                <p className='group-name' style={{ marginLeft: '17px' }}>
-                  <p className='trucated-name'>{groupName}</p>
-                  {chat.isProtected && <InlineVerifiedIcon />}
-                </p>
-              </div>
+            <DialogContent paddingBottom>
+              <ProfileInfoHeader
+                avatarPath={groupImage ? groupImage : undefined}
+                color={chat.color}
+                displayName={groupName}
+                isVerified={chat.isProtected}
+                wasSeenRecently={chat.wasSeenRecently}
+              />
             </DialogContent>
             {isRelatedChatsEnabled && (
               <>

--- a/src/renderer/components/dialogs/ViewProfile/index.tsx
+++ b/src/renderer/components/dialogs/ViewProfile/index.tsx
@@ -5,7 +5,6 @@ import { C } from '@deltachat/jsonrpc-client'
 
 import ChatListItem from '../../chat/ChatListItem'
 import { useChatList } from '../../chat/ChatListHelpers'
-import { Avatar, ClickForFullscreenAvatarWrapper } from '../../Avatar'
 import { useLogicVirtualChatList, ChatListPart } from '../../chat/ChatList'
 import MessageBody from '../../message/MessageBody'
 import { useThemeCssVar } from '../../../ThemeManager'
@@ -24,6 +23,7 @@ import Dialog, {
 import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import useDialog from '../../../hooks/useDialog'
 import { MessagesDisplayContext } from '../../../contexts/MessagesDisplayContext'
+import ProfileInfoHeader from '../../ProfileInfoHeader'
 
 import styles from './styles.module.scss'
 
@@ -53,18 +53,6 @@ function LastSeen({ timestamp }: { timestamp: number }) {
       {lastSeenString}
     </span>
   )
-}
-
-function ProfileInfoAvatar({ contact }: { contact: Type.Contact }) {
-  const { displayName, profileImage, wasSeenRecently } = contact
-  const color = contact.color
-  return Avatar({
-    avatarPath: profileImage,
-    color,
-    displayName,
-    large: true,
-    wasSeenRecently,
-  })
 }
 
 export default function ViewProfile(
@@ -208,44 +196,32 @@ export function ViewProfileInner({
   const CHATLISTITEM_CHAT_HEIGHT =
     Number(useThemeCssVar('--SPECIAL-chatlist-item-chat-height')) || 64
 
-  let displayNameLine = contact.displayName
+  let displayName = contact.displayName
   let addressLine = contact.address
   let statusText = contact.status
+  let avatarPath = contact.profileImage
 
   if (isDeviceChat) {
     addressLine = tx('device_talk_subtitle')
   } else if (isSelfChat) {
-    displayNameLine = tx('saved_messages')
+    displayName = tx('saved_messages')
     addressLine = tx('chat_self_talk_subtitle')
     statusText = tx('saved_messages_explain')
+    avatarPath = selfChatAvatar
   }
 
   return (
     <>
       <div>
         <DialogContent>
-          <div className='profile-info-container'>
-            <ClickForFullscreenAvatarWrapper
-              filename={isSelfChat ? selfChatAvatar : contact.profileImage}
-            >
-              {isSelfChat ? (
-                <ProfileInfoAvatar
-                  contact={{ ...contact, profileImage: selfChatAvatar }}
-                />
-              ) : (
-                <ProfileInfoAvatar contact={contact} />
-              )}
-            </ClickForFullscreenAvatarWrapper>
-            <div className='profile-info-name-container'>
-              <div>
-                <p className='group-name'>
-                  <span className='trucated-name'>{displayNameLine}</span>
-                  {contact.isProfileVerified && <InlineVerifiedIcon />}
-                </p>
-              </div>
-              <div className='address'>{addressLine}</div>
-            </div>
-          </div>
+          <ProfileInfoHeader
+            address={addressLine}
+            avatarPath={avatarPath ? avatarPath : undefined}
+            color={contact.color}
+            displayName={displayName}
+            isVerified={contact.isProfileVerified}
+            wasSeenRecently={contact.wasSeenRecently}
+          />
           {!isSelfChat && (
             <div className='contact-attributes'>
               {verifier && (


### PR DESCRIPTION
Inline verified icon with display name and center it with text when displaying profile info in groups and contacts.

Before:

![2024-01-08-115901_608x312_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/df0d9c6c-e006-4211-bc79-dc2414bf43e4)

After:

![2024-01-08-115231_618x276_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/40271844-a12d-4159-90e6-22d94dfb862b)

Bonus-Level:

* New `ProfileInfoHeader` component which is now reused across "view profile" and "view group" dialogs

Closes #3620 