### PR TITLE
Less vertical empty space for img attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 - cancel old message highlight animations when a new message is highlighted #4203
 - fix: packaging: include architecture in filename for all appimages #4202
 - fix: make open external link scheme case insensive #4201
-- make wide but short message attachments have less empty space on top/bottom
+- wide but narrow images have less empty space on top/bottom
 
 <a id="1_46_8"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - cancel old message highlight animations when a new message is highlighted #4203
 - fix: packaging: include architecture in filename for all appimages #4202
 - fix: make open external link scheme case insensive #4201
+- make wide but short message attachments have less empty space on top/bottom
 
 <a id="1_46_8"></a>
 

--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -17,7 +17,8 @@
   & > .attachment-content {
     object-fit: scale-down;
     object-position: center;
-    height: 200px;
+    max-height: 200px;
+    min-height: 50px;
     max-width: 100%;
 
     // The padding on the bottom of the bubble produces 4 extra pixels of space at the


### PR DESCRIPTION
Make wide but short image attachments display nicer.

Before:
![image](https://github.com/user-attachments/assets/a63e0359-899e-403e-8b15-cedc4f1cf535)
After:
![image](https://github.com/user-attachments/assets/63df8027-c101-4d21-a5df-eedcadf5ed8c)
