### PR TITLE
fix: more `<InfiniteLoader>` fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fix bug that showed placeholders while searching in chat forward dialog until you scrolled #4001
 - Fix the problem of Quit menu item on WebXDC apps closes the whole DC app #3995
 - minor performance improvements #3981
+- fix chat list items (e.g. Archive) and contacts not showing up sometimes #4004
 
 <a id="1_46_1"></a>
 

--- a/src/renderer/components/dialogs/AddMember/AddMemberInnerDialog.tsx
+++ b/src/renderer/components/dialogs/AddMember/AddMemberInnerDialog.tsx
@@ -205,6 +205,20 @@ export function AddMemberInnerDialog({
     }
   }
 
+  const infiniteLoaderRef = useRef<InfiniteLoader | null>(null)
+  // By default InfiniteLoader assumes that each item's index in the list
+  // never changes. But in our case they do change because of filtering.
+  // This code ensures that the currently displayed items get loaded
+  // even if the scroll position didn't change.
+  // Relevant issues:
+  // - https://github.com/deltachat/deltachat-desktop/issues/3921
+  // - https://github.com/deltachat/deltachat-desktop/issues/3208
+  useEffect(() => {
+    infiniteLoaderRef.current?.resetloadMoreItemsCache(true)
+    // We could specify `useEffect`'s dependencies (the major one being
+    // `contactIds`) for some performance, but let's play it safe.
+  })
+
   return (
     <>
       <DialogHeader
@@ -237,6 +251,7 @@ export function AddMemberInnerDialog({
           <AutoSizer disableWidth>
             {({ height }) => (
               <InfiniteLoader
+                ref={infiniteLoaderRef}
                 itemCount={itemCount}
                 // Careful, keep in mind that the rendered array is not the same as
                 // contactIds, `InfiniteLoader` must not call `loadContacts`

--- a/src/renderer/components/dialogs/SelectContact/index.tsx
+++ b/src/renderer/components/dialogs/SelectContact/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 import Dialog, {
   DialogBody,
@@ -38,6 +38,21 @@ export default function SelectContactDialog({
     queryStr
   )
   const tx = useTranslationFunction()
+
+  const infiniteLoaderRef = useRef<InfiniteLoader | null>(null)
+  // By default InfiniteLoader assumes that each item's index in the list
+  // never changes. But in our case they do change because of filtering.
+  // This code ensures that the currently displayed items get loaded
+  // even if the scroll position didn't change.
+  // Relevant issues:
+  // - https://github.com/deltachat/deltachat-desktop/issues/3921
+  // - https://github.com/deltachat/deltachat-desktop/issues/3208
+  useEffect(() => {
+    infiniteLoaderRef.current?.resetloadMoreItemsCache(true)
+    // We could specify `useEffect`'s dependencies (the major one being
+    // `contactIds`) for some performance, but let's play it safe.
+  })
+
   return (
     <Dialog width={400} onClose={onClose} fixed>
       <DialogHeader>
@@ -55,6 +70,7 @@ export default function SelectContactDialog({
           <AutoSizer disableWidth>
             {({ height }) => (
               <InfiniteLoader
+                ref={infiniteLoaderRef}
                 itemCount={contactIds.length}
                 loadMoreItems={loadContacts}
                 // perf: consider using `isContactLoaded` from `useLazyLoadedContacts`


### PR DESCRIPTION
See commits

Please verify that the old skeleton issues didn't come back after the removal of those `useEffect`s.

fixes #3921
fixes #3208