### PR TITLE
add missing top padding to confirm sending files dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - hide "add second device" instructions when transfer has started #3748
 - improve chat scroll performance #3743, #3747
 - reduce CPU load when moving mouse over chat #3751
+- fix add missing top padding to confirm sending files dialog
 
 <a id="1_44_1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - hide "add second device" instructions when transfer has started #3748
 - improve chat scroll performance #3743, #3747
 - reduce CPU load when moving mouse over chat #3751
-- fix add missing top padding to confirm sending files dialog
+- fix add missing top padding to confirm sending files dialog #3767
 
 <a id="1_44_1"></a>
 

--- a/src/renderer/components/dialogs/ConfirmSendingFiles.tsx
+++ b/src/renderer/components/dialogs/ConfirmSendingFiles.tsx
@@ -41,7 +41,7 @@ export default function ConfirmSendingFiles({
   return (
     <Dialog onClose={onClose}>
       <DialogBody>
-        <DialogContent>
+        <DialogContent paddingTop>
           <p style={{ wordBreak: 'break-word' }}>
             {tx(
               'ask_send_following_n_files_to',


### PR DESCRIPTION
when you drag and drop send multiple files on deltachat it asks you if you want to send them in one action, this confirmation dialog lacked top padding, so it looked weird