### PR TITLE
improvement: better scroll for jumpToMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - IMAP COMPRESS support.
   - Sort received outgoing message down if it's fresher than all non fresh messages.
   - Auto-restore 1:1 chat protection after receiving old unverified message.
+- when jumping to a message (e.g. when showing the first unread message, or when jumping to a message through "show in chat"), position it more appropriately in the scrollable area #4286
 
 ## Fixed
 - image thumbnails not showing in chat list #4247

--- a/packages/frontend/src/components/RuntimeAdapter.tsx
+++ b/packages/frontend/src/components/RuntimeAdapter.tsx
@@ -55,7 +55,10 @@ export default function RuntimeAdapter({
           clearNotificationsForChat(notificationAccountId, chatId)
         }
         if (msgId) {
-          window.__internal_jump_to_message?.({ msgId })
+          window.__internal_jump_to_message?.({
+            msgId,
+            scrollIntoViewArg: { block: 'center' },
+          })
         }
       }
     )

--- a/packages/frontend/src/components/RuntimeAdapter.tsx
+++ b/packages/frontend/src/components/RuntimeAdapter.tsx
@@ -55,7 +55,7 @@ export default function RuntimeAdapter({
           clearNotificationsForChat(notificationAccountId, chatId)
         }
         if (msgId) {
-          window.__internal_jump_to_message?.(msgId)
+          window.__internal_jump_to_message?.({ msgId })
         }
       }
     )

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -73,7 +73,12 @@ const contextMenuFactory = (
     },
     {
       label: tx('show_in_chat'),
-      action: () => jumpToMessage(accountId, message.id, message.chatId),
+      action: () =>
+        jumpToMessage({
+          accountId,
+          msgId: message.id,
+          msgChatId: message.chatId,
+        }),
     },
     {
       label: tx('info'),

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -78,6 +78,7 @@ const contextMenuFactory = (
           accountId,
           msgId: message.id,
           msgChatId: message.chatId,
+          scrollIntoViewArg: { block: 'center' },
         }),
     },
     {

--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -122,7 +122,11 @@ export const ChatListItemRowMessage = React.memo<{
           queryStr={queryStr || ''}
           msr={messageSearchResult}
           onClick={() => {
-            jumpToMessage({ accountId, msgId: msrId })
+            jumpToMessage({
+              accountId,
+              msgId: msrId,
+              scrollIntoViewArg: { block: 'center' },
+            })
           }}
         />
       ) : (

--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -122,7 +122,7 @@ export const ChatListItemRowMessage = React.memo<{
           queryStr={queryStr || ''}
           msr={messageSearchResult}
           onClick={() => {
-            jumpToMessage(accountId, msrId)
+            jumpToMessage({ accountId, msgId: msrId })
           }}
         />
       ) : (

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -633,6 +633,9 @@ export function useDraft(
         msgId: messageId,
         msgChatId: chatId,
         highlight: true,
+        // The message is usually already in view,
+        // so let's not scroll at all if so.
+        scrollIntoViewArg: { block: 'nearest' },
       })
     }
     // TODO perf: I imagine this is pretty slow, given IPC and some chats

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -628,7 +628,12 @@ export function useDraft(
 
       // TODO perf: jumpToMessage is not instant, but it should be
       // since the message is (almost?) always already rendered.
-      jumpToMessage(accountId, messageId, chatId, true)
+      jumpToMessage({
+        accountId,
+        msgId: messageId,
+        msgChatId: chatId,
+        highlight: true,
+      })
     }
     // TODO perf: I imagine this is pretty slow, given IPC and some chats
     // being quite large. Perhaps we could hook into the

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -38,7 +38,9 @@ const DisplayedStickerPack = ({
     const stickerPath = fileName.replace('file://', '')
     BackendRemote.rpc
       .sendSticker(accountId, chatId, stickerPath)
-      .then(id => jumpToMessage(accountId, id, chatId, false))
+      .then(msgId =>
+        jumpToMessage({ accountId, msgId, msgChatId: chatId, highlight: false })
+      )
     setShowEmojiPicker(false)
   }
 

--- a/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
@@ -45,7 +45,12 @@ function buildContextMenu(
       action: () => {
         closeDialogCallback()
         setTimeout(() =>
-          jumpToMessage(accountId, message.id, message.chatId, true)
+          jumpToMessage({
+            accountId,
+            msgId: message.id,
+            msgChatId: message.chatId,
+            highlight: true,
+          })
         )
       },
     },
@@ -55,10 +60,15 @@ function buildContextMenu(
       action: () => {
         if (message.parentId) {
           closeDialogCallback()
-          // Currently the info message is always in the same chat
-          // as the message with `message.parentId`,
-          // but let's not pass `chatId` here, for future-proofing.
-          jumpToMessage(accountId, message.parentId, undefined, true)
+          jumpToMessage({
+            accountId,
+            msgId: message.parentId,
+            // Currently the info message is always in the same chat
+            // as the message with `message.parentId`,
+            // but let's not pass `chatId` here, for future-proofing.
+            msgChatId: undefined,
+            highlight: true,
+          })
         }
       },
     },

--- a/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
@@ -50,6 +50,7 @@ function buildContextMenu(
             msgId: message.id,
             msgChatId: message.chatId,
             highlight: true,
+            scrollIntoViewArg: { block: 'center' },
           })
         )
       },
