### PR TITLE
fix: emoji picker: Shift + click not working

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -182,9 +182,7 @@ const Composer = forwardRef<
   // also handle escape key for emoji picker
   useEffect(() => {
     const onKey = (ev: KeyboardEvent) => {
-      if (ev.code === 'Shift') {
-        shiftPressed.current = ev.shiftKey
-      }
+      shiftPressed.current = ev.shiftKey
       if (ev.type === 'keydown' && ev.code === 'Escape') {
         setShowEmojiPicker(false)
       }


### PR DESCRIPTION
The bug was introduced in 23a0791dbe582105f53fd05d7e6b48bf6b2d2a58.
For left shift the `code` value is actually `ShiftLeft`.

I re-checked all other changes related that commit made,
and they appear to be alright.

The bug has not been released yet.
