### PR TITLE
chore: ci: fix preview download link missing

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -113,8 +113,15 @@ jobs:
        PR_ID: ${{ steps.prepare.outputs.prid }}
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload result to artifacts
+      id: upload-github
       if: steps.upload.outcome == 'failure'
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@main
       with:
         name: ${{ matrix.os }} output
         path: packages/target-electron/dist/preview/
+    - name: "Post links to GitHub artifact to details"
+      if: steps.upload-github.outcome == 'success'
+      run: node ./bin/github-actions/postLinksToDetails.js
+      env:
+        FULL_ARTIFACT_URL: ${{ steps.upload-github.outputs.artifact-url }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/bin/github-actions/postLinksToDetails.js
+++ b/bin/github-actions/postLinksToDetails.js
@@ -12,18 +12,27 @@ const GITHUB_API_URL =
 const prId = process.env['PR_ID']
 const GITHUB_TOKEN = process.env['GITHUB_TOKEN']
 
+/** May be absent */
+const FULL_ARTIFACT_URL = process.env['FULL_ARTIFACT_URL']
+
 let platform_status = {}
 
 if (process.platform === 'darwin') {
   platform_status['context'] = '⭐ MacOS Preview Build'
   // platform_status['target_url'] = base_url + prId + '.dmg'
-  platform_status['target_url'] = base_url + 'mas-' + prId + '.zip'
+  platform_status['target_url'] =
+    FULL_ARTIFACT_URL ||
+    base_url + 'mas-' + prId + '.zip'
 } else if (process.platform === 'win32') {
   platform_status['context'] = '⭐ Windows Preview Build (portable)'
-  platform_status['target_url'] = base_url + prId + '.portable.exe'
+  platform_status['target_url'] =
+    FULL_ARTIFACT_URL ||
+    base_url + prId + '.portable.exe'
 } else if (process.platform === 'linux') {
   platform_status['context'] = '⭐ Linux Preview Build'
-  platform_status['target_url'] = base_url + prId + '.AppImage'
+  platform_status['target_url'] =
+    FULL_ARTIFACT_URL ||
+    base_url + prId + '.AppImage'
 } else {
   throw new Error('Unsuported platform: ' + process.platform)
 }


### PR DESCRIPTION
When an upload to our server fails.
Currently upload keeps failing for Mac and Windows for all MRs.
But we still upload to GitHub artifacts in such a case,
so let's not miss out on it and still show the download link.

TODO:
- [x] Let me see if this works.