### PR TITLE
perf: cache chat list & don't delay initial load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - show contact / group name when pasting invite link in the search field #4151
 - Update local help (2024-10-02) #4165
 - trim whitepaces when reading from clipboard in qr code reader #4169
+- load chat lists faster (the chat list on the main screen, "Forward to..." dialog, etc)
 
 ### Fixed
 - fix that you can not click header button in dialog when they are on top of the navbar #4093

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -624,7 +624,10 @@ function useLogicChatPart(
   queryStr: string | undefined,
   showArchivedChats: boolean
 ) {
-  const { chatListIds, setQueryStr, setListFlags } = useChatList()
+  const defaultListFlags = 0
+
+  const { chatListIds, setQueryStr, setListFlags } =
+    useChatList(defaultListFlags)
   const { isChatLoaded, loadChats, chatCache } =
     useLogicVirtualChatList(chatListIds)
 
@@ -637,7 +640,7 @@ function useLogicChatPart(
     () =>
       showArchivedChats && queryStr?.length === 0
         ? setListFlags(C.DC_GCL_ARCHIVED_ONLY)
-        : setListFlags(0),
+        : setListFlags(defaultListFlags),
     [showArchivedChats, queryStr, setListFlags]
   )
 


### PR DESCRIPTION
This has the following effects:
- Upon the initial load of a component that displays a list of chats,
    we start loading them instantly instead of waiting for the
    debounce timeout of 200ms.
- When emptying the query string for a chat list, all chats get
    displayed instantly, instead of getting re-fetched.

The following components are affected:
- The chat list on the main screen
- "Forward message to..."
- Mailto dialog
- View profile: chats in common
- webxdc sendToChat dialog

Please assess whether this is too ugly. Basically what we're doing is caching + removing the debounce. Perhaps a different approach would be more elegant. But IMO this isn't so bad, maybe not even half bad.