### PR TITLE
fix: inconsistent & wrong `composer.focus()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Chat "scrolling up" when typing a multi-line message, quoting a message, or adding an attachment, resulting in new messages not getting scrolled into view #4119
 - crash on clicking "About" when no account is selected (e.g. after deleting an account) #4154
 - show "new group" instead of "new contact" when pasting a group invite link in the search field #4151
+- message input getting unexpectedly re-focused, and not re-focused after some actions if the draft text is not empty #4136
 
 <a id="1_46_8"></a>
 

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -436,8 +436,7 @@ export function useDraft(
 
   const clearDraft = useCallback(() => {
     _setDraft(_ => emptyDraft(chatId))
-    inputRef.current?.focus()
-  }, [chatId, inputRef])
+  }, [chatId])
 
   const loadDraft = useCallback(
     (chatId: number) => {
@@ -549,21 +548,24 @@ export function useDraft(
       draftRef.current.quote = null
     }
     saveDraft()
-  }, [saveDraft])
+    inputRef.current?.focus()
+  }, [inputRef, saveDraft])
 
   const removeFile = useCallback(() => {
     draftRef.current.file = ''
     draftRef.current.viewType = 'Text'
     saveDraft()
-  }, [saveDraft])
+    inputRef.current?.focus()
+  }, [inputRef, saveDraft])
 
   const addFileToDraft = useCallback(
     async (file: string, viewType: Viewtype) => {
       draftRef.current.file = file
       draftRef.current.viewType = viewType
+      inputRef.current?.focus()
       return saveDraft()
     },
-    [saveDraft]
+    [inputRef, saveDraft]
   )
 
   const settingsStore = useSettingsStore()[0]


### PR DESCRIPTION
- Erasing draft text and immediately focusing another element would return the focus to the composer after 500ms, when the draft gets deleted (`clearDraft` would get invoked from `saveDraft()`.
- Composer would not get re-focused when deleting / adding attachments or removing quotation if the draft text is not empty.

`.focus()` inside of `clearDraft()` was introduced in 199ea232539e77ea9b4c903451b90a56dc880554, most likely to re-focus the input after sending a message. We now have separate code for this, see `composerSendMessage`.

This change likely needs some more testing.