### PR TITLE
fix: `webxdc_realtime` toggle incorrect value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix crash on "Settings" click when not on main screen (e.g. no account selected): hide the "settings" button
 - code: comply with react hook rules #3955
 - fix mailto dialog #3976
+- "Realtime Webxdc Channels" toggle not reflecting actual setting value #3992
 
 <a id="1_46_1"></a>
 

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -51,6 +51,7 @@ const settingsKeys: Array<keyof SettingsStoreState['settings']> = [
   'disable_idle',
   'media_quality',
   'is_chatmail',
+  'webxdc_realtime_enabled',
 ]
 
 class SettingsStore extends Store<SettingsStoreState | null> {


### PR DESCRIPTION
The toggle would show `false` after every UI reload event though the actual value is `true` ("1")

For reference, `disable_idle` was added correctly in 147d95624110a