### PR TITLE
Reuse new image selector component for group images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - slightly wider account sidebar (so traffic lights look more centered on macOS) #3698
 - refactor some components to not use the chatstore singleton directly #3700
+- Reuse new image selector component for group images #3713
 
 ### Fixed
 - fix broken html email window (CSP got broken with the recent electron update) #3704

--- a/scss/dialogs/_settings.scss
+++ b/scss/dialogs/_settings.scss
@@ -67,26 +67,6 @@
     align-items: center;
     flex-direction: column;
   }
-  .profile-image-selector {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-
-    img,
-    span {
-      width: 100px;
-      height: 100px;
-      border-radius: 100%;
-      user-select: none;
-      pointer-events: none;
-    }
-    span {
-      line-height: 100px;
-      font-size: 64px;
-      color: white;
-      text-align: center;
-    }
-  }
   .profile-displayname-addr {
     display: flex;
     margin-left: 20px;

--- a/src/renderer/components/ImageSelector/index.tsx
+++ b/src/renderer/components/ImageSelector/index.tsx
@@ -1,0 +1,86 @@
+import React from 'react'
+import { dirname } from 'path'
+
+import Icon from '../Icon'
+import LargeProfileImage from '../LargeProfileImage'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
+import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
+import { runtime } from '../../runtime'
+
+import styles from './styles.module.scss'
+
+type Props = {
+  color: string
+  filePath?: string
+  initials: string
+  lastUsedSlot: LastUsedSlot
+  onChange: (path: string) => void
+  removeLabel?: string
+  selectLabel?: string
+  titleLabel?: string
+}
+
+export default function ImageSelector({
+  color,
+  filePath,
+  initials,
+  lastUsedSlot,
+  onChange,
+  removeLabel,
+  selectLabel,
+  titleLabel,
+}: Props) {
+  const tx = useTranslationFunction()
+  const imageUrl = filePath ? `file://${filePath}` : undefined
+
+  const handleSelect = async () => {
+    const { defaultPath, setLastPath } = rememberLastUsedPath(lastUsedSlot)
+
+    const file = await runtime.showOpenFileDialog({
+      title: titleLabel ? titleLabel : tx('select_your_new_profile_image'),
+      filters: [
+        {
+          name: tx('images'),
+          extensions: ['jpg', 'png', 'gif', 'jpeg'],
+        },
+      ],
+      properties: ['openFile'],
+      defaultPath,
+    })
+
+    if (file) {
+      onChange(file)
+      setLastPath(dirname(file))
+    }
+  }
+
+  const handleRemove = () => onChange('')
+
+  return (
+    <div className={styles.imageSelector}>
+      <LargeProfileImage
+        color={color}
+        imageUrl={imageUrl}
+        initials={initials}
+      />
+      {!imageUrl && (
+        <button
+          title={selectLabel ? selectLabel : tx('profile_image_select')}
+          className={styles.imageSelectorButton}
+          onClick={handleSelect}
+        >
+          <Icon className={styles.imageSelectorIcon} icon='image' />
+        </button>
+      )}
+      {imageUrl && (
+        <button
+          title={removeLabel ? removeLabel : tx('profile_image_delete')}
+          className={styles.imageSelectorButton}
+          onClick={handleRemove}
+        >
+          <Icon className={styles.imageSelectorIcon} icon='cross' />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/ImageSelector/styles.module.scss
+++ b/src/renderer/components/ImageSelector/styles.module.scss
@@ -1,0 +1,25 @@
+.imageSelector {
+  position: relative;
+}
+
+.imageSelectorButton {
+  align-items: center;
+  border-radius: 50%;
+  border: 0;
+  bottom: 0;
+  display: flex;
+  height: 35px;
+  justify-content: center;
+  margin: 0;
+  outline: 0;
+  padding: 0;
+  position: absolute;
+  right: 0;
+  width: 35px;
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
+  background-color: var(--colorPrimary);
+}
+
+.imageSelectorIcon {
+  background-color: white;
+}

--- a/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -1,24 +1,15 @@
 import React from 'react'
-import { dirname } from 'path'
 
-import { runtime } from '../../../runtime'
+import ImageSelector from '../../ImageSelector'
+import { LastUsedSlot } from '../../../utils/lastUsedPaths'
 import { avatarInitial } from '../../Avatar'
-import useTranslationFunction from '../../../hooks/useTranslationFunction'
-import {
-  LastUsedSlot,
-  rememberLastUsedPath,
-} from '../../../utils/lastUsedPaths'
-import LargeProfileImage from '../../LargeProfileImage'
-import Icon from '../../Icon'
-
-import styles from './styles.module.scss'
 
 type Props = {
   addr: string
   color: string
   displayName: string
   hideDeleteButton?: boolean
-  profilePicture: string | null
+  profilePicture?: string
   setProfilePicture: (path: string) => void
 }
 
@@ -29,61 +20,15 @@ export default function ProfileImageSelector({
   profilePicture,
   setProfilePicture,
 }: Props) {
-  const tx = useTranslationFunction()
-
-  const handleSelect = async () => {
-    const { defaultPath, setLastPath } = rememberLastUsedPath(
-      LastUsedSlot.ProfileImage
-    )
-
-    const file = await runtime.showOpenFileDialog({
-      title: tx('select_your_new_profile_image'),
-      filters: [
-        {
-          name: tx('images'),
-          extensions: ['jpg', 'png', 'gif', 'jpeg'],
-        },
-      ],
-      properties: ['openFile'],
-      defaultPath,
-    })
-
-    if (file) {
-      setProfilePicture(file)
-      setLastPath(dirname(file))
-    }
-  }
-
-  const handleRemove = () => setProfilePicture('')
-
-  const imageUrl = profilePicture ? `file://${profilePicture}` : undefined
   const initials = avatarInitial(displayName, addr)
 
   return (
-    <div className={styles.profileImageSelector}>
-      <LargeProfileImage
-        color={color}
-        imageUrl={imageUrl}
-        initials={initials}
-      />
-      {!imageUrl && (
-        <button
-          title={tx('profile_image_select')}
-          className={styles.profileImageSelectorButton}
-          onClick={handleSelect}
-        >
-          <Icon className={styles.profileImageSelectorIcon} icon='image' />
-        </button>
-      )}
-      {imageUrl && (
-        <button
-          title={tx('profile_image_delete')}
-          className={styles.profileImageSelectorButton}
-          onClick={handleRemove}
-        >
-          <Icon className={styles.profileImageSelectorIcon} icon='cross' />
-        </button>
-      )}
-    </div>
+    <ImageSelector
+      color={color}
+      filePath={profilePicture}
+      initials={initials}
+      lastUsedSlot={LastUsedSlot.ProfileImage}
+      onChange={setProfilePicture}
+    />
   )
 }

--- a/src/renderer/components/dialogs/EditProfileDialog/index.tsx
+++ b/src/renderer/components/dialogs/EditProfileDialog/index.tsx
@@ -91,7 +91,7 @@ function EditProfileDialogInner({
               displayName={displayname}
               addr={settingsStore.selfContact.address}
               color={settingsStore.selfContact.color}
-              profilePicture={profilePicture}
+              profilePicture={profilePicture ? profilePicture : undefined}
               setProfilePicture={setProfilePicture}
             />
           </div>

--- a/src/renderer/components/dialogs/EditProfileDialog/styles.module.scss
+++ b/src/renderer/components/dialogs/EditProfileDialog/styles.module.scss
@@ -3,29 +3,3 @@
   justify-content: center;
   margin-bottom: 20px;
 }
-
-.profileImageSelector {
-  position: relative;
-}
-
-.profileImageSelectorButton {
-  align-items: center;
-  border-radius: 50%;
-  border: 0;
-  bottom: 0;
-  display: flex;
-  height: 35px;
-  justify-content: center;
-  margin: 0;
-  outline: 0;
-  padding: 0;
-  position: absolute;
-  right: 0;
-  width: 35px;
-  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.1);
-  background-color: var(--colorPrimary);
-}
-
-.profileImageSelectorIcon {
-  background-color: white;
-}

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { C, DcEventType } from '@deltachat/jsonrpc-client'
-import { dirname } from 'path'
 
 import ChatListItem from '../chat/ChatListItem'
 import { useContactSearch, AddMemberInnerDialog } from './CreateChat'
@@ -15,7 +14,6 @@ import {
 } from '../helpers/PseudoListItem'
 import ViewProfile from './ViewProfile'
 import { avatarInitial } from '../Avatar'
-import { runtime } from '../../runtime'
 import { DeltaInput } from '../Login-Styles'
 import { getLogger } from '../../../shared/logger'
 import { BackendRemote, Type } from '../../backend-com'
@@ -31,11 +29,11 @@ import Dialog, {
 import useDialog from '../../hooks/useDialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useConfirmationDialog from '../../hooks/useConfirmationDialog'
-import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
+import { LastUsedSlot } from '../../utils/lastUsedPaths'
 import ProfileInfoHeader from '../ProfileInfoHeader'
+import ImageSelector from '../ImageSelector'
 
 import type { DialogProps } from '../../contexts/DialogContext'
-import Button from '../Button'
 
 const log = getLogger('renderer/ViewGroup')
 
@@ -477,69 +475,24 @@ export function EditGroupNameDialog({
   )
 }
 
-export function GroupImageSelector({
-  groupName,
-  groupColor,
-  groupImage,
-  setGroupImage,
-}: {
+export function GroupImageSelector(props: {
   groupName: string
   groupColor: string
   groupImage?: string
   setGroupImage: (groupImage: string) => void
 }) {
-  const tx = window.static_translate
-
-  const onClickSelectGroupImage = async () => {
-    const { defaultPath, setLastPath } = rememberLastUsedPath(
-      LastUsedSlot.GroupImage
-    )
-    const file = await runtime.showOpenFileDialog({
-      title: tx('select_your_new_profile_image'),
-      filters: [
-        {
-          name: tx('images'),
-          extensions: ['jpg', 'png', 'gif', 'jpeg', 'jpe'],
-        },
-      ],
-      properties: ['openFile'],
-      defaultPath,
-    })
-    if (file) {
-      setGroupImage(file)
-      setLastPath(dirname(file))
-    }
-  }
-
-  const onClickRemoveGroupImage = () => setGroupImage('')
-
-  const initial = avatarInitial(groupName, '')
+  const tx = useTranslationFunction()
+  const initials = avatarInitial(props.groupName, '')
 
   return (
-    <div className='profile-image-selector'>
-      {/* TODO: show anything else when there is no profile image, like the letter avatar */}
-      {groupImage ? (
-        <img src={'file://' + groupImage} alt={tx('pref_profile_photo')} />
-      ) : (
-        <span style={{ backgroundColor: groupColor }}>{initial}</span>
-      )}
-      <>
-        <Button
-          aria-label={tx('change_group_image')}
-          onClick={onClickSelectGroupImage}
-          type='primary'
-        >
-          {tx('change_group_image')}
-        </Button>
-        <Button
-          aria-label={tx('remove_group_image')}
-          onClick={onClickRemoveGroupImage}
-          type='danger'
-          disabled={groupImage === '' || groupImage === null}
-        >
-          {tx('remove_group_image')}
-        </Button>
-      </>
-    </div>
+    <ImageSelector
+      color={props.groupColor}
+      filePath={props.groupImage}
+      initials={initials}
+      lastUsedSlot={LastUsedSlot.GroupImage}
+      onChange={props.setGroupImage}
+      removeLabel={tx('remove_group_image')}
+      selectLabel={tx('change_group_image')}
+    />
   )
 }


### PR DESCRIPTION
This PR refactors the new `ImageSelector` to not only be used for profile images but also group images.

![2024-03-04-115804_786x538_scrot](https://github.com/deltachat/deltachat-desktop/assets/1822473/889efefb-f341-47f1-8a05-6680a4bd4ab0)
