### PR TITLE
make an own variant of fullscreen media view for avatars to fix #3664

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - Hide reactions UI for info-, system- or video-invite messages and chats #3642
 - Delete old themes before rebuilding in build process #3645
 - More contrast for audio elements in dark mode #3653
+- Fix fullscreen view for avatar images #3669
 
 <a id="1_42_2"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Delete old themes before rebuilding in build process #3645
 - More contrast for audio elements in dark mode #3653
 - Fix fullscreen view for avatar images #3669
+- fix display of avatars with spaces in the name #3669
 
 <a id="1_42_2"></a>
 

--- a/src/renderer/components/Avatar.tsx
+++ b/src/renderer/components/Avatar.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import classNames from 'classnames'
 
-import { Type } from '../backend-com'
 import useDialog from '../hooks/useDialog'
-
-import type { PropsWithChildren } from 'react'
 import FullscreenAvatar from './dialogs/FullscreenAvatar'
+
+import type { Type } from '../backend-com'
+import type { PropsWithChildren } from 'react'
 
 export function QRAvatar() {
   return (

--- a/src/renderer/components/Avatar.tsx
+++ b/src/renderer/components/Avatar.tsx
@@ -1,14 +1,11 @@
 import React from 'react'
 import classNames from 'classnames'
-import { T } from '@deltachat/jsonrpc-client'
 
 import { Type } from '../backend-com'
-import FullscreenMedia, {
-  NeighboringMediaMode,
-} from './dialogs/FullscreenMedia'
 import useDialog from '../hooks/useDialog'
 
 import type { PropsWithChildren } from 'react'
+import FullscreenAvatar from './dialogs/FullscreenAvatar'
 
 export function QRAvatar() {
   return (
@@ -109,12 +106,8 @@ export function ClickForFullscreenAvatarWrapper(
         if (!props.filename) {
           return
         }
-        openDialog(FullscreenMedia, {
-          msg: {
-            fileMime: 'image/x',
-            file: props.filename,
-          } as T.Message,
-          neighboringMedia: NeighboringMediaMode.Off,
+        openDialog(FullscreenAvatar, {
+          imagePath: props.filename,
         })
       }}
       style={{

--- a/src/renderer/components/GroupImage.tsx
+++ b/src/renderer/components/GroupImage.tsx
@@ -1,13 +1,10 @@
-import { T } from '@deltachat/jsonrpc-client'
 import React from 'react'
 
 import useDialog from '../hooks/useDialog'
 import { Avatar } from './Avatar'
 import useTranslationFunction from '../hooks/useTranslationFunction'
-import FullscreenMedia, {
-  NeighboringMediaMode,
-} from './dialogs/FullscreenMedia'
 import useContextMenu from '../hooks/useContextMenu'
+import FullscreenAvatar from './dialogs/FullscreenAvatar'
 
 type Props = {
   groupImage?: string | null
@@ -33,12 +30,9 @@ export default function GroupImage(props: Props) {
   const { openDialog } = useDialog()
 
   const showAvatarFullscreen = () =>
-    openDialog(FullscreenMedia, {
-      msg: {
-        fileMime: 'image/x',
-        file: groupImage,
-      } as T.Message,
-      neighboringMedia: NeighboringMediaMode.Off,
+    groupImage &&
+    openDialog(FullscreenAvatar, {
+      imagePath: groupImage,
     })
 
   const openContextMenu = useContextMenu([

--- a/src/renderer/components/dialogs/FullscreenAvatar.tsx
+++ b/src/renderer/components/dialogs/FullscreenAvatar.tsx
@@ -1,12 +1,13 @@
 import React, { useRef } from 'react'
+import { basename } from 'path'
 import { Icon, Overlay } from '@blueprintjs/core'
 import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch'
+
 import { runtime } from '../../runtime'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useContextMenu from '../../hooks/useContextMenu'
 
 import type { DialogProps } from '../../contexts/DialogContext'
-import { basename } from 'path'
 
 export default function FullscreenAvatar(
   props: { imagePath: string } & DialogProps
@@ -59,7 +60,6 @@ export default function FullscreenAvatar(
             </TransformWrapper>
           </div>
         </div>
-
         <div className='btn-wrapper'>
           <div
             role='button'

--- a/src/renderer/components/dialogs/FullscreenAvatar.tsx
+++ b/src/renderer/components/dialogs/FullscreenAvatar.tsx
@@ -1,0 +1,81 @@
+import React, { useRef } from 'react'
+import { Icon, Overlay } from '@blueprintjs/core'
+import { TransformWrapper, TransformComponent } from 'react-zoom-pan-pinch'
+import { runtime } from '../../runtime'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
+import useContextMenu from '../../hooks/useContextMenu'
+
+import type { DialogProps } from '../../contexts/DialogContext'
+import { basename } from 'path'
+
+export default function FullscreenAvatar(
+  props: { imagePath: string } & DialogProps
+) {
+  const tx = useTranslationFunction()
+  const { onClose, imagePath } = props
+
+  const resetImageZoom = useRef<(() => void) | null>(
+    null
+  ) as React.MutableRefObject<(() => void) | null>
+
+  const saveAs = () => {
+    runtime.downloadFile(imagePath, basename(imagePath))
+  }
+
+  const openMenu = useContextMenu([
+    {
+      label: tx('menu_copy_image_to_clipboard'),
+      action: () => {
+        runtime.writeClipboardImage(imagePath)
+      },
+    },
+    {
+      label: tx('save_as'),
+      action: saveAs,
+    },
+  ])
+
+  return (
+    <Overlay isOpen={true} className='attachment-overlay' onClose={onClose}>
+      <div className='render-media-wrapper' tabIndex={0}>
+        <div className='attachment-view'>
+          <div className='image-container'>
+            <TransformWrapper initialScale={1}>
+              {utils => {
+                resetImageZoom.current = () => {
+                  utils.resetTransform()
+                }
+                return (
+                  <TransformComponent>
+                    <div
+                      className='image-context-menu-container'
+                      onContextMenu={openMenu}
+                    >
+                      <img src={runtime.transformBlobURL(imagePath)} />
+                    </div>
+                  </TransformComponent>
+                )
+              }}
+            </TransformWrapper>
+          </div>
+        </div>
+
+        <div className='btn-wrapper'>
+          <div
+            role='button'
+            onClick={saveAs}
+            className='download-btn'
+            aria-label={tx('save')}
+          />
+          <Icon
+            onClick={onClose}
+            icon='cross'
+            size={32}
+            color={'grey'}
+            aria-label={tx('close')}
+          />
+        </div>
+      </div>
+    </Overlay>
+  )
+}

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -483,7 +483,13 @@ class Electron implements Runtime {
     }
     const path_components = blob.replace(/\\/g, '/').split('/')
     const filename2 = path_components[path_components.length - 1]
-    return blob.replace(filename2, encodeURIComponent(filename2))
+
+    if (decodeURIComponent(filename2) === filename2) {
+      // if it is not already encoded then encode it.
+      return blob.replace(filename2, encodeURIComponent(filename2))
+    } else {
+      return blob
+    }
   }
   async showOpenFileDialog(
     options: Electron.OpenDialogOptions


### PR DESCRIPTION
fixes #3664

This was broken because `onDownload` uses the original filename that is provided by recent cores and this change did not update the workaround/hack to fake message objects for the fullscreen media view to reuse it for avatars.
Making a dedicated component for it avoids such problems in the future in addition to fixing the issue. 