### PR TITLE
fix: window overflowing small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - avoid showing wrong menu items for blocked users #4353
 - fix: save message draft every 200ms if message text changed #3733
 - fix mac drag window issues #4300
+- the main window overflowing small screens, or/and if zoom level is high #4156
 
 <a id="1_48_0"></a>
 

--- a/packages/target-electron/src/application-constants.ts
+++ b/packages/target-electron/src/application-constants.ts
@@ -40,8 +40,10 @@ export function windowDefaults() {
       y,
     },
     headerHeight,
-    minWidth: 450,
-    minHeight: 450,
+    // On 0.6x zoom Delta Chat and 200x window size it's still somewhat usable,
+    // not much is overflowing.
+    minWidth: 225,
+    minHeight: 125,
     main: targetFile,
     preload: join(htmlDistDir(), 'preload.js'),
   }

--- a/packages/target-electron/src/windows/helpers.ts
+++ b/packages/target-electron/src/windows/helpers.ts
@@ -11,7 +11,12 @@ export function initMinWinDimensionHandling(
 ): () => void {
   const update_min_size = () => {
     const { workAreaSize } = screen.getPrimaryDisplay()
-    if (workAreaSize.width < minWidth || workAreaSize.height < minHeight) {
+    if (
+      // A multiplier to make space for the taskbar and the window header.
+      // Remember that the taskbar could also be placed vertically.
+      workAreaSize.width * 0.75 < minWidth ||
+      workAreaSize.height * 0.75 < minHeight
+    ) {
       main_window.setMinimumSize(0, 0)
     } else {
       main_window.setMinimumSize(minWidth, minHeight)


### PR DESCRIPTION
...with high zoom level.

Closes https://github.com/deltachat/deltachat-desktop/issues/4063

I did not test this because for me `setMinimumSize` is not working. Though I played around with window sizes to determine the new numbers.