### PR TITLE
Fix the bug where new message arriving makes the reactions bar and dialogue closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - fix Clicking notification does not bring Delta Chat to foreground on Windows #3793
 - Prevent re-rendering of account sidebar when switching account #3789
 - fix help not opening for languages that have no localized help
+- fix the bug where reactions bar is closed after arriving new message
 
 ### Removed
 - remove disabled composer reason, now composer is just always hidden when `chat.canSend` is `false` #3791

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - fix Clicking notification does not bring Delta Chat to foreground on Windows #3793
 - Prevent re-rendering of account sidebar when switching account #3789
 - fix help not opening for languages that have no localized help
-- fix the bug where reactions bar is closed after arriving new message
+- fix the bug where reactions bar is closed after arriving new message #3760
 
 ### Removed
 - remove disabled composer reason, now composer is just always hidden when `chat.canSend` is `false` #3791

--- a/src/renderer/components/ReactionsBar/ReactionsBarContext.tsx
+++ b/src/renderer/components/ReactionsBar/ReactionsBarContext.tsx
@@ -16,6 +16,7 @@ export type ShowReactionBar = {
 export type ReactionsBarValue = {
   showReactionsBar: (args: ShowReactionBar) => void
   hideReactionsBar: () => void
+  isReactionsBarShown: boolean
 }
 
 export const ReactionsBarContext =
@@ -35,6 +36,7 @@ export const ReactionsBarProvider = ({ children }: PropsWithChildren<{}>) => {
   const value: ReactionsBarValue = {
     showReactionsBar,
     hideReactionsBar,
+    isReactionsBarShown: barArgs !== null,
   }
 
   return (

--- a/src/renderer/components/ReactionsBar/useReactionsBar.ts
+++ b/src/renderer/components/ReactionsBar/useReactionsBar.ts
@@ -6,7 +6,10 @@ import { ReactionsBarContext } from '.'
 import type { ShowReactionBar, ReactionsBarValue } from './ReactionsBarContext'
 import type { T } from '@deltachat/jsonrpc-client'
 
-type UseReactionsBar = Pick<ReactionsBarValue, 'hideReactionsBar' | 'isReactionsBarShown'> & {
+type UseReactionsBar = Pick<
+  ReactionsBarValue,
+  'hideReactionsBar' | 'isReactionsBarShown'
+> & {
   showReactionsBar: (
     args: Pick<ShowReactionBar, 'messageId' | 'x' | 'y'> & {
       reactions: T.Message['reactions']

--- a/src/renderer/components/ReactionsBar/useReactionsBar.ts
+++ b/src/renderer/components/ReactionsBar/useReactionsBar.ts
@@ -6,7 +6,7 @@ import { ReactionsBarContext } from '.'
 import type { ShowReactionBar, ReactionsBarValue } from './ReactionsBarContext'
 import type { T } from '@deltachat/jsonrpc-client'
 
-type UseReactionsBar = Pick<ReactionsBarValue, 'hideReactionsBar'> & {
+type UseReactionsBar = Pick<ReactionsBarValue, 'hideReactionsBar' | 'isReactionsBarShown'> & {
   showReactionsBar: (
     args: Pick<ShowReactionBar, 'messageId' | 'x' | 'y'> & {
       reactions: T.Message['reactions']

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -120,7 +120,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
     fetchMoreBottom,
     fetchMoreTop,
   } = useMessageList(accountId, chat.id)
-  const { hideReactionsBar } = useReactionsBar()
+  const { hideReactionsBar, isReactionsBarShown } = useReactionsBar()
 
   const countUnreadMessages = useUnreadCount(
     accountId,
@@ -204,7 +204,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
   }, [jumpToMessage])
 
   const onScroll = useCallback(
-    (Event: React.UIEvent<HTMLDivElement> | null) => {
+    (evt: React.UIEvent<HTMLDivElement> | null) => {
       if (!messageListRef.current) {
         return
       }
@@ -212,7 +212,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
         return
       }
 
-      hideReactionsBar()
+      if (evt) hideReactionsBar()
 
       const distanceToTop = messageListRef.current.scrollTop
       const distanceToBottom =
@@ -236,20 +236,20 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
         log.debug('onScroll: Lets try loading messages from both ends')
         setTimeout(() => fetchMoreTop(), 0)
         setTimeout(() => fetchMoreBottom(), 0)
-        Event?.preventDefault()
-        Event?.stopPropagation()
+        evt?.preventDefault()
+        evt?.stopPropagation()
         return false
       } else if (distanceToTop < 200) {
         log.debug('onScroll: Scrolled to top, fetching more messages!')
         setTimeout(() => fetchMoreTop(), 0)
-        Event?.preventDefault()
-        Event?.stopPropagation()
+        evt?.preventDefault()
+        evt?.stopPropagation()
         return false
       } else if (distanceToBottom < 200) {
         log.debug('onScroll: Scrolled to bottom, fetching more messages!')
         setTimeout(() => fetchMoreBottom(), 0)
-        Event?.preventDefault()
-        Event?.stopPropagation()
+        evt?.preventDefault()
+        evt?.stopPropagation()
         return false
       }
     },
@@ -284,7 +284,9 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
       'scrollTop:',
       messageListRef.current.scrollTop,
       'scrollHeight:',
-      messageListRef.current.scrollHeight
+      messageListRef.current.scrollHeight,
+      'reactionsBar:',
+      isReactionsBarShown
     )
     if (scrollTo.type === 'scrollToMessage') {
       log.debug('scrollTo: scrollToMessage: ' + scrollTo.msgId)
@@ -346,7 +348,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
         'scrollTo type: scrollToPosition; scrollTop: ' + scrollTo.scrollTop
       )
       messageListRef.current.scrollTop = scrollTo.scrollTop
-    } else if (scrollTo.type === 'scrollToBottom') {
+    } else if (scrollTo.type === 'scrollToBottom' && !isReactionsBarShown) {
       if (scrollTo.ifClose === true) {
         const scrollHeight = lastKnownScrollHeight
         const { scrollTop, clientHeight } = messageListRef.current
@@ -386,6 +388,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
     viewState,
     viewState.lastKnownScrollHeight,
     viewState.scrollTo,
+    isReactionsBarShown,
   ])
 
   useLayoutEffect(() => {

--- a/src/renderer/components/message/MessageList.tsx
+++ b/src/renderer/components/message/MessageList.tsx
@@ -204,7 +204,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
   }, [jumpToMessage])
 
   const onScroll = useCallback(
-    (evt: React.UIEvent<HTMLDivElement> | null) => {
+    (ev: React.UIEvent<HTMLDivElement> | null) => {
       if (!messageListRef.current) {
         return
       }
@@ -212,7 +212,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
         return
       }
 
-      if (evt) hideReactionsBar()
+      if (ev) hideReactionsBar()
 
       const distanceToTop = messageListRef.current.scrollTop
       const distanceToBottom =
@@ -236,20 +236,20 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
         log.debug('onScroll: Lets try loading messages from both ends')
         setTimeout(() => fetchMoreTop(), 0)
         setTimeout(() => fetchMoreBottom(), 0)
-        evt?.preventDefault()
-        evt?.stopPropagation()
+        ev?.preventDefault()
+        ev?.stopPropagation()
         return false
       } else if (distanceToTop < 200) {
         log.debug('onScroll: Scrolled to top, fetching more messages!')
         setTimeout(() => fetchMoreTop(), 0)
-        evt?.preventDefault()
-        evt?.stopPropagation()
+        ev?.preventDefault()
+        ev?.stopPropagation()
         return false
       } else if (distanceToBottom < 200) {
         log.debug('onScroll: Scrolled to bottom, fetching more messages!')
         setTimeout(() => fetchMoreBottom(), 0)
-        evt?.preventDefault()
-        evt?.stopPropagation()
+        ev?.preventDefault()
+        ev?.stopPropagation()
         return false
       }
     },


### PR DESCRIPTION
The bug was with scrolling. On scroll, the reactions bar closes. I'm preventing scrolling to bottom when the reactions bar is open/shown.