### PR TITLE
z-index refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Removed minimal theme from offical themes because it is unmaintained #3645
 - Do not add changelog device message on fresh accounts #3639
 - Copy invite link to clipboard instead of only QR code data #3650
+- Remove unessesary z-index css properties and reorganize the remaining ones #3661
 
 ### Fixed
 - Silently fail when notifications are not supported by OS #3613

--- a/scss/_connectivity-toast.scss
+++ b/scss/_connectivity-toast.scss
@@ -3,7 +3,6 @@
   bottom: 15px;
   left: 8px;
   text-align: center;
-  z-index: 19; // 1 under the .bp4 dialog backdrop
   background-color: var(--contextMenuBg);
   border: 1px solid var(--contextMenuBorder);
   padding: 5px;

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -144,12 +144,13 @@ code {
   image-rendering: pixelated;
 }
 
+// toast for errors and success messages
 .user-feedback {
   position: fixed;
   top: 60px;
   text-align: center;
   width: 100%;
-  z-index: 100;
+  z-index: map-get($z-index, user-feedback);
   pointer-events: none;
 
   p {

--- a/scss/_sidebar.scss
+++ b/scss/_sidebar.scss
@@ -5,7 +5,7 @@
   width: 100vw;
   height: 100vh;
   background-color: #1820268c;
-  z-index: 100;
+  z-index: map-get($z-index, sidebar);
 }
 
 .sidebar {
@@ -17,7 +17,7 @@
   max-width: 90vw;
   height: 100vh;
   background-color: var(--sideBarBackground);
-  z-index: 100;
+  z-index: map-get($z-index, sidebar);
 
   transform: translateX(-100%);
   -webkit-transform: translateX(-100%);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -27,7 +27,14 @@ $border-radius: 5px;
 
 $font-size: 14px;
 
+// Get these keys via: `map-get($z-index, keyname)`
 $z-index: (
+  /* Local Scopes */
+  chatlist-scope-floating-action-button: 1,
+  jump-down-button-scope-counter: 1,
+  import-qr-code-dialog-scope-scan-qr-description: 1,
+
+  /* Global Scope */
   emoji-sticker-picker: 10,
 
   sidebar: 100,
@@ -37,3 +44,6 @@ $z-index: (
   absolutePositioningHelper: 1000,
   context-menu-layer: 9999,
 );
+
+// setting z-index to 0 creates a new scope for children without changing the ordering of the parent element
+$z-index-new-local-scope: 0;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -29,12 +29,14 @@ $font-size: 14px;
 
 // Get these keys via: `map-get($z-index, keyname)`
 $z-index: (
-  /* Local Scopes */
+  // Local Scopes
+  // ============
   chatlist-scope-floating-action-button: 1,
   jump-down-button-scope-counter: 1,
   import-qr-code-dialog-scope-scan-qr-description: 1,
 
-  /* Global Scope */
+  // Global Scope
+  // ============
   emoji-sticker-picker: 10,
 
   sidebar: 100,
@@ -42,7 +44,7 @@ $z-index: (
 
   // toast for errors and success messages
   absolute-positioning-helper: 1000,
-  context-menu-layer: 9999,
+  context-menu-layer: 9999
 );
 
 // setting z-index to 0 creates a new scope for children without changing the ordering of the parent element

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -31,8 +31,9 @@ $z-index: (
   emoji-sticker-picker: 10,
 
   sidebar: 100,
-  user-feedback: 100, // toast for errors and success messages
+  user-feedback: 100,
 
+  // toast for errors and success messages
   absolutePositioningHelper: 1000,
   context-menu-layer: 9999,
 );

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -41,7 +41,7 @@ $z-index: (
   user-feedback: 100,
 
   // toast for errors and success messages
-  absolutePositioningHelper: 1000,
+  absolute-positioning-helper: 1000,
   context-menu-layer: 9999,
 );
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -26,3 +26,13 @@ $button-height: 24px;
 $border-radius: 5px;
 
 $font-size: 14px;
+
+$z-index: (
+  emoji-sticker-picker: 10,
+
+  sidebar: 100,
+  user-feedback: 100, // toast for errors and success messages
+
+  absolutePositioningHelper: 1000,
+  context-menu-layer: 9999,
+);

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -327,7 +327,7 @@
   --size: 50px;
   --iconSize: 20px;
   position: fixed;
-  z-index: 20;
+  z-index: 1; // local z-index scoped to the chatlist
   bottom: 15px;
 
   width: var(--size);

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -327,7 +327,7 @@
   --size: 50px;
   --iconSize: 20px;
   position: fixed;
-  z-index: 1; // local z-index scoped to the chatlist
+  z-index: map-get($z-index, chatlist-scope-floating-action-button);
   bottom: 15px;
 
   width: var(--size);

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,5 +1,5 @@
 .chat-list {
-  z-index: 0; // this scopes the z-index of the floating action button to the chatlist
+  z-index: $z-index-new-local-scope; // needed for .floating-action-button
   width: 30%;
   height: $content-height;
   float: left;

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,4 +1,5 @@
 .chat-list {
+  z-index: 0; // this scopes the z-index of the floating action button to the chatlist
   width: 30%;
   height: $content-height;
   float: left;

--- a/scss/composer/_emoji-sticker-picker.scss
+++ b/scss/composer/_emoji-sticker-picker.scss
@@ -6,7 +6,8 @@ $emojimart-search-height: 31px + 6px;
 
 .emoji-sticker-picker {
   position: fixed;
-  z-index: 10;
+  z-index: map-get($z-index, emoji-sticker-picker);
+
   width: 438px;
   height: $esp-height;
   right: 13px;

--- a/scss/dialogs/_group-styles.scss
+++ b/scss/dialogs/_group-styles.scss
@@ -54,7 +54,6 @@ input.group-name-input {
     top: 5px;
     background-color: var(--colorPrimary);
     border-radius: 50%;
-    z-index: 5;
 
     &:hover {
       cursor: pointer;

--- a/scss/dialogs/_qr-code.scss
+++ b/scss/dialogs/_qr-code.scss
@@ -27,7 +27,7 @@
 
 .scan-qr-description {
   position: relative;
-  z-index: 10;
+  z-index: 1;
   top: -18px;
   margin-top: -18px;
   margin: 0;
@@ -45,7 +45,6 @@
   }
 
   position: relative;
-  z-index: 10;
   top: -225px;
   margin-top: -225px;
   margin: 0;

--- a/scss/dialogs/_qr-code.scss
+++ b/scss/dialogs/_qr-code.scss
@@ -27,7 +27,7 @@
 
 .scan-qr-description {
   position: relative;
-  z-index: 1;
+  z-index: map-get($z-index, import-qr-code-dialog-scope-scan-qr-description);
   top: -18px;
   margin-top: -18px;
   margin: 0;

--- a/scss/dialogs/_qr-import.scss
+++ b/scss/dialogs/_qr-import.scss
@@ -19,6 +19,8 @@ div.import-qr-code-dialog {
   .bp4-button {
     margin: 10px;
   }
+
+  z-index: $z-index-new-local-scope; // needed for .scan-qr-description
 }
 
 .qr-data {

--- a/scss/gallery/_attachment-view.scss
+++ b/scss/gallery/_attachment-view.scss
@@ -29,7 +29,6 @@
   .btn-wrapper {
     float: right;
     position: absolute;
-    z-index: 10;
     background-color: rgba(0, 0, 0, 0.75);
     border-radius: 3px;
 
@@ -66,7 +65,6 @@
   top: calc(50vh - (60px / 2));
   background-color: #3131316b;
   border-radius: 8%;
-  z-index: 1;
 
   .bp4-icon > svg:not([fill]) {
     fill: var(--bp4ButtonHoverBg);

--- a/scss/map/_map.scss
+++ b/scss/map/_map.scss
@@ -84,7 +84,6 @@ div.context-menu {
   right: 20px;
   padding: 10px;
   background-color: $color-map-overlay-bg;
-  z-index: 1;
   border-radius: 5px;
 }
 

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -23,10 +23,11 @@
     bottom: calc(-100% + #{$height} + #{$marginBottom});
     height: $height;
     width: $width;
+    z-index: $z-index-new-local-scope; // needed for .jump-down-button>.counter
 
     .counter {
       position: relative;
-      z-index: 1;
+      z-index: map-get($z-index, jump-down-button-scope-counter);
       width: 25px;
       height: 25px;
       margin: 0 auto;

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -23,11 +23,10 @@
     bottom: calc(-100% + #{$height} + #{$marginBottom});
     height: $height;
     width: $width;
-    z-index: 10;
 
     .counter {
       position: relative;
-      z-index: 10;
+      z-index: 1;
       width: 25px;
       height: 25px;
       margin: 0 auto;
@@ -46,7 +45,6 @@
 
     .button {
       position: relative;
-      z-index: 8;
 
       height: $heightJumpToBottomButton;
       margin: 0 auto;

--- a/scss/misc/_context_menu.scss
+++ b/scss/misc/_context_menu.scss
@@ -2,7 +2,7 @@
   width: 100vw;
   height: 100vh;
   position: absolute;
-  z-index: 9999;
+  z-index: map-get($z-index, context-menu-layer);
   background-color: transparent;
   pointer-events: none;
 

--- a/src/renderer/components/AbsolutePositioningHelper/styles.module.scss
+++ b/src/renderer/components/AbsolutePositioningHelper/styles.module.scss
@@ -2,5 +2,5 @@
 
 .absolutePositioningHelper {
   position: fixed;
-  z-index: map-get($z-index, absolutePositioningHelper);
+  z-index: map-get($z-index, absolute-positioning-helper);
 }

--- a/src/renderer/components/AbsolutePositioningHelper/styles.module.scss
+++ b/src/renderer/components/AbsolutePositioningHelper/styles.module.scss
@@ -1,4 +1,6 @@
+@import '../../../../scss/variables';
+
 .absolutePositioningHelper {
   position: fixed;
-  z-index: 1000;
+  z-index: map-get($z-index, absolutePositioningHelper);
 }

--- a/src/renderer/components/dialogs/FullscreenMedia.tsx
+++ b/src/renderer/components/dialogs/FullscreenMedia.tsx
@@ -249,6 +249,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
       onClose={onClose}
     >
       <div className='render-media-wrapper' tabIndex={0}>
+        <div className='attachment-view'>{elm}</div>
         {elm && (
           <div className='btn-wrapper'>
             <div
@@ -284,7 +285,6 @@ export default function FullscreenMedia(props: Props & DialogProps) {
             />
           </div>
         )}
-        <div className='attachment-view'>{elm}</div>
       </div>
     </Overlay>
   )

--- a/src/renderer/components/map/MapComponent.tsx
+++ b/src/renderer/components/map/MapComponent.tsx
@@ -663,6 +663,7 @@ export default class MapComponent extends React.Component<
   render() {
     return (
       <div className='map-wrapper'>
+        <div id='map' />
         <nav id='controls' className='map-overlay top'>
           <Button
             minimal
@@ -724,7 +725,6 @@ export default class MapComponent extends React.Component<
             </div>
           </Collapse>
         </nav>
-        <div id='map' />
         <div style={{ display: 'none' }}>
           <ContextMenu ref={this.contextMenu} onSetPoi={this.sendPoiMessage} />
         </div>


### PR DESCRIPTION
remove z-index where it was not needed, where it was needed tried to convert it to a lower or local/scoped z-index and put the remaining global ones into one file (`_variables.scss`).

## Commit messages
- scope the FAB z-index to the chatlist to get rid of its global z-index
- remove unessesary z-index from .group-image-edit-button
- reduce dependency on z-index in qr scanner ui
- remove dependence on z-index from fullscreen media view
- rm z-index from connectivity toast
- rm unnecessary z-indexes in jump-down-button
- put all global z-index values into a scss map in _variables.scss
- fix fmt
