### PR TITLE
fix: a11y: wrong positioning of context menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - fix Delta Chat not launching on Debian sometimes due to missing package dependencies (`libasound2`) #4275
 - fix not being able to remove avatar for a mailing list #4270
 - fix deleting messages with broken video attachment from gallery #4283
+- accessibility: wrong positioning of some context menus and popups when activating them with keyboard #4246
 
 <a id="1_47_0"></a>
 

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -29,8 +29,8 @@ export type ContextMenuItem = { label: string } & (
 )
 
 type showFnArguments = {
-  cursorX: number
-  cursorY: number
+  x: number
+  y: number
   items: (ContextMenuItem | false)[]
 }
 
@@ -67,7 +67,7 @@ export function ContextMenuLayer({
   const endPromiseRef = useRef<(() => void) | null>(null)
 
   const show = useCallback(
-    async ({ cursorX: x, cursorY: y, items: rawItems }: showFnArguments) => {
+    async ({ x, y, items: rawItems }: showFnArguments) => {
       if (!layerRef.current) {
         throw new Error('Somehow the ContextMenuLayer went missing')
       }
@@ -389,8 +389,8 @@ export function makeContextMenu(
         : itemsOrItemsFactoryFn
 
     return openContextMenu({
-      cursorX,
-      cursorY,
+      x: cursorX,
+      y: cursorY,
       items,
     })
   }

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -10,6 +10,7 @@ import Icon from './Icon'
 import type { IconName } from './Icon'
 
 import useContextMenu from '../hooks/useContextMenu'
+import { mouseEventToPosition } from '../utils/mouseEventToPosition'
 
 type ContextMenuItemActionable = {
   icon?: IconName
@@ -381,7 +382,6 @@ export function makeContextMenu(
 ) {
   return (ev: React.MouseEvent<any, MouseEvent>) => {
     ev.preventDefault() // prevent default runtime context menu from opening
-    const [cursorX, cursorY] = [ev.clientX, ev.clientY]
 
     const items =
       typeof itemsOrItemsFactoryFn === 'function'
@@ -389,8 +389,7 @@ export function makeContextMenu(
         : itemsOrItemsFactoryFn
 
     return openContextMenu({
-      x: cursorX,
-      y: cursorY,
+      ...mouseEventToPosition(ev),
       items,
     })
   }

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -278,8 +278,8 @@ export default function QrReader({ onError, onScan }: Props) {
       ]
 
       openContextMenu({
-        cursorX,
-        cursorY,
+        x: cursorX,
+        y: cursorY,
         items,
       })
     },

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -22,6 +22,7 @@ import Worker from './qr.worker'
 import styles from './styles.module.scss'
 
 import type { ContextMenuItem } from '../ContextMenu'
+import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 
 type Props = {
   onError: (error: string) => void
@@ -251,8 +252,6 @@ export default function QrReader({ onError, onScan }: Props) {
   // Show a context menu with different video input options to the user.
   const handleSelectInput = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
-      const [cursorX, cursorY] = [event.clientX, event.clientY]
-
       // Allow user to select a different camera when more than one is given
       const cameraItems: ContextMenuItem[] =
         videoDevices.length > 1
@@ -278,8 +277,7 @@ export default function QrReader({ onError, onScan }: Props) {
       ]
 
       openContextMenu({
-        x: cursorX,
-        y: cursorY,
+        ...mouseEventToPosition(event),
         items,
       })
     },

--- a/packages/frontend/src/components/Settings/Appearance.tsx
+++ b/packages/frontend/src/components/Settings/Appearance.tsx
@@ -22,6 +22,7 @@ import useDialog from '../../hooks/dialog/useDialog'
 import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
 import Icon from '../Icon'
 import Callout from '../Callout'
+import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 
 const log = getLogger('renderer/settings/appearance')
 
@@ -162,13 +163,14 @@ function BackgroundSelector({
   const openColorInput = (ev: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     // opens the color input and sets its offset so it lines up with the button
     if (colorInput) {
+      const eventPos = mouseEventToPosition(ev)
       const y =
-        (ev.clientY || 0) -
+        (eventPos.y || 0) -
         (Number(window.getComputedStyle(colorInput).height.replace('px', '')) ||
           0)
       colorInput.setAttribute(
         'style',
-        `position:absolute;top:${y}px;left:${ev.clientX}px;`
+        `position:absolute;top:${y}px;left:${eventPos.x}px;`
       )
       if (desktopSettings?.chatViewBgImg?.startsWith('color: ')) {
         colorInput.value = desktopSettings?.chatViewBgImg.slice(7) || ''

--- a/packages/frontend/src/components/ThreeDotMenu.tsx
+++ b/packages/frontend/src/components/ThreeDotMenu.tsx
@@ -221,15 +221,15 @@ export function useThreeDotMenu(
 
     const boundingBox = threeDotButtonElement.getBoundingClientRect()
 
-    const [cursorX, cursorY] = [
+    const [x, y] = [
       boundingBox.x + boundingBox.width - 3,
       boundingBox.y + boundingBox.height - 2,
     ]
     event.preventDefault() // prevent default runtime context menu from opening
 
     openContextMenu({
-      cursorX,
-      cursorY,
+      x,
+      y,
       items: menu,
     })
   }

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -18,6 +18,7 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { T } from '@deltachat/jsonrpc-client'
 import type { UnselectChat } from '../../contexts/ChatContext'
+import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 
 function archiveStateMenu(
   unselectChat: UnselectChat,
@@ -276,13 +277,11 @@ export function useChatListContextMenu(): {
           ]
         : []
 
-      const [cursorX, cursorY] = [event.clientX, event.clientY]
       event.preventDefault() // prevent default runtime context menu from opening
 
       setActiveContextMenuChatId(chatListItem.id)
       await openContextMenu({
-        x: cursorX,
-        y: cursorY,
+        ...mouseEventToPosition(event),
         items: menu,
       })
       setActiveContextMenuChatId(null)

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -281,8 +281,8 @@ export function useChatListContextMenu(): {
 
       setActiveContextMenuChatId(chatListItem.id)
       await openContextMenu({
-        cursorX,
-        cursorY,
+        x: cursorX,
+        y: cursorY,
         items: menu,
       })
       setActiveContextMenuChatId(null)

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -165,12 +165,12 @@ export default function MenuAttachment({
 
     const boundingBox = attachmentMenuButtonElement.getBoundingClientRect()
 
-    const [cursorX, cursorY] = [boundingBox.x, boundingBox.y]
+    const [x, y] = [boundingBox.x, boundingBox.y]
     event.preventDefault() // prevent default runtime context menu from opening
 
     openContextMenu({
-      cursorX,
-      cursorY,
+      x,
+      y,
       items: menu,
     })
   }

--- a/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
@@ -133,8 +133,8 @@ export default function ChatAuditLogDialog(
     const [cursorX, cursorY] = [event.clientX, event.clientY]
 
     openContextMenu({
-      cursorX,
-      cursorY,
+      x: cursorX,
+      y: cursorY,
       items,
     })
   }

--- a/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
@@ -25,6 +25,7 @@ import { selectedAccountId } from '../../ScreenController'
 import type { DialogProps, OpenDialog } from '../../contexts/DialogContext'
 import type { JumpToMessage } from '../../hooks/chat/useMessage'
 import type { PrivateReply } from '../../hooks/chat/usePrivateReply'
+import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 
 const log = getLogger('render/ChatAuditLog')
 
@@ -130,11 +131,9 @@ export default function ChatAuditLogDialog(
       selectedChat.chatType === C.DC_CHAT_TYPE_GROUP,
       onClose
     )
-    const [cursorX, cursorY] = [event.clientX, event.clientY]
 
     openContextMenu({
-      x: cursorX,
-      y: cursorY,
+      ...mouseEventToPosition(event),
       items,
     })
   }

--- a/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
@@ -109,15 +109,12 @@ export default function useViewProfileMenu(contact: T.Contact) {
 
     const boundingBox = threeDotButtonElement.getBoundingClientRect()
 
-    const [cursorX, cursorY] = [
-      boundingBox.x + 3,
-      boundingBox.y + boundingBox.height - 2,
-    ]
+    const [x, y] = [boundingBox.x + 3, boundingBox.y + boundingBox.height - 2]
     event.preventDefault() // prevent default runtime context menu from opening
 
     openContextMenu({
-      cursorX,
-      cursorY,
+      x,
+      y,
       items: menu,
     })
   }

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -408,8 +408,8 @@ export default function Message(props: {
       const [cursorX, cursorY] = [event.clientX, event.clientY]
 
       openContextMenu({
-        cursorX,
-        cursorY,
+        x: cursorX,
+        y: cursorY,
         items,
       })
     },

--- a/packages/frontend/src/utils/mouseEventToPosition.ts
+++ b/packages/frontend/src/utils/mouseEventToPosition.ts
@@ -1,0 +1,28 @@
+/**
+ * This function is useful for opening a context menu (or something alike)
+ * with a 'click' event instead of 'contextmenu event.
+ *
+ * The 'click' event might not have `clientX` and `clientY` set
+ * if it was activated with the keyboard (or via other means?).
+ * FYI it is not the case for 'contextmenu' event where
+ * `clientY` and `clientX` are already set to the center of the element,
+ * at least in Chromium.
+ */
+export function mouseEventToPosition(event: React.MouseEvent): {
+  x: number
+  y: number
+} {
+  if (event.clientX > 0 && event.clientY > 0) {
+    return {
+      x: event.clientX,
+      y: event.clientY,
+    }
+  }
+
+  const boundingBox = (event.target as HTMLElement).getBoundingClientRect()
+  return {
+    // The middle of the element
+    x: boundingBox.x + boundingBox.width / 2,
+    y: boundingBox.y + boundingBox.height / 2,
+  }
+}


### PR DESCRIPTION
...when activating them with keyboard (or via other means?).

Closes https://github.com/deltachat/deltachat-desktop/issues/4244.

Some of the affected places:
- Three-dot button besides a message.
- Reactions bar when activated from the message context menu.
- "More options" in the QR reader dialog.
- "Appearance" settings color picker
    (it is not yet keyboard-accessible though).
