### PR TITLE
Wait until chat id got set before displaying message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fix broken html email window (CSP got broken with the recent electron update) #3704
 - remove unexpected empty space (bottom padding) from view profile dialog #3707
 - Button style regression #3712
+- Wait until chat id got set before displaying message list #3716
 
 <a id="1_43_1"></a>
 

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -21,8 +21,8 @@ type Chat =
   | Type.FullChat
   | (Type.ChatListItemFetchResult & { kind: 'ChatListItem' })
 
-export const selectChat = (chatId: number) => {
-  ChatStore.effect.selectChat(chatId)
+export const selectChat = async (chatId: number) => {
+  await ChatStore.effect.selectChat(chatId)
 }
 
 export const setChatView = (view: ChatView) => {

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -137,6 +137,10 @@ export default function MainScreen() {
       const lastChatId =
         SettingsStoreInstance.getState()?.settings['ui.lastchatid']
       if (lastChatId) {
+        // Selecting the chat populates the chat store with state all
+        // children component will depend on. To make sure we're rendering
+        // these state-critical components _after_ a successful state
+        // transition, we await here and use a `chatStoreReady` flag
         await selectChat(Number(lastChatId))
         setChatStoreReady(true)
       }

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -49,6 +49,7 @@ export default function MainScreen() {
   const [queryStr, setQueryStr] = useState('')
   const [queryChatId, setQueryChatId] = useState<null | number>(null)
   const [archivedChatsSelected, setArchivedChatsSelected] = useState(false)
+  const [chatStoreReady, setChatStoreReady] = useState(false)
 
   // Small hack/misuse of keyBindingAction to setArchivedChatsSelected from
   // other components (especially ViewProfile when selecting a shared chat/group)
@@ -132,11 +133,12 @@ export default function MainScreen() {
   const isFirstLoad = useRef(true)
   if (isFirstLoad.current) {
     isFirstLoad.current = false
-    SettingsStoreInstance.effect.load().then(() => {
+    SettingsStoreInstance.effect.load().then(async () => {
       const lastChatId =
         SettingsStoreInstance.getState()?.settings['ui.lastchatid']
       if (lastChatId) {
-        selectChat(Number(lastChatId))
+        await selectChat(Number(lastChatId))
+        setChatStoreReady(true)
       }
     })
   }
@@ -423,7 +425,7 @@ export default function MainScreen() {
             setQueryChatId(null)
           }}
         />
-        {MessageListView}
+        {chatStoreReady && MessageListView}
       </div>
       <ConnectivityToast />
     </div>


### PR DESCRIPTION
I think I found a solution to tackle a race condition which caused an error described here: https://github.com/deltachat/deltachat-desktop/issues/3675 - The underlying issue is a race condition where the message list store was temporarily populated with an invalid chat id. To fix this issue we wait with displaying the critical components after the chat id got correctly set and a simple "ready" flag got flipped.

**Background**

- The message list store constructor needs the account id and chat id as arguments: https://github.com/deltachat/deltachat-desktop/blob/43e239fe8e4a9ce855204f9217a97e1dfbc7ff57/src/renderer/components/message/MessageList.tsx#L120 It gets the chat id from the chat store which gets prop-drilled down to the `MessageList` component
- This chat store is initialized in `MainScreen` and then populated with values on "first load" of the `MainScreen` component https://github.com/deltachat/deltachat-desktop/blob/43e239fe8e4a9ce855204f9217a97e1dfbc7ff57/src/renderer/components/screens/MainScreen.tsx#L132-L142 This takes place when `selectChat` is called
- Since the `selectChat` method is not awaited, we're ending up in a state where the chat id is still undefined or outdated. The actual state transition is happening async "in the background", the `MessageList` component gets already rendered with this invalid / outdated chat id
- The final state transition which contains the correct chat id happens later (async): https://github.com/deltachat/deltachat-desktop/blob/43e239fe8e4a9ce855204f9217a97e1dfbc7ff57/src/renderer/stores/chat.ts#L123-L126
- This race condition causes `getFullChatById` to be called with an invalid combination of an account id and chat id, resulting in an error in the RPC call ('no rows returned') https://github.com/deltachat/deltachat-desktop/blob/43e239fe8e4a9ce855204f9217a97e1dfbc7ff57/src/renderer/stores/messagelist.ts#L312-L315