### PR TITLE
Fix broken/wrong/missing background for muted and turned off account badges in multiaccount sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 <a id="1_43_0"></a>
 
+### Fixed
+- Fix broken styles for muted and turned off account badges in multiaccount sidebar
+
 ## [1.43.0] - 2024-02-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 <a id="1_43_0"></a>
 
 ### Fixed
-- Fix broken styles for muted and turned off account badges in multiaccount sidebar
+- Fix broken styles for muted and turned off account badges in multiaccount sidebar #3691
 
 ## [1.43.0] - 2024-02-14
 

--- a/src/renderer/components/AccountListSidebar/AccountItem.tsx
+++ b/src/renderer/components/AccountListSidebar/AccountItem.tsx
@@ -110,7 +110,7 @@ export default function AccountItem({
   if (bgSyncDisabled) {
     badgeContent = (
       <div
-        className={(styles.accountBadgeIcon, styles.bgSyncDisabled)}
+        className={classNames(styles.accountBadgeIcon, styles.bgSyncDisabled)}
         aria-label='Background sync disabled'
       >
         ⏻

--- a/src/renderer/components/AccountListSidebar/styles.module.scss
+++ b/src/renderer/components/AccountListSidebar/styles.module.scss
@@ -196,12 +196,12 @@
   padding: 0 4pt;
   text-align: center;
 
-  .bgSyncDisabled {
+  &.bgSyncDisabled {
     background-color: grey;
     padding: 0 3pt;
   }
 
-  .muted {
+  &.muted {
     background-color: grey;
   }
 }


### PR DESCRIPTION
These bugs were introduced by adz's refactor/merge commits on #3680, those also broke the shadow for the mute icon's shadow on the account, but I haven't addressed this in this small quick fix pr.