### PR TITLE
ImageCropper support smaller images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix message text "wobbling" on hover #3862
 - fix: close alternative options dialog when setting up as a second device #3873
 - fix map not opening #3876
+- fix ImageCropper not working on smaller images
 
 
 <a id="1_45_0"></a>

--- a/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/src/renderer/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -42,8 +42,8 @@ export default function ProfileImageSelector({
             shape: 'circle',
             onResult: setProfilePicture,
             onCancel: () => {},
-            targetWidth: 256,
-            targetHeight: 256,
+            desiredWidth: 256,
+            desiredHeight: 256,
           })
         }
       }}


### PR DESCRIPTION
- rename options targetWidth/Height to desiredWidth/Height
- if any of the dimensions is smaller than desiredWidth/Height we set new targetWidth/Height and work with smaller dimensions