### PR TITLE
further window menu fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Added
 - Remember last position & size of webxdc windows #3754 #3755
 - add quick-key CtrlOrCmd+q for submenu quit #3758
-- add window titlebar for html_email- and help window #3770
-- add quick key `Cmd+W`/`Ctrl+W` to close webxdc-, html_email- and help-window #3770
+- add window titlebar for html_email- and help window #3770 #3778
+- add quick key `Cmd+W`/`Ctrl+W` to close webxdc-, html_email- and help-window #3770 #3778
 
 
 ### Changed

--- a/src/main/deltachat/webxdc.ts
+++ b/src/main/deltachat/webxdc.ts
@@ -22,7 +22,12 @@ import { Bounds, DcOpenWebxdcParameters } from '../../shared/shared-types'
 import { DesktopSettings } from '../desktop_settings'
 import { window as main_window } from '../windows/main'
 import { writeTempFileFromBase64 } from '../ipc'
-import { refresh as refreshTitleMenu } from '../menu'
+import {
+  getAppMenu,
+  getEditMenu,
+  getFileMenu,
+  refresh as refreshTitleMenu,
+} from '../menu'
 import { T } from '@deltachat/jsonrpc-client'
 
 const open_apps: {
@@ -241,72 +246,10 @@ export default class DCWebxdc extends SplitOut {
         const isMac = platform() === 'darwin'
 
         const makeMenu = () => {
-          const appMenu: Electron.MenuItemConstructorOptions[] = [
-            {
-              label: tx('global_menu_file_desktop'),
-              submenu: [
-                { role: 'hide' },
-                { role: 'hideOthers' },
-                { role: 'unhide' },
-                { type: 'separator' },
-                {
-                  label: tx('global_menu_file_quit_desktop'),
-                  role: 'quit',
-                },
-              ],
-            },
-          ]
-
           return Menu.buildFromTemplate([
-            ...(isMac ? appMenu : []),
-            {
-              label: tx('global_menu_file_desktop'),
-              submenu: [
-                {
-                  label: tx('close_window'),
-                  click: () => {
-                    webxdc_windows.close()
-                  },
-                  accelerator: isMac ? 'Cmd+w' : 'Ctrl+w',
-                },
-              ],
-            },
-            {
-              label: tx('global_menu_edit_desktop'),
-              submenu: [
-                {
-                  label: tx('global_menu_edit_undo_desktop'),
-                  role: 'undo',
-                },
-                {
-                  label: tx('global_menu_edit_redo_desktop'),
-                  role: 'redo',
-                },
-                {
-                  type: 'separator',
-                },
-                {
-                  label: tx('global_menu_edit_cut_desktop'),
-                  role: 'cut',
-                },
-                {
-                  label: tx('global_menu_edit_copy_desktop'),
-                  role: 'copy',
-                },
-                {
-                  label: tx('global_menu_edit_paste_desktop'),
-                  role: 'paste',
-                },
-                {
-                  label: tx('delete'),
-                  role: 'delete',
-                },
-                {
-                  label: tx('menu_select_all'),
-                  role: 'selectAll',
-                },
-              ],
-            },
+            ...(isMac ? [getAppMenu(false)] : []),
+            getFileMenu(webxdc_windows, isMac),
+            getEditMenu(),
             {
               label: tx('global_menu_view_desktop'),
               submenu: [

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -249,6 +249,62 @@ export function getEditMenu(): Electron.MenuItemConstructorOptions {
   }
 }
 
+export function getHelpMenu(
+  isMac: boolean
+): Electron.MenuItemConstructorOptions {
+  return {
+    label: tx('global_menu_help_desktop'),
+    role: 'help',
+    submenu: [
+      {
+        label: tx('menu_help'),
+        click: () => {
+          mainWindow.send('showHelpDialog')
+        },
+        accelerator: 'F1',
+      },
+      {
+        label: tx('keybindings'),
+        click: () => {
+          mainWindow.window?.show()
+          mainWindow.window?.focus()
+          mainWindow.send('showKeybindingsDialog')
+        },
+        accelerator: isMac ? 'Cmd+/' : 'Ctrl+/',
+      },
+      {
+        label: tx('global_menu_help_learn_desktop'),
+        click: () => {
+          shell.openExternal(homePageUrl)
+        },
+      },
+      {
+        label: tx('global_menu_help_contribute_desktop'),
+        click: () => {
+          shell.openExternal(gitHubUrl)
+        },
+      },
+      {
+        type: 'separator',
+      },
+      {
+        label: tx('global_menu_help_report_desktop'),
+        click: () => {
+          shell.openExternal(gitHubIssuesUrl)
+        },
+      },
+      {
+        label: tx('global_menu_help_about_desktop'),
+        click: () => {
+          mainWindow.window?.show()
+          mainWindow.window?.focus()
+          mainWindow.send('showAboutDialog')
+        },
+      },
+    ],
+  }
+}
+
 function getMenuTemplate(
   logHandler: LogHandler
 ): Electron.MenuItemConstructorOptions[] {
@@ -323,53 +379,7 @@ function getMenuTemplate(
         },
       ],
     },
-    {
-      label: tx('global_menu_help_desktop'),
-      role: 'help',
-      submenu: [
-        {
-          label: tx('menu_help'),
-          click: () => {
-            mainWindow.send('showHelpDialog')
-          },
-          accelerator: 'F1',
-        },
-        {
-          label: tx('keybindings'),
-          click: () => {
-            mainWindow.send('showKeybindingsDialog')
-          },
-          accelerator: isMac ? 'Cmd+/' : 'Ctrl+/',
-        },
-        {
-          label: tx('global_menu_help_learn_desktop'),
-          click: () => {
-            shell.openExternal(homePageUrl)
-          },
-        },
-        {
-          label: tx('global_menu_help_contribute_desktop'),
-          click: () => {
-            shell.openExternal(gitHubUrl)
-          },
-        },
-        {
-          type: 'separator',
-        },
-        {
-          label: tx('global_menu_help_report_desktop'),
-          click: () => {
-            shell.openExternal(gitHubIssuesUrl)
-          },
-        },
-        {
-          label: tx('global_menu_help_about_desktop'),
-          click: () => {
-            mainWindow.send('showAboutDialog')
-          },
-        },
-      ],
-    },
+    getHelpMenu(isMac),
   ]
 }
 

--- a/src/main/windows/help.ts
+++ b/src/main/windows/help.ts
@@ -8,7 +8,12 @@ import { platform } from 'os'
 import { appWindowTitle } from '../../shared/constants'
 import { tx } from '../load-translations'
 import { window as main_window } from '../windows/main'
-import { getAppMenu, getFileMenu, refresh as refreshTitleMenu } from '../menu'
+import {
+  getAppMenu,
+  getFileMenu,
+  getHelpMenu,
+  refresh as refreshTitleMenu,
+} from '../menu'
 
 const log = getLogger('main/help')
 const app = rawApp as ExtendedAppMainProcess
@@ -163,6 +168,7 @@ export async function openHelpWindow(locale: string, anchor?: string) {
           { role: 'togglefullscreen' },
         ],
       },
+      getHelpMenu(isMac),
     ])
   }
 

