### PR TITLE
add autocompletion for translation keys

### DIFF
--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -10,6 +10,7 @@
     "allowJs": false,
     "esModuleInterop": true,
     "moduleResolution": "node",
+    "resolveJsonModule": true,
     "strictNullChecks": true,
     "strict": true,
     "plugins": [{ "name": "typescript-plugin-css-modules" }]

--- a/packages/shared/translationKeyType.d.ts
+++ b/packages/shared/translationKeyType.d.ts
@@ -1,0 +1,11 @@
+//@ts-ignore
+import type english from '../../_locales/en.json'
+//@ts-ignore
+import type untranslated from '../../_locales/_untranslated_en.json'
+
+//@ts-ignore
+export type TranslationKey = keyof typeof english | keyof typeof untranslated
+
+// The ignore here is to make it optional,
+// if the import fails (because resolveJsonModule=false) it should bring down everything with it.
+// currently this type is not used for checking, but just for autocompletion

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -8,8 +8,9 @@
     "allowJs": false,
     "strictNullChecks": true,
     "strict": true,
+    "resolveJsonModule": true,
     "moduleResolution": "NodeNext"
   },
-  "include": ["./**/*.ts", "./**/*.js"],
+  "include": ["./**/*.ts", "./**/*.js", "../../_locales/*.json"],
   "exclude": ["./ts-compiled-for-tests"]
 }

--- a/packages/target-browser/tsconfig.json
+++ b/packages/target-browser/tsconfig.json
@@ -10,6 +10,7 @@
     "allowJs": false,
     "esModuleInterop": true,
     "moduleResolution": "Node10",
+    "resolveJsonModule": true,
     "strictNullChecks": true,
     "strict": true
   },

--- a/packages/target-electron/src/load-translations.ts
+++ b/packages/target-electron/src/load-translations.ts
@@ -27,7 +27,7 @@ let translateFunction: getMessageFunction | null = null
 export const tx: getMessageFunction = function (key, substitutions, raw_opts) {
   if (translateFunction === null) {
     log.error('tried to use translation function before init')
-    return key
+    return key as string
   }
   return translateFunction(key, substitutions, raw_opts)
 }


### PR DESCRIPTION
<img width="554" alt="Bildschirmfoto 2024-10-28 um 18 05 34" src="https://github.com/user-attachments/assets/58426fd6-9816-4504-b19d-0c23c1fd31b8">

Just for autocompletion not checking, for checking we have 2 ways:
- ./bin/test_for_missing_translations.sh
- the runtime errors

we can think about using it also for checking in the future. But currently I'd to say no.