### PR TITLE
Add Clone Group functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - a way to add contact by pasting invite link to the search field #4041
 - add on-screen controls to ImageCropper and the ability to rotate by 90 degrees #3893
 - Added UI for read receipts in message info dialog #4036
+- add Clone Group functionality to chat list context menu #3933
 
 ### Changed
 - reword advanced setting "Disable Background Sync For All Accounts" -> "Only Synchronize the Currently Selected Account" #3960

--- a/src/renderer/components/chat/ChatListContextMenu.tsx
+++ b/src/renderer/components/chat/ChatListContextMenu.tsx
@@ -9,6 +9,7 @@ import { selectedAccountId } from '../../ScreenController'
 import { ContextMenuContext } from '../../contexts/ContextMenuContext'
 import { unmuteChat } from '../../backend/chat'
 import useChat from '../../hooks/chat/useChat'
+import { CloneChat } from '../dialogs/CreateChat'
 import useChatDialog from '../../hooks/chat/useChatDialog'
 import useDialog from '../../hooks/dialog/useDialog'
 import useOpenViewGroupDialog from '../../hooks/dialog/useOpenViewGroupDialog'
@@ -225,6 +226,16 @@ export function useChatListContextMenu(): {
                 label: tx('menu_edit_group'),
                 action: onViewGroup,
               },
+            // Clone Group
+            chatListItem.isGroup && {
+              label: tx('clone_chat'),
+              action: () => {
+                openDialog(CloneChat, {
+                  setViewMode: 'createGroup',
+                  chatTemplateId: chatListItem.id,
+                })
+              },
+            },
             // Edit Broadcast List
             chatListItem.isBroadcast && {
               label: tx('menu_edit_broadcast_list'),


### PR DESCRIPTION
- useCreateGroup returned function (CreateGroup) now accepts optional groupTemplateId same way Android/iOS version do, this is a group chat id to base new chat on

- resolves #3933