### PR TITLE
#3830 send contact as vcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,10 @@
 
 ### Added
 - Added a Small Screen Mode, when you rezise the window to be small it will only show the chatlist with account sidebar or the Chat View with a back button.
-- show VCard attachement as VCard in message list #3840
+- show VCard attachment as VCard in message list #3840
 - add contact from VCard & start chat on click #3840
 - Webxdc realtime support #3741
-- send contact as VCard form attachment context menu #3906
+- send contact as VCard from attachment context menu #3830
 
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `v1.140.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Added
+- send contact as VCard from attachment context menu #3830
+
 ### Fixed
 - Do not set min window dimensions on screens that are smaller than those min dimensions (such as linux phones)
 - packaging: respect `NO_ASAR` env var in `afterPackHook`
@@ -47,7 +50,6 @@
 - show VCard attachment as VCard in message list #3840
 - add contact from VCard & start chat on click #3840
 - Webxdc realtime support #3741
-- send contact as VCard from attachment context menu #3830
 
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `v1.140.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - show VCard attachement as VCard in message list #3840
 - add contact from VCard & start chat on click #3840
 - Webxdc realtime support #3741
+- send contact as VCard form attachment context menu #3906
 
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `v1.140.0`

--- a/src/main/cleanup_temp_dir.ts
+++ b/src/main/cleanup_temp_dir.ts
@@ -25,7 +25,7 @@ export async function cleanupDraftTempDir() {
         `found old ${files.length} temporary draft files, trying to delete them now`
       )
       const promises = []
