### PR TITLE
Ctrl+Q closes app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 - fix newlines in messages with WebXDC attachments #4079
 - being unable to delete a nonfunctional account imported from ArcaneChat #4104
+- Ctrl/Cmd+Q (also File->Quit) now should properly close the app when focus is on main window
 
 <a id="1_46_7"></a>
 

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -16,6 +16,7 @@ import * as mainWindow from './windows/main.js'
 import { DesktopSettings } from './desktop_settings.js'
 import { getCurrentLocaleDate, tx } from './load-translations.js'
 import { mapPackagePath } from './isAppx.js'
+import { quitDeltaChat } from './tray.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
@@ -181,18 +182,8 @@ export function getFileMenu(
   const fileMenuNonMac: Electron.MenuItemConstructorOptions = {
     label: tx('global_menu_file_desktop'),
     submenu: (() => {
-      let result = [
-        {
-          label:
-            window === mainWindow.window
-              ? tx('global_menu_file_quit_desktop')
-              : tx('close_window'),
-          click: () => window?.close(),
-          accelerator: 'Ctrl+q',
-        },
-      ]
       if (window === mainWindow.window) {
-        result = [
+        return [
           {
             label: tx('menu_settings'),
             click: () => {
@@ -200,10 +191,21 @@ export function getFileMenu(
             },
             accelerator: 'Ctrl+,',
           },
-          ...result,
+          {
+            label: tx('global_menu_file_quit_desktop'),
+            click: quitDeltaChat,
+            accelerator: 'Ctrl+q',
+          },
+        ]
+      } else {
+        return [
+          {
+            label: tx('close_window'),
+            click: () => window?.close(),
+            accelerator: 'Ctrl+q',
+          },
         ]
       }
-      return result
     })(),
   }
   const fileMenuMac: Electron.MenuItemConstructorOptions = {

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -76,7 +76,7 @@ function hideOrShowDeltaChat() {
   mainWindowIsVisible() ? hideDeltaChat(true) : showDeltaChat()
 }
 
-function quitDeltaChat() {
+export function quitDeltaChat() {
   globalShortcut.unregisterAll()
   app.quit()
 }

--- a/src/main/windows/main.ts
+++ b/src/main/windows/main.ts
@@ -235,7 +235,7 @@ export function send(channel: string, ...args: any[]) {
     return
   }
   if (window.isDestroyed()) {
-    log.warn('window is destroyed. not sending message', args)
+    log.info('window is destroyed. not sending message', args)
     return
   }
   try {


### PR DESCRIPTION
- handle ctrl+q when main window is focused to properly close the app
- File->Quit also closes the app

- #4084 tested on Windows, needs further testing