### PR TITLE
refactor: remove dead code

### DIFF
--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -498,7 +498,6 @@ export default function Message(props: {
                 selectedAccountId(),
                 message.parentId
               )}
-              onClick={() => openWebxdc(message.id)}
             />
           )}
           {text}


### PR DESCRIPTION
The correct way would be
`onClick={() => openWebxdc(message.parentId!)}`, but, as discussed in
https://github.com/deltachat/deltachat-desktop/pull/4265,
we don't want this behavior
