### PR TITLE
fix: some shortcuts not working on different langs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fix: spacing around avatars in reaction details dialog #4114
 - fix: wrong translation string for new group creation #4126
 - fix: packaging: windows 64bit and 32bit releases now have different filenames, bring back 64bit windows releases. #4131
+- some shortcuts (e.g. `Ctrl + N`, `Ctrl + K`) not working on some languages' keyboard layots #4140
 
 <a id="1_46_8"></a>
 

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -254,22 +254,22 @@ export function ContextMenu(props: {
     const onKeyDown = (ev: KeyboardEvent) => {
       const current = parent?.querySelector(':focus')
 
-      if (ev.key == 'ArrowDown') {
+      if (ev.code == 'ArrowDown') {
         if (current && current.nextElementSibling) {
           ;(current.nextElementSibling as HTMLDivElement)?.focus()
         } else {
           ;(parent?.firstElementChild as HTMLDivElement).focus()
         }
-      } else if (ev.key == 'ArrowUp') {
+      } else if (ev.code == 'ArrowUp') {
         if (current && current.previousElementSibling) {
           ;(current.previousElementSibling as HTMLDivElement)?.focus()
         } else {
           ;(parent?.lastElementChild as HTMLDivElement).focus()
         }
-      } else if (ev.key == 'ArrowLeft') {
+      } else if (ev.code == 'ArrowLeft') {
         setSublevels(l => l.slice(0, Math.max(0, l.length - 1)))
         keyboardFocus.current = openSublevels[openSublevels.length - 1]
-      } else if (ev.key == 'ArrowRight') {
+      } else if (ev.code == 'ArrowRight') {
         if (current) {
           const el = current as HTMLDivElement
           const index = parseInt(el.dataset.expandableIndex as string, 10)
@@ -278,11 +278,11 @@ export function ContextMenu(props: {
             keyboardFocus.current = 0
           }
         }
-      } else if (ev.key == 'Enter') {
+      } else if (ev.code == 'Enter') {
         if (current) {
           ;(current as HTMLDivElement)?.click()
         }
-      } else if (ev.key == 'Escape') {
+      } else if (ev.code == 'Escape') {
         closeCallback()
         keyboardFocus.current = -1
       }

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -179,10 +179,10 @@ const Composer = forwardRef<
   // also handle escape key for emoji picker
   useEffect(() => {
     const onKey = (ev: KeyboardEvent) => {
-      if (ev.key === 'Shift') {
+      if (ev.code === 'Shift') {
         shiftPressed.current = ev.shiftKey
       }
-      if (ev.type === 'keydown' && ev.key === 'Escape') {
+      if (ev.type === 'keydown' && ev.code === 'Escape') {
         setShowEmojiPicker(false)
       }
     }

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -141,13 +141,13 @@ export default class ComposerMessageInput extends React.Component<
     const enterKeySends = this.props.enterKeySends
 
     // ENTER + SHIFT
-    if (e.key === 'Enter' && e.shiftKey) {
+    if (e.code === 'Enter' && e.shiftKey) {
       return 'NEWLINE'
       // ENTER + CTRL
-    } else if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    } else if (e.code === 'Enter' && (e.ctrlKey || e.metaKey)) {
       return 'SEND'
       // ENTER
-    } else if (e.key === 'Enter' && !e.shiftKey) {
+    } else if (e.code === 'Enter' && !e.shiftKey) {
       return enterKeySends ? 'SEND' : 'NEWLINE'
     }
   }

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
@@ -197,7 +197,7 @@ export function AddMemberInnerDialog({
   }
 
   const addContactOnKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
-    if (ev.key == 'Enter') {
+    if (ev.code == 'Enter') {
       ;(
         document.querySelector<HTMLDivElement>(
           '.delta-checkbox'

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -233,9 +233,9 @@ export default function FullscreenMedia(props: Props & DialogProps) {
       }
       ev.preventDefault()
       ev.stopPropagation()
-      if (ev.key == 'ArrowLeft') {
+      if (ev.code == 'ArrowLeft') {
         previousImage()
-      } else if (ev.key == 'ArrowRight') {
+      } else if (ev.code == 'ArrowRight') {
         nextImage()
       }
     }

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -238,7 +238,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
   }
 
   const onEscapeKeyUp = (ev: KeyboardEvent) => {
-    if (ev.key === 'Escape') {
+    if (ev.code === 'Escape') {
       messageInputRef?.current?.focus()
     }
   }

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -69,72 +69,72 @@ export function keyDownEvent2Action(
   }
   if (!ev.repeat) {
     // fire only on first press
-    if (ev.altKey && ev.key === 'ArrowDown') {
+    if (ev.altKey && ev.code === 'ArrowDown') {
       return KeybindAction.ChatList_SelectNextChat
-    } else if (ev.altKey && ev.key === 'ArrowUp') {
+    } else if (ev.altKey && ev.code === 'ArrowUp') {
       return KeybindAction.ChatList_SelectPreviousChat
-    } else if (ev.ctrlKey && ev.key === 'PageDown') {
+    } else if (ev.ctrlKey && ev.code === 'PageDown') {
       return KeybindAction.ChatList_SelectNextChat
-    } else if (ev.ctrlKey && ev.key === 'PageUp') {
+    } else if (ev.ctrlKey && ev.code === 'PageUp') {
       return KeybindAction.ChatList_SelectPreviousChat
-    } else if (ev.ctrlKey && ev.key === 'Tab') {
+    } else if (ev.ctrlKey && ev.code === 'Tab') {
       return !ev.shiftKey
         ? KeybindAction.ChatList_SelectNextChat
         : KeybindAction.ChatList_SelectPreviousChat
-      // } else if (ev.altKey && ev.key === 'ArrowLeft') {
+      // } else if (ev.altKey && ev.code === 'ArrowLeft') {
       // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
       //   return KeybindAction.ChatList_ScrollToSelectedChat
-    } else if (ev.ctrlKey && ev.key === 'k') {
+    } else if (ev.ctrlKey && ev.code === 'KeyK') {
       return KeybindAction.ChatList_FocusAndClearSearchInput
-    } else if (ev.ctrlKey && ev.key === 'n') {
+    } else if (ev.ctrlKey && ev.code === 'KeyN') {
       return KeybindAction.Composer_Focus
     } else if (
       // Also consider adding this to `ev.repeat` when it stops being so sluggish
-      ev.key === 'ArrowUp' &&
+      ev.code === 'ArrowUp' &&
       (ev.ctrlKey || ev.metaKey) &&
       !(ev.ctrlKey && ev.metaKey) // Both at the same time
     ) {
       return KeybindAction.Composer_SelectReplyToUp
     } else if (
-      ev.key === 'ArrowDown' &&
+      ev.code === 'ArrowDown' &&
       (ev.ctrlKey || ev.metaKey) &&
       !(ev.ctrlKey && ev.metaKey) // Both at the same time
     ) {
       return KeybindAction.Composer_SelectReplyToDown
-    } else if ((ev.metaKey || ev.ctrlKey) && ev.key === ',') {
+    } else if ((ev.metaKey || ev.ctrlKey) && ev.code === 'Comma') {
       return KeybindAction.Settings_Open
     } else if (
-      ev.key === 'Escape' &&
+      ev.code === 'Escape' &&
       (ev.target as any).id === 'chat-list-search'
     ) {
       return KeybindAction.ChatList_ExitSearch
     } else if (
-      ev.key === 'Enter' &&
+      ev.code === 'Enter' &&
       (ev.target as any).id === 'chat-list-search'
     ) {
       return KeybindAction.ChatList_SearchSelectFirstChat
-    } else if (ev.key === 'F5') {
+    } else if (ev.code === 'F5') {
       return KeybindAction.Debug_MaybeNetwork
-    } else if (ev.key === 'PageUp') {
+    } else if (ev.code === 'PageUp') {
       return KeybindAction.MessageList_PageUp
-    } else if (ev.key === 'PageDown') {
+    } else if (ev.code === 'PageDown') {
       return KeybindAction.MessageList_PageDown
-    } else if ((ev.metaKey || ev.ctrlKey) && ev.key === '/') {
+    } else if ((ev.metaKey || ev.ctrlKey) && ev.code === 'Slash') {
       return KeybindAction.KeybindingCheatSheet_Open
     }
   } else {
     // fire continuesly as long as button is pressed
-    if (ev.ctrlKey && ev.key === 'PageDown') {
+    if (ev.ctrlKey && ev.code === 'PageDown') {
       return KeybindAction.ChatList_SelectNextChat
-    } else if (ev.ctrlKey && ev.key === 'PageUp') {
+    } else if (ev.ctrlKey && ev.code === 'PageUp') {
       return KeybindAction.ChatList_SelectPreviousChat
-    } else if (ev.key === 'PageUp') {
+    } else if (ev.code === 'PageUp') {
       return KeybindAction.MessageList_PageUp
-    } else if (ev.key === 'PageDown') {
+    } else if (ev.code === 'PageDown') {
       return KeybindAction.MessageList_PageDown
-    } else if (ev.altKey && ev.key === 'ArrowDown') {
+    } else if (ev.altKey && ev.code === 'ArrowDown') {
       return KeybindAction.ChatList_SelectNextChat
-    } else if (ev.altKey && ev.key === 'ArrowUp') {
+    } else if (ev.altKey && ev.code === 'ArrowUp') {
       return KeybindAction.ChatList_SelectPreviousChat
     }
   }

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -433,7 +433,7 @@ If you think that's a bug and you need that permission, then please open an issu
       )
 
       webxdcWindow.webContents.on('before-input-event', (event, input) => {
-        if (input.key.toLowerCase() === 'f12') {
+        if (input.code === 'F12') {
           if (DesktopSettings.state.enableWebxdcDevTools) {
             webxdcWindow.webContents.toggleDevTools()
             event.preventDefault()

--- a/packages/target-electron/static/webxdc-preload.js
+++ b/packages/target-electron/static/webxdc-preload.js
@@ -303,7 +303,7 @@ class RealtimeListener {
   })
 
   const keydown_handler = ev => {
-    if (ev.key == 'Escape') {
+    if (ev.code == 'Escape') {
       ipcRenderer.invoke('webxdc.exitFullscreen')
     }
   }


### PR DESCRIPTION
Different keyboard layouts (e.g. Russian).
`event.key` gives you the printed character and not the key code.
If the language doesn't use latin letters, you'll never get
Ctrl + N or Ctrl + K to work.

This behavior aligns with e.g. Telegram, and browsers (Ctrl + W).

There is a side-effect, however. The shortcuts cheat-sheet
shows which buttons you're currently pressing, and now it diverges
from actual behavior.
E.g. if you actually press the key with the code "Comma",
it won't show you this for the Russian language where the key
to print a comma is different.
See `KeyboardShortcutHint.tsx`.

I think this can be fixed later, especially that it's already buggy:
it won't show you that you're pressing "N" because
you'd actually need to press "Shift+N", otherwise you get "n".