### PR TITLE
ReactionsDialog: drop email, make rows clickable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 ### Changed
+- do not display email adresses in reactions dialog #4066
+- click on a row in reactions dialog opens contact profile #4066
 
 ### Fixed
 

--- a/src/renderer/components/ContactName/index.tsx
+++ b/src/renderer/components/ContactName/index.tsx
@@ -6,7 +6,7 @@ import styles from './styles.module.scss'
 
 type Props = {
   displayName: string
-  address: string
+  address?: string
   isVerified?: boolean
 }
 
@@ -17,7 +17,9 @@ export default function ContactName(props: Props) {
         <span className={styles.contactNameTruncated}>{props.displayName}</span>
         {props.isVerified && <InlineVerifiedIcon />}
       </div>
-      <div className={styles.contactNameAddress}>{props.address}</div>
+      {!!props.address && (
+        <div className={styles.contactNameAddress}>{props.address}</div>
+      )}
     </div>
   )
 }

--- a/src/renderer/components/dialogs/ReactionsDialog/styles.module.scss
+++ b/src/renderer/components/dialogs/ReactionsDialog/styles.module.scss
@@ -6,6 +6,14 @@
   align-items: center;
   display: flex;
   justify-content: space-between;
+  border-radius: 10px;
+}
+
+.reactionsDialogListClickable {
+  cursor: pointer;
+  &:hover {
+    background-color: var(--chatListItemBgHover);
+  }
 }
 
 .reactionsDialogAvatar {

--- a/src/renderer/components/dialogs/ViewProfile/index.tsx
+++ b/src/renderer/components/dialogs/ViewProfile/index.tsx
@@ -62,9 +62,10 @@ export default function ViewProfile(
   props: {
     contact: T.Contact
     onBack?: () => void
+    onAction?: () => void
   } & DialogProps
 ) {
-  const { onClose, onBack } = props
+  const { onClose, onBack, onAction } = props
 
   const accountId = selectedAccountId()
   const tx = useTranslationFunction()
@@ -110,7 +111,11 @@ export default function ViewProfile(
         onClickBack={onBack}
       />
       <DialogBody className={styles.viewProfileDialogBody}>
-        <ViewProfileInner contact={contact} onClose={onClose} />
+        <ViewProfileInner
+          contact={contact}
+          onClose={onClose}
+          onAction={onAction}
+        />
       </DialogBody>
     </Dialog>
   )
@@ -119,9 +124,11 @@ export default function ViewProfile(
 export function ViewProfileInner({
   contact,
   onClose,
+  onAction,
 }: {
   contact: T.Contact
   onClose: () => void
+  onAction?: () => void
 }) {
   const accountId = selectedAccountId()
   const tx = useTranslationFunction()
@@ -142,6 +149,7 @@ export function ViewProfileInner({
 
   const onChatClick = (chatId: number) => {
     selectChat(accountId, chatId)
+    onAction && onAction()
     onClose()
   }
   const onSendMessage = async () => {

--- a/src/renderer/hooks/dialog/useOpenViewProfileDialog.ts
+++ b/src/renderer/hooks/dialog/useOpenViewProfileDialog.ts
@@ -4,14 +4,16 @@ import ViewProfile from '../../components/dialogs/ViewProfile'
 import useDialog from './useDialog'
 import { BackendRemote } from '../../backend-com'
 
-export default function useOpenViewProfileDialog() {
+export default function useOpenViewProfileDialog(props?: {
+  onAction?: () => void
+}) {
   const { openDialog } = useDialog()
 
   return useCallback(
     async (accountId: number, contactId: number) => {
       const contact = await BackendRemote.rpc.getContact(accountId, contactId)
-      openDialog(ViewProfile, { contact })
+      openDialog(ViewProfile, { contact, onAction: props?.onAction })
     },
-    [openDialog]
+    [openDialog, props?.onAction]
   )
 }


### PR DESCRIPTION
- don't show email in reactions dialog unless user has no display name
- clicking on a row in reactions dialog opens a user profile
- resolved #4066