### PR TITLE
consistent button wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960
 - use 'Info' and 'Message Info' consistently #3961
 - consolidate 'Profile' wording #3963
+- consolidate 'Export/Import secret keys' button format #4019
 - name "Search" fields as such #4015
 - Update local help (2024-06-19)
 - refactor: safer types #3993

--- a/src/renderer/components/Settings/ManageKeys.tsx
+++ b/src/renderer/components/Settings/ManageKeys.tsx
@@ -98,10 +98,10 @@ export default function ManageKeys() {
   return (
     <>
       <SettingsButton onClick={onKeysExport}>
-        {tx('pref_managekeys_export_secret_keys')}...
+        {tx('pref_managekeys_export_secret_keys')}
       </SettingsButton>
       <SettingsButton onClick={onKeysImport}>
-        {tx('pref_managekeys_import_secret_keys')}...
+        {tx('pref_managekeys_import_secret_keys')}
       </SettingsButton>
     </>
   )


### PR DESCRIPTION
we're not using three dots in buttons at most other places, in general it is not that usual (more in menus).
also, adding dots this would become an translation issue.

just do not add the three dots.