### PR TITLE
"add second device" dialog improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Changed
 - Update translations (2024-04-04) #3746
+- minor improvements to "add second device" dialog #3748
 
 ### Fixed
 - fix chat audit dialog was going out of viewport on smaller screens #3736
 - fix long names breaking layout of reactions dialog #3736
+- hide "add second device" instructions when transfer has started #3748
 
 <a id="1_44_1"></a>
 

--- a/src/renderer/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
+++ b/src/renderer/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
@@ -159,21 +159,25 @@ export function SendBackupDialog({ onClose }: DialogProps) {
             <DialogContent>
               <SendBackup>
                 <SendBackupMain>
-                  {error}
                   {stage === 'awaiting_scan' && svgUrl && qrContent && (
                     <img className={styles.qrCode} src={svgUrl} />
                   )}
-                  {stage === 'preparing' && <>{tx('preparing_account')}</>}
-                  {stage === 'transferring' && <>{tx('transferring')}</>}
-                  {progress && stage !== 'awaiting_scan' && (
-                    <>
-                      <br />
-                      <progress value={progress} max={1000} />
-                    </>
-                  )}
+                  <SendBackupMainProgress
+                    style={stage === 'transferring' ? { width: '100%' } : {}}
+                  >
+                    {stage === 'preparing' && <>{tx('preparing_account')}</>}
+                    {stage === 'transferring' && <>{tx('transferring')}</>}
+                    {progress && stage !== 'awaiting_scan' && (
+                      <>
+                        <br />
+                        <progress value={progress} max={1000} />
+                      </>
+                    )}
+                  </SendBackupMainProgress>
                 </SendBackupMain>
                 {stage !== 'transferring' && <SendBackupSteps />}
               </SendBackup>
+              {error}
             </DialogContent>
           </DialogBody>
           <DialogFooter>
@@ -210,6 +214,17 @@ function SendBackup({ children }: PropsWithChildren<{}>) {
 
 function SendBackupMain({ children }: PropsWithChildren<{}>) {
   return <div className={styles.sendBackupMain}>{children}</div>
+}
+
+function SendBackupMainProgress({
+  children,
+  style,
+}: PropsWithChildren<{ style: React.CSSProperties }>) {
+  return (
+    <div className={styles.sendBackupMainProgress} style={style}>
+      {children}
+    </div>
+  )
 }
 
 function SendBackupSteps() {

--- a/src/renderer/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
+++ b/src/renderer/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
@@ -172,7 +172,7 @@ export function SendBackupDialog({ onClose }: DialogProps) {
                     </>
                   )}
                 </SendBackupMain>
-                <SendBackupSteps />
+                {stage !== 'transferring' && <SendBackupSteps />}
               </SendBackup>
             </DialogContent>
           </DialogBody>

--- a/src/renderer/components/dialogs/SetupMultiDevice/styles.module.scss
+++ b/src/renderer/components/dialogs/SetupMultiDevice/styles.module.scss
@@ -2,11 +2,23 @@
   display: flex;
   flex-wrap: wrap;
   min-width: 300px;
+  justify-content: space-between;
 }
 
 .sendBackupMain {
-  max-width: 339px;
-  min-width: 200px;
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  justify-content: center;
+}
+
+.sendBackupMainProgress {
+  display: flex;
+  flex-direction: column;
+
+  progress {
+    width: 100%;
+  }
 }
 
 .sendBackupSteps {


### PR DESCRIPTION
- **hide steps when transfering**
- **opinionated style changes - center progressbar on preparing (IMO looks better centered when switching to qr code) - while transfering make the bar take the whole width of the dialog (centered looked weird (how much width should it have); with a larger bar you can see more progress when you have a slow transfer with a big account)**


fixes #3742

After Screenshots:
- before qr code is shown: <img width="679" alt="Bildschirmfoto 2024-04-04 um 18 38 29" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/5f20bd8e-f967-40ed-b4da-cb68749dfad0">
- after qr code was scanned by other device: <img width="679" alt="Bildschirmfoto 2024-04-04 um 18 38 58" src="https://github.com/deltachat/deltachat-desktop/assets/18725968/4fac628f-6217-42c7-a3ec-2445962477ba">
