### PR TITLE
fix two account sidebar unread update bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@
 - fix chat list items (e.g. Archive) and contacts not showing up sometimes #4004
 - fix bug notifications not being removed on Mac  #4010
 - fix bug "Mark All as Read" does not remove notifications #4002
-- fix update unread badge on when muting / unmuting a chat
-- fix update unread badge on receiving device messages
+- fix update unread badge on when muting / unmuting a chat #4020
+- fix update unread badge on receiving device messages #4020
 
 <a id="1_46_1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - fix bug notifications not being removed on Mac  #4010
 - fix bug "Mark All as Read" does not remove notifications #4002
 - fix update unread badge on when muting / unmuting a chat
+- fix update unread badge on receiving device messages
 
 <a id="1_46_1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - fix chat list items (e.g. Archive) and contacts not showing up sometimes #4004
 - fix bug notifications not being removed on Mac  #4010
 - fix bug "Mark All as Read" does not remove notifications #4002
+- fix update unread badge on when muting / unmuting a chat
 
 <a id="1_46_1"></a>
 

--- a/src/renderer/components/AccountListSidebar/AccountItem.tsx
+++ b/src/renderer/components/AccountListSidebar/AccountItem.tsx
@@ -56,6 +56,11 @@ export default function AccountItem({
 
     const cleanup = [
       onDCEvent(account.id, 'IncomingMsg', update),
+      // IncomingMsg doesn't listen for added device messages,
+      // so we also listen to `ChatlistChanged` because it is a good indicator and not emitted too often
+      // https://github.com/deltachat/deltachat-desktop/issues/4013
+      onDCEvent(account.id, 'ChatlistChanged', update),
+
       onDCEvent(account.id, 'MsgsNoticed', update),
       // when muting or unmuting a chat
       onDCEvent(account.id, 'ChatModified', update),

--- a/src/renderer/components/AccountListSidebar/AccountItem.tsx
+++ b/src/renderer/components/AccountListSidebar/AccountItem.tsx
@@ -57,6 +57,8 @@ export default function AccountItem({
     const cleanup = [
       onDCEvent(account.id, 'IncomingMsg', update),
       onDCEvent(account.id, 'MsgsNoticed', update),
+      // when muting or unmuting a chat
+      onDCEvent(account.id, 'ChatModified', update),
     ]
 
     return () => cleanup.forEach(off => off())


### PR DESCRIPTION
- **fix update unread badge on when muting / unmuting a chat**
- **fix update unread badge on receiving device messages: update unread count also on `ChatlistChanged`, because `IncomingMsg` does not notify on new device messages**

closes #4013