### PR TITLE
add quick-key CtrlOrCmd+q for submenu quit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Remember last position & size of webxdc windows #3754
+- add quick-key CtrlOrCmd+q for submenu quit #3758
 
 ### Changed
 - Update translations (2024-04-04) #3746

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -172,7 +172,11 @@ function getMenuTemplate(logHandler: LogHandler): rawMenuItem[] {
             mainWindow.show()
           },
         },
-        { translate: 'global_menu_file_quit_desktop', role: 'quit' },
+        {
+          translate: 'global_menu_file_quit_desktop',
+          role: 'quit',
+          accelerator: 'Cmd+q',
+        },
       ],
     },
   ]
@@ -193,6 +197,7 @@ function getMenuTemplate(logHandler: LogHandler): rawMenuItem[] {
               {
                 translate: 'global_menu_file_quit_desktop',
                 role: 'quit',
+                accelerator: 'Ctrl+q',
               },
             ],
           },


### PR DESCRIPTION
- macOS
  - `Cmd+q`
- Win/Linux
  - `Ctrl+q`