### PR TITLE
fix: packaging: include architecture in filename for all appimages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - losing scrolling "momentum" while scrolling the messages list fast #4122
 - fix crash when you chose Settings from a context menu on account you haven't selected #4190
 - fix All Media not opening from a context menu on account you haven't selected #4191
+- fix: packaging: include architecture in filename for all appimages #4202
 
 <a id="1_46_8"></a>
 

--- a/packages/target-electron/build/gen-electron-builder-config.js
+++ b/packages/target-electron/build/gen-electron-builder-config.js
@@ -145,6 +145,10 @@ build['linux'] = {
   description: 'The Email messenger (https://delta.chat)',
 }
 
+build['appImage'] = {
+  artifactName: '${productName}-${version}-${arch}.${ext}',
+}
+
 build['deb'] = {
   packageName: previewBuild ? 'deltachat-preview' : 'deltachat',
 }


### PR DESCRIPTION
closes #4181
