### PR TITLE
perf: use 'react-window' for contact list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 - fix long names breaking layout of reactions dialog #3736
 - hide "add second device" instructions when transfer has started #3748
 - improve chat scroll performance #3743, #3747
+- faster load of contact lists in "New Chat" and "New Group" #3842
 - reduce CPU load when moving mouse over chat #3751
 - fix chatlistitem background when context menu for it is shown it is now highlighted correctly on pinned chats #3766
 - fix add missing top padding to confirm sending files dialog #3767

--- a/src/renderer/components/contact/ContactList.tsx
+++ b/src/renderer/components/contact/ContactList.tsx
@@ -6,6 +6,13 @@ import { debounceWithInit } from '../chat/ChatListHelpers'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 
+/**
+ * Make sure not to render all of the user's contacts with this component.
+ * Some users might have thousands of contacts, which can result in
+ * this component taking seconds to render.
+ * Instead consider using 'react-window', like we do in the `CreateChat`
+ * component.
+ */
 export function ContactList(props: {
   contacts: Type.Contact[]
   onClick?: (contact: Type.Contact) => void

--- a/src/renderer/components/dialogs/CreateChat/index.tsx
+++ b/src/renderer/components/dialogs/CreateChat/index.tsx
@@ -15,21 +15,21 @@ import {
   useContacts,
   ContactList,
   useContactsNew,
-} from '../contact/ContactList'
+} from '../../contact/ContactList'
 import {
   PseudoListItem,
   PseudoListItemAddMember,
   PseudoListItemAddContact,
-} from '../helpers/PseudoListItem'
-import GroupImage from '../GroupImage'
-import { runtime } from '../../runtime'
-import { Avatar, QRAvatar } from '../Avatar'
-import { AddMemberDialog } from './ViewGroup'
-import { ContactListItem } from '../contact/ContactListItem'
-import { useSettingsStore } from '../../stores/settings'
-import { BackendRemote, onDCEvent, Type } from '../../backend-com'
-import { selectedAccountId } from '../../ScreenController'
-import { InlineVerifiedIcon } from '../VerifiedIcon'
+} from '../../helpers/PseudoListItem'
+import GroupImage from '../../GroupImage'
+import { runtime } from '../../../runtime'
+import { Avatar, QRAvatar } from '../../Avatar'
+import { AddMemberDialog } from '../ViewGroup'
+import { ContactListItem } from '../../contact/ContactListItem'
+import { useSettingsStore } from '../../../stores/settings'
+import { BackendRemote, onDCEvent, Type } from '../../../backend-com'
+import { selectedAccountId } from '../../../ScreenController'
+import { InlineVerifiedIcon } from '../../VerifiedIcon'
 import Dialog, {
   DialogBody,
   DialogContent,
@@ -38,21 +38,24 @@ import Dialog, {
   FooterActionButton,
   FooterActions,
   OkCancelFooterAction,
-} from '../Dialog'
-import { ScreenContext } from '../../contexts/ScreenContext'
-import useChat from '../../hooks/chat/useChat'
-import useConfirmationDialog from '../../hooks/dialog/useConfirmationDialog'
-import useCreateChatByContactId from '../../hooks/chat/useCreateChatByContactId'
-import useDialog from '../../hooks/dialog/useDialog'
-import useTranslationFunction from '../../hooks/useTranslationFunction'
-import { VerifiedContactsRequiredDialog } from './ProtectionStatusDialog'
-import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
+} from '../../Dialog'
+import { ScreenContext } from '../../../contexts/ScreenContext'
+import useChat from '../../../hooks/chat/useChat'
+import useConfirmationDialog from '../../../hooks/dialog/useConfirmationDialog'
+import useCreateChatByContactId from '../../../hooks/chat/useCreateChatByContactId'
+import useDialog from '../../../hooks/dialog/useDialog'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+import { VerifiedContactsRequiredDialog } from '../ProtectionStatusDialog'
+import {
+  LastUsedSlot,
+  rememberLastUsedPath,
+} from '../../../utils/lastUsedPaths'
 import { dirname } from 'path'
-import QrCode from './QrCode'
-import { areAllContactsVerified } from '../../backend/chat'
+import QrCode from '../QrCode'
+import { areAllContactsVerified } from '../../../backend/chat'
 
 import type { T } from '@deltachat/jsonrpc-client'
-import type { DialogProps } from '../../contexts/DialogContext'
+import type { DialogProps } from '../../../contexts/DialogContext'
 
 type ViewMode = 'main' | 'createGroup' | 'createBroadcastList'
 

--- a/src/renderer/components/dialogs/CreateChat/styles.module.scss
+++ b/src/renderer/components/dialogs/CreateChat/styles.module.scss
@@ -1,0 +1,19 @@
+.createChatDialogBody {
+  // Stretch the parent. The parent is `display: flex`,
+  // so this will not make it overflow.
+  // Why not just let the content stretch the parent? Because this doesn't
+  // work with `react-virtualized-auto-sizer`.
+  // Similar approach is taken by the ForwardMessage component.
+  height: 100vh;
+}
+
+.addMemberDialogBody {
+  // Stretch the parent, same as above.
+  height: 100vh;
+
+  display: flex;
+  flex-direction: column;
+}
+.addMemberContactList {
+  flex-grow: 1;
+}


### PR DESCRIPTION
- [x] Need to clean up, address the TODOs
- [x] Would also need to verualize it in [`CreateChatMain`](https://github.com/deltachat/deltachat-desktop/blob/ad70318c5e7d00089d9cefa6c4702159d0a8486a/src/renderer/components/dialogs/CreateChat.tsx#L209)
- [x] And perhaps separate this into a new component, since we might need to implement lazy loading later (with 'react-window-infinite-loader') (but I guess that's a problem for a future us)
- [x] Personally test it

For huge contact lists (5000 contacts), rendering took ~5 seconds.
This solves this problem by only actually rendering the
part of the list that is currently scrolled to.

We already have this implemented for `ChatList.tsx`

Parially addresses https://github.com/deltachat/deltachat-desktop/issues/1830
Why partially? Because `BackendRemote.rpc.getContacts()`
still takes 3 seconds for 5000 contacts

This commit has side effects:
- a negative: the affected contact lists on non-default app themes
    where the item height is not exactly 64px
    are now slightly more ugly. See TODO about `itemSize={64}`
- a (positive?) side effect: `AddMemberChipsWrapper`
    is now outside the scrollable region (i.e. it's always on top)
    It works fine since it's `max-height: 33%`