### PR TITLE
Escape works as "go back" in settings

### DIFF
--- a/packages/frontend/src/components/Dialog/BackButton.tsx
+++ b/packages/frontend/src/components/Dialog/BackButton.tsx
@@ -14,6 +14,8 @@ export default function BackButton(
 
   return (
     <HeaderButton
+      value='cancel'
+      formMethod='dialog'
       aria-label={tx('back')}
       icon='arrow-left'
       iconSize={24}

--- a/packages/frontend/src/components/Dialog/DialogHeader.tsx
+++ b/packages/frontend/src/components/Dialog/DialogHeader.tsx
@@ -28,7 +28,11 @@ export default function DialogHeader(props: Props) {
       {children}
       {onClickEdit && <EditButton onClick={onClickEdit} />}
       {onClose && (
-        <CloseButton onClick={onClose} data-testid={props.dataTestid} />
+        <CloseButton
+          value='close'
+          formMethod='dialog'
+          data-testid={props.dataTestid}
+        />
       )}
     </header>
   )

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -3,7 +3,12 @@ $paddingHorizontal: 30px;
 $paddingVertical: 20px;
 
 .dialog {
+  opacity: 0;
   padding: 0;
+
+  &:last-of-type {
+    opacity: 1;
+  }
 
   &.unstyled {
     background: none;

--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useEffect } from 'react'
 
 import { useSettingsStore } from '../../stores/settings'
 import { SendBackupDialog } from '../dialogs/SetupMultiDevice'
@@ -20,19 +20,11 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../contexts/DialogContext'
 
-type SettingsView =
-  | 'main'
-  | 'chats_and_media'
-  | 'notifications'
-  | 'appearance'
-  | 'advanced'
-
 export default function Settings({ onClose }: DialogProps) {
   const { openDialog } = useDialog()
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const settingsStore = useSettingsStore()[0]!
   const tx = useTranslationFunction()
-  const [settingsMode, setSettingsMode] = useState<SettingsView>('main')
 
   useEffect(() => {
     if (window.__settingsOpened) {
@@ -48,137 +40,142 @@ export default function Settings({ onClose }: DialogProps) {
 
   return (
     <Dialog onClose={onClose} fixed width={400} data-testid='settings-dialog'>
-      {settingsMode === 'main' && (
-        <>
-          <DialogHeader
-            title={tx('menu_settings')}
-            onClose={onClose}
-            data-testid='close-settings'
-          />
-          <DialogBody>
-            <Profile settingsStore={settingsStore} />
-            <SettingsIconButton
-              icon='person'
-              onClick={() => {
-                openDialog(EditProfileDialog, {
-                  settingsStore,
-                })
-              }}
-            >
-              {tx('pref_edit_profile')}
-            </SettingsIconButton>
-            <SettingsSeparator />
-            <SettingsIconButton
-              icon='forum'
-              onClick={() => setSettingsMode('chats_and_media')}
-            >
-              {tx('pref_chats_and_media')}
-            </SettingsIconButton>
-            <SettingsIconButton
-              icon='bell'
-              onClick={() => setSettingsMode('notifications')}
-            >
-              {tx('pref_notifications')}
-            </SettingsIconButton>
-            <SettingsIconButton
-              icon='brightness-6'
-              onClick={() => setSettingsMode('appearance')}
-            >
-              {tx('pref_appearance')}
-            </SettingsIconButton>
-            <SettingsIconButton
-              icon='devices'
-              onClick={() => {
-                openDialog(SendBackupDialog)
-                onClose()
-              }}
-            >
-              {tx('multidevice_title')}
-            </SettingsIconButton>
-            <ConnectivityButton />
-            <SettingsIconButton
-              icon='code-tags'
-              onClick={() => setSettingsMode('advanced')}
-            >
-              {tx('menu_advanced')}
-            </SettingsIconButton>
-            <SettingsSeparator />
-            {!runtime.getRuntimeInfo().isMac && (
-              <SettingsIconButton
-                icon='favorite'
-                onClick={() => runtime.openLink(donationUrl)}
-                isLink
-              >
-                {tx('donate')}
-              </SettingsIconButton>
-            )}
-            <SettingsIconButton
-              icon='question_mark'
-              onClick={() => runtime.openHelpWindow()}
-            >
-              {tx('menu_help')}
-            </SettingsIconButton>
-            <SettingsIconButton icon='info' onClick={() => openDialog(About)}>
-              {tx('global_menu_help_about_desktop')}
-            </SettingsIconButton>
-          </DialogBody>
-        </>
-      )}
-      {settingsMode === 'chats_and_media' && (
-        <>
-          <DialogHeader
-            title={tx('pref_chats_and_media')}
-            onClickBack={() => setSettingsMode('main')}
-            onClose={onClose}
-          />
-          <DialogBody>
-            <ChatsAndMedia
-              settingsStore={settingsStore}
-              desktopSettings={settingsStore.desktopSettings}
-            />
-          </DialogBody>
-        </>
-      )}
-      {settingsMode === 'notifications' && (
-        <>
-          <DialogHeader
-            title={tx('pref_notifications')}
-            onClickBack={() => setSettingsMode('main')}
-            onClose={onClose}
-          />
-          <DialogBody>
-            <Notifications desktopSettings={settingsStore.desktopSettings} />
-          </DialogBody>
-        </>
-      )}
-      {settingsMode === 'appearance' && (
-        <>
-          <DialogHeader
-            title={tx('pref_appearance')}
-            onClickBack={() => setSettingsMode('main')}
-            onClose={onClose}
-          />
-          <DialogBody>
-            <Appearance
-              rc={settingsStore.rc}
-              desktopSettings={settingsStore.desktopSettings}
-              settingsStore={settingsStore}
-            />
-          </DialogBody>
-        </>
-      )}
-      {settingsMode === 'advanced' && (
-        <>
-          <DialogHeader
-            title={tx('menu_advanced')}
-            onClickBack={() => setSettingsMode('main')}
-            onClose={onClose}
-          />
-          <DialogBody>
-            <Advanced settingsStore={settingsStore} />
-          </DialogBody>
-        </>
-      )}
+      <DialogHeader
+        title={tx('menu_settings')}
+        onClose={onClose}
+        data-testid='close-settings'
+      />
+      <DialogBody>
+        <Profile settingsStore={settingsStore} />
+        <SettingsIconButton
+          icon='person'
+          onClick={() => openDialog(EditProfileDialog, { onClose })}
+        >
+          {tx('pref_edit_profile')}
+        </SettingsIconButton>
+        <SettingsSeparator />
+        <SettingsIconButton
+          icon='forum'
+          onClick={() => openDialog(SettingsDialogChatsAndMedia, { onClose })}
+        >
+          {tx('pref_chats_and_media')}
+        </SettingsIconButton>
+        <SettingsIconButton
+          icon='bell'
+          onClick={() => openDialog(SettingsDialogNotifications, { onClose })}
+        >
+          {tx('pref_notifications')}
+        </SettingsIconButton>
+        <SettingsIconButton
+          icon='brightness-6'
+          onClick={() => openDialog(SettingsDialogAppearance, { onClose })}
+        >
+          {tx('pref_appearance')}
+        </SettingsIconButton>
+        <SettingsIconButton
+          icon='devices'
+          onClick={() => openDialog(SendBackupDialog, { onClose })}
+        >
+          {tx('multidevice_title')}
+        </SettingsIconButton>
+        <ConnectivityButton />
+        <SettingsIconButton
+          icon='code-tags'
+          onClick={() => openDialog(SettingsDialogAdvanced, { onClose })}
+        >
+          {tx('menu_advanced')}
+        </SettingsIconButton>
+        <SettingsSeparator />
+        {!runtime.getRuntimeInfo().isMac && (
+          <SettingsIconButton
+            icon='favorite'
+            onClick={() => runtime.openLink(donationUrl)}
+            isLink
+          >
+            {tx('donate')}
+          </SettingsIconButton>
+        )}
+        <SettingsIconButton
+          icon='question_mark'
+          onClick={() => runtime.openHelpWindow()}
+        >
+          {tx('menu_help')}
+        </SettingsIconButton>
+        <SettingsIconButton
+          icon='info'
+          onClick={() => openDialog(About, { onClose })}
+        >
+          {tx('global_menu_help_about_desktop')}
+        </SettingsIconButton>
+      </DialogBody>
+    </Dialog>
+  )
+}
+
+function SettingsDialogChatsAndMedia({ onClose }: DialogProps & { x: number }) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const settingsStore = useSettingsStore()[0]!
+  const tx = useTranslationFunction()
+  return (
+    <Dialog onClose={onClose} fixed width={400}>
+      <DialogHeader title={tx('pref_chats_and_media')} onClose={onClose} />
+      <DialogBody>
+        <ChatsAndMedia
+          settingsStore={settingsStore}
+          desktopSettings={settingsStore.desktopSettings}
+        />
+      </DialogBody>
+    </Dialog>
+  )
+}
+
+function SettingsDialogNotifications({ onClose }: DialogProps) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const settingsStore = useSettingsStore()[0]!
+  const tx = useTranslationFunction()
+  return (
+    <Dialog onClose={onClose} fixed width={400}>
+      <DialogHeader title={tx('pref_notifications')} onClose={onClose} />
+      <DialogBody>
+        <Notifications desktopSettings={settingsStore.desktopSettings} />
+      </DialogBody>
+    </Dialog>
+  )
+}
+
+function SettingsDialogAppearance({ onClose }: DialogProps) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const settingsStore = useSettingsStore()[0]!
+  const tx = useTranslationFunction()
+
+  return (
+    <Dialog onClose={onClose} fixed width={400}>
+      <DialogHeader
+        onClickBack={() => {}}
+        title={tx('pref_appearance')}
+        onClose={onClose}
+      />
+      <DialogBody>
+        <Appearance
+          rc={settingsStore.rc}
+          desktopSettings={settingsStore.desktopSettings}
+          settingsStore={settingsStore}
+        />
+      </DialogBody>
+    </Dialog>
+  )
+}
+
+function SettingsDialogAdvanced({ onClose }: DialogProps) {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const settingsStore = useSettingsStore()[0]!
+  const tx = useTranslationFunction()
+  return (
+    <Dialog onClose={onClose} fixed width={400}>
+      <DialogHeader title={tx('menu_advanced')} onClose={onClose} />
+      <DialogBody>
+        <Advanced settingsStore={settingsStore} />
+      </DialogBody>
     </Dialog>
   )
 }

--- a/packages/frontend/src/components/dialogs/ConfirmationDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfirmationDialog.tsx
@@ -34,14 +34,9 @@ export default function ConfirmationDialog({
 }: Props) {
   const tx = useTranslationFunction()
 
-  const handleClick = (yes: boolean) => {
+  const handleClose = (result: string) => {
+    cb(result === 'confirm')
     onClose()
-    cb(yes)
-  }
-
-  const handleClose = () => {
-    onClose()
-    cb(false)
   }
 
   return (
@@ -55,14 +50,16 @@ export default function ConfirmationDialog({
       <DialogFooter>
         <FooterActions>
           <FooterActionButton
-            onClick={() => handleClick(false)}
+            formMethod='dialog'
+            value='cancel'
             data-testid='cancel'
           >
             {cancelLabel || tx('cancel')}
           </FooterActionButton>
           <FooterActionButton
             styling={isConfirmDanger ? 'danger' : undefined}
-            onClick={() => handleClick(true)}
+            formMethod='dialog'
+            value='confirm'
             data-testid='confirm'
           >
             {confirmLabel || tx('yes')}

--- a/packages/frontend/src/components/dialogs/EditProfileDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/EditProfileDialog/index.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from 'react'
 
-import SettingsStoreInstance, {
-  SettingsStoreState,
-} from '../../../stores/settings'
+import SettingsStoreInstance from '../../../stores/settings'
+import { useSettingsStore } from '../../../stores/settings'
 import { BackendRemote } from '../../../backend-com'
 import { selectedAccountId } from '../../../ScreenController'
 import { DeltaInput, DeltaTextarea } from '../../Login-Styles'
@@ -24,7 +23,6 @@ import styles from './styles.module.scss'
 import type { DialogProps } from '../../../contexts/DialogContext'
 
 type Props = {
-  settingsStore: SettingsStoreState
   firstSetup?: boolean
 } & DialogProps
 
@@ -39,13 +37,12 @@ export default function EditProfileDialog({ onClose, ...props }: Props) {
   )
 }
 
-function EditProfileDialogInner({
-  onClose,
-  settingsStore,
-  firstSetup = false,
-}: Props) {
+function EditProfileDialogInner({ onClose, firstSetup = false }: Props) {
   const tx = useTranslationFunction()
   const openAlertDialog = useAlertDialog()
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const settingsStore = useSettingsStore()[0]!
 
   const [displayname, setDisplayname] = useState(
     settingsStore.settings.displayname || ''

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -81,16 +81,24 @@ export default function ViewProfile(
 
   const onClickViewProfileMenu = useViewProfileMenu(contact)
 
+  const handleClose = (result: string) => {
+    if (result === 'close') {
+      onClose()
+    } else if (result === 'cancel') {
+      onBack && onBack()
+    }
+  }
+
   return (
     <Dialog
       width={400}
-      onClose={onClose}
+      onClose={handleClose}
       fixed
       className={styles.viewProfileDialog}
     >
       <DialogHeader
         title={tx('contact')}
-        onClose={onClose}
+        onClose={handleClose}
         onClickBack={onBack}
       >
         {showMenu && (

--- a/packages/frontend/src/components/screens/AccountDeletionScreen/AccountDeletionScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountDeletionScreen/AccountDeletionScreen.tsx
@@ -54,7 +54,6 @@ export default function AccountDeletionScreen({
         <Dialog
           canEscapeKeyClose={true}
           fixed={true}
-          onClose={() => {}}
           width={400}
           dataTestid='account-deletion-dialog'
         >

--- a/packages/frontend/src/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
@@ -9,7 +9,7 @@ import useChat from '../../../hooks/chat/useChat'
 import useInstantOnboarding from '../../../hooks/useInstantOnboarding'
 import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import { DeltaInput } from '../../Login-Styles'
-import { DialogBody, DialogContent, DialogHeader } from '../../Dialog'
+import Dialog, { DialogBody, DialogContent, DialogHeader } from '../../Dialog'
 import { ScreenContext } from '../../../contexts/ScreenContext'
 import { Screens } from '../../../ScreenController'
 
@@ -122,17 +122,22 @@ export default function InstantOnboardingScreen({
     openDialog(UseOtherServerDialog)
   }
 
-  const onClickBack = () => {
-    saveDisplayName()
-    onCancel()
+  const onClose = (result: string) => {
+    if (result === 'cancel') {
+      saveDisplayName()
+      onCancel()
+    }
   }
 
   return (
-    <>
-      <DialogHeader
-        onClickBack={onClickBack}
-        title={tx('instant_onboarding_title')}
-      />
+    <Dialog
+      fixed
+      onClose={onClose}
+      width={400}
+      canEscapeKeyClose={false}
+      canOutsideClickClose={false}
+    >
+      <DialogHeader title={tx('instant_onboarding_title')} />
       <DialogBody className={styles.welcomeScreenBody}>
         <DialogContent paddingBottom>
           <ProfileImageSelector
@@ -179,6 +184,6 @@ export default function InstantOnboardingScreen({
           </div>
         </DialogContent>
       </DialogBody>
-    </>
+    </Dialog>
   )
 }

--- a/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
@@ -6,7 +6,7 @@ import Button from '../../Button'
 import useDialog from '../../../hooks/dialog/useDialog'
 import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import { BackendRemote, EffectfulBackendActions } from '../../../backend-com'
-import { DialogBody, DialogContent, DialogHeader } from '../../Dialog'
+import Dialog, { DialogBody, DialogContent, DialogHeader } from '../../Dialog'
 import { getLogger } from '../../../../../shared/logger'
 
 import styles from './styles.module.scss'
@@ -56,8 +56,20 @@ export default function OnboardingScreen(props: Props) {
     }
   }
 
+  const onClose = (result: string) => {
+    if (result === 'cancel') {
+      onClickBackButton()
+    }
+  }
+
   return (
-    <>
+    <Dialog
+      fixed
+      onClose={onClose}
+      width={400}
+      canEscapeKeyClose={false}
+      canOutsideClickClose={false}
+    >
       <DialogHeader
         onClickBack={props.showBackButton ? onClickBackButton : undefined}
         title={
@@ -95,6 +107,6 @@ export default function OnboardingScreen(props: Props) {
           </div>
         </DialogContent>
       </DialogBody>
-    </>
+    </Dialog>
   )
 }

--- a/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
@@ -1,6 +1,5 @@
 import React, { useLayoutEffect, useState } from 'react'
 
-import Dialog from '../../Dialog'
 import ImageBackdrop from '../../ImageBackdrop'
 import InstantOnboardingScreen from './InstantOnboardingScreen'
 import OnboardingScreen from './OnboardingScreen'
@@ -37,27 +36,20 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
 
   return (
     <ImageBackdrop variant='welcome'>
-      <Dialog
-        fixed
-        width={400}
-        canEscapeKeyClose={false}
-        canOutsideClickClose={false}
-      >
-        {!showInstantOnboarding ? (
-          <OnboardingScreen
-            onNextStep={() => startInstantOnboardingFlow()}
-            selectedAccountId={selectedAccountId}
-            showBackButton={showBackButton}
-            hasConfiguredAccounts={hasConfiguredAccounts}
-            {...props}
-          />
-        ) : (
-          <InstantOnboardingScreen
-            selectedAccountId={selectedAccountId}
-            onCancel={() => resetInstantOnboarding()}
-          />
-        )}
-      </Dialog>
+      {!showInstantOnboarding ? (
+        <OnboardingScreen
+          onNextStep={() => startInstantOnboardingFlow()}
+          selectedAccountId={selectedAccountId}
+          showBackButton={showBackButton}
+          hasConfiguredAccounts={hasConfiguredAccounts}
+          {...props}
+        />
+      ) : (
+        <InstantOnboardingScreen
+          selectedAccountId={selectedAccountId}
+          onCancel={() => resetInstantOnboarding()}
+        />
+      )}
     </ImageBackdrop>
   )
 }

--- a/packages/frontend/src/contexts/DialogContext.tsx
+++ b/packages/frontend/src/contexts/DialogContext.tsx
@@ -15,7 +15,7 @@ type DialogElementConstructor<T> = JSXElementConstructor<DialogProps & T>
 
 export type OpenDialog = <T extends { [key: string]: any }>(
   dialogElement: DialogElementConstructor<T>,
-  additionalProps?: T
+  additionalProps?: DialogProps & T
 ) => DialogId
 
 export type CloseDialog = (id: DialogId) => void
@@ -58,11 +58,17 @@ export const DialogContextProvider = ({ children }: PropsWithChildren<{}>) => {
         // From this point on we are only interested in the `DialogProps`
         dialogElement as DialogElementConstructor<DialogProps>,
         {
-          key: `dialog-${newDialogId}`,
-          onClose: () => {
-            closeDialog(newDialogId)
-          },
+          // set additionalProps first so we don't override onClose,
+          // cause we need to combine additionalProps.onClose with our own dialog management
           ...additionalProps,
+          key: `dialog-${newDialogId}`,
+          onClose: (value: string) => {
+            closeDialog(newDialogId)
+
+            if (value !== 'cancel') {
+              additionalProps && additionalProps.onClose?.()
+            }
+          },
         }
       )
 


### PR DESCRIPTION
Did this as a test, cause it seemed like an easy refactor. And it was

Works, Notifications do look kinda weird.
![image](https://github.com/user-attachments/assets/4e2ee658-cf83-462b-b03f-6baa95536e11)

There's an explicit "close settings" call when we click on "Add Second Device". @r10s @nicodh  Should that remain or no? Here's a video of how it works

https://github.com/user-attachments/assets/024c2980-089f-43ae-a1d7-8e0cf8a30c65

Depends on #4006 so I'm not asking for review right now, too many changes displayed here
