### PR TITLE
Use overlay in context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - webxdc stay open when switching accounts (when you have sync all enabled, which is the default) #3621
 - Add more versions to about dialog and update the order of information #3677
 - Refactor message meta data component #3678
+- Use overlay in context menu #3682
 
 ### Fixed
 - Silently fail when notifications are not supported by OS #3613

--- a/scss/misc/_context_menu.scss
+++ b/scss/misc/_context_menu.scss
@@ -6,9 +6,9 @@
   background-color: transparent;
   pointer-events: none;
 
-  // &.active {
-  //   background-color: rgba(0, 0, 0, 0.3);
-  // }
+  &.active {
+    pointer-events: all;
+  }
 
   // prevent double context menu on macOS
   // (when using touchpad it sometimes selects the text in the context menu, and then show a native context menu on top)

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -141,6 +141,7 @@ export function ContextMenuLayer({
       ref={layerRef}
       className={`dc-context-menu-layer ${active ? 'active' : ''}`}
       onClick={cancel}
+      onContextMenuCapture={cancel}
     >
       {active && currentItems.length > 0 && (
         <ContextMenu

--- a/src/renderer/components/ContextMenu.tsx
+++ b/src/renderer/components/ContextMenu.tsx
@@ -288,27 +288,12 @@ export function ContextMenu(props: {
       }
     }
 
-    const onOutsideClick = (ev: MouseEvent | TouchEvent) => {
-      const target = ev.target as HTMLElement
-      const isOnMenu = menuLevelEls.current.find(
-        menuEl => target === menuEl || target.parentElement === menuEl
-      )
-
-      if (!isOnMenu) {
-        closeCallback()
-      }
-    }
-
     const onResize = (_ev: UIEvent) => closeCallback()
 
     document.addEventListener('keydown', onKeyDown)
-    document.addEventListener('mousedown', onOutsideClick)
-    document.addEventListener('touchstart', onOutsideClick)
     window.addEventListener('resize', onResize)
     return () => {
       document.removeEventListener('keydown', onKeyDown)
-      document.removeEventListener('mousedown', onOutsideClick)
-      document.removeEventListener('touchstart', onOutsideClick)
       window.removeEventListener('resize', onResize)
     }
   }, [openSublevels, menuLevelEls, closeCallback])


### PR DESCRIPTION
Uses an transparent overlay to detect clicks to close the context menu. This allows us following the default behaviour of other applications and OS where you need to "click away" the context menu first before you can continue doing something else

Closes: https://github.com/deltachat/deltachat-desktop/issues/3643