### PR TITLE
hide email addresses in chat titlebar for guaranteed e2e DM chats and in verified_by in ViewProfile dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Remember file open dialog locations across the current session and do not persist last save location across sessions anymore #3615
 - Disable three-dot-menu when not applicable (map, other gallery tabs) #3523
 - move pin icon in chatlist after date #3636
+- hide email address for guaranteed e2e DM chats in the titlebar #3629
 
 ### Fixed
 - Silently fail when notifications are not supported by OS #3613

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Disable three-dot-menu when not applicable (map, other gallery tabs) #3523
 - move pin icon in chatlist after date #3636
 - hide email address for guaranteed e2e DM chats in the titlebar #3629
+- use displayName for contact in verified_by in Contact Dialog (also hide email address) #3629
 
 ### Fixed
 - Silently fail when notifications are not supported by OS #3613

--- a/src/renderer/components/dialogs/ViewProfile/index.tsx
+++ b/src/renderer/components/dialogs/ViewProfile/index.tsx
@@ -173,12 +173,12 @@ export function ViewProfileInner({
         setVerifier(null) // make sure it rather shows nothing than wrong values
         const verifierContactId = contact.verifierId
         try {
-          const { nameAndAddr } = await BackendRemote.rpc.getContact(
+          const { displayName } = await BackendRemote.rpc.getContact(
             accountId,
             verifierContactId
           )
           setVerifier({
-            label: tx('verified_by', nameAndAddr),
+            label: tx('verified_by', displayName),
             action: () => openViewProfileDialog(openDialog, verifierContactId),
           })
         } catch (error) {

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -438,7 +438,11 @@ function chatSubtitle(chat: Type.FullChat) {
       } else if (chat.isDeviceChat) {
         return tx('device_talk_subtitle')
       }
-      return chat.contacts[0].address
+      if (chat.isProtected){
+        return null
+      } else {
+        return chat.contacts[0].address
+      }
     }
   }
   return 'ErrTitle'

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -438,7 +438,7 @@ function chatSubtitle(chat: Type.FullChat) {
       } else if (chat.isDeviceChat) {
         return tx('device_talk_subtitle')
       }
-      if (chat.isProtected){
+      if (chat.isProtected) {
         return null
       } else {
         return chat.contacts[0].address


### PR DESCRIPTION
- hide email address for guaranteed e2e DM chats in the titlebar #3629
- use displayName for contact in verified_by in Contact Dialog (also hide email address) #3629

close #3629
