### PR TITLE
fix: don't escape HTML in notification title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `v1.139.6`
 - Always show `msg.overrideSenderName` even when the message is sent by yourself
-- Secure notifications on linux: escape html, like signal does
+- Secure notifications on linux: escape html, like signal does #3875, #3890
 - Update translations (2024-06-01) #3871 #3888
 - adapt title of "Privacy Policy" link for default instance #3872
 - ContextMenuItem now can render icons #3811

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -27,6 +27,13 @@ function createNotification(data: DcNotification): Notification {
   const notificationOptions: Electron.NotificationConstructorOptions = {
     title:
       platform() === 'linux' ? filterNotificationText(data.title) : data.title,
+    // https://www.electronjs.org/docs/latest/tutorial/notifications#linux
+    // says
+    // > Notifications are sent using libnotify, which can show notifications
+    // > on any desktop environment that follows
+    // > [Desktop Notifications Specification](https://web.archive.org/web/20240428012536/https://specifications.freedesktop.org/notification-spec/notification-spec-latest.html)
+    // Which says that the body supports limited markup
+    // So let's escape it.
     body:
       platform() === 'linux' ? filterNotificationText(data.body) : data.body,
     icon,

--- a/src/main/notifications.ts
+++ b/src/main/notifications.ts
@@ -25,8 +25,7 @@ function createNotification(data: DcNotification): Notification {
   }
 
   const notificationOptions: Electron.NotificationConstructorOptions = {
-    title:
-      platform() === 'linux' ? filterNotificationText(data.title) : data.title,
+    title: data.title,
     // https://www.electronjs.org/docs/latest/tutorial/notifications#linux
     // says
     // > Notifications are sent using libnotify, which can show notifications


### PR DESCRIPTION
on Linux
Only body supports markup.
It also appears to be the same in the referenced Signal messenger code

This partially reverts https://github.com/deltachat/deltachat-desktop/commit/7a6f3dafb743cffdf8356080d40c1a6bb637ce45 (#3875)

