### PR TITLE
fix: "Create chat" floating button wrong position

### DIFF
--- a/scss/chat/_chat-list.scss
+++ b/scss/chat/_chat-list.scss
@@ -9,6 +9,8 @@
     0 0 0 rgba(16, 22, 26, 0),
     0 1px 1px rgba(16, 22, 26, 0.2);
   user-select: none;
+  // So that `.floating-action-button` is positioned relative to `.chat-list`.
+  position: relative;
 
   .search-result-divider {
     line-height: 43px;


### PR DESCRIPTION
Apparently introduced by a dependency upgrade, prior to which `.chat-list` had `style="position: relative;"`.

This needs no CHANGELOG entry because no release has been made with this bug.