### PR TITLE
move select selected chat up to select account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Fix Bug: When switching accounts after deleting a chat, the message list is blank, similar issues can come up when using the 2nd device flow. #3724
+
 <a id="1_44_0"></a>
 
 ## [1.44.0] - 2024-03-05

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -22,6 +22,8 @@ import AccountListSidebar from './components/AccountListSidebar/AccountListSideb
 import SettingsStoreInstance from './stores/settings'
 import { NoAccountSelectedScreen } from './components/screens/NoAccountSelectedScreen/NoAccountSelectedScreen'
 import AccountDeletionScreen from './components/screens/AccountDeletionScreen/AccountDeletionScreen'
+import chatStore from './stores/chat'
+import { selectChat } from './components/helpers/ChatMethods'
 
 const log = getLogger('renderer/ScreenController')
 
@@ -121,6 +123,18 @@ export default class ScreenController extends Component {
       this.selectedAccountId
     )
     if (account.kind === 'Configured') {
+      // reset global stores
+      chatStore.reducer.reset(selectedAccountId())
+      await SettingsStoreInstance.effect.load()
+      const lastChatId =
+        SettingsStoreInstance.getState()?.settings['ui.lastchatid']
+      if (lastChatId) {
+        try {
+          await selectChat(Number(lastChatId))
+        } catch (error) {
+          log.error('Selecting last chat failed:', error)
+        }
+      }
       this.changeScreen(Screens.Main)
       updateDeviceChats(this.selectedAccountId)
     } else {

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -49,7 +49,6 @@ export default function MainScreen() {
   const [queryStr, setQueryStr] = useState('')
   const [queryChatId, setQueryChatId] = useState<null | number>(null)
   const [archivedChatsSelected, setArchivedChatsSelected] = useState(false)
-  const [chatStoreReady, setChatStoreReady] = useState(false)
 
   // Small hack/misuse of keyBindingAction to setArchivedChatsSelected from
   // other components (especially ViewProfile when selecting a shared chat/group)
@@ -129,23 +128,6 @@ export default function MainScreen() {
   }
 
   window.__chatlistSetSearch = searchChats
-
-  const isFirstLoad = useRef(true)
-  if (isFirstLoad.current) {
-    isFirstLoad.current = false
-    SettingsStoreInstance.effect.load().then(async () => {
-      const lastChatId =
-        SettingsStoreInstance.getState()?.settings['ui.lastchatid']
-      if (lastChatId) {
-        // Selecting the chat populates the chat store with state all
-        // children component will depend on. To make sure we're rendering
-        // these state-critical components _after_ a successful state
-        // transition, we await here and use a `chatStoreReady` flag
-        await selectChat(Number(lastChatId))
-        setChatStoreReady(true)
-      }
-    })
-  }
 
   const tx = useTranslationFunction()
   const settingsStore = useSettingsStore()[0]
@@ -429,7 +411,7 @@ export default function MainScreen() {
             setQueryChatId(null)
           }}
         />
-        {chatStoreReady && MessageListView}
+        {MessageListView}
       </div>
       <ConnectivityToast />
     </div>

--- a/src/renderer/stores/chat.ts
+++ b/src/renderer/stores/chat.ts
@@ -66,6 +66,15 @@ class ChatStore extends Store<ChatStoreState> {
         return modifiedState
       }, 'unselectChat')
     },
+    reset: (newAccountId: number) => {
+      this.setState(_ => {
+        const modifiedState: ChatStoreState = {
+          ...defaultState(),
+          accountId: newAccountId,
+        }
+        return modifiedState
+      }, 'reset')
+    },
     modifiedChat: (payload: { id: number } & Partial<ChatStoreState>) => {
       this.setState(state => {
         const modifiedState: ChatStoreState = {


### PR DESCRIPTION
this is a possible fix for the bug when you delete the selected chat and then change the account and are unable to select a chat it says white or selects a random chat or other ui bugs caused by undefined behaviour.

related to https://github.com/deltachat/deltachat-desktop/pull/3726, but this pr not only removes the buggy workaround but also attempts to solve the issue, which worked nicely in my testing so far. it adds some small flickering when switching the account when the chat is loaded, but there is not much we can do about that without more refactoring. (#3725 starts with that refactoring)

closes #3726