### PR TITLE
fix: image thumbnails not showing in chat list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+## Fixed
+- image thumbnails not showing in chat list #4247
+
 <a id="1_47_0"></a>
 
 ## [1.47.0] - 2024-09-22

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -108,9 +108,9 @@ const Message = React.memo<
           <div
             className='summary_thumbnail'
             style={{
-              backgroundImage: `url("${JSON.stringify(
+              backgroundImage: `url(${JSON.stringify(
                 runtime.transformBlobURL(summaryPreviewImage)
-              )}")`,
+              )})`,
             }}
           />
         )}


### PR DESCRIPTION
This bug was brought back again in 65bd380986eafc8adb10814b0aea6f18167c3478.
After the recent fix in 78e188cd0e9f009e9f3805b360042972bccd8f63.
