### PR TITLE
fix: not auto-scrolling to new messages

### DIFF
--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -314,8 +314,9 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
           !domElement.classList.contains('info-message') &&
           !domElement.classList.contains('videochat-invitation'))
       ) {
-        log.debug(
-          `scrollTo: scrollToMessage, couldn't find matching message in dom: ${domElement}, returning`
+        log.error(
+          "scrollTo: scrollToMessage, couldn't find matching message in dom, returning",
+          domElement
         )
         return
       }

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -308,17 +308,29 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
       log.debug('scrollTo: scrollToMessage: ' + scrollTo.msgId)
 
       const domElement = document.getElementById(scrollTo.msgId.toString())
-      if (
-        !domElement ||
-        (!domElement.classList.contains('message') &&
-          !domElement.classList.contains('info-message') &&
-          !domElement.classList.contains('videochat-invitation'))
-      ) {
+      if (!domElement) {
         log.error(
           "scrollTo: scrollToMessage, couldn't find matching message in dom, returning",
           domElement
         )
         return
+      }
+      if (
+        !domElement.classList.contains('message') &&
+        !domElement.classList.contains('info-message') &&
+        !domElement.classList.contains('videochat-invitation') &&
+        // Currently we have the same `id=` set on both `<li>` and its child.
+        !domElement.firstElementChild?.classList.contains('message') &&
+        !domElement.firstElementChild?.classList.contains('info-message') &&
+        !domElement.firstElementChild?.classList.contains(
+          'videochat-invitation'
+        )
+      ) {
+        log.warn(
+          `scrollTo: scrollToMessage, found an element with ` +
+            `id=${scrollTo.msgId}, but it's not a message:`,
+          domElement
+        )
       }
 
       domElement.scrollIntoView()


### PR DESCRIPTION
The bug was introduced recently, in https://github.com/deltachat/deltachat-desktop/commit/07cd2b2c5f9d779cb71bb8c034b31b503b348806.
That commit assumed that we do not have multiple elements
with the same id in the document.

No need for a CHANGELOG entry because there has not been a release.