### PR TITLE
style: lower contrast for a border in dark theme

### DIFF
--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -24,7 +24,8 @@
     & > .attachment-quote-section {
       display: flex;
       padding: 9px;
-      border-bottom: 1px solid #eee;
+      border-bottom: 1px solid
+        color-mix(in srgb, var(--messageQuotedText) 15%, transparent);
 
       .quote {
         // this is just overwrites for the quote styles defined in _message.scss


### PR DESCRIPTION
When quoting a message.
In the default dark theme was way too bright.

Before:

![image](https://github.com/user-attachments/assets/33414893-a15b-41f7-95b3-d683a1306c3f)

After:

![image](https://github.com/user-attachments/assets/f10ddd68-7076-400c-98b2-809d053e4b43)
