### PR TITLE
Always run configuration when user clicks "OK" in password dialog

### DIFF
--- a/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -121,8 +121,7 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
   ])
 
   const onOk = useCallback(async () => {
-    const update = await onUpdate()
-    if (update) onClose()
+    await onUpdate()
   }, [onClose, onUpdate])
 
   if (accountSettings === null) return null

--- a/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -122,7 +122,7 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
 
   const onOk = useCallback(async () => {
     await onUpdate()
-  }, [onClose, onUpdate])
+  }, [onUpdate])
 
   if (accountSettings === null) return null
   return (

--- a/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/src/renderer/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -37,14 +37,11 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
   const [accountSettings, _setAccountSettings] =
     useState<Credentials>(defaultCredentials())
 
-  const [disableUpdate, setDisableUpdate] = useState(true)
-
   const { openDialog } = useDialog()
   const openConfirmationDialog = useConfirmationDialog()
   const tx = useTranslationFunction()
 
   const setAccountSettings = (value: Credentials) => {
-    disableUpdate === true && setDisableUpdate(false)
     _setAccountSettings(value)
   }
 
@@ -86,7 +83,6 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
   }, [])
 
   const onUpdate = useCallback(async () => {
-    if (disableUpdate) return true
     const onSuccess = () => onClose()
 
     const update = () => {
@@ -117,7 +113,6 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
     }
   }, [
     accountSettings,
-    disableUpdate,
     initial_settings.addr,
     onClose,
     openConfirmationDialog,


### PR DESCRIPTION
If user wants to skip configuration,
there is a "Cancel" button.
If user clicks "OK" accidenatlly, worst case
configuration fails and does not change anything.

Rerunning configuration may be useful
if autoconfig XML got new servers that work.
This will also enable "automatic reconfiguration"
for accounts that use providers not in provider database once core PR <https://github.com/deltachat/deltachat-core-rust/pull/5866> is merged.

On Android opening configuration dialog and clicking confirm button is already enough, but on Desktop it requires adding and removing a symbol in the address or similar change before clicking OK.