### PR TITLE
Show displayname in ask start chat with

### DIFF
--- a/src/renderer/components/dialogs/AddMember/AddMemberDialog.tsx
+++ b/src/renderer/components/dialogs/AddMember/AddMemberDialog.tsx
@@ -74,7 +74,8 @@ export const AddMemberChip = (props: {
         />
       </div>
       <div className={styles.DisplayName}>
-        <div>{contact.displayName}</div> {contact.isVerified && <InlineVerifiedIcon />}
+        <div>{contact.displayName}</div>
+        {contact.isVerified && <InlineVerifiedIcon />}
       </div>
       <div
         className={styles.removeMember}

--- a/src/renderer/hooks/useProcessQr.ts
+++ b/src/renderer/hooks/useProcessQr.ts
@@ -105,7 +105,10 @@ export default function useProcessQR() {
         )
 
         const userConfirmed = await openConfirmationDialog({
-          message: tx('instant_onboarding_confirm_contact', contact.address),
+          message: tx(
+            'instant_onboarding_confirm_contact',
+            contact.nameAndAddr
+          ),
           confirmLabel: tx('ok'),
         })
 

--- a/src/renderer/hooks/useSecureJoin.ts
+++ b/src/renderer/hooks/useSecureJoin.ts
@@ -29,7 +29,7 @@ export default function useSecureJoin() {
       )
 
       return await openConfirmationDialog({
-        message: tx('ask_start_chat_with', contact.address),
+        message: tx('ask_start_chat_with', contact.nameAndAddr),
         confirmLabel: tx('ok'),
       })
     },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9506c7f2-c039-41da-9a9d-8dd02e631201)

Only showing the mail address can be confusing, since often people don't know the Maildress only the displayname