### PR TITLE
Fix newlines in messages with WebXDC attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   - Display `Config::MdnsEnabled` as true by default.
 
 ### Fixed
+- fix newlines in messages with WebXDC attachments #4079
 
 <a id="1_46_7"></a>
 

--- a/scss/message/_message.scss
+++ b/scss/message/_message.scss
@@ -96,11 +96,6 @@
         border-radius: 8px;
       }
     }
-
-    .webxdc + .text span {
-      display: inline-block;
-      margin-top: 10px;
-    }
   }
 
   .metadata {


### PR DESCRIPTION
- remove margin and inline-block for text in WebXDC message as it seems unnessary since button in content has margins
- resolves #4079