### PR TITLE
perf: hide/show on-hover shortcut menu with CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix long names breaking layout of reactions dialog #3736
 - hide "add second device" instructions when transfer has started #3748
 - improve chat scroll performance #3743, #3747
+- reduce CPU load when moving mouse over chat #3751
 
 <a id="1_44_1"></a>
 

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -1,3 +1,10 @@
+.message-wrapper {
+  --shortcut-menu-visibility: hidden;
+  &:hover {
+    --shortcut-menu-visibility: visible;
+  }
+}
+
 /* Message Bubble */
 .message {
   position: relative;

--- a/src/renderer/components/ShortcutMenu/index.tsx
+++ b/src/renderer/components/ShortcutMenu/index.tsx
@@ -15,7 +15,6 @@ type Props = {
   direction: 'incoming' | 'outgoing'
   message: T.Message
   showContextMenu: (event: OnButtonClick) => Promise<void>
-  visible: boolean
 }
 
 export default function ShortcutMenu(props: Props) {
@@ -24,7 +23,6 @@ export default function ShortcutMenu(props: Props) {
       className={classNames(styles.shortcutMenu, {
         [styles.incoming]: props.direction === 'incoming',
         [styles.outgoing]: props.direction === 'outgoing',
-        [styles.visible]: props.visible,
       })}
     >
       {showReactionsUi(props.message, props.chat) && (

--- a/src/renderer/components/ShortcutMenu/styles.module.scss
+++ b/src/renderer/components/ShortcutMenu/styles.module.scss
@@ -5,12 +5,8 @@ $shortcutMenuWidth: 65px;
   display: flex;
   flex: 0 0 $shortcutMenuWidth;
   justify-content: space-between;
-  visibility: hidden;
+  visibility: var(--shortcut-menu-visibility);
   width: $shortcutMenuWidth;
-
-  &.visible {
-    visibility: visible;
-  }
 
   &.incoming {
     flex-direction: row;

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -323,7 +323,6 @@ export default function Message(props: {
   chat: T.FullChat
   message: T.Message
   conversationType: ConversationType
-  isHover: boolean
 }) {
   const { message, conversationType } = props
   const { id, viewType, text, hasLocation, isSetupmessage, hasHtml } = message
@@ -673,7 +672,6 @@ export default function Message(props: {
         direction={direction}
         message={message}
         showContextMenu={showContextMenu}
-        visible={props.isHover}
       />
     </div>
   )

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -501,21 +501,6 @@ export const MessageListInner = React.memo(
       }
     })
 
-    const [currentHoverMessageId, setCurrentHoverMessageId] = useState<
-      number | null
-    >(null)
-
-    const onMouseMove = (event: React.MouseEvent<HTMLElement, MouseEvent>) => {
-      // Message components are organised as a list
-      const target = event.target as HTMLElement
-      const messageElem = target.closest('li')
-
-      // .. every list element has an HTML `id` tag which contains the message id
-      const id = messageElem ? parseInt(messageElem.id, 10) : null
-
-      setCurrentHoverMessageId(id)
-    }
-
     // This fixes bad FPS when scrolling the chat on some devices,
     // e.g. on one of mine, Windows with a not-good GPU.
     //
@@ -584,7 +569,6 @@ export const MessageListInner = React.memo(
       <div
         id='message-list'
         ref={messageListRef}
-        onMouseMoveCapture={onMouseMove}
         onScroll={onScroll2}
         style={{
           willChange: scrolledRecently ? 'scroll-position' : undefined,
@@ -609,7 +593,6 @@ export const MessageListInner = React.memo(
               if (message?.kind === 'message') {
                 return (
                   <MessageWrapper
-                    isHover={messageId.msg_id === currentHoverMessageId}
                     key={messageId.msg_id}
                     key2={`${messageId.msg_id}`}
                     chat={chatStore.chat}

--- a/src/renderer/components/message/MessageWrapper.tsx
+++ b/src/renderer/components/message/MessageWrapper.tsx
@@ -11,7 +11,6 @@ type RenderMessageProps = {
   key2: string
   chat: T.FullChat
   message: T.Message
-  isHover: boolean
   conversationType: ConversationType
   unreadMessageInViewIntersectionObserver: React.MutableRefObject<IntersectionObserver | null>
 }
@@ -65,7 +64,7 @@ export function MessageWrapper(props: RenderMessageProps) {
   ])
 
   return (
-    <li id={props.key2}>
+    <li id={props.key2} className='message-wrapper'>
       <Message {...props} />
       <div className='message-observer-bottom' id={'bottom-' + props.key2} />
     </li>


### PR DESCRIPTION
Why WIP:
- [x] This is based on #3747 to avoid conflicts, expecting that to get merged first.

...instead of JS. Previously hovering over a different message would
cause the whole message list to re-render.

There are slight behavioral changes:
- Previously if you pointed the cursor to a message, then scrolled the
    chat without moving the pointer, it would keep the menu on top
    of the initial message, despite the cursor pointing at a different
    message after the scroll.
- Now when the three-dot menu is clicked, the shortcuts menu disappears
- When you point on emojis, the menu also disappears

The new behavior more closely resembles that of Signal.