### PR TITLE
Treat overriden sender name as content above attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - fix: packaging: windows 64bit and 32bit releases now have different filenames, bring back 64bit windows releases. #4131
 - some shortcuts (e.g. `Ctrl + N`, `Ctrl + K`) not working on some languages' keyboard layots #4140
 - fix chat "scrolling up" when someone adds a reaction, resulting in new messages not getting scrolled into view when they arrive #4120
+- fix missing space between overriden sender name and image attachment #3914
 
 <a id="1_46_8"></a>
 

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -58,6 +58,7 @@ export default function Attachment({
   // For attachments which aren't full-frame
   const withContentBelow = withCaption
   const withContentAbove =
+    message.overrideSenderName != null ||
     hasQuote ||
     (conversationType.hasMultipleParticipants && direction === 'incoming')
   // const dimensions = message.msg.dimensions || {}


### PR DESCRIPTION
- resolves #3914