### PR TITLE
Fix: Changing display name of a contact does not change it immediately in the messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix broken html email window (CSP got broken with the recent electron update) #3704
 - remove unexpected empty space (bottom padding) from view profile dialog #3707
 - Button style regression #3712
+- changing display name of a contact does not change it immediately in the messages #3703
 
 <a id="1_43_1"></a>
 

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react'
+import React, { useCallback, useContext, useState } from 'react'
 import reactStringReplace from 'react-string-replace'
 import classNames from 'classnames'
 import { C, T } from '@deltachat/jsonrpc-client'
@@ -30,7 +30,7 @@ import { ConversationType } from './MessageList'
 import { getDirection, truncateText } from '../../../shared/util'
 import { mapCoreMsgStatus2String } from '../helpers/MapMsgStatus'
 import { ContextMenuItem } from '../ContextMenu'
-import { BackendRemote } from '../../backend-com'
+import { onDCEvent, BackendRemote } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import {
   ProtectionBrokenDialog,
@@ -88,7 +88,19 @@ const AuthorName = (
   onContactClick: (contact: T.Contact) => void,
   overrideSenderName?: string
 ) => {
-  const { color, displayName } = contact
+  const { id, color } = contact
+  const _displayName = contact.displayName
+  const [displayName, setDisplayName] = useState<string>(_displayName)
+  const update = async ({ contactId }: { contactId: number | null }) => {
+    if (contactId === id) {
+      const contact = await BackendRemote.rpc.getContact(
+        selectedAccountId(),
+        contactId
+      )
+      setDisplayName(contact.displayName)
+    }
+  }
+  onDCEvent(selectedAccountId(), 'ContactsChanged', update)
 
   return (
     <span


### PR DESCRIPTION
Fix the bug where changing display name of a contact does not change it immediately in the messages

Closes #3703