### PR TITLE
clarify that the 'search field' is a 'search field'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960
 - use 'Info' and 'Message Info' consistently #3961
 - consolidate 'Profile' wording #3963
+- name "Search" fields as such #4015
 - Update local help (2024-06-19)
 - refactor: safer types #3993
 - keep aspect ratio in quoted images #3999

--- a/src/renderer/components/dialogs/MailtoDialog/index.tsx
+++ b/src/renderer/components/dialogs/MailtoDialog/index.tsx
@@ -57,7 +57,7 @@ export default function MailtoDialog(props: Props & DialogProps) {
               className='search-input'
               onChange={onSearchChange}
               value={queryStr}
-              placeholder={tx('contacts_enter_name_or_email')}
+              placeholder={tx('search')}
               autoFocus
               spellCheck={false}
             />

--- a/src/renderer/components/dialogs/SelectContact/index.tsx
+++ b/src/renderer/components/dialogs/SelectContact/index.tsx
@@ -60,7 +60,7 @@ export default function SelectContactDialog({
           className='search-input'
           onChange={e => setQueryStr(e.target.value)}
           value={queryStr}
-          placeholder={tx('contacts_enter_name_or_email')}
+          placeholder={tx('search')}
           autoFocus
           spellCheck={false}
         />

--- a/src/renderer/components/dialogs/WebxdcSendToChat/index.tsx
+++ b/src/renderer/components/dialogs/WebxdcSendToChat/index.tsx
@@ -95,7 +95,7 @@ export default function WebxdcSaveToChatDialog(props: Props) {
           className='search-input'
           onChange={onSearchChange}
           value={queryStr}
-          placeholder={tx('contacts_enter_name_or_email')}
+          placeholder={tx('search')}
           autoFocus
           spellCheck={false}
         />


### PR DESCRIPTION
in some contact/chat-select dialogs,
the call to 'enter sth' is misleading as not needed. it is just a 'search' and should be named as such.

the shorter text also unclutters UI and
fits to the approach to tune down 'email wording'.

<img width=340 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/55a683d6-bd9f-4137-a89c-3fd6553e3474>
<img width=340 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/44658235-bb0c-4592-8546-be04284f0e51><br>
<img width=300 src=https://github.com/deltachat/deltachat-desktop/assets/9800740/dc5fba75-c1ee-4ef2-a8bd-db584a07c567>

