### PR TITLE
'read receipt' string is no longer needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
   - Display vCard contact name in the message summary
   - Case-insensitive search for non-ASCII messages
 - make ImageCropper use CSS-transforms for UI and canvas API to cut the result #3893
+- update stock translations #4051
 
 ### Fixed
 - Fix crash on "Settings" click when not on main screen (e.g. no account selected): hide the "settings" button

--- a/src/renderer/stockStrings.ts
+++ b/src/renderer/stockStrings.ts
@@ -26,8 +26,6 @@ export async function updateCoreStrings() {
   // strings[C.DC_STR_ENCR_NONE] = tx('DC_STR_ENCR_NONE')
   strings[C.DC_STR_FINGERPRINTS] = tx('qrscan_fingerprint_label')
   strings[C.DC_STR_CANTDECRYPT_MSG_BODY] = tx('systemmsg_cannot_decrypt')
-  strings[C.DC_STR_READRCPT] = tx('systemmsg_read_receipt_subject')
-  strings[C.DC_STR_READRCPT_MAILBODY] = tx('systemmsg_read_receipt_body')
   strings[C.DC_STR_E2E_PREFERRED] = tx('autocrypt_prefer_e2ee')
   strings[C.DC_STR_ARCHIVEDCHATS] = tx('chat_archived_chats_title')
   strings[C.DC_STR_AC_SETUP_MSG_SUBJECT] = tx('autocrypt_asm_subject')


### PR DESCRIPTION
this PR removes setting the 'read receipt' stock string.

see https://github.com/deltachat/deltachat-android/issues/3179 and  https://github.com/deltachat/deltachat-core-rust/pull/5802 for reasoning.

