### PR TITLE
remember profile picture and displayname by saving it to core earlier

### DIFF
--- a/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -13,7 +13,7 @@ type Props = {
   displayName: string
   hideDeleteButton?: boolean
   profilePicture?: string
-  setProfilePicture: (path: string) => void
+  setProfilePicture: (path: string | null) => void
 }
 
 export default function ProfileImageSelector({
@@ -35,7 +35,7 @@ export default function ProfileImageSelector({
       lastUsedSlot={LastUsedSlot.ProfileImage}
       onChange={filepath => {
         if (!filepath) {
-          setProfilePicture('')
+          setProfilePicture(null)
         } else {
           openDialog(ImageCropper, {
             filepath,

--- a/src/renderer/components/screens/WelcomeScreen/AlternativeSetupsDialog.tsx
+++ b/src/renderer/components/screens/WelcomeScreen/AlternativeSetupsDialog.tsx
@@ -17,14 +17,34 @@ import styles from './styles.module.scss'
 
 import type { DialogProps } from '../../../contexts/DialogContext'
 import { ReceiveBackupDialog } from '../../dialogs/SetupMultiDevice'
+import { BackendRemote } from '../../../backend-com'
 
-export default function AlternativeSetupsDialog({ onClose }: DialogProps) {
+interface Props {
+  selectedAccountId: number
+}
+
+export default function AlternativeSetupsDialog({
+  onClose,
+  selectedAccountId,
+}: DialogProps & Props) {
   const tx = useTranslationFunction()
   const { openDialog } = useDialog()
 
-  const onClickSecondDevice = () => openDialog(ReceiveBackupDialog)
+  /** remove configuration if user did set picture or displayname in the instant onboarding dialog already */
+  const resetAccount = () =>
+    BackendRemote.rpc.batchSetConfig(selectedAccountId, {
+      selfavatar: null,
+      displayname: null,
+    })
+
+  const onClickSecondDevice = () => {
+    resetAccount()
+    openDialog(ReceiveBackupDialog)
+  }
 
   async function onClickImportBackup() {
+    await resetAccount()
+
     const { defaultPath, setLastPath } = rememberLastUsedPath(
       LastUsedSlot.Backup
     )

--- a/src/renderer/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
+++ b/src/renderer/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
@@ -146,6 +146,7 @@ export default function InstantOnboardingScreen({
             placeholder={tx('pref_your_name')}
             value={displayName}
             onChange={onChangeDisplayName}
+            onBlur={saveDisplayName}
           />
           {showMissingNameError && (
             <p className={styles.inputError}>{tx('please_enter_name')}</p>

--- a/src/renderer/components/screens/WelcomeScreen/OnboardingScreen.tsx
+++ b/src/renderer/components/screens/WelcomeScreen/OnboardingScreen.tsx
@@ -27,7 +27,9 @@ export default function OnboardingScreen(props: Props) {
   const { openDialog } = useDialog()
 
   const onAlreadyHaveAccount = () => {
-    openDialog(AlternativeSetupsDialog)
+    openDialog(AlternativeSetupsDialog, {
+      selectedAccountId: props.selectedAccountId,
+    })
   }
 
   const onClickBackButton = async () => {

--- a/src/renderer/hooks/useInstantOnboarding.ts
+++ b/src/renderer/hooks/useInstantOnboarding.ts
@@ -17,11 +17,7 @@ import type {
 } from '../backend/qr'
 
 type InstantOnboarding = {
-  createInstantAccount: (
-    accountId: number,
-    displayName: string,
-    profilePicture?: string
-  ) => Promise<T.FullChat['id'] | null>
+  createInstantAccount: (accountId: number) => Promise<T.FullChat['id'] | null>
   /** Exit the instant onboarding flow */
   resetInstantOnboarding: () => void
   /** Whether instant onboarding is active */
@@ -69,11 +65,7 @@ export default function useInstantOnboarding(): InstantOnboarding {
   )
 
   const createInstantAccount = useCallback(
-    async (
-      accountId: number,
-      displayName: string,
-      profilePicture?: string
-    ): Promise<T.FullChat['id'] | null> => {
+    async (accountId: number): Promise<T.FullChat['id'] | null> => {
       let configurationQR = `dcaccount:${DEFAULT_CHATMAIL_QR_URL}`
 
       if (welcomeQr) {
@@ -102,16 +94,8 @@ export default function useInstantOnboarding(): InstantOnboarding {
 
       await BackendRemote.rpc.setConfigFromQr(accountId, configurationQR)
 
-      // 2. Additionally we set the `selfavatar` / profile picture
-      // and `displayname` configuration for this account
-      if (profilePicture) {
-        await BackendRemote.rpc.setConfig(
-          accountId,
-          'selfavatar',
-          profilePicture
-        )
-      }
-      await BackendRemote.rpc.setConfig(accountId, 'displayname', displayName)
+      // 2. ~~Additionally we set the `selfavatar` / profile picture~~
+      // ~~and `displayname` configuration for this account~~ -> this is now done before calling this method.
 
       return new Promise((resolve, reject) => {
         // 3. Kick-off the actual account creation process by calling


### PR DESCRIPTION
profile picture is saved as soon as it is set,
displayname is set when you leave the dialog (by clicking other options, login or going back) or loose focus on the input field
