### PR TITLE
improvement: wording for background_sync_disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Changed
+- reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960
+
 <a id="1_46_1"></a>
 
 ## [v1.46.1] - 2024-06-17

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -7,10 +7,10 @@
     "message": "No Account is selected"
   },
   "pref_background_sync_disabled": {
-    "message": "Disable Background Sync For All Accounts"
+    "message": "Only Synchronize the Currently Selected Account"
   },
   "explain_background_sync_disabled": {
-    "message": "Only synchronize the currently selected account; All the other accounts will be deactivated and get no notifications."
+    "message": "All the other accounts will be deactivated and get no notifications."
   },
   "background_sync_disabled_explaination": {
     "message": "Background Sync Disabled, Account is only synced when selected"


### PR DESCRIPTION
It was recently updated in #3717, and became a little awkward. The title could be interpreted as "disable sync for all accounts, including the current one".