### PR TITLE
feat: more shortcuts to switch between chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+## Added
+- More shortcuts to switch between chats: `Ctrl + PageDown`, `Ctrl + PageUp`, `Ctrl + Tab`, `Ctrl + Shift + Tab` #3984
+
 ### Changed
 - reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960
 - use 'Info' and 'Message Info' consistently #3961

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -2,7 +2,9 @@
 
 > If you are on mac replace alt with the option key.
 
-Switch between chats: `alt + arrow down`, `alt + arrow up`
+Switch between chats: `alt + arrow down`, `alt + arrow up`,
+`Ctrl + PageDown`, `Ctrl + PageUp`,
+`Ctrl + Tab`, `Ctrl + Shift + Tab`
 
 Scroll active chat into view ~~`alt + arrow left`~~ _(disabled until we find a better key combo, because this one collides with to mac system shortcut to move a word (see [#1796](https://github.com/deltachat/deltachat-desktop/issues/1796)))_
 

--- a/src/renderer/components/KeyboardShortcutHint.tsx
+++ b/src/renderer/components/KeyboardShortcutHint.tsx
@@ -217,6 +217,10 @@ export function getKeybindings(
         keyBindings: [
           ['Alt', 'ArrowUp'],
           ['Alt', 'ArrowDown'],
+          ['Control', 'PageUp'],
+          ['Control', 'PageDown'],
+          ['Control', 'Tab'],
+          ['Control', 'Shift', 'Tab'],
         ],
       },
       {

--- a/src/renderer/keybindings.ts
+++ b/src/renderer/keybindings.ts
@@ -71,6 +71,14 @@ export function keyDownEvent2Action(
       return KeybindAction.ChatList_SelectNextChat
     } else if (ev.altKey && ev.key === 'ArrowUp') {
       return KeybindAction.ChatList_SelectPreviousChat
+    } else if (ev.ctrlKey && ev.key === 'PageDown') {
+      return KeybindAction.ChatList_SelectNextChat
+    } else if (ev.ctrlKey && ev.key === 'PageUp') {
+      return KeybindAction.ChatList_SelectPreviousChat
+    } else if (ev.ctrlKey && ev.key === 'Tab') {
+      return !ev.shiftKey
+        ? KeybindAction.ChatList_SelectNextChat
+        : KeybindAction.ChatList_SelectPreviousChat
       // } else if (ev.altKey && ev.key === 'ArrowLeft') {
       // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
       //   return KeybindAction.ChatList_ScrollToSelectedChat
@@ -101,7 +109,11 @@ export function keyDownEvent2Action(
     }
   } else {
     // fire continuesly as long as button is pressed
-    if (ev.key === 'PageUp') {
+    if (ev.ctrlKey && ev.key === 'PageDown') {
+      return KeybindAction.ChatList_SelectNextChat
+    } else if (ev.ctrlKey && ev.key === 'PageUp') {
+      return KeybindAction.ChatList_SelectPreviousChat
+    } else if (ev.key === 'PageUp') {
       return KeybindAction.MessageList_PageUp
     } else if (ev.key === 'PageDown') {
       return KeybindAction.MessageList_PageDown


### PR DESCRIPTION
`Ctrl + PageDown`, `Ctrl + PageUp`,
`Ctrl + Tab`, `Ctrl + Shift + Tab`

These are used by Telegram: https://github.com/telegramdesktop/tdesktop/wiki/Keyboard-Shortcuts

Related MR: https://github.com/deltachat/deltachat-desktop/pull/3965

I tested it a bit. Appears to work, and not break existing "PageUp" shortcut. ~~Those on Mac, please verify that these shortcuts are alright.~~ see [comment about Mac below](https://github.com/deltachat/deltachat-desktop/pull/3984#issuecomment-2196586587)

![image](https://github.com/deltachat/deltachat-desktop/assets/39462442/56d2c41f-a75a-4459-9493-f13562315e94)
