### PR TITLE
improvement: better search for invite link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - scroll the selected account into view in the accounts sidebar #4137
 - dev: clarify scrolling-related code #4121
 - improved performance a bit #4145, #4188
-- show contact / group name when pasting invite link in the search field #4151
+- show contact / group name & avatar when pasting invite link in the search field #4151, #4178
 - Update local help (2024-10-02) #4165
 - trim whitepaces when reading from clipboard in qr code reader #4169
 - load chat lists faster (the chat list on the main screen, "Forward to..." dialog, etc)

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -71,5 +71,8 @@
   },
   "edit_name_placeholder": {
     "message": "Nickname for '%1'"
+  },
+  "join_group": {
+    "message": "Join Group"
   }
 }

--- a/packages/frontend/src/components/helpers/PseudoListItem.tsx
+++ b/packages/frontend/src/components/helpers/PseudoListItem.tsx
@@ -182,12 +182,12 @@ export const PseudoListItemAddContactOrGroupFromInviteLink = ({
       id='newcontactorgroupfrominvitelink'
       cutoff='+'
       text={
+        parsedQr?.kind === 'askVerifyGroup' ? parsedQr.grpname : contactName
+      }
+      subText={
         parsedQr?.kind === 'askVerifyGroup'
           ? tx('menu_new_group')
           : tx('menu_new_contact')
-      }
-      subText={
-        parsedQr?.kind === 'askVerifyGroup' ? parsedQr.grpname : contactName
       }
       onClick={() => processQr(accountId, inviteLinkTrimmed)}
     />


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/7abed3e3-9e81-4c68-86f6-5af6fb8e541a) ![image](https://github.com/user-attachments/assets/64c2f7f1-8784-45e5-be26-a3ec31ce6b41)

After:

![image](https://github.com/user-attachments/assets/cdbcba9f-4086-496b-b1e4-6a6a8fd12a06) ![image](https://github.com/user-attachments/assets/7f61062d-04ec-4ba1-b4ed-b3020bfea67b)


Partially addresses https://github.com/deltachat/deltachat-desktop/issues/4158. What's left I guess is adding this to the "plus button" dialog.