### PR TITLE
fix: message text "wobbling" on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixed
 - fix that map tab is highlighted when you are in the media/gallery tab #3867
+- fix message text "wobbling" on hover #3862
 
 
 <a id="1_45_0"></a>

--- a/src/renderer/components/ShortcutMenu/styles.module.scss
+++ b/src/renderer/components/ShortcutMenu/styles.module.scss
@@ -35,8 +35,18 @@ $transitionDuration: 50ms;
   margin: 0;
   padding: 5px;
 
-  transform: scale(calc(0.75 + 0.25 * var(--shortcut-menu-multiplier)));
-  transition: transform ease-out $transitionDuration;
+  // Commented out because apparently messages that are below the message
+  // that is performing this transition seem to get moved to another
+  // "layer" (see https://dev.opera.com/articles/css-will-change-property#does-will-change-affect-the-element-it-is-applied-to-beyond-hinting-the-browser-about-the-changes-to-that-element)
+  // which turns off subpixel antialiasing making "wobble" as you move
+  // the cursor above the messages.
+  //
+  // For reference, we already had to deal with antialiasing shenanigans, see
+  // `willChange` of `id='message-list'`, this commit:
+  // https://github.com/deltachat/deltachat-desktop/commit/24a5107d440d9f2041d34f60f4bde16a0dba6be8
+  //
+  // transform: scale(calc(0.75 + 0.25 * var(--shortcut-menu-multiplier)));
+  // transition: transform ease-out $transitionDuration;
 }
 
 .shortcutMenuIcon {


### PR DESCRIPTION
Introduced in a99910eaee

Before ("Layer Borders" in dev tools is turned on):

https://github.com/deltachat/deltachat-desktop/assets/39462442/8102a210-d33c-4f63-9840-67d375a7495e

Watch the text wobble (it's not just a compression thing).

Does not require a CHANGELOG entry because that commit is unreleased