### PR TITLE
Add fallback to displayName

### DIFF
--- a/src/renderer/components/dialogs/ViewProfile/index.tsx
+++ b/src/renderer/components/dialogs/ViewProfile/index.tsx
@@ -75,7 +75,7 @@ export default function ViewProfile(
 
   const onClickEdit = () => {
     openDialog(EditContactNameDialog, {
-      contactName: contact.name,
+      contactName: contact.name === '' ? contact.displayName : contact.name,
       onOk: async (contactName: string) => {
         await BackendRemote.rpc.changeContactName(
           accountId,


### PR DESCRIPTION
When editing the name in the EditProfile Dialog the form shows sometimes the name of the user sometimes not:

![Bildschirmfoto vom 2024-08-18 18-55-02](https://github.com/user-attachments/assets/98b001ef-b354-4bd3-8926-73b974aabd8f)

The reason is: sometimes a user has a name besides the displayName sometimes not.

Is there a reason why we have 3 name properties for a Contact:
authName
displayName
name

