### PR TITLE
feat: paste invite link to search to add contact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New keyboard shortcuts (experimental setting): Telegram-style Ctrl+Up/Down to select the message to reply to #3965
 - More shortcuts to switch between chats: `Ctrl + PageDown`, `Ctrl + PageUp`, `Ctrl + Tab`, `Ctrl + Shift + Tab` #3984
 - Better keyboard accessibility: make more elements focusable, add outline them #4005
+- a way to add contact by pasting invite link to the search field #4041
 
 ### Changed
 - reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960

--- a/src/renderer/components/chat/ChatList.tsx
+++ b/src/renderer/components/chat/ChatList.tsx
@@ -23,7 +23,10 @@ import {
   ChatListItemRowContact,
   ChatListItemRowMessage,
 } from './ChatListItemRow'
-import { PseudoListItemAddContact } from '../helpers/PseudoListItem'
+import {
+  PseudoListItemAddContact,
+  PseudoListItemAddContactFromInviteLink,
+} from '../helpers/PseudoListItem'
 import { KeybindAction } from '../../keybindings'
 import { useThemeCssVar } from '../../ThemeManager'
 import { BackendRemote, onDCEvent, Type } from '../../backend-com'
@@ -40,6 +43,7 @@ import type {
   ContactChatListItemData,
   MessageChatListItemData,
 } from './ChatListItemRow'
+import { isInviteLink } from '../../../shared/util'
 
 const enum LoadStatus {
   FETCHING = 1,
@@ -201,12 +205,17 @@ export default function ChatList(props: {
       contactIds.length * CHATLISTITEM_CONTACT_HEIGHT
     )
 
+  const showPseudoListItemAddContactFromInviteLink =
+    queryStr && isInviteLink(queryStr)
   const messagesHeight = (height: number) =>
     height -
     (DIVIDER_HEIGHT * 3 +
       chatsHeight(height) +
       contactsHeight(height) +
       (chatListIds.length == 0 && queryStrIsValidEmail
+        ? CHATLISTITEM_MESSAGE_HEIGHT
+        : 0) +
+      (showPseudoListItemAddContactFromInviteLink
         ? CHATLISTITEM_MESSAGE_HEIGHT
         : 0))
 
@@ -421,6 +430,14 @@ export default function ChatList(props: {
                         />
                       </div>
                     )}
+                  {showPseudoListItemAddContactFromInviteLink && (
+                    <div style={{ width: width }}>
+                      <PseudoListItemAddContactFromInviteLink
+                        inviteLink={queryStr!}
+                        accountId={accountId}
+                      />
+                    </div>
+                  )}
                   <div
                     className='search-result-divider'
                     style={{ width: width }}

--- a/src/renderer/components/helpers/PseudoListItem.tsx
+++ b/src/renderer/components/helpers/PseudoListItem.tsx
@@ -4,6 +4,7 @@ import { PseudoContact } from '../contact/Contact'
 import { QRAvatar } from '../Avatar'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { useSettingsStore } from '../../stores/settings'
+import useProcessQR from '../../hooks/useProcessQr'
 
 export function PseudoListItem(
   props: PropsWithChildren<{
@@ -107,5 +108,27 @@ export const PseudoListItemAddContact = ({
       }
       onClick={onClick}
     />
+  )
+}
+
+export const PseudoListItemAddContactFromInviteLink = ({
+  inviteLink,
+  accountId,
+}: {
+  inviteLink: string
+  accountId: number
+}) => {
+  const tx = useTranslationFunction()
+  const processQr = useProcessQR()
+
+  return (
+    <PseudoListItem
+      id='newcontactfrominvitelink'
+      cutoff='+'
+      text={tx('menu_new_contact')}
+      onClick={() => processQr(accountId, inviteLink.trim())}
+    />
+    // Perhaps we could also parse username from the link
+    // and put it into `subText`.
   )
 }


### PR DESCRIPTION
Adds a pseudo item similar to "add contact" when you type an email

The "standard" way of pasting the invite link under the gear button
on the second tab of the "scan QR" dialog is not very straigtforward.

The first reflex is to paste it in the search field,
so let's handle this.

![image](https://github.com/user-attachments/assets/e512336c-1dd6-4891-84fa-fd6d0469dea2)
