### PR TITLE
Preset lastChatId before switching accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - fix bug "Mark All as Read" does not remove notifications #4002
 - fix update unread badge on when muting / unmuting a chat #4020
 - fix update unread badge on receiving device messages #4020
+- fix target chat was not opened on notification click #3983
 
 <a id="1_46_1"></a>
 


### PR DESCRIPTION
resolves #3983

The error came from the wrong accountId in selectChat which still had the state from the time it was set via runtime.setNotificationCallback

This change also avoids the loading of (the possibly wrong) lastChat, which is triggered by switching account, but might be superfluous if the chat from notification is not the lastChat