@@ -68,6 +69,7 @@ function buildContextMenu(
             // but let's not pass `chatId` here, for future-proofing.
             msgChatId: undefined,
             highlight: true,
+            scrollIntoViewArg: { block: 'center' },
           })
         }
       },

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -65,7 +65,7 @@ export default function ForwardMessage(props: Props) {
         )
         const lastMessage = messageIds[messageIds.length - 1]
         if (lastMessage) {
-          jumpToMessage(accountId, lastMessage, chatId)
+          jumpToMessage({ accountId, msgId: lastMessage, msgChatId: chatId })
         }
       } else {
         selectChat(accountId, message.chatId)

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -115,7 +115,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
     {
       label: tx('show_in_chat'),
       action: () => {
-        jumpToMessage(accountId, msg.id, msg.chatId)
+        jumpToMessage({ accountId, msgId: msg.id, msgChatId: msg.chatId })
         onClose()
       },
     },

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -115,7 +115,12 @@ export default function FullscreenMedia(props: Props & DialogProps) {
     {
       label: tx('show_in_chat'),
       action: () => {
-        jumpToMessage({ accountId, msgId: msg.id, msgChatId: msg.chatId })
+        jumpToMessage({
+          accountId,
+          msgId: msg.id,
+          msgChatId: msg.chatId,
+          scrollIntoViewArg: { block: 'center' },
+        })
         onClose()
       },
     },

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -449,13 +449,13 @@ export default function Message(props: {
     if (isInteractive) {
       onClick = async () => {
         if (isWebxdcInfo && message.parentId) {
-          jumpToMessage(
+          jumpToMessage({
             accountId,
-            message.parentId,
-            undefined,
-            true,
-            message.id
-          )
+            msgId: message.parentId,
+            msgChatId: undefined,
+            highlight: true,
+            msgParentId: message.id,
+          })
         } else if (isProtectionBrokenMsg) {
           const { name } = await BackendRemote.rpc.getBasicChatInfo(
             selectedAccountId(),
@@ -743,13 +743,13 @@ export const Quote = ({
       className='quote-background'
       onClick={() => {
         quote.kind === 'WithMessage' &&
-          jumpToMessage(
+          jumpToMessage({
             accountId,
-            quote.messageId,
-            undefined,
-            true,
-            msgParentId
-          )
+            msgId: quote.messageId,
+            msgChatId: undefined,
+            highlight: true,
+            msgParentId,
+          })
       }}
     >
       <div

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -455,6 +455,7 @@ export default function Message(props: {
             msgChatId: undefined,
             highlight: true,
             msgParentId: message.id,
+            scrollIntoViewArg: { block: 'center' },
           })
         } else if (isProtectionBrokenMsg) {
           const { name } = await BackendRemote.rpc.getBasicChatInfo(
@@ -749,6 +750,9 @@ export const Quote = ({
             msgChatId: undefined,
             highlight: true,
             msgParentId,
+            // Often times the quoted message is already in view,
+            // so let's not scroll at all if so.
+            scrollIntoViewArg: { block: 'nearest' },
           })
       }}
     >

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -796,11 +796,11 @@ function JumpDownButton({
   jumpToMessageStack,
 }: {
   countUnreadMessages: number
-  jumpToMessage: (
-    msgId: number | undefined,
-    highlight?: boolean,
+  jumpToMessage: (params: {
+    msgId: number | undefined
+    highlight?: boolean
     addMessageIdToStack?: undefined | number
-  ) => Promise<void>
+  }) => Promise<void>
   jumpToMessageStack: number[]
 }) {
   let countToShow: string = countUnreadMessages.toString()
@@ -823,7 +823,7 @@ function JumpDownButton({
         <div
           className='button'
           onClick={() => {
-            jumpToMessage(undefined, true)
+            jumpToMessage({ msgId: undefined, highlight: true })
           }}
         >
           <div

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -333,17 +333,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
         )
       }
 
-      domElement.scrollIntoView({
-        // "nearest" so as to not scroll if the message is already in view.
-        // Otherwise we'd try to scroll in such a way that the message
-        // is at the very top of the messages list.
-        // This would not be nice for the Ctrl + Down shortcut
-        // (when quoting a message that a bit far up),
-        // or when highlighting the reply that is already in view.
-        block: 'nearest',
-        inline: 'nearest',
-        // behavior:
-      })
+      domElement.scrollIntoView(scrollTo.scrollIntoViewArg)
 
       if (scrollTo.highlight === true) {
         // Trigger highlight animation
@@ -800,6 +790,7 @@ function JumpDownButton({
     msgId: number | undefined
     highlight?: boolean
     addMessageIdToStack?: undefined | number
+    scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
   }) => Promise<void>
   jumpToMessageStack: number[]
 }) {
@@ -823,7 +814,14 @@ function JumpDownButton({
         <div
           className='button'
           onClick={() => {
-            jumpToMessage({ msgId: undefined, highlight: true })
+            jumpToMessage({
+              msgId: undefined,
+              highlight: true,
+              // 'center' is for when we're jumping the message stack.
+              // When the stack is empty, we'll jump to last message,
+              // and 'center' will make the chat scroll down all the way.
+              scrollIntoViewArg: { block: 'center' },
+            })
           }}
         >
           <div

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -79,6 +79,8 @@ export const ChatProvider = ({
           msgId: undefined,
           highlight: false,
           addMessageIdToStack: undefined,
+          // `scrollIntoViewArg:` doesn't really have effect when
+          // jumping to the last message.
         })
       }
 

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -75,7 +75,11 @@ export const ChatProvider = ({
       // Jump to last message if user clicked chat twice
       // @TODO: We probably want this to be part of the UI logic instead
       if (nextChatId === chatId) {
-        window.__internal_jump_to_message?.(undefined, false, undefined)
+        window.__internal_jump_to_message?.({
+          msgId: undefined,
+          highlight: false,
+          addMessageIdToStack: undefined,
+        })
       }
 
       // Already set known state

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -27,6 +27,7 @@ declare global {
           msgId: number | undefined
           highlight?: boolean
           addMessageIdToStack?: undefined | number
+          scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
         }) => Promise<void>)
     __updateAccountListSidebar: (() => void) | undefined
   }

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -23,11 +23,11 @@ declare global {
     __refetchChatlist: undefined | (() => void)
     __internal_jump_to_message:
       | undefined
-      | ((
-          msgId: number | undefined,
-          highlight?: boolean,
+      | ((params: {
+          msgId: number | undefined
+          highlight?: boolean
           addMessageIdToStack?: undefined | number
-        ) => Promise<void>)
+        }) => Promise<void>)
     __updateAccountListSidebar: (() => void) | undefined
   }
 }

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -19,6 +19,13 @@ export type JumpToMessage = (params: {
   msgChatId?: number
   highlight?: boolean
   msgParentId?: number
+  /**
+   * `behavior: 'smooth'` should not be used due to "scroll locking":
+   * they don't behave well together currently.
+   * `inline` also isn't supposed to have effect because
+   * the messages list should not be horizontally scrollable.
+   */
+  scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
 }) => Promise<void>
 
 export type SendMessage = (
@@ -55,7 +62,14 @@ export default function useMessage() {
   const { chatId, setChatView, selectChat } = useChat()
 
   const jumpToMessage = useCallback<JumpToMessage>(
-    async ({ accountId, msgId, msgChatId, highlight = true, msgParentId }) => {
+    async ({
+      accountId,
+      msgId,
+      msgChatId,
+      highlight = true,
+      msgParentId,
+      scrollIntoViewArg,
+    }) => {
       log.debug(`jumpToMessage with messageId: ${msgId}`)
 
       if (msgChatId == undefined) {
@@ -74,6 +88,7 @@ export default function useMessage() {
           msgId,
           highlight,
           addMessageIdToStack: msgParentId,
+          scrollIntoViewArg,
         })
       }, 0)
     },

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -7,19 +7,19 @@ import { getLogger } from '../../../../shared/logger'
 
 import type { T } from '@deltachat/jsonrpc-client'
 
-export type JumpToMessage = (
-  accountId: number,
-  msgId: number,
+export type JumpToMessage = (params: {
+  accountId: number
+  msgId: number
   /**
    * Optional, but if it is known, it's best to provide it
    * for better performance.
    * When provided, the caller guarantees that
    * `msgChatId === await rpc.getMessage(accountId, msgId)).chatId`.
    */
-  msgChatId?: number,
-  highlight?: boolean,
+  msgChatId?: number
+  highlight?: boolean
   msgParentId?: number
-) => Promise<void>
+}) => Promise<void>
 
 export type SendMessage = (
   accountId: number,
@@ -55,13 +55,7 @@ export default function useMessage() {
   const { chatId, setChatView, selectChat } = useChat()
 
   const jumpToMessage = useCallback<JumpToMessage>(
-    async (
-      accountId: number,
-      msgId: number,
-      msgChatId?: number,
-      highlight = true,
-      msgParentId?: number
-    ) => {
+    async ({ accountId, msgId, msgChatId, highlight = true, msgParentId }) => {
       log.debug(`jumpToMessage with messageId: ${msgId}`)
 
       if (msgChatId == undefined) {
@@ -88,13 +82,13 @@ export default function useMessage() {
       chatId: number,
       message: Partial<T.MessageData>
     ) => {
-      const id = await BackendRemote.rpc.sendMsg(accountId, chatId, {
+      const msgId = await BackendRemote.rpc.sendMsg(accountId, chatId, {
         ...MESSAGE_DEFAULT,
         ...message,
       })
 
       // Jump down on sending
-      jumpToMessage(accountId, id, chatId, false)
+      jumpToMessage({ accountId, msgId, msgChatId: chatId, highlight: false })
     },
     [jumpToMessage]
   )

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -70,7 +70,11 @@ export default function useMessage() {
 
       // Workaround to actual jump to message in regarding mounted component view
       setTimeout(() => {
-        window.__internal_jump_to_message?.(msgId, highlight, msgParentId)
+        window.__internal_jump_to_message?.({
+          msgId,
+          highlight,
+          addMessageIdToStack: msgParentId,
+        })
       }, 0)
     },
     [chatId, selectChat, setChatView]

--- a/packages/frontend/src/hooks/useVideoChat.ts
+++ b/packages/frontend/src/hooks/useVideoChat.ts
@@ -47,7 +47,12 @@ export default function useVideoChat() {
           accountId,
           chatId
         )
-        jumpToMessage(accountId, messageId, chatId, false)
+        jumpToMessage({
+          accountId,
+          msgId: messageId,
+          msgChatId: chatId,
+          highlight: false,
+        })
         await joinVideoChat(accountId, messageId)
       } catch (error: todo) {
         log.error('failed send call invitation', error)

--- a/packages/frontend/src/stores/chat/chat_view_reducer.ts
+++ b/packages/frontend/src/stores/chat/chat_view_reducer.ts
@@ -8,6 +8,7 @@ type ScrollTo =
 interface ScrollToMessage {
   type: 'scrollToMessage'
   msgId: number
+  scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
   highlight: boolean
 }
 
@@ -140,7 +141,8 @@ export class ChatViewReducer {
   static jumpToMessage(
     prevState: ChatViewState,
     jumpToMessageId: number,
-    highlight: boolean
+    highlight: boolean,
+    scrollIntoViewArg: ScrollToMessage['scrollIntoViewArg']
   ): ChatViewState {
     return {
       ...prevState,
@@ -148,6 +150,7 @@ export class ChatViewReducer {
         type: 'scrollToMessage',
         msgId: jumpToMessageId,
         highlight,
+        scrollIntoViewArg,
       },
     }
   }

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -346,7 +346,10 @@ class MessageListStore extends Store<MessageListState> {
         if (firstUnreadMsgId !== null) {
           setTimeout(async () => {
             const chat = await chatP
-            this.effect.jumpToMessage(firstUnreadMsgId, false)
+            this.effect.jumpToMessage({
+              msgId: firstUnreadMsgId,
+              highlight: false,
+            })
             ActionEmitter.emitAction(
               chat.archived
                 ? KeybindAction.ChatList_SwitchToArchiveView
@@ -403,11 +406,15 @@ class MessageListStore extends Store<MessageListState> {
      */
     jumpToMessage: this.scheduler.lockedQueuedEffect(
       'scroll',
-      async (
-        jumpToMessageId: number | undefined,
+      async ({
+        msgId: jumpToMessageId,
         highlight = true,
+        addMessageIdToStack,
+      }: {
+        msgId: number | undefined
+        highlight?: boolean
         addMessageIdToStack?: undefined | number
-      ) => {
+      }) => {
         const startTime = performance.now()
 
         this.log.debug('jumpToMessage with messageId: ', jumpToMessageId)

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -349,6 +349,9 @@ class MessageListStore extends Store<MessageListState> {
             this.effect.jumpToMessage({
               msgId: firstUnreadMsgId,
               highlight: false,
+              // 'center' so that old messages are also shown, for context.
+              // See https://github.com/deltachat/deltachat-desktop/issues/4284
+              scrollIntoViewArg: { block: 'center' },
             })
             ActionEmitter.emitAction(
               chat.archived
@@ -410,10 +413,12 @@ class MessageListStore extends Store<MessageListState> {
         msgId: jumpToMessageId,
         highlight = true,
         addMessageIdToStack,
+        scrollIntoViewArg,
       }: {
         msgId: number | undefined
         highlight?: boolean
         addMessageIdToStack?: undefined | number
+        scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
       }) => {
         const startTime = performance.now()
 
@@ -621,7 +626,8 @@ class MessageListStore extends Store<MessageListState> {
           viewState: ChatViewReducer.jumpToMessage(
             this.state.viewState,
             jumpToMessageId,
-            highlight
+            highlight,
+            scrollIntoViewArg
           ),
           jumpToMessageStack,
         })


### PR DESCRIPTION
Add `scrollIntoViewArg` parameter to `jumpToMessage`
and specify different values for it depending on context.

More specifically, prefer scrolling the target message
to the center, e.g. when showing the first unread message.
Prior to this commit, we'd scroll the first unread message
such that it's at the bottom of the message list,
which can be considered a regression, which was introduced in
https://github.com/deltachat/deltachat-desktop/commit/5f0efe169a56113f25d6aee48fab045956c83a00.

Closes https://github.com/deltachat/deltachat-desktop/issues/4284.

I recommend reviewing commit by commit.

TODO:
- [x] Merge https://github.com/deltachat/deltachat-desktop/pull/4283