### PR TITLE
fix: weird navbar widths on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - Update local help (2024-10-02) #4165
 - trim whitepaces when reading from clipboard in qr code reader #4169
 - load chat lists faster (the chat list on the main screen, "Forward to..." dialog, etc)
-- replace BlueprintJS Button, Icon, Radio, RadioGroup, Collapse, Dialog with our implementation
+- replace BlueprintJS Button, Icon, Radio, RadioGroup, Collapse, Dialog with our implementation #4006, #4226
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.147.1`
 - Update proxy configuration - a full url can be entered now
 

--- a/packages/frontend/src/components/Navbar/styles.module.scss
+++ b/packages/frontend/src/components/Navbar/styles.module.scss
@@ -17,9 +17,19 @@
 }
 
 .navbarGroupRight {
-  width: 70%;
+  // Otherwise it will refuse to truncate the chat name
+  // and will overflow instead.
+  width: 0;
+  flex-grow: 1;
+
   height: var(--navBarHeight);
   display: flex;
   align-items: center;
   padding: 0px;
+}
+
+:global(.small-screen) {
+  .navbarGroupLeft {
+    flex-grow: 1;
+  }
 }


### PR DESCRIPTION
The issue was introduced in 0e0d0b80d598802.
It has to do with these lines having been removed:
https://github.com/deltachat/deltachat-desktop/blob/a5c02433976909fe01a64f3049c96d0d101ae9d8/packages/frontend/scss/main_screen/_main_screen.scss#L16-L19

Before:

https://github.com/user-attachments/assets/18b1cbaa-cbff-4fc7-af96-a296bb222b28

After:

https://github.com/user-attachments/assets/e593afff-fe89-4ef1-858b-4af983a4ac82

