### PR TITLE
improvement: better Telegram-style Ctrl+Up/Down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- Experimental Telegram-style Ctrl+Up/Down: improve behavior to align more with Telegram #4088
 
 <a id="1_46_5"></a>
 

--- a/src/renderer/components/composer/Composer.tsx
+++ b/src/renderer/components/composer/Composer.tsx
@@ -622,7 +622,9 @@ export function useDraft(
     )
     const currQuote = draftRef.current.quote
     if (!currQuote) {
-      quoteMessage(messageIds[messageIds.length - 1])
+      if (upOrDown === KeybindAction.Composer_SelectReplyToUp) {
+        quoteMessage(messageIds[messageIds.length - 1])
+      }
       return
     }
     if (currQuote.kind !== 'WithMessage') {
@@ -630,6 +632,13 @@ export function useDraft(
       return
     }
     const currQuoteMessageIdInd = messageIds.lastIndexOf(currQuote.messageId)
+    if (
+      currQuoteMessageIdInd === messageIds.length - 1 && // Last message
+      upOrDown === KeybindAction.Composer_SelectReplyToDown
+    ) {
+      removeQuote()
+      return
+    }
     const newId: number | undefined =
       messageIds[
         upOrDown === KeybindAction.Composer_SelectReplyToUp


### PR DESCRIPTION
- remove quote on Ctrl+Down when the currently quoted message is the last message
- don't quote a message on Ctrl+Down when no message is quoted instead only quote on Ctrl+Up