### PR TITLE
remove deprecated string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - Update translations (2024-04-04) #3746
+- Remove deprecated translations #3756
 
 ### Fixed
 - fix chat audit dialog was going out of viewport on smaller screens #3736

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -19,8 +19,8 @@ const DisabledMessageInput = ({ reason }: Props) => {
       case DisabledChatReasons.DEADDROP:
         return tx('messaging_disabled_deaddrop')
       case DisabledChatReasons.DEVICE_CHAT:
-        // no call to tx(), the bar will be removed below to no clutter UI
-        return 'messaging_disabled_device_chat'
+        // To not clutter UI, hide reasoning bar for "Device Messages"
+        return null
       case DisabledChatReasons.UNKNOWN:
         // Unknown cases are likely to be caused by a new case introduced by a new core update that is not yet handled here,
         // but we don't want to crash the UI
@@ -30,13 +30,7 @@ const DisabledMessageInput = ({ reason }: Props) => {
     }
   }, [reason, tx])
 
-  // If no reason was given we return no component
-  if (!reason) {
-    return null
-  }
-
-  // If we're in the "device message" chat we also do not want to show anything
-  if (reason === DisabledChatReasons.DEVICE_CHAT) {
+  if (!reasonMessage) {
     return null
   }
 

--- a/src/renderer/components/composer/DisabledMessageInput.tsx
+++ b/src/renderer/components/composer/DisabledMessageInput.tsx
@@ -19,7 +19,8 @@ const DisabledMessageInput = ({ reason }: Props) => {
       case DisabledChatReasons.DEADDROP:
         return tx('messaging_disabled_deaddrop')
       case DisabledChatReasons.DEVICE_CHAT:
-        return tx('messaging_disabled_device_chat')
+        // no call to tx(), the bar will be removed below to no clutter UI
+        return 'messaging_disabled_device_chat'
       case DisabledChatReasons.UNKNOWN:
         // Unknown cases are likely to be caused by a new case introduced by a new core update that is not yet handled here,
         // but we don't want to crash the UI


### PR DESCRIPTION
this PR avoids getting translation for the string `messaging_disabled_device_chat` that is discarded a few lines later anyways.

(to not clutter UI, we do not show a "reasoning bar" at all for the device chat and the string is about to being removed to not add unnecessary work to the translators)

moreover, the second commit aims to cleanup the flow