### PR TITLE
WIP: perf: avoid re-renders caused by `useEffect`

### DIFF
--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -44,6 +44,7 @@ import type {
   MessageChatListItemData,
 } from './ChatListItemRow'
 import { isInviteLink } from '../../../../shared/util'
+import { useHasChanged2 } from '../../hooks/useHasChanged'
 
 const enum LoadStatus {
   FETCHING = 1,
@@ -629,17 +630,21 @@ function useLogicChatPart(
     useLogicVirtualChatList(chatListIds)
 
   // effects
-  useEffect(() => {
+  const queryStrHasChanged = useHasChanged2(queryStr)
+  // TODO why don't we just call this unconditionally?????
+  // `Object.is()` will take care of infinite loops.
+  if (queryStrHasChanged) {
     setQueryStr(queryStr)
-  }, [queryStr, setQueryStr])
+  }
 
-  useEffect(
-    () =>
-      showArchivedChats && queryStr?.length === 0
-        ? setListFlags(C.DC_GCL_ARCHIVED_ONLY)
-        : setListFlags(0),
-    [showArchivedChats, queryStr, setListFlags]
-  )
+  const showArchivedChatsHasChanged = useHasChanged2(showArchivedChats)
+  // TODO why don't we just call this unconditionally?????
+  // `Object.is()` will take care of infinite loops.
+  if (showArchivedChatsHasChanged && queryStrHasChanged) {
+    showArchivedChats && queryStr?.length === 0
+      ? setListFlags(C.DC_GCL_ARCHIVED_ONLY)
+      : setListFlags(0)
+  }
 
   return { chatListIds, isChatLoaded, loadChats, chatCache }
 }

--- a/packages/frontend/src/components/chat/ChatListHelpers.tsx
+++ b/packages/frontend/src/components/chat/ChatListHelpers.tsx
@@ -3,6 +3,7 @@ import { getLogger } from '../../../../shared/logger'
 import { debounce } from 'debounce'
 import { BackendRemote, onDCEvent } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
+import { useHasChanged2 } from '../../hooks/useHasChanged'
 
 const log = getLogger('renderer/helpers/ChatList')
 
@@ -45,10 +46,10 @@ export function useMessageResults(
     [chatId]
   )
 
-  useEffect(
-    () => debouncedSearchMessages(queryStr),
-    [queryStr, debouncedSearchMessages]
-  )
+  const queryStrHasChanged = useHasChanged2(queryStr)
+  if (queryStrHasChanged) {
+    debouncedSearchMessages(queryStr)
+  }
 
   return ids
 }

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -38,6 +38,7 @@ import { VisualVCardComponent } from '../message/VCard'
 import { KeybindAction } from '../../keybindings'
 import useKeyBindingAction from '../../hooks/useKeyBindingAction'
 import { CloseButton } from '../Dialog'
+import { useHasChanged2 } from '../../hooks/useHasChanged'
 
 const log = getLogger('renderer/composer')
 

--- a/packages/frontend/src/components/conversations/Timestamp.tsx
+++ b/packages/frontend/src/components/conversations/Timestamp.tsx
@@ -77,6 +77,7 @@ const UpdatingTimestamp = (props: TimestampProps) => {
   )
 
   useEffect(() => {
+    // TODO so, do we run `recalculateRelativeTime` twice even if props don't change?
     //register in global updater
     const key = `${timestamp}|${deduplicationCounter++}`
     updateRefs[key] = recalculateRelativeTime

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -664,6 +664,7 @@ export const MessageListInner = React.memo(
 
       onScroll(...args)
     }
+    // TODO here?
     const hasChatChanged = useHasChanged(chat)
     const [switchedChatAt, setSwitchedChatAt] = useState(0)
     useEffect(() => {

--- a/packages/frontend/src/hooks/chat/useSelectLastChat.ts
+++ b/packages/frontend/src/hooks/chat/useSelectLastChat.ts
@@ -33,6 +33,7 @@ export default function useSelectLastChat(accountId?: number) {
     }
   }, [accountId, selectChat, smallScreenMode])
 
+  // TODO here.
   useEffect(() => {
     if (
       hasAccountIdChanged ||

--- a/packages/frontend/src/hooks/useHasChanged.ts
+++ b/packages/frontend/src/hooks/useHasChanged.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import usePrevious from './usePrevious'
 
 /**
@@ -14,4 +15,26 @@ import usePrevious from './usePrevious'
 export default function useHasChanged(val: any) {
   const prevVal = usePrevious(val)
   return prevVal !== val
+}
+
+// TODO but this doesn't return `true` on initial render, unlike a `useEffect`,
+// which also runs after initial render.
+/**
+ * Like {@link useHasChanged}, but the returned value
+ * can only be `true` once per hook execution per one change to `val`.
+ * It does not remain being `true` until the actual render of the commponent,
+ * like it is for `useHasChanged`.
+ * Use this if you need to adjust some state based on some other state,
+ * without causing a re-render that you'd get when using `useEffect`.
+ *
+ * It is this pattern:
+ * https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+ */
+export function useHasChanged2(val: any /* , trueOnFirstRun: boolean */) {
+  const prev = useRef(val)
+  if (prev.current !== val) {
+    prev.current = val
+    return true
+  }
+  return false
 }


### PR DESCRIPTION
Having read https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes, I think we might be overusing `useEffect` to detect prop/state changes.
I'm not a huge React expert, but I would like to ask if these changes make sense.