### PR TITLE
consolidate wording for "Message Info"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 - reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960
+- use 'Info' and 'Message Info' consistently #3961
 
 ### Fixed
 - Fix crash on "Settings" click when not on main screen (e.g. no account selected): hide the "settings" button

--- a/src/renderer/components/attachment/mediaAttachment.tsx
+++ b/src/renderer/components/attachment/mediaAttachment.tsx
@@ -76,7 +76,7 @@ const contextMenuFactory = (
       action: () => jumpToMessage(accountId, message.id),
     },
     {
-      label: tx('menu_message_details'),
+      label: tx('info'),
       action: () => {
         openDialog(MessageDetail, { id: msgId })
       },

--- a/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
+++ b/src/renderer/components/dialogs/ChatAuditLogDialog.tsx
@@ -81,9 +81,9 @@ function buildContextMenu(
         navigator.clipboard.writeText(message.text || '')
       },
     },
-    // Message details
+    // Message Info
     {
-      label: tx('menu_message_details'),
+      label: tx('info'),
       action: openMessageInfo.bind(null, openDialog, message),
     },
   ]

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -312,9 +312,9 @@ function buildContextMenu(
         BackendRemote.rpc.resendMessages(selectedAccountId(), [message.id])
       },
     },
-    // Message details
+    // Message Info
     {
-      label: tx('menu_message_details'),
+      label: tx('info'),
       action: openMessageInfo.bind(null, openDialog, message),
     },
     // Delete message


### PR DESCRIPTION
gist is to use an easier, less cluttering language - before, we had context menu items named 'Info', 'Message Details' or just 'i', opening then 'Message Details'.

together with https://github.com/deltachat/deltachat-android/pull/3137 , the menu entry will be named 'Info' everywhere and open a 'Message Info' dialog, this has the following benefits:

- inner consistency to other Delta Chat apps all apps have recognizable 'Info' in their context menu, opening a 'Message Info' dialog

- inner consistency to other desktopn menu entries: 'Message Details' is a little too much as the context 'Message' is already clear. (we also do not say 'Forward Message' or 'Reply to Message'; as an exception, we regard only 'Delete Message').

- also, 'Info' is shorter and fits better to the otherwise short menu titles.

- outer consistency: 'Info' is very well known for that kind of, well, info

to take full effect, strings need to be re-pulled,
however, this is no blocker and can be done also after merging.