--- a/src/main/windows/help.ts
+++ b/src/main/windows/help.ts
@@ -8,7 +8,7 @@ import { platform } from 'os'
 import { appWindowTitle } from '../../shared/constants'
 import { tx } from '../load-translations'
 import { window as main_window } from '../windows/main'
-import { refresh as refreshTitleMenu } from '../menu'
+import { getAppMenu, getFileMenu, refresh as refreshTitleMenu } from '../menu'
 
 const log = getLogger('main/help')
 const app = rawApp as ExtendedAppMainProcess
@@ -123,36 +123,9 @@ export async function openHelpWindow(locale: string, anchor?: string) {
   // copied and adapted from webxdc menu
   // TODO: would make sense to refactor these menus at some point
   const makeMenu = () => {
-    const appMenu: Electron.MenuItemConstructorOptions[] = [
-      {
-        label: tx('global_menu_file_desktop'),
-        submenu: [
-          { role: 'hide' },
-          { role: 'hideOthers' },
-          { role: 'unhide' },
-          { type: 'separator' },
-          {
-            label: tx('global_menu_file_quit_desktop'),
-            role: 'quit',
-          },
-        ],
-      },
-    ]
-
     return Menu.buildFromTemplate([
-      ...(isMac ? appMenu : []),
-      {
-        label: tx('global_menu_file_desktop'),
-        submenu: [
-          {
-            label: tx('close_window'),
-            click: () => {
-              win?.close()
-            },
-            accelerator: isMac ? 'Cmd+w' : 'Ctrl+w',
-          },
-        ],
-      },
+      ...(isMac ? [getAppMenu(false)] : []),
+      getFileMenu(win, isMac),
       {
         label: tx('global_menu_edit_desktop'),
         submenu: [

--- a/src/main/windows/html_email.ts
+++ b/src/main/windows/html_email.ts
@@ -21,7 +21,7 @@ import { getDCJsonrpcClient } from '../ipc'
 import { getLogger } from '../../shared/logger'
 import { clipboard } from 'electron/common'
 import * as mainWindow from './main'
-import { refresh as refreshTitleMenu } from '../menu'
+import { getAppMenu, getFileMenu, refresh as refreshTitleMenu } from '../menu'
 
 const log = getLogger('html_email')
 
@@ -132,36 +132,9 @@ export function openHtmlEmailWindow(
   // copied and adapted from webxdc menu
   // TODO: would make sense to refactor these menus at some point
   const makeMenu = () => {
-    const appMenu: Electron.MenuItemConstructorOptions[] = [
-      {
-        label: tx('global_menu_file_desktop'),
-        submenu: [
-          { role: 'hide' },
-          { role: 'hideOthers' },
-          { role: 'unhide' },
-          { type: 'separator' },
-          {
-            label: tx('global_menu_file_quit_desktop'),
-            role: 'quit',
-          },
-        ],
-      },
-    ]
-
     return Menu.buildFromTemplate([
-      ...(isMac ? appMenu : []),
-      {
-        label: tx('global_menu_file_desktop'),
-        submenu: [
-          {
-            label: tx('close_window'),
-            click: () => {
-              window.close()
-            },
-            accelerator: isMac ? 'Cmd+w' : 'Ctrl+w',
-          },
-        ],
-      },
+      ...(isMac ? [getAppMenu(false)] : []),
+      getFileMenu(window, isMac),
       {
         label: tx('global_menu_edit_desktop'),
         submenu: [

--- a/src/main/windows/html_email.ts
+++ b/src/main/windows/html_email.ts
@@ -149,7 +149,11 @@ export function openHtmlEmailWindow(
           },
           {
             label: tx('menu_select_all'),
-            role: 'selectAll',
+            click: () => {
+              sandboxedView.webContents.focus()
+              sandboxedView.webContents.selectAll()
+            },
+            accelerator: isMac ? 'Cmd+A' : 'Ctrl+A',
           },
         ],
       },

--- a/src/main/windows/html_email.ts
+++ b/src/main/windows/html_email.ts
@@ -21,7 +21,12 @@ import { getDCJsonrpcClient } from '../ipc'
 import { getLogger } from '../../shared/logger'
 import { clipboard } from 'electron/common'
 import * as mainWindow from './main'
-import { getAppMenu, getFileMenu, refresh as refreshTitleMenu } from '../menu'
+import {
+  getAppMenu,
+  getFileMenu,
+  getHelpMenu,
+  refresh as refreshTitleMenu,
+} from '../menu'
 
 const log = getLogger('html_email')
 
@@ -172,6 +177,7 @@ export function openHtmlEmailWindow(
           { role: 'togglefullscreen' },
         ],
       },
+      getHelpMenu(isMac),
     ])
   }
 


### PR DESCRIPTION
- **refactor menu code a bit to reuse some code**
- **add help menu to html email window and help window**
- **html-email: make select all always select the sandboxed email text**

fixes #3775

note that opening the about dialog from the menu is currently broken, I fixed that in #3777
