### PR TITLE
fix: "Contact info" contents jumping continuously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - fix HTML email content not being zoomed #4052
 - fix Icon preview of latest WebXDC displayed when summary is reaction event #4062
 - fix stretched summaryPreviewIcon #4064
+- fix "Contact info" card layout continuously jumping for contact names of certain length #4068
 
 
 <a id="1_46_1"></a>

--- a/src/renderer/components/dialogs/ViewProfile/index.tsx
+++ b/src/renderer/components/dialogs/ViewProfile/index.tsx
@@ -300,7 +300,7 @@ export function ViewProfileInner({
                   loadMoreRows={loadChats}
                   rowCount={chatListIds.length}
                   width={width}
-                  height={height}
+                  height={height - 2}
                   itemKey={index => 'key' + chatListIds[index]}
                   itemHeight={CHATLISTITEM_CHAT_HEIGHT}
                 >


### PR DESCRIPTION
given the right contact name length, e.g. "aaaaaaa@example.com"

Not the best solution, but appears to work for now.

Closes https://github.com/deltachat/deltachat-desktop/issues/3971