### PR TITLE
fix runtime-opened dialogs

### DIFF
--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -5,7 +5,6 @@ import { debounce } from 'debounce'
 
 import MainScreen from './components/screens/MainScreen'
 import { getLogger } from '../shared/logger'
-import { ActionEmitter, KeybindAction } from './keybindings'
 import AccountSetupScreen from './components/screens/AccountSetupScreen'
 import WelcomeScreen from './components/screens/WelcomeScreen'
 import { BackendRemote, EffectfulBackendActions } from './backend-com'
@@ -13,7 +12,6 @@ import { updateDeviceChats } from './deviceMessages'
 import { runtime } from './runtime'
 import { updateTimestamps } from './components/conversations/Timestamp'
 import { ScreenContext } from './contexts/ScreenContext'
-import About from './components/dialogs/About'
 import { KeybindingsContextProvider } from './contexts/KeybindingsContext'
 import { DialogContext, DialogContextProvider } from './contexts/DialogContext'
 import WebxdcSaveToChatDialog from './components/dialogs/WebxdcSendToChat'
@@ -43,9 +41,6 @@ export enum Screens {
 
 export default class ScreenController extends Component {
   state: { message: userFeedback | false; screen: Screens }
-  onShowAbout: any
-  onShowKeybindings: any
-  onShowSettings: any
   selectedAccountId: number | undefined
   openSendToDialogId?: string
   lastAccountBeforeAddingNewAccount: number | null = null
@@ -62,9 +57,6 @@ export default class ScreenController extends Component {
     this.userFeedback = this.userFeedback.bind(this)
     this.userFeedbackClick = this.userFeedbackClick.bind(this)
     this.changeScreen = this.changeScreen.bind(this)
-    this.onShowAbout = this.showAbout.bind(this)
-    this.onShowKeybindings = this.showKeyBindings.bind(this)
-    this.onShowSettings = this.showSettings.bind(this)
     this.selectAccount = this.selectAccount.bind(this)
     this.unSelectAccount = this.unSelectAccount.bind(this)
     this.openAccountDeletionScreen = this.openAccountDeletionScreen.bind(this)
@@ -209,16 +201,6 @@ export default class ScreenController extends Component {
   componentDidMount() {
     BackendRemote.on('Error', this.onError)
 
-    runtime.onShowDialog = kind => {
-      if (kind === 'about') {
-        this.onShowAbout()
-      } else if (kind === 'keybindings') {
-        this.onShowKeybindings()
-      } else if (kind === 'settings') {
-        this.onShowSettings()
-      }
-    }
-
     runtime.onWebxdcSendToChat = (file, text) => {
       if (this.openSendToDialogId) {
         this.context.closeDialog(this.openSendToDialogId)
@@ -263,18 +245,6 @@ export default class ScreenController extends Component {
 
   onSuccess(_event: any, text: string) {
     this.userFeedback({ type: 'success', text })
-  }
-
-  showAbout() {
-    this.context.openDialog(About)
-  }
-
-  showSettings() {
-    ActionEmitter.emitAction(KeybindAction.Settings_Open)
-  }
-
-  showKeyBindings() {
-    ActionEmitter.emitAction(KeybindAction.KeybindingCheatSheet_Open)
   }
 
   renderScreen() {

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -13,8 +13,7 @@ import { runtime } from './runtime'
 import { updateTimestamps } from './components/conversations/Timestamp'
 import { ScreenContext } from './contexts/ScreenContext'
 import { KeybindingsContextProvider } from './contexts/KeybindingsContext'
-import { DialogContext, DialogContextProvider } from './contexts/DialogContext'
-import WebxdcSaveToChatDialog from './components/dialogs/WebxdcSendToChat'
+import { DialogContextProvider } from './contexts/DialogContext'
 import AccountListSidebar from './components/AccountListSidebar/AccountListSidebar'
 import SettingsStoreInstance from './stores/settings'
 import { NoAccountSelectedScreen } from './components/screens/NoAccountSelectedScreen/NoAccountSelectedScreen'
@@ -42,7 +41,6 @@ export enum Screens {
 export default class ScreenController extends Component {
   state: { message: userFeedback | false; screen: Screens }
   selectedAccountId: number | undefined
-  openSendToDialogId?: string
   lastAccountBeforeAddingNewAccount: number | null = null
 
   constructor(public props: {}) {
@@ -201,21 +199,6 @@ export default class ScreenController extends Component {
   componentDidMount() {
     BackendRemote.on('Error', this.onError)
 
-    runtime.onWebxdcSendToChat = (file, text) => {
-      if (this.openSendToDialogId) {
-        this.context.closeDialog(this.openSendToDialogId)
-        this.openSendToDialogId = undefined
-      }
-
-      this.openSendToDialogId = this.context.openDialog(
-        WebxdcSaveToChatDialog,
-        {
-          messageText: text,
-          file,
-        }
-      )
-    }
-
     runtime.onResumeFromSleep = debounce(() => {
       log.info('onResumeFromSleep')
       // update timestamps
@@ -339,8 +322,6 @@ export default class ScreenController extends Component {
     )
   }
 }
-
-ScreenController.contextType = DialogContext
 
 export function selectedAccountId(): number {
   const selectedAccountId = window.__selectedAccountId

--- a/src/renderer/components/RuntimeAdapter.tsx
+++ b/src/renderer/components/RuntimeAdapter.tsx
@@ -6,6 +6,7 @@ import { clearNotificationsForChat } from '../system-integration/notifications'
 import { runtime } from '../runtime'
 
 import type { PropsWithChildren } from 'react'
+import { ActionEmitter, KeybindAction } from '../keybindings'
 
 type Props = {
   accountId?: number
@@ -47,6 +48,16 @@ export default function RuntimeAdapter({
         }
       }
     )
+
+    runtime.onShowDialog = kind => {
+      if (kind === 'about') {
+        ActionEmitter.emitAction(KeybindAction.Settings_Open)
+      } else if (kind === 'keybindings') {
+        ActionEmitter.emitAction(KeybindAction.KeybindingCheatSheet_Open)
+      } else if (kind === 'settings') {
+        ActionEmitter.emitAction(KeybindAction.Settings_Open)
+      }
+    }
   }, [accountId, jumpToMessage, processQr])
 
   return <>{children}</>

--- a/src/renderer/components/RuntimeAdapter.tsx
+++ b/src/renderer/components/RuntimeAdapter.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 import useMessage from '../hooks/chat/useMessage'
 import useProcessQr from '../hooks/useProcessQr'
@@ -7,6 +7,8 @@ import { runtime } from '../runtime'
 
 import type { PropsWithChildren } from 'react'
 import { ActionEmitter, KeybindAction } from '../keybindings'
+import useDialog from '../hooks/dialog/useDialog'
+import WebxdcSaveToChatDialog from './dialogs/WebxdcSendToChat'
 
 type Props = {
   accountId?: number
@@ -59,6 +61,23 @@ export default function RuntimeAdapter({
       }
     }
   }, [accountId, jumpToMessage, processQr])
+
+  const { closeDialog, openDialog } = useDialog()
+  const openSendToDialogId = useRef<string | undefined>(undefined)
+
+  useEffect(() => {
+    runtime.onWebxdcSendToChat = (file, text) => {
+      if (openSendToDialogId.current) {
+        closeDialog(openSendToDialogId.current)
+        openSendToDialogId.current = undefined
+      }
+
+      openSendToDialogId.current = openDialog(WebxdcSaveToChatDialog, {
+        messageText: text,
+        file,
+      })
+    }
+  }, [closeDialog, openDialog])
 
   return <>{children}</>
 }

--- a/src/renderer/components/dialogs/About.tsx
+++ b/src/renderer/components/dialogs/About.tsx
@@ -74,6 +74,13 @@ export default function About({ onClose }: DialogProps) {
   const [sqliteVersion, setSqliteVersion] = useState('')
 
   useEffect(() => {
+    window.__aboutDialogOpened = true
+    return () => {
+      window.__aboutDialogOpened = false
+    }
+  }, [])
+
+  useEffect(() => {
     BackendRemote.rpc.getSystemInfo().then(info => {
       setCoreVersion(info['deltachat_core_version'])
       setSqliteVersion(info['sqlite_version'])

--- a/src/renderer/contexts/KeybindingsContext.tsx
+++ b/src/renderer/contexts/KeybindingsContext.tsx
@@ -12,6 +12,7 @@ import KeybindingCheatSheet from '../components/dialogs/KeybindingCheatSheet'
 import Settings from '../components/Settings'
 
 import type { PropsWithChildren } from 'react'
+import About from '../components/dialogs/About'
 
 export const KeybindingsContext = createContext(null)
 
@@ -34,6 +35,13 @@ export const KeybindingsContextProvider = ({
   useKeyBindingAction(KeybindAction.KeybindingCheatSheet_Open, () => {
     if (!window.__keybindingsDialogOpened) {
       openDialog(KeybindingCheatSheet)
+    }
+  })
+
+  // @TODO: This probably needs another place
+  useKeyBindingAction(KeybindAction.AboutDialog_Open, () => {
+    if (!window.__aboutDialogOpened) {
+      openDialog(About)
     }
   })
 

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -22,6 +22,7 @@ declare global {
     __setContextMenuActive: (newVal: boolean) => void
     __settingsOpened: boolean
     __keybindingsDialogOpened: boolean
+    __aboutDialogOpened: boolean
     __setQuoteInDraft: ((msgId: number) => void) | null
     __reloadDraft: (() => void) | null
     __chatlistSetSearch:

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -19,6 +19,7 @@ export enum KeybindAction {
   // Actions that are not necessarily triggered by keybindings
   ChatList_SwitchToArchiveView = 'chatlist:switch-to-archive-view',
   ChatList_SwitchToNormalView = 'chatlist:switch-to-normal-view',
+  AboutDialog_Open = 'about:open',
 
   // Composite Actions (actions that trigger other actions)
   ChatList_FocusAndClearSearchInput = 'chatlist:focus-and-clear-search',


### PR DESCRIPTION
- **fix open about dialog and continue moving code into RuntimeAdapter**
- **fix webxdc sendToChat by moving `runtime.onWebxdcSendToChat` to `RuntimeAdapter`**


follow up to #3725. fixing 2 bugs that were introduced by that big refactoring.

This needs no changelog entry as the bugs were not released yet.