### PR TITLE
blocked users in chatlist menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ## Fixed
 - image attachments not being centered within a message #4313
+- fix blocked status of a contact in context menu for ChatListItem and ThreeDotMenu #4046
 
 
 <a id="1_47_1"></a>


### PR DESCRIPTION
There's an issue #4046, short summary:

1. Block contact
2. Find a group chat with this contact
3. Open blocked contact profile
4. Press 'Send Message'
5. Now you have a chat with blocked contact in `ChatList` (on the left), but when you open a context menu on this chat there's only "Block Contact"

Same scenario works for the ThreeDotMenu in chat view.