### PR TITLE
refactor: remove unused SCSS

### DIFF
--- a/packages/frontend/scss/message/_message-detail.scss
+++ b/packages/frontend/scss/message/_message-detail.scss
@@ -9,19 +9,6 @@
   }
 }
 
-.module-message-detail__message-container {
-  padding-top: 20px;
-  padding-bottom: 20px;
-
-  &:after {
-    content: '.';
-    visibility: hidden;
-    display: block;
-    height: 0;
-    clear: both;
-  }
-}
-
 .module-message-detail__label {
   font-weight: 300;
   padding-right: 5px;
@@ -29,29 +16,4 @@
 
 .module-message-detail__unix-timestamp {
   color: #eeefef;
-}
-
-.module-message-detail__delete-button-container {
-  text-align: center;
-  margin-top: 10px;
-}
-
-.module-message-detail__delete-button {
-  @include button-reset;
-
-  background-color: $color-message-detail-delete-bg;
-  color: $color-message-detail-delete;
-  box-shadow: 0 0 10px -3px rgba(97, 97, 97, 0.7);
-  border-radius: 5px;
-  border: solid 1px $color-message-detail-delete-button-border;
-  cursor: pointer;
-  margin: 1em auto;
-  padding: 1em;
-}
-
-.module-message-detail .message-content * {
-  background-color: lightgrey;
-  width: 100%;
-  resize: none;
-  padding: 1rem;
 }


### PR DESCRIPTION
`delete-button-container` was removed in ec6f12e4bd751.
`message-content` was removed in a9313d00c892.
`message-container` was removed in 75b2c1b4830dc.
