### PR TITLE
style: add `scroll-margin` for account list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+## Changed
+- style: avoid scrolling to account list items such that they're at the very edge of the list #4252
+
 ## Fixed
 - image thumbnails not showing in chat list #4247
 - progress bar not working #4248

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -72,6 +72,8 @@
     height: var(--als-avatar-size);
     margin-bottom: var(--als-avatar-margin);
     margin-top: var(--als-avatar-margin);
+    scroll-margin-bottom: var(--als-avatar-margin);
+    scroll-margin-top: var(--als-avatar-margin);
     position: relative;
     z-index: $z-index-new-local-scope;
 


### PR DESCRIPTION
Follow-up to 46d98111b69764b278f15c3dfe300e794dd64dcc
and c71fafa6235dfc3036db5b7be434dae0fff6961d.

Before and after:

![image](https://github.com/user-attachments/assets/2340df10-fc85-4d08-8c6a-873517b0ff3d) ![image](https://github.com/user-attachments/assets/a470f26d-5c9a-4dba-8057-4a5c1dc9bceb)