-      for (const file in files) {
+      for (const file of files) {
         log.debug('delete', join(path, file))
         promises.push(rm(join(path, file)))
       }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -214,6 +214,9 @@ ${error instanceof Error ? error.message : inspect(error, { depth: null })}`
   ipcMain.handle('app.writeTempFileFromBase64', (_ev, name, content) =>
     writeTempFileFromBase64(name, content)
   )
+  ipcMain.handle('app.writeTempFile', (_ev, name, content) =>
+    writeTempFile(name, content)
+  )
   ipcMain.handle('app.removeTempFile', (_ev, path) => removeTempFile(path))
 
   ipcMain.handle('electron.shell.openExternal', (_ev, url) =>
@@ -322,6 +325,24 @@ export async function writeTempFileFromBase64(
   const pathToFile = join(getDraftTempDir(), basename(name))
   log.debug(`Writing base64 encoded file ${pathToFile}`)
   await writeFile(pathToFile, Buffer.from(content, 'base64'), 'binary')
+  return pathToFile
+}
+
+/**
+ * this function is only needed to temporarily
+ * save a VCard to attach it to a draft message
+ * should be removed once composer uses draft
+ * message id and set_draft_vcard can be used
+ * see https://github.com/deltachat/deltachat-core-rust/pull/5677
+ */
+export async function writeTempFile(
+  name: string,
+  content: string
+): Promise<string> {
+  await mkdir(getDraftTempDir(), { recursive: true })
+  const pathToFile = join(getDraftTempDir(), basename(name))
+  log.debug(`Writing tmp file ${pathToFile}`)
+  await writeFile(pathToFile, Buffer.from(content, 'utf8'), 'binary')
   return pathToFile
 }
 

--- a/src/renderer/components/composer/menuAttachment.tsx
+++ b/src/renderer/components/composer/menuAttachment.tsx
@@ -106,12 +106,12 @@ export default function MenuAttachment({
   ])
 
   const selectContact = async () => {
-    const { setLastPath } = rememberLastUsedPath(LastUsedSlot.Attachment)
     let dialogId = ''
     /**
      * TODO: reduce the overhead: just provide a vcardContact to draft/message
      * and send it as a message. No need to get the vcard from core to create
      * a tmp file to attach it as a file which is then converted into a vcardContact again
+     * see https://github.com/deltachat/deltachat-core-rust/pull/5677
      */
     const addContactAsVcard = async (selectedContact: T.Contact) => {
       if (selectedContact) {
@@ -123,11 +123,10 @@ export default function MenuAttachment({
           /[^a-z_A-Z0-9]/gi,
           ''
         )
-        const tmp_file = await runtime.writeTempFileFromBase64(
+        const tmp_file = await runtime.writeTempFile(
           `VCard-${cleanDisplayname}.vcf`,
-          btoa(vCardContact)
+          vCardContact
         )
-        setLastPath(dirname(tmp_file))
         addFileToDraft(tmp_file, 'Vcard')
         closeDialog(dialogId)
       }

--- a/src/renderer/components/dialogs/SelectContact/index.tsx
+++ b/src/renderer/components/dialogs/SelectContact/index.tsx
@@ -63,7 +63,6 @@ export default function SelectContactDialog({
               >
                 {({ index, style }) => {
                   const item = Array.from(searchContacts)[index][1]
-                  console.log(item)
                   const el = (() => {
                     const contact: T.Contact = item
                     return (

--- a/src/renderer/components/dialogs/SelectContact/index.tsx
+++ b/src/renderer/components/dialogs/SelectContact/index.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { C } from '@deltachat/jsonrpc-client'
+import { useContactSearch } from '../CreateChat'
+import Dialog, {
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+  FooterActionButton,
+  FooterActions,
+} from '../../Dialog'
+import styles from './styles.module.scss'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+import type { T } from '@deltachat/jsonrpc-client'
+import { DialogProps } from '../../../contexts/DialogContext'
+import { useContactsMap } from '../../contact/ContactList'
+import { ContactListItem } from '../../contact/ContactListItem'
+import { FixedSizeList } from 'react-window'
+import AutoSizer from 'react-virtualized-auto-sizer'
+
+/**
+ * display a dialog with a react-window of contacts
+ * and pass it to provided onOk function immediately
+ * after one contact is selected (clicked)
+ *
+ * TODO: this is a a adjusted copy of CreateChat dialog,
+ * we should provide one generic list of contacts components
+ * with some configurable extensions
+ */
+export default function SelectContactDialog({
+  onOk,
+  onClose,
+}: {
+  onOk: (contact: T.Contact) => void
+} & DialogProps) {
+  const [searchContacts, updateSearchContacts] = useContactsMap(
+    C.DC_GCL_ADD_SELF,
+    ''
+  )
+  const [queryStr, onSearchChange] = useContactSearch(updateSearchContacts)
+  const tx = useTranslationFunction()
+  return (
+    <Dialog width={400} onClose={onClose} fixed>
+      <DialogHeader>
+        <input
+          className='search-input'
+          onChange={onSearchChange}
+          value={queryStr}
+          placeholder={tx('contacts_enter_name_or_email')}
+          autoFocus
+          spellCheck={false}
+        />
+      </DialogHeader>
+      <DialogBody className={styles.selectContactDialogBody}>
+        {/* <AutoSizer> not working here ?? */}
+        <div className={styles.selectContactList}>
+          <AutoSizer disableWidth>
+            {({ height }) => (
+              <FixedSizeList
+                itemCount={Array.from(searchContacts).length}
+                itemKey={index => Array.from(searchContacts)[index][0]}
+                height={height}
+                width='100%'
+                itemSize={64}
+              >
+                {({ index, style }) => {
+                  const item = Array.from(searchContacts)[index][1]
+                  console.log(item)
+                  const el = (() => {
+                    const contact: T.Contact = item
+                    return (
+                      <ContactListItem
+                        contact={contact}
+                        onClick={onOk}
+                        showCheckbox={false}
+                        checked={false}
+                        showRemove={false}
+                      />
+                    )
+                  })()
+
+                  return <div style={style}>{el}</div>
+                }}
+              </FixedSizeList>
+            )}
+          </AutoSizer>
+        </div>
+      </DialogBody>
+      <DialogFooter>
+        <FooterActions>
+          <FooterActionButton onClick={onClose}>
+            {tx('close')}
+          </FooterActionButton>
+        </FooterActions>
+      </DialogFooter>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/dialogs/SelectContact/index.tsx
+++ b/src/renderer/components/dialogs/SelectContact/index.tsx
@@ -51,7 +51,6 @@ export default function SelectContactDialog({
         />
       </DialogHeader>
       <DialogBody className={styles.selectContactDialogBody}>
-        {/* <AutoSizer> not working here ?? */}
         <div className={styles.selectContactList}>
           <AutoSizer disableWidth>
             {({ height }) => (

--- a/src/renderer/components/dialogs/SelectContact/styles.module.scss
+++ b/src/renderer/components/dialogs/SelectContact/styles.module.scss
@@ -1,0 +1,10 @@
+/* needed to enable AutoSizer calculating dynamic height */
+.selectContactDialogBody {
+  height: 100vh;
+
+  display: flex;
+  flex-direction: column;
+}
+.selectContactList {
+  flex-grow: 1;
+}

--- a/src/renderer/runtime.ts
+++ b/src/renderer/runtime.ts
@@ -120,6 +120,7 @@ interface Runtime {
   ): void
   writeClipboardToTempFile(): Promise<string>
   writeTempFileFromBase64(name: string, content: string): Promise<string>
+  writeTempFile(name: string, content: string): Promise<string>
   removeTempFile(path: string): Promise<void>
   getWebxdcDiskUsage(accountId: number): Promise<{
     total_size: number
@@ -246,6 +247,9 @@ class Browser implements Runtime {
     throw new Error('Method not implemented.')
   }
   writeTempFileFromBase64(_name: string, _content: string): Promise<string> {
+    throw new Error('Method not implemented.')
+  }
+  writeTempFile(_name: string, _content: string): Promise<string> {
     throw new Error('Method not implemented.')
   }
   removeTempFile(_name: string): Promise<void> {
@@ -442,6 +446,9 @@ class Electron implements Runtime {
   }
   writeTempFileFromBase64(name: string, content: string): Promise<string> {
     return ipcBackend.invoke('app.writeTempFileFromBase64', name, content)
+  }
+  writeTempFile(name: string, content: string): Promise<string> {
+    return ipcBackend.invoke('app.writeTempFile', name, content)
   }
   removeTempFile(path: string): Promise<void> {
     return ipcBackend.invoke('app.removeTempFile', path)


### PR DESCRIPTION
Works for now but needs some improvements in core for the future as mentioned in some comments

1. reduce this overhead:  call rpc.makeVcard by contact id, save the Vcard in a tmp file and attach it to the message which is converted into a vcardContact again - would be easier just to add a vcardContact directly in draft message
2. avoid duplicate code in contact list with react-window: currently several contact list dialogs are using the CreateChat dialog (broadcast, addGroupMember etc.)