### PR TITLE
go back to a custom progressbar implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - avoid showing horizontal scrollbars in chat list #4253
 - style: fix VCard color being too bright in dark theme #4255
 - remove unnecessary horizontal scrollbar in "View Group" dialog #4254
+- fix styling of progressbars in light theme #4274
 
 <a id="1_47_0"></a>
 

--- a/packages/frontend/scss/login/_login.scss
+++ b/packages/frontend/scss/login/_login.scss
@@ -201,25 +201,29 @@ div.delta-form-group {
   }
 }
 
-progress.delta-progress-bar {
+div.delta-progress-bar {
   width: 100%;
+  background-color: var(--progressBarBg);
+  height: 8px;
+  margin-block: 21pt;
+  --progressBarBorderRadius: 5px;
+  border-radius: var(--progressBarBorderRadius);
 
-  // https://stackoverflow.com/questions/18368202/how-can-i-set-the-color-for-the-progress-element
-  accent-color: var(--progress-bar-color);
-  &::-moz-progress-bar,
-  &::-webkit-progress-value {
+  div.bar {
     background: var(--progress-bar-color);
+    height: 100%;
+    border-radius: var(--progressBarBorderRadius);
   }
 
   &.delta-intent-primary {
-    --progress-bar-color: var(--colorPrimary);
+    --progress-bar-color: var(--progressBarPrimary);
   }
 
   &.delta-intent-success {
-    --progress-bar-color: green;
+    --progress-bar-color: var(--progressBarSuccess);
   }
 
   &.delta-intent-danger {
-    --progress-bar-color: var(--colorDanger);
+    --progress-bar-color: var(--progressBarDanger);
   }
 }

--- a/packages/frontend/src/components/Login-Styles.tsx
+++ b/packages/frontend/src/components/Login-Styles.tsx
@@ -212,7 +212,7 @@ type ProgressBarProps = React.PropsWithChildren<{
 
 export const DeltaProgressBar = React.memo<ProgressBarProps>(
   ({ progress, intent = 'primary', max = 1000 }) => {
-    const progressPercent = (progress||0) * 100 / max
+    const progressPercent = ((progress || 0) * 100) / max
     return (
       <div style={{ marginTop: '20px', marginBottom: '10px' }}>
         <div
@@ -222,7 +222,7 @@ export const DeltaProgressBar = React.memo<ProgressBarProps>(
           aria-valuemin={0}
           aria-valuemax={100}
         >
-          <div className="bar" style={{width: `${progressPercent}%`}}></div>
+          <div className='bar' style={{ width: `${progressPercent}%` }}></div>
         </div>
       </div>
     )

--- a/packages/frontend/src/components/Login-Styles.tsx
+++ b/packages/frontend/src/components/Login-Styles.tsx
@@ -212,13 +212,18 @@ type ProgressBarProps = React.PropsWithChildren<{
 
 export const DeltaProgressBar = React.memo<ProgressBarProps>(
   ({ progress, intent = 'primary', max = 1000 }) => {
+    const progressPercent = (progress||0) * 100 / max
     return (
       <div style={{ marginTop: '20px', marginBottom: '10px' }}>
-        <progress
+        <div
           className={`delta-progress-bar delta-intent-${intent}`}
-          value={progress ? progress : 0}
-          max={max}
-        ></progress>
+          role='progressbar'
+          aria-valuenow={progressPercent}
+          aria-valuemin={0}
+          aria-valuemax={100}
+        >
+          <div className="bar" style={{width: `${progressPercent}%`}}></div>
+        </div>
       </div>
     )
   }

--- a/packages/frontend/src/components/screens/WelcomeScreen/ImportBackupProgressDialog.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/ImportBackupProgressDialog.tsx
@@ -68,7 +68,7 @@ export default function ImportBackupProgressDialog({
           )}
           <DeltaProgressBar
             progress={importProgress}
-            intent={error ? 'danger' : 'success'}
+            intent={error ? 'danger' : 'primary'}
           />
         </DialogContent>
       </DialogBody>

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -165,6 +165,12 @@ $hover-contrast-change: 2%;
   --delta-dialog-separator: #{$bgSecondary};
   --delta-dialog-separator-text: #{changeContrast($bgSecondary, 24%)};
 
+  /* progressBar */
+  --progressBarBg: #{changeContrast($bgPrimary, 10%)};
+  --progressBarSuccess: green;
+  --progressBarPrimary: var(--colorPrimary);
+  --progressBarDanger: var(--colorDanger);
+
   /* Misc */
   --galleryBg: #{$bgPrimary};
   --avatarLabelColor: #ffffff; // Manual value: This will not get generated in the future


### PR DESCRIPTION
because the browser native element is too limited.
I added the aria role and attributes, so acessibility should work in theory.

(/me wasted way too much time trying to understand how to style the native element.)

fixes #4263

preview:

| dark | light |
|--------|--------|
| ![Bildschirmfoto 2024-10-26 um 21 24 50](https://github.com/user-attachments/assets/9ed59681-b741-4bba-93f6-116f361caa2a) | ![Bildschirmfoto 2024-10-26 um 21 23 27](https://github.com/user-attachments/assets/6b146313-a94b-4452-b40c-553238d2a3b2) | 
