### PR TITLE
simon/start with chatstore cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 - slightly wider account sidebar (so traffic lights look more centered on macOS) #3698
+- remove chatstore global for prevention of possible race condition #3700
 
 
 <a id="1_43_1"></a>

--- a/src/renderer/components/message/EmptyChatMessage.tsx
+++ b/src/renderer/components/message/EmptyChatMessage.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
+import { ChatStoreStateWithChatSet } from '../../stores/chat'
+import { C } from '@deltachat/jsonrpc-client'
+
+export default function EmptyChatMessage({
+  chatStore,
+}: {
+  chatStore: ChatStoreStateWithChatSet
+}) {
+  const tx = useTranslationFunction()
+  const { chat } = chatStore
+
+  let emptyChatMessage = tx('chat_new_one_to_one_hint', [chat.name, chat.name])
+
+  if (chat.chatType === C.DC_CHAT_TYPE_BROADCAST) {
+    emptyChatMessage = tx('chat_new_broadcast_hint')
+  } else if (chat.chatType === C.DC_CHAT_TYPE_GROUP && !chat.isContactRequest) {
+    emptyChatMessage = chat.isUnpromoted
+      ? tx('chat_new_group_hint')
+      : tx('chat_no_messages')
+  } else if (chat.isSelfTalk) {
+    emptyChatMessage = tx('saved_messages_explain')
+  } else if (chat.isDeviceChat) {
+    emptyChatMessage = tx('device_talk_explain')
+  } else if (chat.isContactRequest) {
+    emptyChatMessage = tx('chat_no_messages')
+  }
+
+  return (
+    <li>
+      <div className='info-message big'>
+        <div className='bubble'>{emptyChatMessage}</div>
+      </div>
+    </li>
+  )
+}

--- a/src/renderer/components/message/Link.tsx
+++ b/src/renderer/components/message/Link.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react'
+import React, { useContext, useState } from 'react'
 import { LinkDestination } from '@deltachat/message_parser_wasm'
 
 import { DeltaCheckbox } from '../contact/ContactListItem'
 import { getLogger } from '../../../shared/logger'
-import chatStore from '../../stores/chat'
 import reactStringReplace from 'react-string-replace'
 import { runtime } from '../../runtime'
 import { openLinkSafely } from '../helpers/LinkConfirmation'
@@ -18,6 +17,7 @@ import useDialog from '../../hooks/useDialog'
 import { OpenDialog } from '../../contexts/DialogContext'
 import processOpenQrUrl from '../helpers/OpenQrUrl'
 import { isInviteLink } from '../../../shared/util'
+import { MessagesDisplayContext } from '../../contexts/MessagesDisplayContext'
 
 const log = getLogger('renderer/LabeledLink')
 
