### PR TITLE
WIP: improvement: arrow-key navigation for chat list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 - cancel old message highlight animations when a new message is highlighted #4203
 - fix: packaging: include architecture in filename for all appimages #4202
 - fix: make open external link scheme case insensive #4201
-- improve accessibility a little #4133
+- improve accessibility a little #4133, #4210
 
 <a id="1_46_8"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - cancel old message highlight animations when a new message is highlighted #4203
 - fix: packaging: include architecture in filename for all appimages #4202
 - fix: make open external link scheme case insensive #4201
+- improve accessibility a little #4133
 
 <a id="1_46_8"></a>
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -74,5 +74,8 @@
   },
   "join_group": {
     "message": "Join Group"
+  },
+  "react_more_emojis": {
+    "message": "More emojis…"
   }
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -40,6 +40,7 @@
     "path-browserify": "^1.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-roving-tabindex": "^3.2.0",
     "react-string-replace": "^1.1.1",
     "react-virtualized-auto-sizer": "^1.0.24",
     "react-window": "^1.8.10",

--- a/packages/frontend/scss/chat/_chat-list-item.scss
+++ b/packages/frontend/scss/chat/_chat-list-item.scss
@@ -3,6 +3,11 @@
 .chat-list-item,
 .pseudo-chat-list-item {
   height: 64px;
+  width: 100%;
+  text-align: unset;
+  color: var(--globalText);
+  background-color: transparent;
+  border: none;
   display: flex;
   flex-direction: row;
   padding: 0px 10px;

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -150,7 +150,7 @@ export default function AccountItem({
     )
   }
 
-  const ref = useRef<HTMLDivElement>(null)
+  const ref = useRef<HTMLButtonElement>(null)
   useLayoutEffect(() => {
     if (!isSelected) {
       return
@@ -186,7 +186,7 @@ export default function AccountItem({
   }, [isSelected, window.__screen])
 
   return (
-    <div
+    <button
       className={classNames(styles.account, {
         [styles.active]: isSelected,
         [styles['context-menu-active']]: isContextMenuActive,
@@ -232,7 +232,7 @@ export default function AccountItem({
         </div>
       )}
       <div className={classNames(styles.accountBadge)}>{badgeContent}</div>
-    </div>
+    </button>
   )
 }
 

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -133,7 +133,7 @@ export default function AccountItem({
     badgeContent = (
       <div
         className={classNames(styles.accountBadgeIcon, styles.bgSyncDisabled)}
-        aria-label='Background sync disabled'
+        aria-label={tx('background_sync_disabled_explaination')}
       >
         ⏻
       </div>

--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -24,6 +24,7 @@ import { ScreenContext } from '../../contexts/ScreenContext'
 import useChat from '../../hooks/chat/useChat'
 import { Screens } from '../../ScreenController'
 import { ActionEmitter, KeybindAction } from '../../keybindings'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 type Props = {
   onAddAccount: () => Promise<number>
@@ -38,6 +39,8 @@ export default function AccountListSidebar({
   openAccountDeletionScreen,
   selectedAccountId,
 }: Props) {
+  const tx = useTranslationFunction()
+
   const { openDialog } = useDialog()
   const [accounts, setAccounts] = useState<T.Account[]>([])
   const [{ accounts: noficationSettings }] = useAccountNotificationStore()
@@ -138,14 +141,22 @@ export default function AccountListSidebar({
             muted={noficationSettings[account.id]?.muted || false}
           />
         ))}
-        <button className={styles.addButton} onClick={onAddAccount}>
+        <button
+          aria-label={tx('add_account')}
+          className={styles.addButton}
+          onClick={onAddAccount}
+        >
           +
         </button>
       </div>
       {/* The condition is the same as in https://github.com/deltachat/deltachat-desktop/blob/63af023437ff1828a27de2da37bf94ab180ec528/src/renderer/contexts/KeybindingsContext.tsx#L26 */}
       {window.__screen === Screens.Main && (
         <div className={styles.buttonsContainer}>
-          <button className={styles.settingsButton} onClick={openSettings}>
+          <button
+            aria-label={tx('menu_settings')}
+            className={styles.settingsButton}
+            onClick={openSettings}
+          >
             <Icon
               size={38}
               className={styles.settingsButtonIcon}

--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -94,7 +94,7 @@ export default function AccountListSidebar({
   const updateHoverInfoPosition = useCallback(() => {
     if (hoverInfo.current && accountForHoverInfo) {
       const elem = document.querySelector(
-        `div[x-account-sidebar-account-id="${accountForHoverInfo.id}"]`
+        `[x-account-sidebar-account-id="${accountForHoverInfo.id}"]`
       )
       if (elem) {
         const rect = elem.getBoundingClientRect()

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -6,7 +6,6 @@
   --local-avatar-vertical-margin: 8px;
   --local-avatar-font-size: 26px;
 
-  cursor: pointer;
   display: inline-block;
   font-weight: normal;
   height: var(--local-avatar-size);
@@ -65,6 +64,11 @@
   }
 
   .account {
+    border: none;
+    background: none;
+    padding: 0;
+    text-align: start; // To align the "active" indicator
+
     height: var(--als-avatar-size);
     margin-bottom: var(--als-avatar-margin);
     margin-top: var(--als-avatar-margin);

--- a/packages/frontend/src/components/Dialog/BackButton.tsx
+++ b/packages/frontend/src/components/Dialog/BackButton.tsx
@@ -5,13 +5,16 @@ import HeaderButton from './HeaderButton'
 import type { ButtonHTMLAttributes } from 'react'
 
 import styles from './styles.module.scss'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 export default function BackButton(
   props: ButtonHTMLAttributes<HTMLButtonElement>
 ) {
+  const tx = useTranslationFunction()
+
   return (
     <HeaderButton
-      aria-label='Back'
+      aria-label={tx('back')}
       icon='arrow-left'
       iconSize={24}
       className={styles.backButton}

--- a/packages/frontend/src/components/Dialog/CloseButton.tsx
+++ b/packages/frontend/src/components/Dialog/CloseButton.tsx
@@ -3,11 +3,19 @@ import React from 'react'
 import HeaderButton from './HeaderButton'
 
 import type { ButtonHTMLAttributes } from 'react'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 export default function CloseButton(
   props: ButtonHTMLAttributes<HTMLButtonElement>
 ) {
+  const tx = useTranslationFunction()
+
   return (
-    <HeaderButton aria-label='Close' icon='cross' iconSize={26} {...props} />
+    <HeaderButton
+      aria-label={tx('close')}
+      icon='cross'
+      iconSize={26}
+      {...props}
+    />
   )
 }

--- a/packages/frontend/src/components/Dialog/HeaderButton.tsx
+++ b/packages/frontend/src/components/Dialog/HeaderButton.tsx
@@ -12,6 +12,7 @@ type Props = ButtonHTMLAttributes<HTMLButtonElement> & {
   icon: IconName
   iconSize: number
   rotation?: number
+  'aria-label': string
 }
 
 export default function HeaderButton({

--- a/packages/frontend/src/components/ImageSelector/index.tsx
+++ b/packages/frontend/src/components/ImageSelector/index.tsx
@@ -67,6 +67,7 @@ export default function ImageSelector({
         {!imageUrl && (
           <button
             title={selectLabel ? selectLabel : tx('profile_image_select')}
+            aria-label={selectLabel ? selectLabel : tx('profile_image_select')}
             className={styles.imageSelectorButton}
             onClick={handleSelect}
           >
@@ -76,6 +77,7 @@ export default function ImageSelector({
         {imageUrl && (
           <button
             title={removeLabel ? removeLabel : tx('profile_image_delete')}
+            aria-label={removeLabel ? removeLabel : tx('profile_image_delete')}
             className={styles.imageSelectorButton}
             onClick={handleRemove}
           >

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -159,6 +159,8 @@ export function enterKeySendsKeyboardShortcuts(
   const CtrlOrMetaEnter = isMac ? MetaEnter : CtrlEnter
   const ShiftEnter = ['Shift', 'Enter']
 
+  // FYI the send button's `aria-keyshortcuts` relies on this code,
+  // in a not-so-beautiful way.
   if (enterKeySends) {
     return [
       {

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -464,7 +464,11 @@ export default function QrReader({ onError, onScan }: Props) {
       {!error && (
         <div className={styles.qrReaderHint}>{tx('qrscan_hint_desktop')}</div>
       )}
-      <button className={styles.qrReaderButton} onClick={handleSelectInput}>
+      <button
+        className={styles.qrReaderButton}
+        onClick={handleSelectInput}
+        aria-label={tx('menu_settings')}
+      >
         <Icon icon='settings' size={24} className={styles.qrReaderButtonIcon} />
       </button>
       <input

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -9,6 +9,7 @@ import EmojiPicker from '../EmojiPicker'
 import styles from './styles.module.scss'
 
 import type { BaseEmoji } from 'emoji-mart/index'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 type Props = {
   messageId: number
@@ -23,6 +24,8 @@ export default function ReactionsBar({
   messageId,
   myReaction,
 }: Props) {
+  const tx = useTranslationFunction()
+
   const [showAllEmojis, setShowAllEmojis] = useState(false)
   const accountId = selectedAccountId()
 
@@ -87,6 +90,7 @@ export default function ReactionsBar({
               styles.showAllEmojis
             )}
             onClick={handleShowAllEmojis}
+            aria-label={tx('react_more_emojis')}
           >
             <Icon className={styles.showAllIcon} icon='more' />
           </button>

--- a/packages/frontend/src/components/SearchInput/index.tsx
+++ b/packages/frontend/src/components/SearchInput/index.tsx
@@ -51,6 +51,7 @@ export default function SearchInput(props: Props) {
         className={classNames(styles.searchInput)}
         ref={props.inputRef}
         spellCheck={false}
+        aria-keyshortcuts='Control+K'
       />
       {hasValue && (
         <SearchInputButton

--- a/packages/frontend/src/components/ShortcutMenu/index.tsx
+++ b/packages/frontend/src/components/ShortcutMenu/index.tsx
@@ -7,6 +7,7 @@ import Icon from '../Icon'
 import styles from './styles.module.scss'
 
 import type { T } from '@deltachat/jsonrpc-client'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 type OnButtonClick = React.MouseEvent<HTMLButtonElement, MouseEvent>
 
@@ -40,6 +41,8 @@ function ReactButton(props: {
   messageId: number
   reactions: T.Message['reactions']
 }) {
+  const tx = useTranslationFunction()
+
   const { showReactionsBar } = useReactionsBar()
 
   const onClick = (event: OnButtonClick) => {
@@ -60,15 +63,25 @@ function ReactButton(props: {
   }
 
   return (
-    <button className={styles.shortcutMenuButton} onClick={onClick}>
+    <button
+      aria-label={tx('react')}
+      className={styles.shortcutMenuButton}
+      onClick={onClick}
+    >
       <Icon className={styles.shortcutMenuIcon} icon='reaction' />
     </button>
   )
 }
 
 function ContextMenuButton(props: { onClick: (event: OnButtonClick) => void }) {
+  const tx = useTranslationFunction()
+
   return (
-    <button className={styles.shortcutMenuButton} onClick={props.onClick}>
+    <button
+      aria-label={tx('a11y_message_context_menu_btn_label')}
+      className={styles.shortcutMenuButton}
+      onClick={props.onClick}
+    >
       <Icon className={styles.shortcutMenuIcon} icon='more' />
     </button>
   )

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -44,6 +44,7 @@ import type {
   MessageChatListItemData,
 } from './ChatListItemRow'
 import { isInviteLink } from '../../../../shared/util'
+import { RovingTabIndexProvider } from 'react-roving-tabindex'
 
 const enum LoadStatus {
   FETCHING = 1,
@@ -338,6 +339,7 @@ export default function ChatList(props: {
   // Render --------------------
   const tx = useTranslationFunction()
 
+  // TODO add here as well...
   if (queryChatId && searchChatInfo) {
     return (
       <>
@@ -384,84 +386,96 @@ export default function ChatList(props: {
                   {translate_n('n_chats', chatListIds.length)}
                 </div>
               )}
-              <ChatListPart
-                isRowLoaded={isChatLoaded}
-                loadMoreRows={loadChats}
-                rowCount={chatListIds.length}
-                width={width}
-                height={chatsHeight(height)}
-                setListRef={(ref: List<any> | null) =>
-                  ((listRefRef.current as any) = ref)
-                }
-                itemKey={index => 'key' + chatListIds[index]}
-                itemData={chatlistData}
-                itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+              <RovingTabIndexProvider
+                options={{
+                  focusOnClick: true,
+                  direction: 'vertical',
+                  // `loopAround` doesn't really work for long lists
+                  // because we use 'react-window', i.e. only a part
+                  // of the entire list is actually  rendered.
+                  // loopAround: true,
+                  // Also "End" and "Home" don't quite work.
+                }}
               >
-                {ChatListItemRowChat}
-              </ChatListPart>
-              {isSearchActive && (
-                <>
-                  <div
-                    className='search-result-divider'
-                    style={{ width: width }}
-                  >
-                    {translate_n('n_contacts', contactIds.length)}
-                  </div>
-                  <ChatListPart
-                    isRowLoaded={isContactLoaded}
-                    loadMoreRows={loadContact}
-                    rowCount={contactIds.length}
-                    width={width}
-                    height={contactsHeight(height)}
-                    itemKey={index => 'key' + contactIds[index]}
-                    itemData={contactlistData}
-                    itemHeight={CHATLISTITEM_CONTACT_HEIGHT}
-                  >
-                    {ChatListItemRowContact}
-                  </ChatListPart>
-                  {contactIds.length === 0 &&
-                    chatListIds.length === 0 &&
-                    queryStrIsValidEmail && (
+                <ChatListPart
+                  isRowLoaded={isChatLoaded}
+                  loadMoreRows={loadChats}
+                  rowCount={chatListIds.length}
+                  width={width}
+                  height={chatsHeight(height)}
+                  setListRef={(ref: List<any> | null) =>
+                    ((listRefRef.current as any) = ref)
+                  }
+                  itemKey={index => 'key' + chatListIds[index]}
+                  itemData={chatlistData}
+                  itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                >
+                  {ChatListItemRowChat}
+                </ChatListPart>
+                {isSearchActive && (
+                  <>
+                    <div
+                      className='search-result-divider'
+                      style={{ width: width }}
+                    >
+                      {translate_n('n_contacts', contactIds.length)}
+                    </div>
+                    <ChatListPart
+                      isRowLoaded={isContactLoaded}
+                      loadMoreRows={loadContact}
+                      rowCount={contactIds.length}
+                      width={width}
+                      height={contactsHeight(height)}
+                      itemKey={index => 'key' + contactIds[index]}
+                      itemData={contactlistData}
+                      itemHeight={CHATLISTITEM_CONTACT_HEIGHT}
+                    >
+                      {ChatListItemRowContact}
+                    </ChatListPart>
+                    {contactIds.length === 0 &&
+                      chatListIds.length === 0 &&
+                      queryStrIsValidEmail && (
+                        <div style={{ width: width }}>
+                          <PseudoListItemAddContact
+                            queryStr={queryStr?.trim() || ''}
+                            queryStrIsEmail={queryStrIsValidEmail}
+                            onClick={addContactOnClick}
+                          />
+                        </div>
+                      )}
+                    {showPseudoListItemAddContactFromInviteLink && (
                       <div style={{ width: width }}>
-                        <PseudoListItemAddContact
-                          queryStr={queryStr?.trim() || ''}
-                          queryStrIsEmail={queryStrIsValidEmail}
-                          onClick={addContactOnClick}
+                        <PseudoListItemAddContactOrGroupFromInviteLink
+                          inviteLink={queryStr!}
+                          accountId={accountId}
                         />
                       </div>
                     )}
-                  {showPseudoListItemAddContactFromInviteLink && (
-                    <div style={{ width: width }}>
-                      <PseudoListItemAddContactOrGroupFromInviteLink
-                        inviteLink={queryStr!}
-                        accountId={accountId}
-                      />
+                    <div
+                      className='search-result-divider'
+                      style={{ width: width }}
+                    >
+                      {translated_messages_label(messageResultIds.length)}
                     </div>
-                  )}
-                  <div
-                    className='search-result-divider'
-                    style={{ width: width }}
-                  >
-                    {translated_messages_label(messageResultIds.length)}
-                  </div>
 
-                  <ChatListPart
-                    isRowLoaded={isMessageLoaded}
-                    loadMoreRows={loadMessages}
-                    rowCount={messageResultIds.length}
-                    width={width}
-                    height={
-                      // take remaining space
-                      messagesHeight(height)
-                    }
-                    itemKey={index => 'key' + messageResultIds[index]}
-                    itemData={messagelistData}
-                    itemHeight={CHATLISTITEM_MESSAGE_HEIGHT}
-                  >
-                    {ChatListItemRowMessage}
-                  </ChatListPart>
-                </>
-              )}
+                    <ChatListPart
+                      isRowLoaded={isMessageLoaded}
+                      loadMoreRows={loadMessages}
+                      rowCount={messageResultIds.length}
+                      width={width}
+                      height={
+                        // take remaining space
+                        messagesHeight(height)
+                      }
+                      itemKey={index => 'key' + messageResultIds[index]}
+                      itemData={messagelistData}
+                      itemHeight={CHATLISTITEM_MESSAGE_HEIGHT}
+                    >
+                      {ChatListItemRowMessage}
+                    </ChatListPart>
+                  </>
+                )}
+              </RovingTabIndexProvider>
               <div
                 className='floating-action-button'
                 onClick={onCreateChat}

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import classNames from 'classnames'
 import { T, C } from '@deltachat/jsonrpc-client'
 
@@ -12,6 +12,7 @@ import { selectedAccountId } from '../../ScreenController'
 import { InlineVerifiedIcon } from '../VerifiedIcon'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { message2React } from '../message/MessageMarkdown'
+import { useFocusEffect, useRovingTabIndex } from 'react-roving-tabindex'
 
 const log = getLogger('renderer/chatlist/item')
 
@@ -171,9 +172,21 @@ function ChatListItemArchiveLink({
     },
   ])
 
+  const ref = useRef<HTMLButtonElement>(null)
+
+  const [tabIndex, focused, tabindexHandleKeyDown, tabindexHandleClick] =
+    useRovingTabIndex(ref, false)
+  useFocusEffect(focused, ref)
+
   return (
     <button
-      onClick={onClick}
+      ref={ref}
+      tabIndex={tabIndex}
+      onClick={() => {
+        onClick()
+        tabindexHandleClick()
+      }}
+      onKeyDown={tabindexHandleKeyDown}
       onContextMenu={onContextMenu}
       className={`chat-list-item archive-link-item ${
         isContextMenuActive ? 'context-menu-active' : ''
@@ -206,9 +219,22 @@ function ChatListItemError({
   isSelected?: boolean
 }) {
   log.info('Error Loading Chatlistitem ' + chatListItem.id, chatListItem.error)
+
+  const ref = useRef<HTMLButtonElement>(null)
+
+  const [tabIndex, focused, tabindexHandleKeyDown, tabindexHandleClick] =
+    useRovingTabIndex(ref, false)
+  useFocusEffect(focused, ref)
+
   return (
     <button
-      onClick={onClick}
+      ref={ref}
+      tabIndex={tabIndex}
+      onClick={() => {
+        onClick()
+        tabindexHandleClick()
+      }}
+      onKeyDown={tabindexHandleKeyDown}
       onContextMenu={onContextMenu}
       className={classNames('chat-list-item', {
         isError: true,
@@ -256,9 +282,21 @@ function ChatListItemNormal({
   isSelected?: boolean
   hover?: boolean
 }) {
+  const ref = useRef<HTMLButtonElement>(null)
+
+  const [tabIndex, focused, tabindexHandleKeyDown, tabindexHandleClick] =
+    useRovingTabIndex(ref, false)
+  useFocusEffect(focused, ref)
+
   return (
     <button
-      onClick={onClick}
+      ref={ref}
+      tabIndex={tabIndex}
+      onClick={() => {
+        onClick()
+        tabindexHandleClick()
+      }}
+      onKeyDown={tabindexHandleKeyDown}
       onContextMenu={onContextMenu}
       className={classNames('chat-list-item', {
         'has-unread': chatListItem.freshMessageCounter > 0,
@@ -368,10 +406,24 @@ export const ChatListItemMessageResult = React.memo<{
   queryStr: string
 }>(props => {
   const { msr, onClick, queryStr } = props
+
+  const ref = useRef<HTMLButtonElement>(null)
+
+  const [tabIndex, focused, tabindexHandleKeyDown, tabindexHandleClick] =
+    useRovingTabIndex(ref, false)
+  useFocusEffect(focused, ref)
+
   if (typeof msr === 'undefined') return <PlaceholderChatListItem />
+
   return (
     <button
-      onClick={onClick}
+      ref={ref}
+      tabIndex={tabIndex}
+      onClick={() => {
+        onClick()
+        tabindexHandleClick()
+      }}
+      onKeyDown={tabindexHandleKeyDown}
       className='pseudo-chat-list-item message-search-result'
     >
       <div className='avatars'>

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -172,8 +172,7 @@ function ChatListItemArchiveLink({
   ])
 
   return (
-    <div
-      role='button'
+    <button
       onClick={onClick}
       onContextMenu={onContextMenu}
       className={`chat-list-item archive-link-item ${
@@ -187,7 +186,7 @@ function ChatListItemArchiveLink({
         <div className='archive-link'>{tx('chat_archived_chats_title')}</div>
       </div>
       <FreshMessageCounter counter={chatListItem.freshMessageCounter} />
-    </div>
+    </button>
   )
 }
 
@@ -201,13 +200,14 @@ function ChatListItemError({
     kind: 'Error'
   }
   onClick: () => void
-  onContextMenu?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+  onContextMenu?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void
   isSelected?: boolean
 }) {
   log.info('Error Loading Chatlistitem ' + chatListItem.id, chatListItem.error)
   return (
-    <div
-      role='button'
+    <button
       onClick={onClick}
       onContextMenu={onContextMenu}
       className={classNames('chat-list-item', {
@@ -233,7 +233,7 @@ function ChatListItemError({
           </div>
         </div>
       </div>
-    </div>
+    </button>
   )
 }
 
@@ -249,14 +249,15 @@ function ChatListItemNormal({
     kind: 'ChatListItem'
   }
   onClick: () => void
-  onContextMenu?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+  onContextMenu?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void
   isContextMenuActive?: boolean
   isSelected?: boolean
   hover?: boolean
 }) {
   return (
-    <div
-      role='button'
+    <button
       onClick={onClick}
       onContextMenu={onContextMenu}
       className={classNames('chat-list-item', {
@@ -297,14 +298,16 @@ function ChatListItemNormal({
           lastMessageId={chatListItem.lastMessageId}
         />
       </div>
-    </div>
+    </button>
   )
 }
 
 type ChatListItemProps = {
   chatListItem: Type.ChatListItemFetchResult | undefined
   onClick: () => void
-  onContextMenu?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
+  onContextMenu?: (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void
   isContextMenuActive?: boolean
   isSelected?: boolean
   hover?: boolean
@@ -367,8 +370,7 @@ export const ChatListItemMessageResult = React.memo<{
   const { msr, onClick, queryStr } = props
   if (typeof msr === 'undefined') return <PlaceholderChatListItem />
   return (
-    <div
-      role='button'
+    <button
       onClick={onClick}
       className='pseudo-chat-list-item message-search-result'
     >
@@ -424,7 +426,7 @@ export const ChatListItemMessageResult = React.memo<{
           <div className='text'>{rMessage(msr.message, queryStr)}</div>
         </div>
       </div>
-    </div>
+    </button>
   )
 })
 

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -5,6 +5,7 @@ import React, {
   forwardRef,
   useLayoutEffect,
   useCallback,
+  useMemo,
 } from 'react'
 import { C, T } from '@deltachat/jsonrpc-client'
 
@@ -38,6 +39,7 @@ import { VisualVCardComponent } from '../message/VCard'
 import { KeybindAction } from '../../keybindings'
 import useKeyBindingAction from '../../hooks/useKeyBindingAction'
 import { CloseButton } from '../Dialog'
+import { enterKeySendsKeyboardShortcuts } from '../KeyboardShortcutHint'
 
 const log = getLogger('renderer/composer')
 
@@ -263,6 +265,23 @@ const Composer = forwardRef<
     messageInputRef.current?.focus()
   }, [chatId, messageInputRef])
 
+  const ariaSendShortcut: string = useMemo(() => {
+    if (settingsStore == undefined) {
+      return ''
+    }
+
+    const firstShortcut = enterKeySendsKeyboardShortcuts(
+      settingsStore.desktopSettings.enterKeySends
+    )[0].keyBindings[0]
+
+    if (!Array.isArray(firstShortcut) || !firstShortcut.includes('Enter')) {
+      log.warn('Unexpected shortcut for "Send Message"')
+      return ''
+    }
+
+    return firstShortcut.join('+')
+  }, [settingsStore])
+
   if (chatId === null) {
     return <div ref={ref}>Error, chatid missing</div>
   }
@@ -378,7 +397,10 @@ const Composer = forwardRef<
             <span />
           </button>
           <div className='send-button-wrapper' onClick={composerSendMessage}>
-            <button aria-label={tx('menu_send')} />
+            <button
+              aria-label={tx('menu_send')}
+              aria-keyshortcuts={ariaSendShortcut}
+            />
           </div>
         </div>
         {showEmojiPicker && (

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -229,6 +229,7 @@ export default class ComposerMessageInput extends React.Component<
         disabled={this.state.loadingDraft}
         dir='auto'
         spellCheck={true}
+        aria-keyshortcuts='Control+N'
       />
     )
   }

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -177,6 +177,7 @@ export default function MenuAttachment({
 
   return (
     <button
+      aria-label={tx('menu_add_attachment')}
       id='attachment-menu-button'
       className='attachment-button'
       onClick={onClickAttachmentMenu}

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -68,6 +68,8 @@ export function keyDownEvent2Action(
   if (window.__contextMenuActive) {
     return
   }
+  // When modifying this, don't forget to also update the corresponding
+  // `aria-keyshortcuts` properties, and the "Keybindings" help window.
   if (!ev.repeat) {
     // fire only on first press
     if (ev.altKey && ev.code === 'ArrowDown') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       react-dom:
         specifier: ^17.0.2
         version: 17.0.2(react@17.0.2)
+      react-roving-tabindex:
+        specifier: ^3.2.0
+        version: 3.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-string-replace:
         specifier: ^1.1.1
         version: 1.1.1
@@ -336,7 +339,7 @@ importers:
         version: 32.1.0
       electron-builder:
         specifier: ^24.13.3
-        version: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+        version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
       esbuild:
         specifier: ^0.19.8
         version: 0.19.8
@@ -501,8 +504,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.23.1':
-    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+  '@esbuild/aix-ppc64@0.24.0':
+    resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -519,8 +522,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.23.1':
-    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+  '@esbuild/android-arm64@0.24.0':
+    resolution: {integrity: sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -537,8 +540,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.23.1':
-    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+  '@esbuild/android-arm@0.24.0':
+    resolution: {integrity: sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -555,8 +558,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.23.1':
-    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+  '@esbuild/android-x64@0.24.0':
+    resolution: {integrity: sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -573,8 +576,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.23.1':
-    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+  '@esbuild/darwin-arm64@0.24.0':
+    resolution: {integrity: sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -591,8 +594,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.23.1':
-    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+  '@esbuild/darwin-x64@0.24.0':
+    resolution: {integrity: sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -609,8 +612,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.23.1':
-    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+  '@esbuild/freebsd-arm64@0.24.0':
+    resolution: {integrity: sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -627,8 +630,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.23.1':
-    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+  '@esbuild/freebsd-x64@0.24.0':
+    resolution: {integrity: sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -645,8 +648,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.23.1':
-    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+  '@esbuild/linux-arm64@0.24.0':
+    resolution: {integrity: sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -663,8 +666,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.23.1':
-    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+  '@esbuild/linux-arm@0.24.0':
+    resolution: {integrity: sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -681,8 +684,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.23.1':
-    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+  '@esbuild/linux-ia32@0.24.0':
+    resolution: {integrity: sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -699,8 +702,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.23.1':
-    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+  '@esbuild/linux-loong64@0.24.0':
+    resolution: {integrity: sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -717,8 +720,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.23.1':
-    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+  '@esbuild/linux-mips64el@0.24.0':
+    resolution: {integrity: sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -735,8 +738,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.23.1':
-    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+  '@esbuild/linux-ppc64@0.24.0':
+    resolution: {integrity: sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -753,8 +756,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.23.1':
-    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+  '@esbuild/linux-riscv64@0.24.0':
+    resolution: {integrity: sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -771,8 +774,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.23.1':
-    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+  '@esbuild/linux-s390x@0.24.0':
+    resolution: {integrity: sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -789,8 +792,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.23.1':
-    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+  '@esbuild/linux-x64@0.24.0':
+    resolution: {integrity: sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -807,8 +810,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+  '@esbuild/netbsd-x64@0.24.0':
+    resolution: {integrity: sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -819,8 +822,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.23.1':
-    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+  '@esbuild/openbsd-arm64@0.24.0':
+    resolution: {integrity: sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -837,8 +840,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.23.1':
-    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+  '@esbuild/openbsd-x64@0.24.0':
+    resolution: {integrity: sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -855,8 +858,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.23.1':
-    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+  '@esbuild/sunos-x64@0.24.0':
+    resolution: {integrity: sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -873,8 +876,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.23.1':
-    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+  '@esbuild/win32-arm64@0.24.0':
+    resolution: {integrity: sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -891,8 +894,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.23.1':
-    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+  '@esbuild/win32-ia32@0.24.0':
+    resolution: {integrity: sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -909,8 +912,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.23.1':
-    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+  '@esbuild/win32-x64@0.24.0':
+    resolution: {integrity: sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1737,8 +1740,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.23.1:
-    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+  esbuild@0.24.0:
+    resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1787,6 +1790,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -2626,6 +2630,13 @@ packages:
     peerDependencies:
       react: 0.14.x || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  react-roving-tabindex@3.2.0:
+    resolution: {integrity: sha512-WY5d46Y/QuS2zgXs4MgYJlmi3uIyq7M9UD4l3SWim8ClnyV1L3r84brxElLxEBXdKuWFUbll9mOBpxfcDZsCVQ==}
+    engines: {node: '>=10', yarn: ^1.0.0}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   react-string-replace@1.1.1:
     resolution: {integrity: sha512-26TUbLzLfHQ5jO5N7y3Mx88eeKo0Ml0UjCQuX4BMfOd/JX+enQqlKpL1CZnmjeBRvQE8TR+ds9j1rqx9CxhKHQ==}
     engines: {node: '>=0.12.0'}
@@ -3342,7 +3353,7 @@ snapshots:
   '@esbuild/aix-ppc64@0.23.0':
     optional: true
 
-  '@esbuild/aix-ppc64@0.23.1':
+  '@esbuild/aix-ppc64@0.24.0':
     optional: true
 
   '@esbuild/android-arm64@0.19.8':
@@ -3351,7 +3362,7 @@ snapshots:
   '@esbuild/android-arm64@0.23.0':
     optional: true
 
-  '@esbuild/android-arm64@0.23.1':
+  '@esbuild/android-arm64@0.24.0':
     optional: true
 
   '@esbuild/android-arm@0.19.8':
@@ -3360,7 +3371,7 @@ snapshots:
   '@esbuild/android-arm@0.23.0':
     optional: true
 
-  '@esbuild/android-arm@0.23.1':
+  '@esbuild/android-arm@0.24.0':
     optional: true
 
   '@esbuild/android-x64@0.19.8':
@@ -3369,7 +3380,7 @@ snapshots:
   '@esbuild/android-x64@0.23.0':
     optional: true
 
-  '@esbuild/android-x64@0.23.1':
+  '@esbuild/android-x64@0.24.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.8':
@@ -3378,7 +3389,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.23.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.23.1':
+  '@esbuild/darwin-arm64@0.24.0':
     optional: true
 
   '@esbuild/darwin-x64@0.19.8':
@@ -3387,7 +3398,7 @@ snapshots:
   '@esbuild/darwin-x64@0.23.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.23.1':
+  '@esbuild/darwin-x64@0.24.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.8':
@@ -3396,7 +3407,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.23.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.23.1':
+  '@esbuild/freebsd-arm64@0.24.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.19.8':
@@ -3405,7 +3416,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.23.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.23.1':
+  '@esbuild/freebsd-x64@0.24.0':
     optional: true
 
   '@esbuild/linux-arm64@0.19.8':
@@ -3414,7 +3425,7 @@ snapshots:
   '@esbuild/linux-arm64@0.23.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.23.1':
+  '@esbuild/linux-arm64@0.24.0':
     optional: true
 
   '@esbuild/linux-arm@0.19.8':
@@ -3423,7 +3434,7 @@ snapshots:
   '@esbuild/linux-arm@0.23.0':
     optional: true
 
-  '@esbuild/linux-arm@0.23.1':
+  '@esbuild/linux-arm@0.24.0':
     optional: true
 
   '@esbuild/linux-ia32@0.19.8':
@@ -3432,7 +3443,7 @@ snapshots:
   '@esbuild/linux-ia32@0.23.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.23.1':
+  '@esbuild/linux-ia32@0.24.0':
     optional: true
 
   '@esbuild/linux-loong64@0.19.8':
@@ -3441,7 +3452,7 @@ snapshots:
   '@esbuild/linux-loong64@0.23.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.23.1':
+  '@esbuild/linux-loong64@0.24.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.8':
@@ -3450,7 +3461,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.23.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.23.1':
+  '@esbuild/linux-mips64el@0.24.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.19.8':
@@ -3459,7 +3470,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.23.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.23.1':
+  '@esbuild/linux-ppc64@0.24.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.8':
@@ -3468,7 +3479,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.23.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.23.1':
+  '@esbuild/linux-riscv64@0.24.0':
     optional: true
 
   '@esbuild/linux-s390x@0.19.8':
@@ -3477,7 +3488,7 @@ snapshots:
   '@esbuild/linux-s390x@0.23.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.23.1':
+  '@esbuild/linux-s390x@0.24.0':
     optional: true
 
   '@esbuild/linux-x64@0.19.8':
@@ -3486,7 +3497,7 @@ snapshots:
   '@esbuild/linux-x64@0.23.0':
     optional: true
 
-  '@esbuild/linux-x64@0.23.1':
+  '@esbuild/linux-x64@0.24.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.19.8':
@@ -3495,13 +3506,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.23.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.23.1':
+  '@esbuild/netbsd-x64@0.24.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.23.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.23.1':
+  '@esbuild/openbsd-arm64@0.24.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.8':
@@ -3510,7 +3521,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.23.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.23.1':
+  '@esbuild/openbsd-x64@0.24.0':
     optional: true
 
   '@esbuild/sunos-x64@0.19.8':
@@ -3519,7 +3530,7 @@ snapshots:
   '@esbuild/sunos-x64@0.23.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.23.1':
+  '@esbuild/sunos-x64@0.24.0':
     optional: true
 
   '@esbuild/win32-arm64@0.19.8':
@@ -3528,7 +3539,7 @@ snapshots:
   '@esbuild/win32-arm64@0.23.0':
     optional: true
 
-  '@esbuild/win32-arm64@0.23.1':
+  '@esbuild/win32-arm64@0.24.0':
     optional: true
 
   '@esbuild/win32-ia32@0.19.8':
@@ -3537,7 +3548,7 @@ snapshots:
   '@esbuild/win32-ia32@0.23.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.23.1':
+  '@esbuild/win32-ia32@0.24.0':
     optional: true
 
   '@esbuild/win32-x64@0.19.8':
@@ -3546,7 +3557,7 @@ snapshots:
   '@esbuild/win32-x64@0.23.0':
     optional: true
 
-  '@esbuild/win32-x64@0.23.1':
+  '@esbuild/win32-x64@0.24.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -3990,7 +4001,7 @@ snapshots:
 
   app-builder-bin@4.0.0: {}
 
-  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
+  app-builder-lib@24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -4414,7 +4425,7 @@ snapshots:
 
   dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       fs-extra: 10.1.0
@@ -4468,7 +4479,7 @@ snapshots:
 
   electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -4476,9 +4487,9 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
+  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       chalk: 4.1.2
@@ -4543,7 +4554,7 @@ snapshots:
 
   esbuild-plugin-inline-worker@0.1.1:
     dependencies:
-      esbuild: 0.23.1
+      esbuild: 0.24.0
       find-cache-dir: 3.3.2
 
   esbuild@0.19.8:
@@ -4598,32 +4609,32 @@ snapshots:
       '@esbuild/win32-ia32': 0.23.0
       '@esbuild/win32-x64': 0.23.0
 
-  esbuild@0.23.1:
+  esbuild@0.24.0:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.23.1
-      '@esbuild/android-arm': 0.23.1
-      '@esbuild/android-arm64': 0.23.1
-      '@esbuild/android-x64': 0.23.1
-      '@esbuild/darwin-arm64': 0.23.1
-      '@esbuild/darwin-x64': 0.23.1
-      '@esbuild/freebsd-arm64': 0.23.1
-      '@esbuild/freebsd-x64': 0.23.1
-      '@esbuild/linux-arm': 0.23.1
-      '@esbuild/linux-arm64': 0.23.1
-      '@esbuild/linux-ia32': 0.23.1
-      '@esbuild/linux-loong64': 0.23.1
-      '@esbuild/linux-mips64el': 0.23.1
-      '@esbuild/linux-ppc64': 0.23.1
-      '@esbuild/linux-riscv64': 0.23.1
-      '@esbuild/linux-s390x': 0.23.1
-      '@esbuild/linux-x64': 0.23.1
-      '@esbuild/netbsd-x64': 0.23.1
-      '@esbuild/openbsd-arm64': 0.23.1
-      '@esbuild/openbsd-x64': 0.23.1
-      '@esbuild/sunos-x64': 0.23.1
-      '@esbuild/win32-arm64': 0.23.1
-      '@esbuild/win32-ia32': 0.23.1
-      '@esbuild/win32-x64': 0.23.1
+      '@esbuild/aix-ppc64': 0.24.0
+      '@esbuild/android-arm': 0.24.0
+      '@esbuild/android-arm64': 0.24.0
+      '@esbuild/android-x64': 0.24.0
+      '@esbuild/darwin-arm64': 0.24.0
+      '@esbuild/darwin-x64': 0.24.0
+      '@esbuild/freebsd-arm64': 0.24.0
+      '@esbuild/freebsd-x64': 0.24.0
+      '@esbuild/linux-arm': 0.24.0
+      '@esbuild/linux-arm64': 0.24.0
+      '@esbuild/linux-ia32': 0.24.0
+      '@esbuild/linux-loong64': 0.24.0
+      '@esbuild/linux-mips64el': 0.24.0
+      '@esbuild/linux-ppc64': 0.24.0
+      '@esbuild/linux-riscv64': 0.24.0
+      '@esbuild/linux-s390x': 0.24.0
+      '@esbuild/linux-x64': 0.24.0
+      '@esbuild/netbsd-x64': 0.24.0
+      '@esbuild/openbsd-arm64': 0.24.0
+      '@esbuild/openbsd-x64': 0.24.0
+      '@esbuild/sunos-x64': 0.24.0
+      '@esbuild/win32-arm64': 0.24.0
+      '@esbuild/win32-ia32': 0.24.0
+      '@esbuild/win32-x64': 0.24.0
 
   escalade@3.1.1: {}
 
@@ -5535,6 +5546,12 @@ snapshots:
       prop-types: 15.8.1
       react: 17.0.2
       typed-styles: 0.0.7
+      warning: 4.0.3
+
+  react-roving-tabindex@3.2.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2):
+    dependencies:
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
       warning: 4.0.3
 
   react-string-replace@1.1.1: {}


### PR DESCRIPTION
https://github.com/user-attachments/assets/b43fb2c6-4c04-4080-ba15-7e644114c8d1


This is more of a show and tell rather than an MR for now. It sort of works, but there are a lot of issues:
- [ ] The tab order is such that the chat list does not immediately follow the search field, so you have to tab through the other navbar items before you get to the chat list, same for going back from the chat list to the search bar.
- [ ] chat list might get reordered. A chat is moved up when a message is sent to it, but the arrow-key order remains the same as it was on initial render. This results in the focus jumping several items
- [ ] "Home" and "End" do not work due to the fact that we use `react-window` - not all items are rendered, so we can't jump to the first and the last item
- [ ] Worst of all, while you scroll the chat list, it keeps jumping by itself, because when the currently focused chat item gets unrendered, `react-roving-tabindex` focuses the next element (which is out of view) and the browser scrolls it in view.

Related: https://github.com/deltachat/deltachat-desktop/issues/2784

This is based on #4210.