### PR TITLE
Fix the problem where Ok Button does not close EditAccountAndPassword dialogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - quoted messages with single emoji as text look too big #3813
 - fix the bug where reactions bar is closed after arriving new message #3760
 - fix problem of focus when opening create chat dialogue #3816
+- fix the bug where EditAccountAndPassword dialog does not close with OK button
 
 ### Removed
 - remove disabled composer reason, now composer is just always hidden when `chat.canSend` is `false` #3791

--- a/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -122,7 +122,7 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
   ])
 
   const onOk = useCallback(async () => {
-    let update = await onUpdate()
+    const update = await onUpdate()
     if (update) onClose()
   }, [onClose, onUpdate])
 

--- a/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -85,7 +85,7 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
   }, [])
 
   const onUpdate = useCallback(async () => {
-    if (disableUpdate) return
+    if (disableUpdate) return true
     const onSuccess = () => onClose()
 
     const update = () => {
@@ -121,6 +121,11 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
     tx,
   ])
 
+  const onOk = useCallback(async () => {
+    let update = await onUpdate()
+    if (update) onClose()
+  }, [onClose, onUpdate])
+
   if (accountSettings === null) return null
   return (
     <>
@@ -134,7 +139,7 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
           )}
         </DialogContent>
       </DialogBody>
-      <OkCancelFooterAction onCancel={() => onClose()} onOk={onUpdate} />
+      <OkCancelFooterAction onCancel={() => onClose()} onOk={onOk} />
     </>
   )
 }


### PR DESCRIPTION
I am not sure about my solution. Perhaps a better solution would be removing `disableUpdate` state?