@@ -44,6 +44,7 @@ export const LabeledLink = ({
   destination: LinkDestination
 }) => {
   const { openDialog, closeDialog } = useDialog()
+  const messageDisplay = useContext(MessagesDisplayContext)
   const { target, punycode, hostname } = destination
 
   // encode the punycode to make phishing harder
@@ -53,7 +54,10 @@ export const LabeledLink = ({
   const onClick = (ev: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
     ev.preventDefault()
     ev.stopPropagation()
-    const isDeviceChat = chatStore.getState().chat?.isDeviceChat
+    const isDeviceChat =
+      messageDisplay?.context == 'chat_messagelist'
+        ? messageDisplay.isDeviceChat
+        : false
 
     if (isInviteLink(target)) {
       processOpenQrUrl(openDialog, closeDialog, target)

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -25,6 +25,7 @@ import { MessagesDisplayContext } from '../../contexts/MessagesDisplayContext'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useKeyBindingAction from '../../hooks/useKeyBindingAction'
 import { useReactionsBar } from '../ReactionsBar'
+import EmptyChatMessage from './EmptyChatMessage'
 
 const log = getLogger('render/components/message/MessageList')
 
@@ -528,7 +529,9 @@ export const MessageListInner = React.memo(
         onScroll={onScroll}
       >
         <ul>
-          {messageListItems.length === 0 && <EmptyChatMessage />}
+          {messageListItems.length === 0 && (
+            <EmptyChatMessage chatStore={chatStore} />
+          )}
           {activeView.map(messageId => {
             if (messageId.kind === 'dayMarker') {
               return (
@@ -646,40 +649,6 @@ function JumpDownButton({
         </div>
       </div>
     </>
-  )
-}
-
-function EmptyChatMessage() {
-  const tx = useTranslationFunction()
-  const chatStore = useChatStore()
-  const chat = chatStore.chat
-
-  if (!chat) {
-    throw new Error('no chat selected')
-  }
-
-  let emptyChatMessage = tx('chat_new_one_to_one_hint', [chat.name, chat.name])
-
-  if (chat.chatType === C.DC_CHAT_TYPE_BROADCAST) {
-    emptyChatMessage = tx('chat_new_broadcast_hint')
-  } else if (chat.chatType === C.DC_CHAT_TYPE_GROUP && !chat.isContactRequest) {
-    emptyChatMessage = chat.isUnpromoted
-      ? tx('chat_new_group_hint')
-      : tx('chat_no_messages')
-  } else if (chat.isSelfTalk) {
-    emptyChatMessage = tx('saved_messages_explain')
-  } else if (chat.isDeviceChat) {
-    emptyChatMessage = tx('device_talk_explain')
-  } else if (chat.isContactRequest) {
-    emptyChatMessage = tx('chat_no_messages')
-  }
-
-  return (
-    <li>
-      <div className='info-message big'>
-        <div className='bubble'>{emptyChatMessage}</div>
-      </div>
-    </li>
   )
 }
 

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -11,10 +11,7 @@ import { C, T } from '@deltachat/jsonrpc-client'
 import moment from 'moment'
 
 import { MessageWrapper } from './MessageWrapper'
-import ChatStore, {
-  useChatStore,
-  ChatStoreStateWithChatSet,
-} from '../../stores/chat'
+import ChatStore, { ChatStoreStateWithChatSet } from '../../stores/chat'
 import { getLogger } from '../../../shared/logger'
 import { KeybindAction } from '../../keybindings'
 import { selectedAccountId } from '../../ScreenController'
@@ -408,7 +405,11 @@ export default function MessageList({
 
   return (
     <MessagesDisplayContext.Provider
-      value={{ context: 'chat_messagelist', chatId: chatStore.chat.id }}
+      value={{
+        context: 'chat_messagelist',
+        chatId: chatStore.chat.id,
+        isDeviceChat: chatStore.chat.isDeviceChat,
+      }}
     >
       <MessageListInner
         onScroll={onScroll}

--- a/src/renderer/contexts/MessagesDisplayContext.tsx
+++ b/src/renderer/contexts/MessagesDisplayContext.tsx
@@ -1,7 +1,7 @@
 import { createContext } from 'react'
 
 type MessagesDisplayContextValue =
-  | { context: 'chat_messagelist'; chatId: number }
+  | { context: 'chat_messagelist'; chatId: number; isDeviceChat: boolean }
   | { context: 'chat_map'; chatId: number }
   | {
       context: 'contact_profile_status'

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -26,7 +26,6 @@ declare global {
     __chatlistSetSearch:
       | ((searchTerm: string, chatId: number | null) => void)
       | undefined
-    __chatStore: any
     __refetchChatlist: undefined | (() => void)
     __welcome_qr: undefined | string
     __askForName: boolean

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -268,7 +268,6 @@ export const useChatStore2 = () => {
 }
 
 export default chatStore
-window.__chatStore = chatStore
 
 export type ChatStoreDispatch = Store<ChatStoreState>['dispatch']
 


### PR DESCRIPTION
- remove unused global window reference to chatstore if it was used probably only ever for debugging
- do not use global instance of chatstore in EmptyChatMessage, also move it to own file
- move isDeviceChat for link from global chatstore to  MessagesDisplayContext
- starting with #3675