### PR TITLE
fix: i18n: wrong pluralization for many languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - fix tray icon explaination in settings that appears when started with `--minimized` #3949
 - performance: memorize MessageBody, don't run message parser multiple times for the same message #3951
 - performance: add limits for MessageBody text generally and for quotes, core already has limits on text size, but for the cases where core has a bug it's still useful to have a failsave #3951
+- Fix some strings not being translated on some locales (e.g. "1 minute" message age in Indonesian) #3910
+- Fix strings being incorrectly pluralized for many locales (such as "2 members" in Russian) #3910
 
 ### Removed
 - removed unused Roboto font variants #3949
@@ -64,8 +66,6 @@
 ### Fixed
 
 - Show error to user if core process exits unexpectedly #3904
-- Fix some strings not being translated on some locales (e.g. "1 minute" message age in Indonesian) #3910
-- Fix strings being incorrectly pluralized for many locales (such as "2 members" in Russian) #3910
 
 <a id="1_45_3"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@
 ### Fixed
 
 - Show error to user if core process exits unexpectedly #3904
+- Fix some strings not being translated on some locales (e.g. "1 minute" message age in Indonesian) #3910
+- Fix strings being incorrectly pluralized for many locales (such as "2 members" in Russian) #3910
 
 <a id="1_45_3"></a>
 

--- a/src/main/load-translations.ts
+++ b/src/main/load-translations.ts
@@ -37,7 +37,10 @@ export const tx: getMessageFunction = function (key, substitutions, raw_opts) {
 export default function setLanguage(locale: string) {
   const localeData = loadTranslations(locale)
   currentlocaleData = localeData
-  translateFunction = getTranslateFunction(localeData.messages)
+  translateFunction = getTranslateFunction(
+    localeData.locale,
+    localeData.messages
+  )
 }
 
 export function loadTranslations(locale: string) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -57,7 +57,7 @@ export default function App(_props: any) {
   async function reloadLocaleData(locale: string) {
     const localeData = await runtime.getLocaleData(locale)
     window.localeData = localeData
-    window.static_translate = translate(localeData.messages)
+    window.static_translate = translate(localeData.locale, localeData.messages)
     setLocaleData(localeData)
     moment.locale(localeData.locale)
     updateCoreStrings()

--- a/src/renderer/components/conversations/formatRelativeTime.ts
+++ b/src/renderer/components/conversations/formatRelativeTime.ts
@@ -45,13 +45,13 @@ export default function formatRelativeTime(
     const key = 'n_hours'
 
     return tx(key, String(diff.hours()), {
-      quantity: diff.hours() === 1 ? 'one' : 'other',
+      quantity: diff.hours(),
     })
   } else if (diff.minutes() >= 1) {
     const key = 'n_minutes'
 
     return tx(key, String(diff.minutes()), {
-      quantity: diff.minutes() === 1 ? 'one' : 'other',
+      quantity: diff.minutes(),
     })
   }
 

--- a/src/renderer/components/dialogs/CreateChat/index.tsx
+++ b/src/renderer/components/dialogs/CreateChat/index.tsx
@@ -363,11 +363,9 @@ function CreateGroup(props: CreateGroupProps) {
           />
         </DialogContent>
         <div className='group-separator'>
-          {tx(
-            'n_members',
-            groupMembers.length.toString(),
-            groupMembers.length <= 1 ? 'one' : 'other'
-          )}
+          {tx('n_members', groupMembers.length.toString(), {
+            quantity: groupMembers.length,
+          })}
         </div>
         <div className='group-member-contact-list-wrapper'>
           <PseudoListItemAddMember
@@ -471,11 +469,9 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
           <br />
           {broadcastRecipients.length > 0 && (
             <div className='group-separator'>
-              {tx(
-                'n_recipients',
-                broadcastRecipients.length.toString(),
-                broadcastRecipients.length == 1 ? 'one' : 'other'
-              )}
+              {tx('n_recipients', broadcastRecipients.length.toString(), {
+                quantity: broadcastRecipients.length,
+              })}
             </div>
           )}
           <div className='group-member-contact-list-wrapper'>

--- a/src/renderer/components/dialogs/ViewGroup.tsx
+++ b/src/renderer/components/dialogs/ViewGroup.tsx
@@ -247,16 +247,12 @@ function ViewGroupInner(
             )}
             <div className='group-separator'>
               {!isBroadcast
-                ? tx(
-                    'n_members',
-                    groupMembers.length.toString(),
-                    groupMembers.length == 1 ? 'one' : 'other'
-                  )
-                : tx(
-                    'n_recipients',
-                    groupMembers.length.toString(),
-                    groupMembers.length == 1 ? 'one' : 'other'
-                  )}
+                ? tx('n_members', groupMembers.length.toString(), {
+                    quantity: groupMembers.length,
+                  })
+                : tx('n_recipients', groupMembers.length.toString(), {
+                    quantity: groupMembers.length,
+                  })}
             </div>
             <div className='group-member-contact-list-wrapper'>
               {!chatDisabled && (

--- a/test/mocha/shared/localize.js
+++ b/test/mocha/shared/localize.js
@@ -79,7 +79,7 @@ describe('/shared/localize', () => { // the tests container
   })
 
   it('translations methods should work as expected', () => {
-    const tx = translate({
+    const tx = translate('ru', {
       test_a: {
         message: 'foo %1$s %2$s blubb',
       },
@@ -87,8 +87,14 @@ describe('/shared/localize', () => { // the tests container
         message: 'fo2o %s %d blu2bb',
       },
       test_c: {
-        other: '%n foo',
-        one: '1 foo',
+        one: '%n foo',
+        few: '%n few foos',
+        many: '%n many foos',
+        other: '%n other foos',
+      },
+      test_d: {
+        one: '%n foo',
+        other: '%n other foos',
       },
     })
 
@@ -96,6 +102,15 @@ describe('/shared/localize', () => { // the tests container
     expect(tx('test_b', ['asd', 'dsa'])).to.eq('fo2o asd dsa blu2bb')
     expect(tx('test_b')).to.eq('fo2o %s %d blu2bb')
 
+    expect(tx('test_c', ['1'], { quantity: 1 })).to.eq('1 foo')
+    expect(tx('test_c', ['2'], { quantity: 2 })).to.eq('2 few foos')
+    expect(tx('test_c', ['5'], { quantity: 5 })).to.eq('5 many foos')
+
+    // In case the string is untranslated, so it falls back to English
+    // which only has 'one' and 'other' plural categories.
+    // https://github.com/deltachat/deltachat-desktop/blob/b342a1d47b505e68caaec71f79c381c3f304405a/src/main/load-translations.ts#L67
+    expect(tx('test_d', ['1'], { quantity: 1 })).to.eq('1 foo')
+    expect(tx('test_d', ['5'], { quantity: 5 })).to.eq('5 other foos')
   })
 });
 


### PR DESCRIPTION
Closes #3870

Also fix some strings being displayed as keys and not actual strings, e.g. "1 minute" message age in Indonesian, which would show as "n_minutes:one" instead of "1 menit".

However, some strings are still not pluralized at all, such as `autodel_device_ask`, but let's consider that a different issue.

This is somewhat of an alternative to #3889 as a fix to the "message age" part of #3870