### PR TITLE
fix: chatlist image thumbnails not showing on Win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - security: harden electron_functions, only runtime can use them now
 - security: harden runtime interface by deleting the reference on window (`window.r`) after the first use. For development it is now accessible at `exp.runtime` but only in `--devmode` like `exp.rpc`
 - dev: update `./bin/update_background_thumbnails.sh` script
-- fix chatlist image thumbnails #4101
+- fix chatlist image thumbnails #4101, #4139
 - fix: spacing around avatars in reaction details dialog #4114
 - fix: wrong translation string for new group creation #4126
 - fix: packaging: windows 64bit and 32bit releases now have different filenames, bring back 64bit windows releases. #4131

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -102,7 +102,9 @@ function Message({
         {summaryPreviewImage && !iswebxdc && (
           <div
             className='summary_thumbnail'
-            style={{ backgroundImage: `url("${summaryPreviewImage}")` }}
+            style={{
+              backgroundImage: `url(${JSON.stringify(summaryPreviewImage)})`,
+            }}
           />
         )}
         {iswebxdc && lastMessageId && (


### PR DESCRIPTION
The `url()` wants a string, so let's give it a string. Otherwise it treats backwards slashes, which used in Windows paths, as escape characters, which results in an invalid URL.

The bug was introduced in 72bb581da4,
then there was a fix for something in 87ba793e66d.

Though it feels like there should be a proper way to convert file paths to URL...

I checked some other places where `url(` is used and didn't find a problem. Maybe it's best to unify such usage, and more thoroughly explain in JSON-RPC that those are file paths and not URLs.