### PR TITLE
performance: memorize MessageBody, don't run message parser multiple times for the same message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - skip `requestSingleInstanceLock` on mac appstore builds (mas), because it made it unable to start the app on older macOS devices. #3946
 - fix tray icon explaination in settings that appears when started with `--minimized` #3949
+- performance: memorize MessageBody, don't run message parser multiple times for the same message #3951
 
 ### Removed
 - removed unused Roboto font variants #3949

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - skip `requestSingleInstanceLock` on mac appstore builds (mas), because it made it unable to start the app on older macOS devices. #3946
 - fix tray icon explaination in settings that appears when started with `--minimized` #3949
 - performance: memorize MessageBody, don't run message parser multiple times for the same message #3951
+- performance: add limits for MessageBody text generally and for quotes, core already has limits on text size, but for the cases where core has a bug it's still useful to have a failsave #3951
 
 ### Removed
 - removed unused Roboto font variants #3949

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -761,7 +761,12 @@ export const Quote = ({
             </>
           )}
           <div className='quoted-text'>
-            <MessageBody text={quote.text || ''} disableJumbomoji />
+            <MessageBody
+              text={
+                quote.text.slice(0, 3000 /* limit quoted message size */) || ''
+              }
+              disableJumbomoji
+            />
           </div>
         </div>
         {hasMessage && quote.image && (

--- a/src/renderer/components/message/MessageBody.tsx
+++ b/src/renderer/components/message/MessageBody.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { getSizeClass, replaceColons } from '../conversations/emoji'
 import { message2React } from './MessageMarkdown'
 
-export default function MessageBody({
+function MessageBody({
   text,
   disableJumbomoji,
 }: {
@@ -25,6 +25,9 @@ export default function MessageBody({
   return message2React(emojifiedText, false)
 }
 const trimRegex = /^[\s\uFEFF\xA0\n\t]+|[\s\uFEFF\xA0\n\t]+$/g
+
+// Do not run expensive message parser multiple times for the same message
+export default React.memo(MessageBody)
 
 /** removes linebreaks at start and end */
 function trim(str: string) {

--- a/src/renderer/components/message/MessageBody.tsx
+++ b/src/renderer/components/message/MessageBody.tsx
@@ -3,6 +3,9 @@ import classNames from 'classnames'
 import { getSizeClass, replaceColons } from '../conversations/emoji'
 import { message2React } from './MessageMarkdown'
 
+/** limit where message parser will not parse the message, limit of core is lower, this is just a failsafe */
+const UPPER_LIMIT_FOR_PARSED_MESSAGES = 20_000
+
 function MessageBody({
   text,
   disableJumbomoji,
@@ -10,6 +13,9 @@ function MessageBody({
   text: string
   disableJumbomoji?: boolean
 }): JSX.Element {
+  if (text.length >= UPPER_LIMIT_FOR_PARSED_MESSAGES) {
+    return <>{text}</>
+  }
   // if text is only emojis and Jumbomoji is enabled
   const emojifiedText = trim(text.replace(/:[\w\d_\-+]*:/g, replaceColons))
   if (!disableJumbomoji) {


### PR DESCRIPTION
- performance: memorize MessageBody, don't run message parser multiple times for the same message
- performance: add limits for MessageBody text generally and for quotes, core already has limits on text size, but for the cases where core has a bug it's still useful to have a failsave