### PR TITLE
style: ugly reactions positioning on image msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - target-electron: make sure log of stdio server is also logged to file
 - improve accessibility a little #4133
 - use authname instead of displayname for vcard filename #4233
+- ugly positioning of reactions on image-only messages #4237
 
 
 <a id="1_46_8"></a>

--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -7,10 +7,6 @@
   margin-bottom: -3px;
 
   &.with-image-no-caption {
-    position: absolute;
-    right: 5px;
-    bottom: 5px;
-    float: right;
     padding: 4px 10px 1px 10px;
     margin: 0;
     background-color: #0000008f;

--- a/packages/frontend/src/components/message/styles.module.scss
+++ b/packages/frontend/src/components/message/styles.module.scss
@@ -20,11 +20,11 @@
   // transition: margin-bottom ease-out $reaction-transition-duration;
 
   &.onlyMedia {
-    bottom: 0;
+    bottom: 5px;
     left: 0;
     margin-left: 10px;
     position: absolute;
-    right: 0;
+    right: 5px;
   }
 
   // &.withReactionsNoText {


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4235

The issue probably existed ever since the reactions were added
in the first place https://github.com/deltachat/deltachat-desktop/pull/2964,
but it got worse after the removal of margin addition
when adding a reaction (60e52c772d788b1b5399b38b438630b90b120f7a).

This should make things simpler as all positioning-related stuff
is only done in `message/styles.module.scss`.

Before:

![image](https://github.com/user-attachments/assets/e0bcb21e-93a3-4d3c-a77b-c521b5001d77) ![image](https://github.com/user-attachments/assets/abe65728-4f7e-4280-8df8-1c191205cc2f)

After:

![image](https://github.com/user-attachments/assets/81930310-5192-4869-a7a8-282b1de65a2e) ![image](https://github.com/user-attachments/assets/38a8958d-b109-4d9b-8e20-dde597f237c0)

