### PR TITLE
emphasize 'Existing Password'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   - `@typescript-eslint/parser`: `6.13.1` -> `7.8.0`
 - bump nodejs requirement to `>=18.18.0` #3808
 - reorganise some settings acording changes on android & ios #3812
+- reword password label to 'Existing Password' #3826
 
 ### Fixed
 - fix chat audit dialog was going out of viewport on smaller screens #3736

--- a/src/renderer/components/LoginForm.tsx
+++ b/src/renderer/components/LoginForm.tsx
@@ -170,7 +170,7 @@ export default function LoginForm({ credentials, setCredentials }: LoginProps) {
           <DeltaPasswordInput
             key='mail_pw'
             id='mail_pw'
-            placeholder={tx('password')}
+            placeholder={tx('existing_password')}
             password={mail_pw || ''}
             onChange={handleCredentialsChange}
           />


### PR DESCRIPTION
make clearer, this is not a password the user can define here, esp. later editing lacks the information completely.

we found out by complains / user testing in the past that the term 'Existing' is needed here,
cmp https://github.com/deltachat/deltachat-android/pull/1256 .

in case of chatmail creating accounts
by using new passwords for non-existing addreses,
this is a special, not recommended case anyways -
and you still cannot change passwords eg. on editing account settings.

<img width="518" alt="Screenshot 2024-05-16 at 16 14 48" src="https://github.com/deltachat/deltachat-desktop/assets/9800740/deab83e1-509f-4959-9780-ab62083a9a89">

