### PR TITLE
slightly wider account sidebar as suggested in the forum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Changed
-- slightly wider account sidebar (so trafic lights look more centered on macOS) #3698
+- slightly wider account sidebar (so traffic lights look more centered on macOS) #3698
 
 <a id="1_43_1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Changed
+- slightly wider account sidebar (so trafic lights look more centered on macOS) #3698
+
 <a id="1_43_1"></a>
 
 ## [1.43.1] - 2024-02-19

--- a/src/renderer/components/AccountListSidebar/styles.module.scss
+++ b/src/renderer/components/AccountListSidebar/styles.module.scss
@@ -43,7 +43,7 @@
   background-color: var(--accountSidebarBg);
   display: flex;
   flex-direction: column;
-  min-width: 66px;
+  min-width: 68px;
   overflow: hidden;
 
   .accountList {
@@ -94,7 +94,7 @@
         border-radius: 20px;
         content: ' ';
         height: var(--als-active-indicator-height);
-        margin-inline-start: -15.5px;
+        margin-inline-start: -16.5px;
         overflow: hidden;
         pointer-events: none;
         position: absolute;


### PR DESCRIPTION
make account switcher 2px wider: https://support.delta.chat/t/a-few-ideas-to-make-dc-desktop-1-43-even-better/2931

(so traffic lights look more centered on macOS)

before:
<img width="133" alt="Bildschirmfoto 2024-02-19 um 22 41 19" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/96eb8714-248f-4979-81c0-6c449b8967c7">

after:
<img width="133" alt="Bildschirmfoto 2024-02-19 um 22 41 44" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/71143bf1-aaed-40cf-825c-2f741ab191d2">
