### PR TITLE
fix: a11y: keyboard navigation: add outline and focusability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Added
 - More shortcuts to switch between chats: `Ctrl + PageDown`, `Ctrl + PageUp`, `Ctrl + Tab`, `Ctrl + Shift + Tab` #3984
+- Better keyboard accessibility: make more elements focusable, add outline them #4005
 
 ### Changed
 - reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960

--- a/scss/_global.scss
+++ b/scss/_global.scss
@@ -71,6 +71,12 @@ a {
 
 $unread-badge-size: 21px;
 
+// Let's not add `:not(:focus-visible)` since the blinking cursor
+// might be enough, (or it might not, we'll see).
+input:focus {
+  outline: none;
+}
+
 input[type='text'],
 input[type='search'],
 textarea {
@@ -80,15 +86,8 @@ textarea {
   }
 }
 
-input:focus {
-  outline: 0 !important;
-}
-
 //yellow/blue border fix
-button:focus {
-  outline: none;
-}
-button:focus {
+button:focus:not(:focus-visible) {
   outline: none;
 }
 

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -77,7 +77,7 @@
         background: none;
         cursor: pointer;
       }
-      &:focus {
+      &:focus:not(:focus-visible) {
         outline: none;
       }
     }
@@ -85,7 +85,7 @@
     .emoji-button {
       height: 40px;
       padding: 0px 3px;
-      &:focus {
+      &:focus:not(:focus-visible) {
         outline: none;
       }
       &:hover {
@@ -111,7 +111,7 @@
       border-radius: 180px;
       cursor: pointer;
 
-      &:focus {
+      &:focus:not(:focus-visible) {
         outline: none;
       }
 
@@ -127,7 +127,7 @@
         background-size: contain;
         vertical-align: middle;
 
-        &:focus {
+        &:focus:not(:focus-visible) {
           outline: none;
         }
       }
@@ -150,6 +150,8 @@
         color: var(--composerPlaceholderText);
       }
 
+      // Let's not add `:not(:focus-visible)` since the blinking cursor
+      // might be enough, (or it might not, we'll see).
       &:focus {
         outline: none;
       }

--- a/scss/composer/_composer.scss
+++ b/scss/composer/_composer.scss
@@ -60,11 +60,16 @@
     display: flex;
     align-items: flex-end;
 
+    .attachment-button,
+    .emoji-button {
+      background: none;
+      border: none;
+    }
+
     .attachment-button {
       width: 40px;
       height: 40px;
 
-      background: none;
       box-shadow: none;
       border: none;
 
@@ -91,7 +96,6 @@
         display: block;
         width: 25px;
         height: 25px;
-        margin-top: calc((40px - 25px) / 2);
         background-image: url(../images/emoji.png);
         background-size: contain;
       }

--- a/scss/manifest.scss
+++ b/scss/manifest.scss
@@ -5,6 +5,10 @@
 @import '../node_modules/@blueprintjs/icons/lib/css/blueprint-icons.css';
 @import '../node_modules/@blueprintjs/core/lib/css/blueprint.css';
 
+// Overwrites for third party node modules.
+// Above our styles, so that our styles take priority by being defined after.
+@import 'overwrites/_bp4-overwrites';
+
 // Global Settings, Variables, and Mixins
 @import 'variables';
 @import 'mixins';
@@ -67,9 +71,6 @@
 @import 'misc/_context_menu.scss';
 @import 'misc/_keyboard_hint_box.scss';
 @import 'misc/_search-input.scss';
-
-// Overwrites for third party node modules
-@import 'overwrites/_bp4-overwrites';
 
 // ConnectivityToast
 @import '_connectivity-toast';

--- a/scss/overwrites/_bp4-overwrites.scss
+++ b/scss/overwrites/_bp4-overwrites.scss
@@ -156,7 +156,8 @@
 .bp4-control input:focus ~ .bp4-control-indicator,
 input[type='text']:active,
 input[type='text']:focus {
-  outline: unset;
+  outline: revert;
+  outline-offset: revert;
 }
 
 .bp4-spinner-animation {

--- a/src/renderer/components/AccountListSidebar/styles.module.scss
+++ b/src/renderer/components/AccountListSidebar/styles.module.scss
@@ -162,7 +162,6 @@
   border: 0;
   height: 42px;
   margin: 0;
-  outline: 0;
   padding: 0;
   width: 42px;
 

--- a/src/renderer/components/ImageSelector/styles.module.scss
+++ b/src/renderer/components/ImageSelector/styles.module.scss
@@ -16,7 +16,6 @@
   height: 35px;
   justify-content: center;
   margin: 0;
-  outline: 0;
   padding: 0;
   position: absolute;
   right: 0;

--- a/src/renderer/components/QrReader/styles.module.scss
+++ b/src/renderer/components/QrReader/styles.module.scss
@@ -29,7 +29,6 @@
   filter: drop-shadow(1px 1px 2px rgba(0, 0, 0, 0.2));
   height: 35px;
   margin: 15px;
-  outline: 0;
   padding: 5px;
   position: absolute;
   right: 5px;

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -93,7 +93,7 @@ const Composer = forwardRef<
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
 
   const emojiAndStickerRef = useRef<HTMLDivElement>(null)
-  const pickerButtonRef = useRef<HTMLDivElement>(null)
+  const pickerButtonRef = useRef<HTMLButtonElement>(null)
 
   const tx = useTranslationFunction()
   const accountId = selectedAccountId()
@@ -370,14 +370,15 @@ const Composer = forwardRef<
               onPaste={handlePaste}
             />
           )}
-          <div
+          <button
+            type='button'
             className='emoji-button'
             ref={pickerButtonRef}
             onClick={onEmojiIconClick}
             aria-label={tx('emoji')}
           >
             <span />
-          </div>
+          </button>
           <div className='send-button-wrapper' onClick={composerSendMessage}>
             <button aria-label={tx('menu_send')} />
           </div>

--- a/static/main.html
+++ b/static/main.html
@@ -34,7 +34,7 @@
     <script type="text/javascript" src="./fix-missing-vars.js"></script>
     <script type="text/javascript" src="./bundle.js"></script>
     <div aria-hidden="true" style="position: absolute; touch-action: none; z-index: 0; user-select: none; pointer-events: none; opacity: 0;">
-      <input id="color-input" type="color" />
+      <input id="color-input" tabindex="-1" type="color" />
     </div>
   </body>
 </html>

--- a/static/test.html
+++ b/static/test.html
@@ -14,7 +14,7 @@
     <script type="text/javascript" src="./fix-missing-vars.js"></script>
     <script type="text/javascript" src="./bundle.js"></script>
     <div aria-hidden="true" style="position: absolute; touch-action: none; z-index: 0; user-select: none; pointer-events: none; opacity: 0;">
-      <input id='color-input' type='color'/>
+      <input id='color-input' tabindex='-1' type='color'/>
     </div>
 </body>
 </html>


### PR DESCRIPTION
See commit messages

I tested it. Appears to be working good, but some rarely used elements might get ugly even for mouse-only navigation.

This by no means makes DC fully keyboard-accessible, but it's an improvement.