### PR TITLE
Indicate better that some info bubbles are interactive

### DIFF
--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -418,10 +418,12 @@
     display: inline-block;
     text-align: center;
     padding: 7px 14px;
+    padding-bottom: 5px;
     background-color: var(--infoMessageBubbleBg);
-    border-radius: 10px;
+    border-radius: 20px;
     opacity: 0.9;
     color: var(--infoMessageBubbleText);
+
     .status-icon.sending {
       background-color: var(--infoMessageBubbleText);
     }
@@ -430,6 +432,14 @@
   &.daymarker {
     .bubble {
       font-weight: bold;
+    }
+  }
+
+  &.interactive > .bubble {
+    cursor: pointer;
+
+    &:hover {
+      opacity: 1;
     }
   }
 


### PR DESCRIPTION
This PR is a minor adjustment to indicate better to the user that some of the info bubbles are clickable / interactive as they for example show further dialogs:

- Show a cursor pointer
- Add a hover style

Bonus level:

- Do _not_ register an `onClick` event on _all_ info bubbles, even when they're not interactive
- Minor design tweak: Make them a little rounder and text better horizontally centered

I haven't made a proper refactoring around styles for now as the message component logic is too interwined.

**Before**

![2024-02-01-123412_1041x361_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/22788fd8-7563-4b8f-9fb7-d62cc4fa0dc1)

**After**

![2024-02-01-123438_1041x425_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/74c014f5-3014-4345-9bf3-cc1e0ec2bde3)

https://github.com/deltachat/deltachat-desktop/assets/1822473/4ee30b31-690c-4d3e-872f-6ee861fe7783