### PR TITLE
Fix "Broken protection" message not opening info dialog on tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixed
 - Fix broken styles for muted and turned off account badges in multiaccount sidebar #3691
+- "Broken protection" message did not allow opening info dialog on tap #3695
 
 ## [1.43.0] - 2024-02-14
 

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -398,7 +398,7 @@ export default function Message(props: {
     // Some info messages can be clicked by the user to receive further information
     const isInteractive =
       (isWebxdcInfo && message.parentId) ||
-      isProtectionEnabledMsg ||
+      isProtectionBrokenMsg ||
       isProtectionEnabledMsg ||
       isInvalidUnencryptedMail
 


### PR DESCRIPTION
Closes: #3687 