### PR TITLE
simon/small screen support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- Added a Small Screen Mode, when you rezise the window to be small it will only show the chatlist with account sidebar or the Chat View with a back button.
+
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `v1.139.6`
 - Always show `msg.overrideSenderName` even when the message is sent by yourself

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -19,16 +19,6 @@ body {
   cursor: default;
 }
 
-.window {
-  height: $content-height;
-  margin-top: $nav-bar-height;
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-  overflow: auto;
-  padding: 10px 10px;
-}
-
 ul {
   list-style: none;
   padding-left: 0;
@@ -207,10 +197,16 @@ samp {
   font-family: monospace, $emojifonts;
 }
 
+.main-container-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  position: absolute;
+}
+
 .main-container {
   display: flex;
-  position: absolute;
-  width: 100%;
-  height: 100%;
+  flex-grow: 1;
   overflow: hidden;
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -6,8 +6,6 @@ $roboto: Roboto, $emojifonts, 'Helvetica Neue', Arial, Helvetica, NotoMono,
 $roboto-light: Roboto-Light, $emojifonts, 'Helvetica Neue', Arial, Helvetica,
   NotoMono, sans-serif;
 
-$nav-bar-height: 50px;
-$content-height: calc(100vh - #{$nav-bar-height});
 /* Theming Colors */
 
 // Belongs to stuff we plan to remove / change anyway

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,7 +1,7 @@
 .chat-list {
   z-index: $z-index-new-local-scope; // needed for .floating-action-button
   width: 30%;
-  min-width: 295px;
+  min-width: 295px; /* don't forget to update navbar, .bp4-align-left */
   height: 100%;
   overflow-y: auto;
   box-shadow:

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,8 +1,7 @@
 .chat-list {
   z-index: $z-index-new-local-scope; // needed for .floating-action-button
   width: 30%;
-  height: $content-height;
-  float: left;
+  height: 100%;
   overflow-y: auto;
   box-shadow:
     0 0 4px 1px rgba(16, 22, 26, 0.1),

--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -1,6 +1,7 @@
 .chat-list {
   z-index: $z-index-new-local-scope; // needed for .floating-action-button
   width: 30%;
+  min-width: 295px;
   height: 100%;
   overflow-y: auto;
   box-shadow:

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -18,7 +18,7 @@ $tab-height: 46px;
   }
 
   & .gallery {
-    height: calc(100vh - #{$tab-height} - #{$nav-bar-height});
+    height: 100%;
 
     & > .empty-screen {
       display: flex;

--- a/scss/gallery/_media.scss
+++ b/scss/gallery/_media.scss
@@ -4,8 +4,11 @@ $tab-height: 46px;
   width: calc(100% - var(--chat-list-width, 30%));
   background-color: var(--galleryBg);
   padding-left: 10px;
-  max-height: calc(100vh - 50px);
   overflow: hidden;
+  min-width: 200px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
 
   .big-date {
     flex-grow: 1;

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -3,6 +3,32 @@
   position: relative;
   overflow: hidden;
 
+  &.small-screen {
+    .message-list-and-composer,
+    .chat-list,
+    .media-view {
+      float: none;
+      width: unset;
+    }
+
+    .navbar-wrapper .bp4-align-right,
+    .navbar-wrapper .bp4-align-left {
+      width: 100%;
+    }
+
+    &.chat-view-open {
+      .chat-list {
+        display: none;
+      }
+    }
+
+    &:not(.chat-view-open) {
+      .message-list-and-composer {
+        display: none;
+      }
+    }
+  }
+
   .navbar-chat-name {
     font-size: medium;
     font-weight: bold;

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -1,5 +1,7 @@
 .main-screen {
   flex-grow: 1;
+  display: flex;
+  flex-direction: column;
   position: relative;
   overflow: hidden;
 
@@ -9,6 +11,7 @@
     .media-view {
       float: none;
       width: unset;
+      flex-grow: 1;
     }
 
     .navbar-wrapper .bp4-align-right,
@@ -27,6 +30,11 @@
         display: none;
       }
     }
+  }
+
+  .main-app-content {
+    display: flex;
+    flex-grow: 1;
   }
 
   .navbar-chat-name {
@@ -77,8 +85,7 @@
 
   .no-chat-selected-screen {
     width: 70%;
-    float: right;
-    height: $content-height;
+    height: 100%;
     margin-top: 50px;
     text-align: center;
   }

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -18,6 +18,17 @@
     .navbar-wrapper .bp4-align-left {
       width: 100%;
     }
+    
+    .backButton {
+      $backBtnText: white;
+      .backButtonIcon {
+        background-color: $backBtnText;
+      }
+
+      &:hover {
+        background-color: rgba(143, 153, 168, 0.15);
+      }
+    }
 
     &.chat-view-open {
       .chat-list {

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -9,7 +9,6 @@
     .message-list-and-composer,
     .chat-list,
     .media-view {
-      float: none;
       width: unset;
       flex-grow: 1;
     }

--- a/scss/main_screen/_main_screen.scss
+++ b/scss/main_screen/_main_screen.scss
@@ -17,7 +17,7 @@
     .navbar-wrapper .bp4-align-left {
       width: 100%;
     }
-    
+
     .backButton {
       $backBtnText: white;
       .backButtonIcon {

--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -33,7 +33,6 @@
   }
 
   .bp4-align-right {
-    width: 70%;
     float: none;
   }
 

--- a/scss/main_screen/_navbar_wrapper.scss
+++ b/scss/main_screen/_navbar_wrapper.scss
@@ -28,6 +28,7 @@
 
   .bp4-align-left {
     width: 30%;
+    min-width: 295px; /* don't forget to update .chat-list */
     padding: 0px 10px;
   }
 

--- a/scss/message/_message-list.scss
+++ b/scss/message/_message-list.scss
@@ -1,9 +1,8 @@
 .message-list-and-composer {
   width: 70%;
-  float: right;
   display: flex;
   flex-direction: column;
-  height: $content-height;
+  height: 100%;
   background-image: var(--chatViewBgImgPath);
   background-size: cover;
   background-color: var(--chatViewBg);

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -39,8 +39,18 @@ export enum Screens {
   NoAccountSelected = 'noAccountSelected',
 }
 
+const BREAKPOINT_FOR_SMALLSCREEN_MODE = 600
+
+function isSmallScreenMode(): boolean {
+  return window.innerWidth <= BREAKPOINT_FOR_SMALLSCREEN_MODE
+}
+
 export default class ScreenController extends Component {
-  state: { message: userFeedback | false; screen: Screens }
+  state: {
+    message: userFeedback | false
+    screen: Screens
+    smallScreenMode: boolean
+  }
   selectedAccountId: number | undefined
   lastAccountBeforeAddingNewAccount: number | null = null
   unselectChatRef = createRef<UnselectChat>()
@@ -50,6 +60,7 @@ export default class ScreenController extends Component {
     this.state = {
       message: false,
       screen: Screens.Loading,
+      smallScreenMode: isSmallScreenMode(),
     }
 
     this.onError = this.onError.bind(this)
@@ -63,6 +74,7 @@ export default class ScreenController extends Component {
     this.openAccountDeletionScreen = this.openAccountDeletionScreen.bind(this)
     this.onDeleteAccount = this.onDeleteAccount.bind(this)
     this.onExitWelcomeScreen = this.onExitWelcomeScreen.bind(this)
+    this.updateSmallScreenMode = this.updateSmallScreenMode.bind(this)
 
     window.__userFeedback = this.userFeedback.bind(this)
     window.__changeScreen = this.changeScreen.bind(this)
@@ -202,6 +214,10 @@ export default class ScreenController extends Component {
     }
   }
 
+  updateSmallScreenMode() {
+    this.setState({ smallScreenMode: isSmallScreenMode() })
+  }
+
   componentDidMount() {
     BackendRemote.on('Error', this.onError)
 
@@ -216,10 +232,14 @@ export default class ScreenController extends Component {
     this.startup().then(() => {
       runtime.emitUIFullyReady()
     })
+
+    window.addEventListener('resize', this.updateSmallScreenMode)
   }
 
   componentWillUnmount() {
     BackendRemote.off('Error', this.onError)
+
+    window.removeEventListener('resize', this.updateSmallScreenMode)
   }
 
   onError(accountId: number, { msg }: DcEventType<'Error'>) {
@@ -298,6 +318,7 @@ export default class ScreenController extends Component {
             changeScreen: this.changeScreen,
             screen: this.state.screen,
             addAndSelectAccount: this.addAndSelectAccount,
+            smallScreenMode: this.state.smallScreenMode,
           }}
         >
           <InstantOnboardingProvider>

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -39,7 +39,7 @@ export enum Screens {
   NoAccountSelected = 'noAccountSelected',
 }
 
-const BREAKPOINT_FOR_SMALLSCREEN_MODE = 600
+const BREAKPOINT_FOR_SMALLSCREEN_MODE = 635
 
 function isSmallScreenMode(): boolean {
   return window.innerWidth <= BREAKPOINT_FOR_SMALLSCREEN_MODE

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -330,16 +330,18 @@ export default class ScreenController extends Component {
                 <DialogContextProvider>
                   <RuntimeAdapter accountId={this.selectedAccountId} />
                   <KeybindingsContextProvider>
-                    <div className='main-container'>
-                      <AccountListSidebar
-                        selectedAccountId={this.selectedAccountId}
-                        onAddAccount={this.addAndSelectAccount}
-                        onSelectAccount={this.selectAccount.bind(this)}
-                        openAccountDeletionScreen={this.openAccountDeletionScreen.bind(
-                          this
-                        )}
-                      />
-                      {this.renderScreen(this.selectedAccountId)}
+                    <div className='main-container-container'>
+                      <div className='main-container'>
+                        <AccountListSidebar
+                          selectedAccountId={this.selectedAccountId}
+                          onAddAccount={this.addAndSelectAccount}
+                          onSelectAccount={this.selectAccount.bind(this)}
+                          openAccountDeletionScreen={this.openAccountDeletionScreen.bind(
+                            this
+                          )}
+                        />
+                        {this.renderScreen(this.selectedAccountId)}
+                      </div>
                     </div>
                   </KeybindingsContextProvider>
                 </DialogContextProvider>

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -331,6 +331,20 @@ export default class ScreenController extends Component {
                   <RuntimeAdapter accountId={this.selectedAccountId} />
                   <KeybindingsContextProvider>
                     <div className='main-container-container'>
+                      {this.state.smallScreenMode &&
+                        runtime.getRuntimeInfo().isMac && (
+                          <div
+                            style={{
+                              height: '30px',
+                              textAlign: 'center',
+                              '-webkit-app-region': 'drag',
+                              flexShrink: 0,
+                              flexGrow: 0
+                            }}
+                          >
+                            Deltachat
+                          </div>
+                        )}
                       <div className='main-container'>
                         <AccountListSidebar
                           selectedAccountId={this.selectedAccountId}

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -22,6 +22,7 @@ import RuntimeAdapter from './components/RuntimeAdapter'
 import { ChatProvider, UnselectChat } from './contexts/ChatContext'
 import { ContextMenuProvider } from './contexts/ContextMenuContext'
 import { InstantOnboardingProvider } from './contexts/InstantOnboardingContext'
+import { SmallScreenModeMacOSTitleBar } from './components/SmallScreenModeMacOSTitleBar'
 
 const log = getLogger('renderer/ScreenController')
 
@@ -333,17 +334,7 @@ export default class ScreenController extends Component {
                     <div className='main-container-container'>
                       {this.state.smallScreenMode &&
                         runtime.getRuntimeInfo().isMac && (
-                          <div
-                            style={{
-                              height: '30px',
-                              textAlign: 'center',
-                              '-webkit-app-region': 'drag',
-                              flexShrink: 0,
-                              flexGrow: 0
-                            }}
-                          >
-                            Deltachat
-                          </div>
+                          <SmallScreenModeMacOSTitleBar />
                         )}
                       <div className='main-container'>
                         <AccountListSidebar

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -39,7 +39,7 @@ export enum Screens {
   NoAccountSelected = 'noAccountSelected',
 }
 
-const BREAKPOINT_FOR_SMALLSCREEN_MODE = 635
+const BREAKPOINT_FOR_SMALLSCREEN_MODE = 720
 
 function isSmallScreenMode(): boolean {
   return window.innerWidth <= BREAKPOINT_FOR_SMALLSCREEN_MODE

--- a/src/renderer/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/src/renderer/components/AccountListSidebar/AccountListSidebar.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import { debounce } from 'debounce'
 
 import AccountHoverInfo from './AccountHoverInfo'
@@ -13,6 +20,8 @@ import { useAccountNotificationStore } from '../../stores/accountNotifications'
 import styles from './styles.module.scss'
 
 import type { T } from '@deltachat/jsonrpc-client'
+import { ScreenContext } from '../../contexts/ScreenContext'
+import useChat from '../../hooks/chat/useChat'
 
 type Props = {
   onAddAccount: () => Promise<number>
@@ -30,6 +39,11 @@ export default function AccountListSidebar({
   const { openDialog } = useDialog()
   const [accounts, setAccounts] = useState<T.Account[]>([])
   const [{ accounts: noficationSettings }] = useAccountNotificationStore()
+
+  const { smallScreenMode } = useContext(ScreenContext)
+  const { chatId } = useChat()
+
+  const shouldBeHidden = smallScreenMode && chatId !== undefined
 
   const selectAccount = async (accountId: number) => {
     if (selectedAccountId === accountId) {
@@ -98,6 +112,10 @@ export default function AccountListSidebar({
   }, [refresh])
 
   const openSettings = () => openDialog(Settings)
+
+  if (shouldBeHidden) {
+    return <div></div>
+  }
 
   return (
     <div className={styles.accountListSidebar}>

--- a/src/renderer/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/src/renderer/components/AccountListSidebar/AccountListSidebar.tsx
@@ -119,7 +119,7 @@ export default function AccountListSidebar({
 
   return (
     <div className={styles.accountListSidebar}>
-      {runtime.getRuntimeInfo().isMac && (
+      {runtime.getRuntimeInfo().isMac && !smallScreenMode && (
         <div className={styles.macOSTrafficLightBackground} />
       )}
       <div className={styles.accountList} onScroll={updateHoverInfoPosition}>

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -232,7 +232,14 @@ export default class Gallery extends Component<
 
     return (
       <div className='media-view'>
-        <div style={{ minWidth: 200 }}>
+        <div
+          style={{
+            minWidth: 200,
+            height: '100%',
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
           <ul
             className='bp4-tab-list .modifier'
             role='tablist'
@@ -268,7 +275,7 @@ export default class Gallery extends Component<
               </>
             )}
           </ul>
-          <div role='tabpanel'>
+          <div role='tabpanel' style={{ flexGrow: 1 }}>
             <div
               className={`gallery gallery-image-object-fit_${
                 galleryImageKeepAspectRatio ? 'contain' : 'cover'

--- a/src/renderer/components/Gallery.tsx
+++ b/src/renderer/components/Gallery.tsx
@@ -232,174 +232,163 @@ export default class Gallery extends Component<
 
     return (
       <div className='media-view'>
-        <div
-          style={{
-            minWidth: 200,
-            height: '100%',
-            display: 'flex',
-            flexDirection: 'column',
-          }}
+        <ul
+          className='bp4-tab-list .modifier'
+          role='tablist'
+          style={{ display: 'flex', alignItems: 'center' }}
         >
-          <ul
-            className='bp4-tab-list .modifier'
-            role='tablist'
-            style={{ display: 'flex', alignItems: 'center' }}
+          {Object.keys(MediaTabs).map(realId => {
+            const tabId = realId as MediaTabKey
+            return (
+              <li
+                key={tabId}
+                className='bp4-tab'
+                role='tab'
+                aria-selected={currentTab === tabId}
+                onClick={() => this.onSelect(tabId)}
+              >
+                {tx(tabId)}
+              </li>
+            )
+          })}
+          {showDateHeader && (
+            <div className='big-date' ref={this.dateHeader}></div>
+          )}
+          {currentTab === 'files' && (
+            <>
+              <div style={{ flexGrow: 1 }}></div>
+              <div className='searchbar'>
+                <input
+                  type='search'
+                  placeholder={tx('search_files')}
+                  onChange={this.onChangeInput.bind(this)}
+                />
+              </div>
+            </>
+          )}
+        </ul>
+        <div role='tabpanel' style={{ flexGrow: 1 }}>
+          <div
+            className={`gallery gallery-image-object-fit_${
+              galleryImageKeepAspectRatio ? 'contain' : 'cover'
+            }`}
+            key={msgTypes.join('.') + String(this.props.chatId)}
           >
-            {Object.keys(MediaTabs).map(realId => {
-              const tabId = realId as MediaTabKey
-              return (
-                <li
-                  key={tabId}
-                  className='bp4-tab'
-                  role='tab'
-                  aria-selected={currentTab === tabId}
-                  onClick={() => this.onSelect(tabId)}
-                >
-                  {tx(tabId)}
-                </li>
-              )
-            })}
-            {showDateHeader && (
-              <div className='big-date' ref={this.dateHeader}></div>
+            {mediaMessageIds.length < 1 && !loading && (
+              <div className='empty-screen'>
+                {/* IDEA: when we have someone doing illustrations this would be a great place to add some */}
+                <p className='no-media-message'>{emptyTabMessage}</p>
+              </div>
             )}
+
             {currentTab === 'files' && (
               <>
-                <div style={{ flexGrow: 1 }}></div>
-                <div className='searchbar'>
-                  <input
-                    type='search'
-                    placeholder={tx('search_files')}
-                    onChange={this.onChangeInput.bind(this)}
-                  />
-                </div>
+                <AutoSizer>
+                  {({ width, height }) => (
+                    <FileTable
+                      width={width}
+                      height={height}
+                      mediaLoadResult={mediaLoadResult}
+                      mediaMessageIds={filteredMediaMessageIds}
+                      queryText={queryText}
+                    ></FileTable>
+                  )}
+                </AutoSizer>
+                {filteredMediaMessageIds.length === 0 && (
+                  <div className='empty-screen'>
+                    <p className='no-media-message'>
+                      {tx('search_no_result_for_x', queryText)}
+                    </p>
+                  </div>
+                )}
               </>
             )}
-          </ul>
-          <div role='tabpanel' style={{ flexGrow: 1 }}>
-            <div
-              className={`gallery gallery-image-object-fit_${
-                galleryImageKeepAspectRatio ? 'contain' : 'cover'
-              }`}
-              key={msgTypes.join('.') + String(this.props.chatId)}
-            >
-              {mediaMessageIds.length < 1 && !loading && (
-                <div className='empty-screen'>
-                  {/* IDEA: when we have someone doing illustrations this would be a great place to add some */}
-                  <p className='no-media-message'>{emptyTabMessage}</p>
-                </div>
-              )}
 
-              {currentTab === 'files' && (
-                <>
-                  <AutoSizer>
-                    {({ width, height }) => (
-                      <FileTable
-                        width={width}
-                        height={height}
-                        mediaLoadResult={mediaLoadResult}
-                        mediaMessageIds={filteredMediaMessageIds}
-                        queryText={queryText}
-                      ></FileTable>
-                    )}
-                  </AutoSizer>
-                  {filteredMediaMessageIds.length === 0 && (
-                    <div className='empty-screen'>
-                      <p className='no-media-message'>
-                        {tx('search_no_result_for_x', queryText)}
-                      </p>
-                    </div>
-                  )}
-                </>
-              )}
+            {currentTab !== 'files' && (
+              <AutoSizer>
+                {({ width, height }) => {
+                  const widthWithoutScrollbar = width - 6
 
-              {currentTab !== 'files' && (
-                <AutoSizer>
-                  {({ width, height }) => {
-                    const widthWithoutScrollbar = width - 6
+                  let minWidth = 160
 
-                    let minWidth = 160
+                  if (currentTab === 'webxdc_apps') {
+                    minWidth = 265
+                  } else if (currentTab === 'audio') {
+                    minWidth = 322
+                  }
 
-                    if (currentTab === 'webxdc_apps') {
-                      minWidth = 265
-                    } else if (currentTab === 'audio') {
-                      minWidth = 322
-                    }
+                  const itemsPerRow = Math.max(
+                    Math.floor(widthWithoutScrollbar / minWidth),
+                    1
+                  )
 
-                    const itemsPerRow = Math.max(
-                      Math.floor(widthWithoutScrollbar / minWidth),
-                      1
-                    )
+                  const itemWidth = widthWithoutScrollbar / itemsPerRow
 
-                    const itemWidth = widthWithoutScrollbar / itemsPerRow
+                  const rowCount = Math.ceil(
+                    mediaMessageIds.length / itemsPerRow
+                  )
 
-                    const rowCount = Math.ceil(
-                      mediaMessageIds.length / itemsPerRow
-                    )
+                  let itemHeight = itemWidth
 
-                    let itemHeight = itemWidth
+                  if (currentTab === 'webxdc_apps') {
+                    itemHeight = 61
+                  } else if (currentTab === 'audio') {
+                    itemHeight = 94
+                  }
 
-                    if (currentTab === 'webxdc_apps') {
-                      itemHeight = 61
-                    } else if (currentTab === 'audio') {
-                      itemHeight = 94
-                    }
-
-                    return (
-                      <FixedSizeGrid
-                        width={width}
-                        height={height}
-                        columnWidth={itemWidth}
-                        rowHeight={itemHeight}
-                        columnCount={itemsPerRow}
-                        rowCount={rowCount}
-                        overscanRowCount={10}
-                        onItemsRendered={({
-                          visibleColumnStartIndex,
-                          visibleRowStartIndex,
-                        }) => {
-                          const msgId =
-                            mediaMessageIds[
-                              visibleRowStartIndex * itemsPerRow +
-                                visibleColumnStartIndex
-                            ]
-                          const message = mediaLoadResult[msgId]
-                          if (!message) {
-                            return
-                          }
-                          this.updateFirstVisibleMessage(message)
-                        }}
-                      >
-                        {({ columnIndex, rowIndex, style }) => {
-                          const msgId =
-                            mediaMessageIds[
-                              rowIndex * itemsPerRow + columnIndex
-                            ]
-                          const message = mediaLoadResult[msgId]
-                          if (!message) {
-                            return null
-                          }
-                          return (
-                            <div
-                              style={{ ...style }}
-                              className='item'
-                              key={msgId}
-                            >
-                              <this.state.element
-                                messageId={msgId}
-                                loadResult={message}
-                                openFullscreenMedia={this.openFullscreenMedia.bind(
-                                  this
-                                )}
-                              />
-                            </div>
-                          )
-                        }}
-                      </FixedSizeGrid>
-                    )
-                  }}
-                </AutoSizer>
-              )}
-            </div>
+                  return (
+                    <FixedSizeGrid
+                      width={width}
+                      height={height}
+                      columnWidth={itemWidth}
+                      rowHeight={itemHeight}
+                      columnCount={itemsPerRow}
+                      rowCount={rowCount}
+                      overscanRowCount={10}
+                      onItemsRendered={({
+                        visibleColumnStartIndex,
+                        visibleRowStartIndex,
+                      }) => {
+                        const msgId =
+                          mediaMessageIds[
+                            visibleRowStartIndex * itemsPerRow +
+                              visibleColumnStartIndex
+                          ]
+                        const message = mediaLoadResult[msgId]
+                        if (!message) {
+                          return
+                        }
+                        this.updateFirstVisibleMessage(message)
+                      }}
+                    >
+                      {({ columnIndex, rowIndex, style }) => {
+                        const msgId =
+                          mediaMessageIds[rowIndex * itemsPerRow + columnIndex]
+                        const message = mediaLoadResult[msgId]
+                        if (!message) {
+                          return null
+                        }
+                        return (
+                          <div
+                            style={{ ...style }}
+                            className='item'
+                            key={msgId}
+                          >
+                            <this.state.element
+                              messageId={msgId}
+                              loadResult={message}
+                              openFullscreenMedia={this.openFullscreenMedia.bind(
+                                this
+                              )}
+                            />
+                          </div>
+                        )
+                      }}
+                    </FixedSizeGrid>
+                  )
+                }}
+              </AutoSizer>
+            )}
           </div>
         </div>
       </div>

--- a/src/renderer/components/SmallScreenModeMacOSTitleBar.tsx
+++ b/src/renderer/components/SmallScreenModeMacOSTitleBar.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react'
+import { appWindowTitle } from '../../shared/constants'
+
+/** because the window is borderless and the traffic lights hover over the document on MacOS,
+ *  we need some more space so the traffic lights (close, minimize fullscreen buttons)
+ *  do not overlay over the content, this bar is a spacer. */
+export function SmallScreenModeMacOSTitleBar() {
+  const [hasFocus, setHasFocus] = useState(true)
+
+  useEffect(() => {
+    const updateIsFocused = () => setHasFocus(document.hasFocus())
+
+    window.addEventListener('focus', updateIsFocused)
+    window.addEventListener('blur', updateIsFocused)
+    return () => {
+      window.removeEventListener('focus', updateIsFocused)
+      window.removeEventListener('blur', updateIsFocused)
+    }
+  }, [])
+
+  return (
+    <div
+      style={{
+        height: '26px',
+        lineHeight: '26px',
+        textAlign: 'center',
+        //@ts-ignore
+        '-webkit-app-region': 'drag',
+        flexShrink: 0,
+        flexGrow: 0,
+        backgroundColor: '#2c2c2c',
+        color: hasFocus ? '#d2d2d2' : '#565656',
+        fontWeight: 'bold',
+      }}
+    >
+      {appWindowTitle}
+    </div>
+  )
+}

--- a/src/renderer/components/dialogs/FullscreenAvatar.tsx
+++ b/src/renderer/components/dialogs/FullscreenAvatar.tsx
@@ -60,7 +60,7 @@ export default function FullscreenAvatar(
             </TransformWrapper>
           </div>
         </div>
-        <div className='btn-wrapper'>
+        <div className='btn-wrapper no-drag'>
           <div
             role='button'
             onClick={saveAs}

--- a/src/renderer/components/dialogs/FullscreenMedia.tsx
+++ b/src/renderer/components/dialogs/FullscreenMedia.tsx
@@ -244,7 +244,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
       <div className='render-media-wrapper' tabIndex={0}>
         <div className='attachment-view'>{elm}</div>
         {elm && (
-          <div className='btn-wrapper'>
+          <div className='btn-wrapper no-drag'>
             <div
               role='button'
               onClick={onDownload.bind(null, msg)}

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -42,7 +42,6 @@ import { ScreenContext } from '../../contexts/ScreenContext'
 
 import type { T } from '@deltachat/jsonrpc-client'
 
-
 export type AlternativeView = 'global-gallery' | null
 
 type Props = {
@@ -184,26 +183,26 @@ export default function MainScreen({ accountId }: Props) {
             <NavbarGroup align={Alignment.LEFT}>
               {showArchivedChats && (
                 <>
-                <div className='archived-chats-title no-drag'>
-                  {tx('chat_archived_chats_title')}
-                </div>
-                {/* reusing SearchInputButton here so that the button has the same style as the qr code button */}
-                <SearchInputButton
-                  className='no-drag'
-                  onClick={() => setArchivedChatsSelected(false)}
-                  aria-label={tx('back')}
-                  icon='undo'
-                />
-              </>
+                  <div className='archived-chats-title no-drag'>
+                    {tx('chat_archived_chats_title')}
+                  </div>
+                  {/* reusing SearchInputButton here so that the button has the same style as the qr code button */}
+                  <SearchInputButton
+                    className='no-drag'
+                    onClick={() => setArchivedChatsSelected(false)}
+                    aria-label={tx('back')}
+                    icon='undo'
+                  />
+                </>
               )}
               {!showArchivedChats && (
                 <SearchInput
-                id='chat-list-search'
-                inputRef={searchRef}
-                onChange={handleSearchChange}
-                onClear={queryChatId ? () => handleSearchClear() : undefined}
-                value={queryStr}
-              />
+                  id='chat-list-search'
+                  inputRef={searchRef}
+                  onChange={handleSearchChange}
+                  onClear={queryChatId ? () => handleSearchClear() : undefined}
+                  value={queryStr}
+                />
               )}
             </NavbarGroup>
           )}
@@ -236,13 +235,18 @@ export default function MainScreen({ accountId }: Props) {
                   aria-disabled={threeDotMenuHidden}
                 >
                   <Button
-                  id='three-dot-menu-button'
-                  className='navbar-button'
-                  aria-label={tx('main_menu')}
-                  onClick={onClickThreeDotMenu}
-                >
-                  <Icon coloring='navbar' icon='more' rotation={90} size={24} />
-                </Button>
+                    id='three-dot-menu-button'
+                    className='navbar-button'
+                    aria-label={tx('main_menu')}
+                    onClick={onClickThreeDotMenu}
+                  >
+                    <Icon
+                      coloring='navbar'
+                      icon='more'
+                      rotation={90}
+                      size={24}
+                    />
+                  </Button>
                 </span>
               )}
             </NavbarGroup>

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -268,7 +268,7 @@ export default function MainScreen({ accountId }: Props) {
           onUpdateGalleryView={updatethreeDotMenuHidden}
         />
       </div>
-      <ConnectivityToast />
+      {!chatListShouldBeHidden && <ConnectivityToast />}
     </div>
   )
 }

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -246,7 +246,7 @@ export default function MainScreen({ accountId }: Props) {
           )}
         </Navbar>
       </div>
-      <div>
+      <div className='main-app-content'>
         <ChatList
           queryStr={queryStr}
           showArchivedChats={showArchivedChats}

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -211,9 +211,12 @@ export default function MainScreen({ accountId }: Props) {
             <NavbarGroup align={Alignment.RIGHT}>
               {smallScreenMode && (
                 <span className='no-drag'>
-                  <Button aria-label={tx('back')} onClick={onBackButton}>
-                    <Icon icon='arrow-left'></Icon>
-                    {tx('back')}
+                  <Button
+                    aria-label={tx('back')}
+                    onClick={onBackButton}
+                    className='backButton'
+                  >
+                    <Icon icon='arrow-left' className='backButtonIcon'></Icon>
                   </Button>
                 </span>
               )}

--- a/src/renderer/contexts/ScreenContext.tsx
+++ b/src/renderer/contexts/ScreenContext.tsx
@@ -8,4 +8,5 @@ export const ScreenContext = createContext({
   screen: null as Screens | null,
   addAndSelectAccount: (() =>
     Promise.reject('screen context not defined')) as () => Promise<number>,
+  smallScreenMode: false as boolean,
 })

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,4 +1,4 @@
-export const appName = 'DeltaChat'
+export const appName = 'Delta Chat'
 export const homePageUrl = 'https://delta.chat'
 export const gitHubUrl = 'https://github.com/deltachat/deltachat-desktop'
 export const gitHubIssuesUrl = gitHubUrl + '/issues'


### PR DESCRIPTION


https://github.com/deltachat/deltachat-desktop/assets/18725968/84f288b4-586b-46ac-8612-914e3fd91ab9



- **break layout on small screens - only show chatview when a chat is selected otherwise show messagelist and account sidebar**
- **rm unused class**
- **use flexbox instead of hight calculation**
- **macOS show somekind of header over navbar that traffic lights don't clash with the ui in the small mode**

Even though we do not have the capacity right now to really support the usecase of using deltachat desktop electron on gnu+linux mobile phones yet, I started to make the splitscreen collabse to chat or chatlist+accountsSidebar, this should make it atleast usable again.
Also it helps desktop users with smaller screens or users that want to use a smaller window size for DC.

This pr also locks the min width for the chatlist to 295px.


## TODO:
- [x] rebase
- ~~clean-up code~~ I think it's not so bad / good enough now
- [x] better design for window titlebar in small mode on macOS
- [x] better back button design
- [x] hide offline toast in chat/message-list view

### Future improvement ideas:
- show some unread count badge on the back button (new messages or chats with new messages I'm not sure, and what is with accounts with new messages?)

### references

- closes #3649
- closes #3706