### PR TITLE
Revert buggy workaround for race conditions in chat store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@
 - fix broken html email window (CSP got broken with the recent electron update) #3704
 - remove unexpected empty space (bottom padding) from view profile dialog #3707
 - Button style regression #3712
-- Wait until chat id got set before displaying message list #3716
 - change export keys open directory confirm button label to "select" #3710
 - Make chat title and subtitle unselectable to prevent unusual behaviour #3688
 - changing display name of a contact does not change it immediately in the messages #3703

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fix broken html email window (CSP got broken with the recent electron update) #3704
 - remove unexpected empty space (bottom padding) from view profile dialog #3707
 - Button style regression #3712
+- Wait until chat id got set before displaying message list #3716
 - change export keys open directory confirm button label to "select" #3710
 - Make chat title and subtitle unselectable to prevent unusual behaviour #3688
 - changing display name of a contact does not change it immediately in the messages #3703

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- Reverted buggy workaround to handle chat store race conditions
+
 <a id="1_44_0"></a>
 
 ## [1.44.0] - 2024-03-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Fixed
-- Reverted buggy workaround to handle chat store race conditions
+- Reverted buggy workaround to handle chat store race conditions #3726
 
 <a id="1_44_0"></a>
 

--- a/src/renderer/components/helpers/ChatMethods.ts
+++ b/src/renderer/components/helpers/ChatMethods.ts
@@ -21,8 +21,8 @@ type Chat =
   | Type.FullChat
   | (Type.ChatListItemFetchResult & { kind: 'ChatListItem' })
 
-export const selectChat = async (chatId: number) => {
-  await ChatStore.effect.selectChat(chatId)
+export const selectChat = (chatId: number) => {
+  ChatStore.effect.selectChat(chatId)
 }
 
 export const setChatView = (view: ChatView) => {

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -49,7 +49,6 @@ export default function MainScreen() {
   const [queryStr, setQueryStr] = useState('')
   const [queryChatId, setQueryChatId] = useState<null | number>(null)
   const [archivedChatsSelected, setArchivedChatsSelected] = useState(false)
-  const [chatStoreReady, setChatStoreReady] = useState(false)
 
   // Small hack/misuse of keyBindingAction to setArchivedChatsSelected from
   // other components (especially ViewProfile when selecting a shared chat/group)
@@ -133,16 +132,11 @@ export default function MainScreen() {
   const isFirstLoad = useRef(true)
   if (isFirstLoad.current) {
     isFirstLoad.current = false
-    SettingsStoreInstance.effect.load().then(async () => {
+    SettingsStoreInstance.effect.load().then(() => {
       const lastChatId =
         SettingsStoreInstance.getState()?.settings['ui.lastchatid']
       if (lastChatId) {
-        // Selecting the chat populates the chat store with state all
-        // children component will depend on. To make sure we're rendering
-        // these state-critical components _after_ a successful state
-        // transition, we await here and use a `chatStoreReady` flag
-        await selectChat(Number(lastChatId))
-        setChatStoreReady(true)
+        selectChat(Number(lastChatId))
       }
     })
   }
@@ -429,7 +423,7 @@ export default function MainScreen() {
             setQueryChatId(null)
           }}
         />
-        {chatStoreReady && MessageListView}
+        {MessageListView}
       </div>
       <ConnectivityToast />
     </div>


### PR DESCRIPTION
This "workaround" solved the race conditions (https://github.com/deltachat/deltachat-desktop/pull/3716) but didn't prevent other buggy behaviour around the chat store, and even worse, these issues affect the user now: When switching accounts after deleting a chat, the message list is blank, similar issues can come up when using the 2nd device flow.

For now we roll back that change, getting back to these race conditions and occasional exceptions, which at least do not affect the user. This is a temporary solution.

For a real fix we're looking into a chat store logic refactoring which will take a little bit more time, pending PR here: https://github.com/deltachat/deltachat-desktop/pull/3725