### PR TITLE
Fix Settings/AllMedia in Account List context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@
 - fix: exit search when clicking on profile when the selected profile is already the selected account #4166
 - "Encryption Info" dialog showing all info in one line #4162
 - losing scrolling "momentum" while scrolling the messages list fast #4122
+- fix crash when you chose Settings from a context menu on account you haven't selected #4190
+- fix All Media not opening from a context menu on account you haven't selected #4191
 
 <a id="1_46_8"></a>
 

--- a/packages/frontend/src/ScreenController.tsx
+++ b/packages/frontend/src/ScreenController.tsx
@@ -121,6 +121,9 @@ export default class ScreenController extends Component {
       await this.unSelectAccount()
       this.selectedAccountId = accountId
       ;(window.__selectedAccountId as number) = accountId
+      // forcing to load settings here so when we for example switch to Settings
+      // from context menu they're already present and we avoid crashing
+      SettingsStoreInstance.effect.load()
     } else {
       log.info('account is already selected')
       // do not return here as this can be the state transition between unconfigured to configured
@@ -138,13 +141,15 @@ export default class ScreenController extends Component {
     if (!dontStartIo) {
       await BackendRemote.rpc.startIo(accountId)
     }
-    runtime.setDesktopSetting('lastAccount', accountId)
-    BackendRemote.rpc.getSystemInfo().then(info => {
-      log.info('system_info', info)
-    })
+
     BackendRemote.rpc.getInfo(accountId).then(info => {
       log.info('account_info', info)
     })
+    BackendRemote.rpc.getSystemInfo().then(info => {
+      log.info('system_info', info)
+    })
+
+    await runtime.setDesktopSetting('lastAccount', accountId)
   }
 
   async unSelectAccount() {

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -100,7 +100,8 @@ export default function AccountItem({
         setTimeout(() => {
           ActionEmitter.emitAction(KeybindAction.GlobalGallery_Open)
           // NOTE(maxph): Gallery.tsx gets unmounted before receiving media data
-          // and breaks markdown, so here 50ms is a temprorary workaround for that
+          // and only partially updates chat header without changing chat view to Gallery, 
+          // so here 50ms is a temprorary workaround for that
         }, 50)
       },
     },

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -100,7 +100,7 @@ export default function AccountItem({
         setTimeout(() => {
           ActionEmitter.emitAction(KeybindAction.GlobalGallery_Open)
           // NOTE(maxph): Gallery.tsx gets unmounted before receiving media data
-          // and only partially updates chat header without changing chat view to Gallery, 
+          // and only partially updates chat header without changing chat view to Gallery,
           // so here 50ms is a temprorary workaround for that
         }, 50)
       },

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -99,7 +99,9 @@ export default function AccountItem({
         // set Timeout forces it to be run after react update
         setTimeout(() => {
           ActionEmitter.emitAction(KeybindAction.GlobalGallery_Open)
-        }, 0)
+          // NOTE(maxph): Gallery.tsx gets unmounted before receiving media data
+          // and breaks markdown, so here 50ms is a temprorary workaround for that
+        }, 50)
       },
     },
     {

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -133,7 +133,7 @@ class SettingsStore extends Store<SettingsStoreState | null> {
       )
       const desktopSettings = await runtime.getDesktopSettings()
 
-      const rc = await runtime.getRC_Config()
+      const rc = runtime.getRC_Config()
       this.reducer.setState({
         settings,
         selfContact,


### PR DESCRIPTION
- combine all settings-gathering when changing account since some functions await for SelectAccount
- give additional 50ms to switching to Gallery since there's a conflict of setState and async media query in Gallery.tsx
- resolves #4190
- resolves #4191