### PR TITLE
Small screen improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 ### Added
 - Add image cropper to setting group avatars #3905
 
+### Changed
+- do not open last chat when switching accounts in small screen mode
+- open last chat when exiting small screen mode
+
 ### Fix
 - Fix map in packaged build #3900
 - Fix removing group avatars #3905

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,13 @@
 - Add image cropper to setting group avatars #3905
 
 ### Changed
-- do not open last chat when switching accounts in small screen mode
-- open last chat when exiting small screen mode
+- do not open last chat when switching accounts in small screen mode #3912
+- open last chat when exiting small screen mode #3912
 
 ### Fix
 - Fix map in packaged build #3900
 - Fix removing group avatars #3905
-- Do not unselect chat when opening global map
+- Do not unselect chat when opening global map #3912
 
 <a id="1_45_2"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fix
 - Fix map in packaged build #3900
 - Fix removing group avatars #3905
+- Do not unselect chat when opening global map
 
 <a id="1_45_2"></a>
 

--- a/src/renderer/components/AccountListSidebar/AccountItem.tsx
+++ b/src/renderer/components/AccountListSidebar/AccountItem.tsx
@@ -14,6 +14,7 @@ import Icon from '../Icon'
 import styles from './styles.module.scss'
 
 import type { T } from '@deltachat/jsonrpc-client'
