### PR TITLE
skip `requestSingleInstanceLock` on mac appstore builds (mas), because it made it unable to start the app on older macOS devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- skip `requestSingleInstanceLock` on mac appstore builds (mas), because it made it unable to start the app on older macOS devices.
+
 <a id="1_46_0"></a>
 
 ## [v1.46.0] - 2024-06-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Fixed
-- skip `requestSingleInstanceLock` on mac appstore builds (mas), because it made it unable to start the app on older macOS devices.
+- skip `requestSingleInstanceLock` on mac appstore builds (mas), because it made it unable to start the app on older macOS devices. #3946
 
 <a id="1_46_0"></a>
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -70,7 +70,10 @@ protocol.registerSchemesAsPrivileged([
 const app = rawApp as ExtendedAppMainProcess
 app.rc = rc
 
-if (!app.requestSingleInstanceLock()) {
+// requestSingleInstanceLock always returns false on mas (mac app store) builds
+// due to electron issue https://github.com/electron/electron/issues/35540
+// dc-desktop issue: https://github.com/deltachat/deltachat-desktop/issues/3938
+if (!process.mas && !app.requestSingleInstanceLock()) {
   /* ignore-console-log */
   console.error('Only one instance allowed. Quitting.')
   app.quit()


### PR DESCRIPTION
closes #3938
