### PR TITLE
refactor into proper function components, otherwise we would not be allowed to use hooks in those functions if they just return JSX without being a component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - "Realtime Webxdc Channels" toggle not reflecting actual setting value #3992
 - even faster load of contact lists in "New Chat" and "New Group" #3927
 - really hide 3dot menu when it is hidden #3998
+- fix react crash when downloading a video message on demand #4000
 
 <a id="1_46_1"></a>
 

--- a/src/renderer/components/message/Message.tsx
+++ b/src/renderer/components/message/Message.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useState,
-} from 'react'
+import React, { useCallback, useContext, useEffect, useState } from 'react'
 import reactStringReplace from 'react-string-replace'
 import classNames from 'classnames'
 import { C, T } from '@deltachat/jsonrpc-client'


### PR DESCRIPTION
fixes #3945
