### PR TITLE
Truncate strings in chat list preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
   - Display vCard contact name in the message summary
   - Case-insensitive search for non-ASCII messages
 - upgrade `electron` from `30.0.2` to `30.3.1`
+- truncate message previews in chat list #4059
+- renderElementPreview calls renderElementPreview for message element children #4059
 
 ### Fixed
 - Fix crash on "Settings" click when not on main screen (e.g. no account selected): hide the "settings" button

--- a/scss/chat/_chat-list-item.scss
+++ b/scss/chat/_chat-list-item.scss
@@ -110,6 +110,11 @@
         color: var(--chat-list-item-summary-text);
         user-select: none;
 
+        .truncated {
+          text-overflow: ellipsis;
+          overflow: hidden;
+        }
+
         & > .summary_thumbnail {
           height: 18px;
           width: 18px;

--- a/src/renderer/components/chat/ChatListItem.tsx
+++ b/src/renderer/components/chat/ChatListItem.tsx
@@ -116,7 +116,7 @@ function Message({
             }}
           />
         )}
-        <div>{message2React(summaryText2 || '', true)}</div>
+        {message2React(summaryText2 || '', true)}
       </div>
       {isContactRequest && (
         <div className='label'>

--- a/src/renderer/components/message/MessageMarkdown.tsx
+++ b/src/renderer/components/message/MessageMarkdown.tsx
@@ -111,23 +111,19 @@ function renderElementPreview(elm: ParsedElement, key?: number): JSX.Element {
       )
 
     case 'StrikeThrough':
-      return <s key={key}>{elm.c.map(renderElement)}</s>
+      return <s key={key}>{elm.c.map(renderElementPreview)}</s>
 
     case 'Italics':
-      return <i key={key}>{elm.c.map(renderElement)}</i>
+      return <i key={key}>{elm.c.map(renderElementPreview)}</i>
 
     case 'Bold':
-      return <b key={key}>{elm.c.map(renderElement)}</b>
+      return <b key={key}>{elm.c.map(renderElementPreview)}</b>
 
     case 'Link':
       return <span key={key}>{elm.c.destination.target}</span>
 
     case 'LabeledLink':
-      return (
-        <span key={key}>
-          <span>{elm.c.label.map(renderElement)}</span>{' '}
-        </span>
-      )
+      return <span key={key}>{elm.c.label.map(renderElementPreview)} </span>
 
     case 'Linebreak':
       return <span key={key}>{''}</span>
@@ -141,9 +137,9 @@ function renderElementPreview(elm: ParsedElement, key?: number): JSX.Element {
       //@ts-ignore
       log.error(`type ${elm.t} not known/implemented yet`, elm)
       return (
-        <span key={key} style={{ color: 'red' }}>
+        <div key={key} style={{ color: 'red' }}>
           {JSON.stringify(elm)}
-        </span>
+        </div>
       )
   }
 }
@@ -151,7 +147,11 @@ function renderElementPreview(elm: ParsedElement, key?: number): JSX.Element {
 export function message2React(message: string, preview: boolean): JSX.Element {
   try {
     const elements = parseMessage(message)
-    return <>{elements.map(preview ? renderElementPreview : renderElement)}</>
+    return preview ? (
+      <div className='truncated'>{elements.map(renderElementPreview)}</div>
+    ) : (
+      <>{elements.map(renderElement)}</>
+    )
   } catch (error) {
     log.error('parseMessage failed:', { input: message, error })
     return <>{message}</>


### PR DESCRIPTION
- add truncated-class to text preview in chat list
- removed excessive div from chat message preview
- resolves #4049