### PR TITLE
Work on ImageCropper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Introduce new `Spinner` component #3786
 - Instant Onboarding #3773 #3801
 - Add instructions and troubleshooting button to "Add as Second Device" dialog #3801
+- Add image cropper for profile image selector #1779
 
 ### Changed
 - Update translations (2024-05-01) #3746 #3802

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -26,5 +26,14 @@
   },
   "camera_access_failed": {
     "message": "Could not access video camera. You might want to check your video permissions or if the camera is used already by another program"
+  },
+  "reset": {
+    "message": "Reset"
+  },
+  "crop_image": {
+    "message": "Crop Image"
+  },
+  "image_cropper_hint_desktop": {
+    "message": "Select an area on the image"
   }
 }

--- a/src/main/application-constants.ts
+++ b/src/main/application-constants.ts
@@ -87,6 +87,7 @@ export const ALLOWED_STATIC_FOLDERS = [
     join(AppFilesDir, folder)
   ),
   ...ALLOWED_CONFIG_FOLDERS.map(folder => join(getConfigPath(), folder)),
+  getDraftTempDir(),
 ]
 
 export const ALLOWED_ACCOUNT_FOLDERS = [

--- a/src/renderer/components/Dialog/DialogContent.tsx
+++ b/src/renderer/components/Dialog/DialogContent.tsx
@@ -6,18 +6,20 @@ import type { PropsWithChildren } from 'react'
 import styles from './styles.module.scss'
 
 type Props = PropsWithChildren<{
+  className?: string
   paddingBottom?: boolean
   paddingTop?: boolean
 }>
 
 export default function DialogContent({
   children,
+  className,
   paddingBottom = false,
   paddingTop = false,
 }: Props) {
   return (
     <div
-      className={classNames(styles.dialogContent, {
+      className={classNames(styles.dialogContent, className, {
         [styles.paddingBottom]: paddingBottom,
         [styles.paddingTop]: paddingTop,
       })}

--- a/src/renderer/components/ImageCropper/index.tsx
+++ b/src/renderer/components/ImageCropper/index.tsx
@@ -88,7 +88,7 @@ export default function ProfileImageCropper({
       targetHeight
     )
     ;(async () => {
-      const tempfilename = 'tmp_profile_pic.png'
+      const tempfilename = `profile_pic_${Date.now()}.png`
       const tempfilepath = await runtime.writeTempFileFromBase64(
         tempfilename,
         canvas.toDataURL('image/png').split(';base64,')[1]
@@ -233,8 +233,12 @@ export default function ProfileImageCropper({
     }
 
     const onZoom = (ev: WheelEvent) => {
-      // negate delta so when we wheel forward we zoom in
-      zoom.current *= Math.exp((ev.deltaY > 1 ? -1 : 1) * 0.05)
+      const absDelta = Math.abs(ev.deltaY)
+      // NOTE(maxph): I'm not sure about this, but there are many sources stating that 'wheel' delta on touchpad is smaller (somewhere like 50 vs 100 at maximum)
+      // so here we treat small delta as not a mouse wheel and zoom in different direction
+      const dir = absDelta < 50 ? 1 : -1
+      const normDelta = Math.min(8, absDelta)
+      zoom.current *= 1 + (dir * Math.sign(ev.deltaY) * normDelta) / 100
       const [x, y] = moveImages(posX.current, posY.current)
       posX.current = x
       posY.current = y

--- a/src/renderer/components/ImageCropper/index.tsx
+++ b/src/renderer/components/ImageCropper/index.tsx
@@ -1,0 +1,309 @@
+import React, { useRef, useLayoutEffect } from 'react'
+
+import { dirname } from 'path'
+
+import { runtime } from '../../runtime'
+
+import Dialog, {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  FooterActions,
+  FooterActionButton,
+} from '../Dialog'
+
+import useTranslationFunction from '../../hooks/useTranslationFunction'
+import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
+
+import styles from './styles.module.scss'
+
+export default function ProfileImageCropper({
+  setProfilePicture,
+  filepath,
+  shape,
+  onClose,
+  onCancel,
+  targetWidth,
+  targetHeight = targetWidth,
+}: {
+  setProfilePicture: (path: string) => void
+  filepath: string
+  shape: string
+  onClose: () => void
+  onCancel: () => void
+  targetWidth: number
+  targetHeight: number
+}) {
+  const tx = useTranslationFunction()
+  const { setLastPath } = rememberLastUsedPath(LastUsedSlot.ProfileImage)
+
+  // cut pattern from the full image
+  const cutImage = useRef<HTMLImageElement>(null)
+  // full image in background
+  const fullImage = useRef<HTMLImageElement>(null)
+  // semi-transparent layer to fade the full image
+  const shade = useRef<HTMLImageElement>(null)
+  // a wrapper inside which we drag an image
+  const container = useRef<HTMLImageElement>(null)
+
+  const dragging = useRef<boolean>(false)
+  // where we start dragging
+  const startX = useRef<number>(0)
+  const startY = useRef<number>(0)
+  // center of the cut region
+  const posX = useRef<number>(0)
+  const posY = useRef<number>(0)
+
+  const speedMultiplier = 2
+  const zoom = useRef<number>(1.0)
+  const initialZoom = useRef<number>(1.0)
+
+  const onSubmit = () => {
+    const canvas = document.createElement('canvas')
+    const context = canvas.getContext('2d', {
+      willReadFrequently: false,
+    }) as CanvasRenderingContext2D
+    canvas.width = targetWidth
+    canvas.height = targetHeight
+    const imgW = fullImage.current?.clientWidth
+    const imgH = fullImage.current?.clientHeight
+    if (!imgW || !imgH) {
+      return
+    }
+    context.imageSmoothingEnabled = false
+    context.drawImage(
+      fullImage.current as CanvasImageSource,
+      posX.current * zoom.current - (targetWidth / zoom.current - imgW) / 2,
+      posY.current * zoom.current - (targetHeight / zoom.current - imgH) / 2,
+      targetWidth / zoom.current,
+      targetHeight / zoom.current,
+      0,
+      0,
+      targetWidth,
+      targetHeight
+    )
+
+    const tempfilename = 'tmp_profile_pic.png'
+
+    ;(async () => {
+      const tempfilepath = await runtime.writeTempFileFromBase64(
+        tempfilename,
+        canvas.toDataURL('image/png').split(';base64,')[1]
+      )
+      setLastPath(dirname(filepath))
+      setProfilePicture(tempfilepath)
+      onClose()
+    })()
+  }
+
+  const onZoomReset = () => {
+    posX.current = 0
+    posY.current = 0
+    zoom.current = initialZoom.current
+    moveImages(0, 0)
+  }
+
+  const makeSelector = (
+    shape: string,
+    w: number,
+    h: number,
+    x: number,
+    y: number
+  ) => {
+    if (shape === 'circle') {
+      return 'circle(' + w / 2 + 'px at ' + x + 'px ' + y + 'px)'
+    } else {
+      return (
+        'rect(' +
+        (y - h / 2) +
+        'px ' +
+        (x + w / 2) +
+        'px ' +
+        (y + h / 2) +
+        'px ' +
+        (x - w / 2) +
+        'px)'
+      )
+    }
+  }
+
+  const setupImages = () => {
+    if (!fullImage.current || !container.current) {
+      return
+    }
+
+    container.current.style.transform =
+      'scale(' +
+      Math.min(
+        container.current?.clientWidth / targetWidth,
+        container.current?.clientHeight / targetHeight
+      ) +
+      ')'
+    initialZoom.current = zoom.current = Math.min(
+      targetWidth / fullImage.current.clientWidth,
+      targetHeight / fullImage.current.clientHeight
+    )
+    posX.current = 0
+    posY.current = 0
+
+    moveImages(0, 0)
+  }
+
+  // returns new position after clamping
+  const moveImages = (x: number, y: number) => {
+    if (!cutImage.current || !fullImage.current || !container.current) {
+      return [x, y]
+    }
+
+    const imgW = fullImage.current.clientWidth
+    const imgH = fullImage.current.clientHeight
+    const ctxW = container.current.clientWidth
+    const ctxH = container.current.clientHeight
+
+    // cut zoom on width
+    zoom.current = Math.min(
+      imgW / targetWidth,
+      Math.max(targetWidth / imgW, zoom.current)
+    )
+
+    // cut zoom on height
+    zoom.current = Math.min(
+      imgH / targetHeight,
+      Math.max(targetHeight / imgH, zoom.current)
+    )
+
+    const nX = Math.max(
+      Math.min(imgW / 2 - targetWidth / zoom.current / 2, x),
+      targetWidth / zoom.current / 2 - imgW / 2
+    )
+    const nY = Math.max(
+      Math.min(imgH / 2 - targetHeight / zoom.current / 2, y),
+      targetHeight / zoom.current / 2 - imgH / 2
+    )
+
+    cutImage.current.style.clipPath = makeSelector(
+      shape,
+      targetWidth / zoom.current,
+      targetHeight / zoom.current,
+      imgW / 2 + nX,
+      imgH / 2 + nY
+    )
+
+    const imgX = (ctxW - imgW) / 2 - nX * zoom.current
+    const imgY = (ctxH - imgH) / 2 - nY * zoom.current
+
+    const transformValue = `translate(${imgX}px, ${imgY}px) scale(${zoom.current})`
+
+    cutImage.current.style.transform = transformValue
+    fullImage.current.style.transform = transformValue
+
+    return [nX, nY]
+  }
+
+  useLayoutEffect(() => {
+    const onMouseDown = (ev: MouseEvent) => {
+      ev.preventDefault()
+
+      dragging.current = true
+
+      startX.current = ev.clientX
+      startY.current = ev.clientY
+    }
+
+    const onMouseUp = (ev: MouseEvent) => {
+      ev.preventDefault()
+
+      dragging.current = false
+
+      posX.current -=
+        (ev.clientX - startX.current) *
+        Math.min(speedMultiplier / zoom.current, speedMultiplier)
+      posY.current -=
+        (ev.clientY - startY.current) *
+        Math.min(speedMultiplier / zoom.current, speedMultiplier)
+      const [x, y] = moveImages(posX.current, posY.current)
+      posX.current = x
+      posY.current = y
+    }
+
+    const onMouseMove = (ev: MouseEvent) => {
+      if (!dragging.current) {
+        return
+      }
+      // we never go faster with zoom above 1, but we speed up zoomed-out (below 1) by inverting the zoom value
+      const dX =
+        (ev.clientX - startX.current) *
+        Math.min(speedMultiplier / zoom.current, speedMultiplier)
+      const dY =
+        (ev.clientY - startY.current) *
+        Math.min(speedMultiplier / zoom.current, speedMultiplier)
+
+      moveImages(posX.current - dX, posY.current - dY)
+    }
+
+    const onZoom = (ev: WheelEvent) => {
+      // negate delta so when we wheel forward we zoom in
+      zoom.current *= Math.exp((ev.deltaY > 1 ? -1 : 1) * 0.05)
+      const [x, y] = moveImages(posX.current, posY.current)
+      posX.current = x
+      posY.current = y
+    }
+
+    document.addEventListener('mousemove', onMouseMove)
+    document.addEventListener('mousedown', onMouseDown)
+    document.addEventListener('mouseup', onMouseUp)
+    document.addEventListener('wheel', onZoom)
+
+    return () => {
+      document.removeEventListener('mousemove', onMouseMove)
+      document.removeEventListener('mousedown', onMouseDown)
+      document.removeEventListener('mouseup', onMouseUp)
+      document.removeEventListener('wheel', onZoom)
+    }
+  })
+  return (
+    <Dialog canEscapeKeyClose onClose={onClose} canOutsideClickClose={false}>
+      <DialogHeader>{tx('crop_image')}</DialogHeader>
+      <DialogBody className={styles.imageCropperDialogBody}>
+        <DialogContent className={styles.imageCropperDialogContent}>
+          <div ref={container} className={styles.imageCropperContainer}>
+            <div ref={shade} className={styles.imageCropperShade}></div>
+            <img
+              ref={cutImage}
+              className={styles.imageCropperCutImage}
+              src={filepath}
+              onLoad={setupImages}
+            />
+            <img
+              ref={fullImage}
+              className={styles.imageCropperFullImage}
+              src={filepath}
+            />
+          </div>
+          <div className={styles.imageCropperHint}>
+            {tx('image_cropper_hint_desktop')}
+          </div>
+        </DialogContent>
+      </DialogBody>
+      <DialogFooter>
+        <FooterActions>
+          <FooterActionButton
+            onClick={() => {
+              onCancel()
+              onClose()
+            }}
+          >
+            {tx('cancel')}
+          </FooterActionButton>
+          <FooterActionButton onClick={onZoomReset}>
+            {tx('reset')}
+          </FooterActionButton>
+          <FooterActionButton onClick={onSubmit}>
+            {tx('save')}
+          </FooterActionButton>
+        </FooterActions>
+      </DialogFooter>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/ImageCropper/index.tsx
+++ b/src/renderer/components/ImageCropper/index.tsx
@@ -18,18 +18,18 @@ import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
 
 import styles from './styles.module.scss'
 
-export default function ProfileImageCropper({
-  setProfilePicture,
+export default function ImageCropper({
   filepath,
   shape,
+  onResult,
   onClose,
   onCancel,
   targetWidth,
   targetHeight = targetWidth,
 }: {
-  setProfilePicture: (path: string) => void
   filepath: string
   shape: string
+  onResult: (path: string) => void
   onClose: () => void
   onCancel: () => void
   targetWidth: number
@@ -95,7 +95,7 @@ export default function ProfileImageCropper({
       )
 
       setLastPath(dirname(filepath))
-      setProfilePicture(tempfilepath)
+      onResult(tempfilepath)
       onClose()
     })()
   }

--- a/src/renderer/components/ImageCropper/index.tsx
+++ b/src/renderer/components/ImageCropper/index.tsx
@@ -264,7 +264,7 @@ export default function ProfileImageCropper({
   })
   return (
     <Dialog canEscapeKeyClose onClose={onClose} canOutsideClickClose={false}>
-      <DialogHeader>{tx('crop_image')}</DialogHeader>
+      <DialogHeader title={tx('crop_image')} />
       <DialogBody className={styles.imageCropperDialogBody}>
         <DialogContent className={styles.imageCropperDialogContent}>
           <div ref={container} className={styles.imageCropperContainer}>

--- a/src/renderer/components/ImageCropper/styles.module.scss
+++ b/src/renderer/components/ImageCropper/styles.module.scss
@@ -1,0 +1,48 @@
+.imageCropperDialogBody,
+.imageCropperDialogContent {
+  overflow: hidden;
+}
+
+.imageCropperContainer {
+  height: 500px;
+  position: relative;
+  overflow: hidden;
+  background: black;
+}
+
+.imageCropperShade {
+  width: 100%;
+  height: 100%;
+  position: relative;
+  opacity: 0.5;
+  background: black;
+  z-index: 1;
+}
+
+.imageCropperCutImage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  zoom: 1;
+}
+
+.imageCropperFullImage {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+  background: black;
+  zoom: 1;
+}
+
+.imageCropperHint {
+  bottom: 0;
+  color: white;
+  left: 0;
+  padding: 10px;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  user-select: none;
+}

--- a/src/renderer/components/ImageCropper/styles.module.scss
+++ b/src/renderer/components/ImageCropper/styles.module.scss
@@ -1,6 +1,6 @@
-.imageCropperDialogBody,
 .imageCropperDialogContent {
   overflow: hidden;
+  position: relative;
 }
 
 .imageCropperContainer {

--- a/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -40,7 +40,7 @@ export default function ProfileImageSelector({
           openDialog(ImageCropper, {
             filepath,
             shape: 'circle',
-            setProfilePicture,
+            onResult: setProfilePicture,
             onCancel: () => {},
             targetWidth: 256,
             targetHeight: 256,

--- a/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 
 import ImageSelector from '../../ImageSelector'
+import ImageCropper from '../../ImageCropper'
+
 import { LastUsedSlot } from '../../../utils/lastUsedPaths'
 import { avatarInitial } from '../../Avatar'
+import useDialog from '../../../hooks/dialog/useDialog'
 
 type Props = {
   addr?: string
@@ -22,13 +25,28 @@ export default function ProfileImageSelector({
 }: Props) {
   const initials = avatarInitial(displayName, addr)
 
+  const { openDialog } = useDialog()
+
   return (
     <ImageSelector
       color={color}
       filePath={profilePicture}
       initials={initials}
       lastUsedSlot={LastUsedSlot.ProfileImage}
-      onChange={setProfilePicture}
+      onChange={filepath => {
+        if (!filepath) {
+          setProfilePicture('')
+        } else {
+          openDialog(ImageCropper, {
+            filepath,
+            shape: 'circle',
+            setProfilePicture,
+            onCancel: () => {},
+            targetWidth: 256,
+            targetHeight: 256,
+          })
+        }
+      }}
     />
   )
 }


### PR DESCRIPTION
fixes #1779

- a component to crop any image to a certain size by zooming and dragging the original to fit a predefined shape
- this component is used in ProfileImageSelector by altering result of ImageSelector upload
- there's a circle pattern as default and square pattern, images are cropped as square

What's left to do:
- decide on cancel behavior
- decide if there should be some way to tell cropper to use the whole image besides the zooming in manually