### PR TITLE
Fix empty context menu in HTML viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fix missing remove button in AddMemberChip #393
 - fix composite emoji in text avatar #4038
 - fix "Password and Account" dialog not indicating invalid credentials, making it seem that you can change password like this #4032
+- fix empty context menu and unneccessary separators in HTML mail view #4053
 
 <a id="1_46_1"></a>
 


### PR DESCRIPTION
- don't disply HTML mail viewer context menu if it's empty
- hide unnecessary separators
- resolves #4053