### PR TITLE
fix: don't overflow gallery tabs on narrow screen

### DIFF
--- a/packages/frontend/scss/gallery/_media.scss
+++ b/packages/frontend/scss/gallery/_media.scss
@@ -24,6 +24,9 @@ $tab-height: 46px;
     display: flex;
     justify-content: space-between;
     gap: 30px;
+
+    overflow-x: auto;
+
     .tab-item {
       font-size: 1.1rem;
       padding-bottom: 6px;


### PR DESCRIPTION
Make the tabs list scrollable instead of expanding
the entire gallery view