+import { openMapWebxdc } from '../../system-integration/webxdc'
 
 type Props = {
   account: T.Account
@@ -94,10 +95,7 @@ export default function AccountItem({
       label: tx('menu_global_map'),
       action: async () => {
         await onSelectAccount(account.id)
-        // set Timeout forces it to be run after react update
-        setTimeout(() => {
-          ActionEmitter.emitAction(KeybindAction.GlobalMap_Open)
-        }, 0)
+        openMapWebxdc(account.id)
       },
     },
     {

--- a/src/renderer/components/MessageListView.tsx
+++ b/src/renderer/components/MessageListView.tsx
@@ -7,7 +7,7 @@ import useChat from '../hooks/chat/useChat'
 import { ChatView } from '../contexts/ChatContext'
 import { RecoverableCrashScreen } from './screens/RecoverableCrashScreen'
 
-import type { AlternativeView } from './screens/MainScreen'
+import type { AlternativeView } from '../contexts/ChatContext'
 
 type Props = {
   accountId?: number

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -42,8 +42,6 @@ import { ScreenContext } from '../../contexts/ScreenContext'
 
 import type { T } from '@deltachat/jsonrpc-client'
 
-export type AlternativeView = 'global-gallery' | null
-
 type Props = {
   accountId?: number
 }
@@ -57,7 +55,7 @@ export default function MainScreen({ accountId }: Props) {
   const [queryStr, setQueryStr] = useState('')
   const [queryChatId, setQueryChatId] = useState<null | number>(null)
   const [archivedChatsSelected, setArchivedChatsSelected] = useState(false)
-  const { activeView, chatId, chat, selectChat, unselectChat } = useChat()
+  const { activeView, chatId, chat, alternativeView, selectChat, unselectChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
   // Small hack/misuse of keyBindingAction to setArchivedChatsSelected from
@@ -69,17 +67,6 @@ export default function MainScreen({ accountId }: Props) {
     setArchivedChatsSelected(false)
   )
 
-  const [alternativeView, setAlternativeView] = useState<AlternativeView>(null)
-  useEffect(() => {
-    if (chatId) {
-      setAlternativeView(null)
-    }
-  }, [chatId])
-  useKeyBindingAction(KeybindAction.GlobalGallery_Open, () => {
-    unselectChat()
-    setAlternativeView('global-gallery')
-  })
-
   const chatListShouldBeHidden =
     smallScreenMode && (chatId !== undefined || alternativeView !== null)
   const messageSectionShouldBeHidden =
@@ -87,7 +74,6 @@ export default function MainScreen({ accountId }: Props) {
 
   const onBackButton = () => {
     unselectChat()
-    setAlternativeView(null)
   }
 
   const onChatClick = (chatId: number) => {

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -55,7 +55,14 @@ export default function MainScreen({ accountId }: Props) {
   const [queryStr, setQueryStr] = useState('')
   const [queryChatId, setQueryChatId] = useState<null | number>(null)
   const [archivedChatsSelected, setArchivedChatsSelected] = useState(false)
-  const { activeView, chatId, chat, alternativeView, selectChat, unselectChat } = useChat()
+  const {
+    activeView,
+    chatId,
+    chat,
+    alternativeView,
+    selectChat,
+    unselectChat,
+  } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
   // Small hack/misuse of keyBindingAction to setArchivedChatsSelected from

--- a/src/renderer/components/screens/MainScreen.tsx
+++ b/src/renderer/components/screens/MainScreen.tsx
@@ -79,10 +79,6 @@ export default function MainScreen({ accountId }: Props) {
     unselectChat()
     setAlternativeView('global-gallery')
   })
-  useKeyBindingAction(KeybindAction.GlobalMap_Open, () => {
-    unselectChat()
-    openMapWebxdc()
-  })
 
   const chatListShouldBeHidden =
     smallScreenMode && (chatId !== undefined || alternativeView !== null)
@@ -417,7 +413,7 @@ function ChatNavButtons() {
         </Button>
         {settingsStore?.desktopSettings.enableOnDemandLocationStreaming && (
           <Button
-            onClick={() => openMapWebxdc(chatId)}
+            onClick={() => openMapWebxdc(selectedAccountId(), chatId)}
             active={activeView === ChatView.Map}
             aria-label={tx('tab_map')}
             className='navbar-button'

--- a/src/renderer/contexts/ChatContext.tsx
+++ b/src/renderer/contexts/ChatContext.tsx
@@ -8,7 +8,7 @@ import { BackendRemote } from '../backend-com'
 import type { MutableRefObject, PropsWithChildren } from 'react'
 import type { T } from '@deltachat/jsonrpc-client'
 
-type AlternativeView = 'global-gallery' | null
+export type AlternativeView = 'global-gallery' | null
 
 export enum ChatView {
   Map,

--- a/src/renderer/hooks/chat/useSelectLastChat.ts
+++ b/src/renderer/hooks/chat/useSelectLastChat.ts
@@ -1,17 +1,22 @@
-import { useCallback, useEffect } from 'react'
+import { useCallback, useContext, useEffect } from 'react'
 
 import useChat from './useChat'
 import useHasChanged from '../useHasChanged'
 import { BackendRemote } from '../../backend-com'
 import { getLastChatId } from '../../backend/chat'
+import { ScreenContext } from '../../contexts/ScreenContext'
 
 /**
  * Detects account changes and selects last known, selected chat for the user
  * for this account.
  */
 export default function useSelectLastChat(accountId?: number) {
+  const { smallScreenMode } = useContext(ScreenContext)
   const hasAccountIdChanged = useHasChanged(accountId)
-  const { selectChat } = useChat()
+  const hasSmallScreenModeChanged = useHasChanged(smallScreenMode)
+  const { selectChat, chatId, alternativeView } = useChat()
+
+  const smallScreenModeChatListVisible = !(chatId || alternativeView)
 
   const selectLastChat = useCallback(async () => {
     if (!accountId) {
@@ -22,15 +27,26 @@ export default function useSelectLastChat(accountId?: number) {
 
     if (account.kind === 'Configured') {
       const lastChatId = await getLastChatId(accountId)
-      if (lastChatId) {
+      if (lastChatId && !smallScreenMode) {
         await selectChat(accountId, lastChatId)
       }
     }
-  }, [accountId, selectChat])
+  }, [accountId, selectChat, smallScreenMode])
 
   useEffect(() => {
-    if (hasAccountIdChanged) {
+    if (
+      hasAccountIdChanged ||
+      (hasSmallScreenModeChanged &&
+        !smallScreenMode &&
+        smallScreenModeChatListVisible) /* if small screen mode changed to false and it was not inside of a chat or global gallery */
+    ) {
       selectLastChat()
     }
-  }, [hasAccountIdChanged, selectLastChat])
+  }, [
+    hasAccountIdChanged,
+    hasSmallScreenModeChanged,
+    smallScreenModeChatListVisible,
+    smallScreenMode,
+    selectLastChat,
+  ])
 }

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -15,7 +15,6 @@ export enum KeybindAction {
   MessageList_PageUp = 'msglist:pageup',
   MessageList_PageDown = 'msglist:pagedown',
   GlobalGallery_Open = 'globalgallery:open',
-  GlobalMap_Open = 'globalmap:open',
 
   // Actions that are not necessarily triggered by keybindings
   ChatList_SwitchToArchiveView = 'chatlist:switch-to-archive-view',

--- a/src/renderer/system-integration/webxdc.ts
+++ b/src/renderer/system-integration/webxdc.ts
@@ -4,7 +4,6 @@
 
 import { BackendRemote } from '../backend-com'
 import { runtime } from '../runtime'
-import { selectedAccountId } from '../ScreenController'
 
 export function initWebxdc() {
   BackendRemote.on('WebxdcStatusUpdate', (accountId, { msgId }) => {
@@ -42,6 +41,6 @@ export async function internalOpenWebxdc(accountId: number, messageId: number) {
   })
 }
 
-export async function openMapWebxdc(chatId?: number) {
-  runtime.openMapsWebxdc(selectedAccountId(), chatId)
+export async function openMapWebxdc(accountId: number, chatId?: number) {
+  runtime.openMapsWebxdc(accountId, chatId)
 }


### PR DESCRIPTION
- Do not unselect chat when opening global map
- move alternativeView (global gallery) state into chat context
- do not open last chat when switching accounts in small screen mode, fixes #3908 
- open last chat when exiting small screen mode, closes #3909


best reviewed commit by commit