### PR TITLE
fix: click on webxdc info icon not opening app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+## Added
+- clicking on webxdc info message icon opens the webxdc app #4265
+
 ## Changed
 - style: avoid scrolling to account list items such that they're at the very edge of the list #4252
 

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -498,7 +498,7 @@ export default function Message(props: {
                 selectedAccountId(),
                 message.parentId
               )}
-              onClick={() => openWebxdc(message.id)}
+              onClick={() => openWebxdc(message.parentId!)}
             />
           )}
           {text}


### PR DESCRIPTION
The feature was introduced in 7d24b5a64a5e240070aaae07a45663c065cd7eef,
but apparently it never worked.
