### PR TITLE
fix: unable to delete broken account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 - fix newlines in messages with WebXDC attachments #4079
+- being unable to delete a nonfunctional account imported from ArcaneChat #4104
 
 <a id="1_46_7"></a>
 

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -137,8 +137,12 @@ export default class ScreenController extends Component {
 
     await BackendRemote.rpc.startIo(accountId)
     runtime.setDesktopSetting('lastAccount', accountId)
-    log.info('system_info', await BackendRemote.rpc.getSystemInfo())
-    log.info('account_info', await BackendRemote.rpc.getInfo(accountId))
+    BackendRemote.rpc.getSystemInfo().then(info => {
+      log.info('system_info', info)
+    })
+    BackendRemote.rpc.getInfo(accountId).then(info => {
+      log.info('account_info', info)
+    })
   }
 
   async unSelectAccount() {

--- a/src/renderer/ScreenController.tsx
+++ b/src/renderer/ScreenController.tsx
@@ -116,7 +116,7 @@ export default class ScreenController extends Component {
     }
   }
 
-  async selectAccount(accountId: number) {
+  async selectAccount(accountId: number, dontStartIo = false) {
     if (accountId !== this.selectedAccountId) {
       await this.unSelectAccount()
       this.selectedAccountId = accountId
@@ -135,7 +135,9 @@ export default class ScreenController extends Component {
       this.changeScreen(Screens.Welcome)
     }
 
-    await BackendRemote.rpc.startIo(accountId)
+    if (!dontStartIo) {
+      await BackendRemote.rpc.startIo(accountId)
+    }
     runtime.setDesktopSetting('lastAccount', accountId)
     BackendRemote.rpc.getSystemInfo().then(info => {
       log.info('system_info', info)
@@ -190,7 +192,8 @@ export default class ScreenController extends Component {
   }
 
   async openAccountDeletionScreen(accountId: number) {
-    await this.selectAccount(accountId)
+    const dontStartIo = true
+    await this.selectAccount(accountId, dontStartIo)
     this.changeScreen(Screens.DeleteAccount)
   }
 


### PR DESCRIPTION
...imported from ArcaneChat, generated by a newer version of core.

Closes https://github.com/deltachat/deltachat-desktop/issues/4104.

I am not sure whether the rest of the discussion in #4104 was relevant to this issue, but I tested for a few minutes and didn't find a case where I can't delete the account or was unable to use the working accounts. Tried both with "Only Synchronize Selected Account" and without.