### PR TITLE
Add block contact and encryption info to profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Experimental Telegram-style Esc to cancel reply (quote) #4153
+- new ViewProfile context menu for blocking/unblocking contact and checking encryption #4043
 
 ### Changed
 - Update electron from `30.3.1` to `32.1.0` #4138

--- a/packages/frontend/src/components/Dialog/HeaderButton.tsx
+++ b/packages/frontend/src/components/Dialog/HeaderButton.tsx
@@ -11,17 +11,24 @@ import styles from './styles.module.scss'
 type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   icon: IconName
   iconSize: number
+  rotation?: number
 }
 
 export default function HeaderButton({
   className,
   icon,
   iconSize,
+  rotation,
   ...props
 }: Props) {
   return (
     <button className={classNames(styles.headerButton, className)} {...props}>
-      <Icon className={styles.headerButtonIcon} icon={icon} size={iconSize} />
+      <Icon
+        className={styles.headerButtonIcon}
+        icon={icon}
+        size={iconSize}
+        rotation={rotation || 0}
+      />
     </button>
   )
 }

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -107,7 +107,11 @@ export function useChatListContextMenu(): {
     openContextMenu: async (event, chatListItem, selectedChatId) => {
       const onDeleteChat = () =>
         openDeleteChatDialog(accountId, chatListItem, selectedChatId)
-      const onEncrInfo = () => openEncryptionInfoDialog(chatListItem)
+      const onEncrInfo = () =>
+        openEncryptionInfoDialog({
+          chatId: chatListItem.id,
+          dmChatContact: chatListItem.dmChatContact,
+        })
       const onViewGroup = async () => {
         // throws error if chat was not found
         const fullChat = await BackendRemote.rpc.getFullChatById(

--- a/packages/frontend/src/components/dialogs/EncryptionInfo.tsx
+++ b/packages/frontend/src/components/dialogs/EncryptionInfo.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 
-import { BackendRemote, Type } from '../../backend-com'
+import { BackendRemote } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import Dialog, {
   DialogBody,
@@ -13,31 +13,30 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../contexts/DialogContext'
 
-type Props = {
-  chatListItem: Pick<
-    Type.ChatListItemFetchResult & { kind: 'ChatListItem' },
-    'id' | 'dmChatContact'
-  >
+export type Props = {
+  chatId: number | null
+  dmChatContact: number | null
 }
 
-export default function EncryptionInfo({
-  chatListItem,
+export function EncryptionInfo({
+  chatId,
+  dmChatContact,
   onClose,
 }: Props & DialogProps) {
   const [encryptionInfo, setEncryptionInfo] = useState('Fetching...')
   useEffect(() => {
-    if (!chatListItem) return
-    ;(chatListItem.dmChatContact
+    if (dmChatContact == null && chatId == null) return
+    ;(dmChatContact != null
       ? BackendRemote.rpc.getContactEncryptionInfo(
           selectedAccountId(),
-          chatListItem.dmChatContact
+          dmChatContact
         )
       : BackendRemote.rpc.getChatEncryptionInfo(
           selectedAccountId(),
-          chatListItem.id
+          chatId as number
         )
     ).then(setEncryptionInfo)
-  }, [chatListItem])
+  }, [dmChatContact, chatId])
 
   const tx = useTranslationFunction()
 

--- a/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
@@ -1,0 +1,171 @@
+import React, { useState, useContext, useEffect } from 'react'
+import { BackendRemote, onDCEvent } from '../../../backend-com'
+
+import { DeltaInput } from '../../Login-Styles'
+import Dialog, {
+  DialogBody,
+  DialogContent,
+  DialogHeader,
+  OkCancelFooterAction,
+} from '../../Dialog'
+import { ContextMenuItem } from '../../ContextMenu'
+import { ContextMenuContext } from '../../../contexts/ContextMenuContext'
+
+import { selectedAccountId } from '../../../ScreenController'
+import useDialog from '../../../hooks/dialog/useDialog'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+import useChatDialog from '../../../hooks/chat/useChatDialog'
+import useConfirmationDialog from '../../../hooks/dialog/useConfirmationDialog'
+
+import type { T } from '@deltachat/jsonrpc-client'
+import type { DialogProps } from '../../../contexts/DialogContext'
+
+import debounce from 'debounce'
+
+export default function useViewProfileMenu(contact: T.Contact) {
+  const { openContextMenu } = useContext(ContextMenuContext)
+
+  const [isBlocked, setBlocked] = useState(false)
+
+  const tx = useTranslationFunction()
+  const accountId = selectedAccountId()
+  const openConfirmationDialog = useConfirmationDialog()
+
+  const { openBlockContactById, openEncryptionInfoDialog } = useChatDialog()
+
+  const onUnblockContact = async () => {
+    const confirmed = await openConfirmationDialog({
+      message: tx('ask_unblock_contact'),
+      confirmLabel: tx('menu_unblock_contact'),
+    })
+
+    if (confirmed) {
+      await BackendRemote.rpc.unblockContact(accountId, contact.id)
+    }
+  }
+
+  useEffect(() => {
+    const onContactsUpdate = async () => {
+      const allBlocked = await BackendRemote.rpc.getBlockedContacts(accountId)
+
+      setBlocked(
+        !!allBlocked &&
+          allBlocked.length > 0 &&
+          allBlocked.some(bContact => bContact.id === contact.id)
+      )
+    }
+    onContactsUpdate()
+    return onDCEvent(
+      accountId,
+      'ContactsChanged',
+      debounce(onContactsUpdate, 500)
+    )
+  }, [accountId, contact.id])
+
+  const { openDialog } = useDialog()
+
+  const onClickEdit = () => {
+    openDialog(EditContactNameDialog, {
+      contactName: contact.name,
+      originalName:
+        contact.authName !== '' ? contact.authName : contact.address,
+      onOk: async (contactName: string) => {
+        await BackendRemote.rpc.changeContactName(
+          accountId,
+          contact.id,
+          contactName
+        )
+      },
+    })
+  }
+
+  const menu: (ContextMenuItem | false)[] = [
+    // we show Edit Name option every time since this menu
+    // is only accessible from ViewProfile which you can edit name for
+    {
+      label: tx('menu_edit_name'),
+      action: onClickEdit,
+    },
+    isBlocked
+      ? {
+          label: tx('menu_unblock_contact'),
+          action: onUnblockContact,
+        }
+      : {
+          label: tx('menu_block_contact'),
+          action: () => openBlockContactById(accountId, contact.id),
+        },
+    {
+      label: tx('encryption_info_title_desktop'),
+      action: () =>
+        openEncryptionInfoDialog({ chatId: null, dmChatContact: contact.id }),
+    },
+  ]
+
+  return (event: React.MouseEvent<any, MouseEvent>) => {
+    const threeDotButtonElement = document.querySelector(
+      '#view-profile-menu'
+    ) as HTMLDivElement
+
+    const boundingBox = threeDotButtonElement.getBoundingClientRect()
+
+    const [cursorX, cursorY] = [
+      boundingBox.x + 3,
+      boundingBox.y + boundingBox.height - 2,
+    ]
+    event.preventDefault() // prevent default runtime context menu from opening
+
+    openContextMenu({
+      cursorX,
+      cursorY,
+      items: menu,
+    })
+  }
+}
+
+function EditContactNameDialog({
+  onClose,
+  onOk,
+  contactName: initialGroupName,
+  originalName,
+}: {
+  onOk: (contactName: string) => void
+  contactName: string
+  originalName: string
+} & DialogProps) {
+  const [contactName, setContactName] = useState(initialGroupName)
+  const tx = useTranslationFunction()
+
+  const onClickCancel = () => {
+    onClose()
+  }
+
+  const onClickOk = () => {
+    onClose()
+    onOk(contactName)
+  }
+
+  return (
+    <Dialog canOutsideClickClose={false} fixed onClose={onClose}>
+      <DialogHeader title={tx('menu_edit_name')} />
+      <DialogBody>
+        <DialogContent>
+          <p>{tx('edit_name_explain', originalName)}</p>
+          <DeltaInput
+            key='contactname'
+            id='contactname'
+            placeholder={tx('edit_name_placeholder', originalName)}
+            value={contactName}
+            onChange={(
+              event: React.FormEvent<HTMLElement> &
+                React.ChangeEvent<HTMLInputElement>
+            ) => {
+              setContactName(event.target.value)
+            }}
+          />
+        </DialogContent>
+      </DialogBody>
+      <OkCancelFooterAction onCancel={onClickCancel} onOk={onClickOk} />
+    </Dialog>
+  )
+}


### PR DESCRIPTION
- new `useViewProfileMenu` menu with two items: Block/Unblock Contact and Encryption Info
- minor refactor of `useChatDialog`, so we don't have to have a ChatListItem to block contact or get EncryptionInfo
- resolves #4043