### PR TITLE
fix: deleting broken video not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - fix styling of progressbars in light theme #4274
 - fix Delta Chat not launching on Debian sometimes due to missing package dependencies (`libasound2`) #4275
 - fix not being able to remove avatar for a mailing list #4270
+- fix deleting messages with broken video attachment from gallery #4283
 
 <a id="1_47_0"></a>
 

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -248,7 +248,7 @@ export function VideoAttachment({
     const onContextMenu = getBrokenMediaContextMenu(
       contextMenu.openContextMenu,
       openDialog,
-      jumpToMessage,
+      deleteMessage,
       messageId,
       accountId
     )


### PR DESCRIPTION
The bug exists since at least e2f9cdb915d59ac7d718de5eb60ecf779d8289a6.
