### PR TITLE
change importing location of constants to jsonrpc client

### DIFF
--- a/src/shared/util.ts
+++ b/src/shared/util.ts
@@ -1,4 +1,4 @@
-import { C } from 'deltachat-node/node/dist/constants'
+import { C } from "@deltachat/jsonrpc-client"
 
 export function getDirection({ fromId }: { fromId: number }) {
   return fromId === C.DC_CONTACT_ID_SELF ? 'outgoing' : 'incoming'


### PR DESCRIPTION
I don't think this mini change of import location in one file is worth a changelog entry
