### PR TITLE
fix packaging on windows (documentation and file path limit)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -5,5 +5,6 @@ shell-emulator=true
 # to not run into windows max length for paths (260 chars)
 #
 # The `pnpm pack:patch-node-modules` script needs the folder names for the stdio packages unchanged
-# and longest folder name there is 49 chars currently so we sey it to 60 to be on the safe side.
-virtual-store-dir-max-length=60
+# the longest folder name there is 49 chars, but nsis processing breaks on allowOnlyOneInstallerInstance.nsh path
+# and it seems to be fixed by setting this to 70
+virtual-store-dir-max-length=70

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,9 @@
 # this allows us to use env vars in scripts in package.json crossplatform
 shell-emulator=true
+
+# shorten paths in node_modules/.pnpm/<module>
+# to not run into windows max length for paths (260 chars)
+#
+# The `pnpm pack:patch-node-modules` script needs the folder names for the stdio packages unchanged
+# and longest folder name there is 49 chars currently so we sey it to 60 to be on the safe side.
+virtual-store-dir-max-length=60

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -197,6 +197,9 @@ Possible options for `pnpm pack:generate_config`:
 
 If you haven't done so run `pnpm build` now.
 
+Then you need to run `pnpm pack:patch-node-modules` to patch `node_modules`. (**DON'T forget this step!**)
+So that the `electron-builder` `afterPackHook` is able to find the rpc binaries.
+
 Start electron-builder:
 
 | Command               | Description                                                                 |
@@ -212,6 +215,9 @@ The commands for windows10 appx and the App Store package for mac are currently 
 
 - `mas` - mac appstore build
 - `appx` - windows appstore build, you can find info on how to build a self-signed appx in [`APPX_TESTING.md`](./APPX_TESTING.md).
+
+> If you are building window on windows you might run into the file path limit of 260 characters.
+> To avoid that, make a folder with a short name directly on your drive (like c.tmp).
 
 ### Release Workflow <a id="release"></a>
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -195,6 +195,8 @@ Possible options for `pnpm pack:generate_config`:
 
 #### 2. Run electron-builder
 
+> note: on Windows you need to enable Developer Mode in System settings > For developers before packing
+
 If you haven't done so run `pnpm build` now.
 
 Then you need to run `pnpm pack:patch-node-modules` to patch `node_modules`. (**DON'T forget this step!**)

--- a/packages/target-electron/build/gen-electron-builder-config.js
+++ b/packages/target-electron/build/gen-electron-builder-config.js
@@ -150,9 +150,18 @@ build['deb'] = {
 }
 
 build['win'] = {
-  artifactName: '${productName}-${version}.${arch}.${ext}',
   icon: 'html-dist/images/deltachat.ico',
+  artifactName: '${productName}-${version}-Setup.${arch}.${ext}', // specifying it inside of build['nsis'] does not work for unknown reasons.
   files: [...files, PREBUILD_FILTERS.NOT_MAC, PREBUILD_FILTERS.NOT_LINUX],
+}
+
+build['appx'] = {
+  // TODO: find out why this is not working
+  artifactName: '${productName}-${version}-Package.${arch}.${ext}',
+}
+
+build['portable'] = {
+  artifactName: '${productName}-${version}-Portable.${arch}.${ext}',
 }
 
 // supported languages are on https://learn.microsoft.com/en-us/windows/apps/publish/publish-your-app/supported-languages?pivots=store-installer-msix


### PR DESCRIPTION
- there is a new step before running `pnpm run pack`: `pnpm pack:patch-node-modules` (I added that to the documentation
- and there was the window path length limit that I ran into, added a note about it in docs and set a configuration variable to limit path length generated by pnpm internally to make the issue less likely.