### PR TITLE
fix: spacing around avatars in reaction details dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - security: harden runtime interface by deleting the reference on window (`window.r`) after the first use. For development it is now accessible at `exp.runtime` but only in `--devmode` like `exp.rpc`
 - dev: update `./bin/update_background_thumbnails.sh` script
 - fix chatlist image thumbnails #4101
+- fix: spacing around avatars in reaction details dialog #4114
 
 <a id="1_46_8"></a>
 

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/styles.module.scss
@@ -18,7 +18,7 @@
 
 .reactionsDialogAvatar {
   flex: 0 0 48px;
-  margin-right: 10px;
+  margin-inline: 10px;
 }
 
 .reactionsDialogContactName {


### PR DESCRIPTION
Small CSS bugfix. Followup to #4066

Before:
<img width="404" alt="Bildschirmfoto 2024-09-09 um 01 47 29" src="https://github.com/user-attachments/assets/8f278fbf-7f6e-425a-890e-e5f94489646d">

After:
<img width="404" alt="Bildschirmfoto 2024-09-09 um 01 47 08" src="https://github.com/user-attachments/assets/f7bfed91-a08f-48a8-8ac0-96a14b807750">
