### PR TITLE
improvement: a11y: arrow-key navigation for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ## Added
-- accessibility: arrow-key navigation for gallery and sticker picker #4376, #4372
+- accessibility: arrow-key navigation for message list, gallery and sticker picker #4294, #4376, #4372,
 - accessibility: arrow-key navigation: handle "End" and "Home" keys to go to last / first item #4438
 - add show_app_in_chat option to webxdc info message context menu #4459
 

--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -123,9 +123,25 @@
       scroll-margin-bottom: $margin-bottom;
       // And this is purely cosmetic. For scrolling to a message
       // that is above the visible area.
-      scroll-margin-top: math.div($margin-bottom, 2);
+      $scroll-margin-top: math.div($margin-bottom, 2);
+      scroll-margin-top: $scroll-margin-top;
 
       min-width: 200px;
+
+      .roving-tabindex {
+        // The contents of the `<li>` are focusable (see `useRovingTabindex`).
+        // Focusing an element inside a scrollable region makes the browser
+        // scroll the focused element into view, so let's also apply the same
+        // margins for it.
+        // This is not as important though, but still nice.
+        //
+        // But ideally we'd probably want to refactor this in such a way that
+        // the focusabe element and the element that we `scrollIntoView()`
+        // when `jumpToMessage` is the same element, so only one
+        // needs `scroll-margin`.
+        scroll-margin-bottom: $margin-bottom;
+        scroll-margin-top: $scroll-margin-top;
+      }
 
       &::after {
         visibility: hidden;

--- a/packages/frontend/src/components/Avatar/index.tsx
+++ b/packages/frontend/src/components/Avatar/index.tsx
@@ -43,6 +43,7 @@ export function Avatar(props: {
   wasSeenRecently?: boolean
   style?: htmlDivProps['style']
   onClick?: () => void
+  tabIndex?: -1 | 0
   className?: string
 }) {
   const {
@@ -54,6 +55,7 @@ export function Avatar(props: {
     small,
     wasSeenRecently,
     onClick,
+    tabIndex,
     className,
   } = props
 
@@ -73,6 +75,7 @@ export function Avatar(props: {
         className
       )}
       onClick={onClick}
+      tabIndex={tabIndex}
     >
       {content}
     </div>
@@ -80,11 +83,15 @@ export function Avatar(props: {
 }
 
 export function AvatarFromContact(
-  props: { contact: Type.Contact; onClick?: (contact: Type.Contact) => void },
+  props: {
+    contact: Type.Contact
+    onClick?: (contact: Type.Contact) => void
+    tabIndex?: -1 | 0
+  },
   large?: boolean,
   small?: boolean
 ) {
-  const { contact, onClick } = props
+  const { contact, onClick, tabIndex } = props
   return (
     <Avatar
       avatarPath={contact.profileImage || undefined}
@@ -94,6 +101,7 @@ export function AvatarFromContact(
       large={large === true}
       small={small === true}
       onClick={() => onClick && onClick(contact)}
+      tabIndex={tabIndex}
     />
   )
 }

--- a/packages/frontend/src/components/Reactions/index.tsx
+++ b/packages/frontend/src/components/Reactions/index.tsx
@@ -18,6 +18,7 @@ const SHOW_MAX_DIFFERENT_EMOJIS = 5
 
 type Props = {
   reactions: T.Reactions
+  tabindexForInteractiveContents: -1 | 0
 }
 
 export default function Reactions(props: Props) {
@@ -56,6 +57,7 @@ export default function Reactions(props: Props) {
         className={styles.openReactionsListDialogButton}
         aria-label={tx('more_info_desktop')}
         onClick={handleClick}
+        tabIndex={props.tabindexForInteractiveContents}
       ></button>
     </div>
   )

--- a/packages/frontend/src/components/ShortcutMenu/index.tsx
+++ b/packages/frontend/src/components/ShortcutMenu/index.tsx
@@ -16,6 +16,7 @@ type Props = {
   direction: 'incoming' | 'outgoing'
   message: T.Message
   showContextMenu: (event: OnButtonClick) => Promise<void>
+  tabindexForInteractiveContents: -1 | 0
 }
 
 export default function ShortcutMenu(props: Props) {
@@ -30,9 +31,13 @@ export default function ShortcutMenu(props: Props) {
         <ReactButton
           messageId={props.message.id}
           reactions={props.message.reactions}
+          tabIndex={props.tabindexForInteractiveContents}
         />
       )}
-      <ContextMenuButton onClick={props.showContextMenu} />
+      <ContextMenuButton
+        onClick={props.showContextMenu}
+        tabIndex={props.tabindexForInteractiveContents}
+      />
     </div>
   )
 }
@@ -40,6 +45,7 @@ export default function ShortcutMenu(props: Props) {
 function ReactButton(props: {
   messageId: number
   reactions: T.Message['reactions']
+  tabIndex: -1 | 0
 }) {
   const tx = useTranslationFunction()
 
@@ -67,13 +73,17 @@ function ReactButton(props: {
       aria-label={tx('react')}
       className={styles.shortcutMenuButton}
       onClick={onClick}
+      tabIndex={props.tabIndex}
     >
       <Icon className={styles.shortcutMenuIcon} icon='reaction' />
     </button>
   )
 }
 
-function ContextMenuButton(props: { onClick: (event: OnButtonClick) => void }) {
+function ContextMenuButton(props: {
+  onClick: (event: OnButtonClick) => void
+  tabIndex: -1 | 0
+}) {
   const tx = useTranslationFunction()
 
   return (
@@ -81,6 +91,7 @@ function ContextMenuButton(props: { onClick: (event: OnButtonClick) => void }) {
       aria-label={tx('a11y_message_context_menu_btn_label')}
       className={styles.shortcutMenuButton}
       onClick={props.onClick}
+      tabIndex={props.tabIndex}
     >
       <Icon className={styles.shortcutMenuIcon} icon='more' />
     </button>

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -423,6 +423,8 @@ export function AudioAttachment({
           // and performs seeking and volume changes,
           // so, still, let's only switch focus when this wrapper element
           // is focused (and not one of its children).
+          //
+          // The same goes for the `onKeyDown` code in `Message.tsx`.
           if (e.target !== e.currentTarget) {
             return
           }

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -29,6 +29,7 @@ type AttachmentProps = {
   conversationType: ConversationType
   message: Type.Message
   hasQuote: boolean
+  tabindexForInteractiveContents: -1 | 0
 }
 
 export default function Attachment({
@@ -36,6 +37,7 @@ export default function Attachment({
   conversationType,
   message,
   hasQuote,
+  tabindexForInteractiveContents,
 }: AttachmentProps) {
   const tx = useTranslationFunction()
   const { openDialog } = useDialog()
@@ -87,6 +89,7 @@ export default function Attachment({
     return (
       <button
         onClick={onClickAttachment}
+        tabIndex={tabindexForInteractiveContents}
         className={classNames(
           'message-attachment-media',
           withCaption ? 'content-below' : null,
@@ -107,6 +110,7 @@ export default function Attachment({
       return (
         <button
           onClick={onClickAttachment}
+          tabIndex={tabindexForInteractiveContents}
           style={{ cursor: 'pointer' }}
           className={classNames('message-attachment-broken-media', direction)}
         >
@@ -127,6 +131,9 @@ export default function Attachment({
           className='attachment-content video-content'
           src={runtime.transformBlobURL(message.file)}
           controls={true}
+          // Despite the element having multiple interactive
+          // (pseudo?) elements inside of it, tabindex applies to all of them.
+          tabIndex={tabindexForInteractiveContents}
         />
       </div>
     )
@@ -139,7 +146,12 @@ export default function Attachment({
           withContentAbove ? 'content-above' : null
         )}
       >
-        <AudioPlayer src={runtime.transformBlobURL(message.file)} />
+        <AudioPlayer
+          src={runtime.transformBlobURL(message.file)}
+          // Despite the element having multiple interactive
+          // (pseudo?) elements inside of it, tabindex applies to all of them.
+          tabIndex={tabindexForInteractiveContents}
+        />
       </div>
     )
   } else {
@@ -153,6 +165,7 @@ export default function Attachment({
           withContentAbove ? 'content-above' : null
         )}
         onClick={onClickAttachment}
+        tabIndex={tabindexForInteractiveContents}
       >
         <div
           className='file-icon'

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -126,7 +126,7 @@ const Message = React.memo<
             }}
           />
         )}
-        {message2React(summaryText2 || '', true)}
+        {message2React(summaryText2 || '', true, -1)}
       </div>
       {isContactRequest && (
         <div className='label'>

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -339,7 +339,7 @@ const Composer = forwardRef<
         <div className='upper-bar'>
           {draftState.quote !== null && (
             <div className='attachment-quote-section is-quote'>
-              <Quote quote={draftState.quote} />
+              <Quote quote={draftState.quote} tabIndex={0} />
               <CloseButton onClick={removeQuote} />
             </div>
           )}

--- a/packages/frontend/src/components/message/EmptyChatMessage.tsx
+++ b/packages/frontend/src/components/message/EmptyChatMessage.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { T } from '@deltachat/jsonrpc-client'
+import { useRovingTabindex } from '../../contexts/RovingTabindex'
 
 type Props = {
   chat: T.FullChat
@@ -11,6 +12,9 @@ type Props = {
 
 export default function EmptyChatMessage({ chat }: Props) {
   const tx = useTranslationFunction()
+
+  const ref = useRef<HTMLLIElement>(null)
+  const rovingTabindex = useRovingTabindex(ref)
 
   let emptyChatMessage = tx('chat_new_one_to_one_hint', [chat.name, chat.name])
 
@@ -29,7 +33,13 @@ export default function EmptyChatMessage({ chat }: Props) {
   }
 
   return (
-    <li>
+    <li
+      ref={ref}
+      className={rovingTabindex.className}
+      tabIndex={rovingTabindex.tabIndex}
+      onKeyDown={rovingTabindex.onKeydown}
+      onFocus={rovingTabindex.setAsActiveElement}
+    >
       <div className='info-message big'>
         <div className='bubble'>{emptyChatMessage}</div>
       </div>

--- a/packages/frontend/src/components/message/Link.tsx
+++ b/packages/frontend/src/components/message/Link.tsx
@@ -42,9 +42,11 @@ function isDomainTrusted(domain: string): boolean {
 export const LabeledLink = ({
   label,
   destination,
+  tabIndex,
 }: {
   label: string | JSX.Element | JSX.Element[]
   destination: LinkDestination
+  tabIndex: -1 | 0
 }) => {
   const { openDialog } = useDialog()
   const openLinkSafely = useOpenLinkSafely()
@@ -84,6 +86,7 @@ export const LabeledLink = ({
       x-target-url={target}
       title={realUrl}
       onClick={onClick}
+      tabIndex={tabIndex}
       onContextMenu={ev => ((ev as any).t = ev.currentTarget)}
     >
       {label}
@@ -164,7 +167,13 @@ function LabeledLinkConfirmationDialog(
   )
 }
 
-export const Link = ({ destination }: { destination: LinkDestination }) => {
+export const Link = ({
+  destination,
+  tabIndex,
+}: {
+  destination: LinkDestination
+  tabIndex: -1 | 0
+}) => {
   const { openDialog } = useDialog()
   const openLinkSafely = useOpenLinkSafely()
   const accountId = selectedAccountId()
@@ -193,7 +202,13 @@ export const Link = ({ destination }: { destination: LinkDestination }) => {
   }
 
   return (
-    <a href='#' x-target-url={asciiUrl} title={asciiUrl} onClick={onClick}>
+    <a
+      href='#'
+      x-target-url={asciiUrl}
+      title={asciiUrl}
+      onClick={onClick}
+      tabIndex={tabIndex}
+    >
       {target}
     </a>
   )

--- a/packages/frontend/src/components/message/MessageBody.tsx
+++ b/packages/frontend/src/components/message/MessageBody.tsx
@@ -10,6 +10,7 @@ function MessageBody({
   text,
   disableJumbomoji,
   nonInteractiveContent = false,
+  tabindexForInteractiveContents,
 }: {
   text: string
   disableJumbomoji?: boolean
@@ -18,6 +19,10 @@ function MessageBody({
    * display them as regular text.
    */
   nonInteractiveContent?: boolean
+  /**
+   * Has no effect when {@link nonInteractiveContent} === true.
+   */
+  tabindexForInteractiveContents?: -1 | 0
 }): JSX.Element {
   if (text.length >= UPPER_LIMIT_FOR_PARSED_MESSAGES) {
     return <>{text}</>
@@ -34,7 +39,11 @@ function MessageBody({
       )
     }
   }
-  return message2React(emojifiedText, nonInteractiveContent)
+  return message2React(
+    emojifiedText,
+    nonInteractiveContent,
+    tabindexForInteractiveContents ?? 0
+  )
 }
 const trimRegex = /^[\s\uFEFF\xA0\n\t]+|[\s\uFEFF\xA0\n\t]+$/g
 

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -827,7 +827,6 @@ export const MessageListInner = React.memo(
                     />
                   )
                 } else if (message?.kind === 'loadingError') {
-                  // TODO shall we add `useRovingTabindex` here as well?
                   return (
                     <MessageLoadingError
                       messageId={messageId}
@@ -838,7 +837,6 @@ export const MessageListInner = React.memo(
                   // setTimeout tells it to call method in next event loop iteration, so after rendering
                   // it is debounced later so we can call it here multiple times and it's ok
                   setTimeout(loadMissingMessages)
-                  // TODO shall we add `useRovingTabindex` here as well?
                   return <MessageLoading messageId={messageId} />
                 }
               }
@@ -866,13 +864,20 @@ function MessageLoadingError({
   messageId: T.MessageListItem & { kind: 'message' }
   message: T.MessageLoadResult
 }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const rovingTabindex = useRovingTabindex(ref)
+
   return (
     <div className='info-message' id={String(messageId.msg_id)}>
       <div
-        className='bubble'
+        ref={ref}
+        className={'bubble ' + rovingTabindex.className}
         style={{
           backgroundColor: 'rgba(55,0,0,0.5)',
         }}
+        tabIndex={rovingTabindex.tabIndex}
+        onKeyDown={rovingTabindex.onKeydown}
+        onFocus={rovingTabindex.setAsActiveElement}
       >
         loading message {messageId.msg_id} failed: {message.error}
       </div>
@@ -884,13 +889,20 @@ function MessageLoading({
 }: {
   messageId: T.MessageListItem & { kind: 'message' }
 }) {
+  const ref = useRef<HTMLDivElement>(null)
+  const rovingTabindex = useRovingTabindex(ref)
+
   return (
     <div className='info-message' id={String(messageId.msg_id)}>
       <div
-        className='bubble'
+        ref={ref}
+        className={'bubble ' + rovingTabindex.className}
         style={{
           backgroundColor: 'rgba(55,0,0,0.5)',
         }}
+        tabIndex={rovingTabindex.tabIndex}
+        onKeyDown={rovingTabindex.onKeydown}
+        onFocus={rovingTabindex.setAsActiveElement}
       >
         Loading Message {messageId.msg_id}
       </div>

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -829,35 +829,17 @@ export const MessageListInner = React.memo(
                 } else if (message?.kind === 'loadingError') {
                   // TODO shall we add `useRovingTabindex` here as well?
                   return (
-                    <div className='info-message' id={String(messageId.msg_id)}>
-                      <div
-                        className='bubble'
-                        style={{
-                          backgroundColor: 'rgba(55,0,0,0.5)',
-                        }}
-                      >
-                        loading message {messageId.msg_id} failed:{' '}
-                        {message.error}
-                      </div>
-                    </div>
+                    <MessageLoadingError
+                      messageId={messageId}
+                      message={message}
+                    />
                   )
                 } else {
                   // setTimeout tells it to call method in next event loop iteration, so after rendering
                   // it is debounced later so we can call it here multiple times and it's ok
                   setTimeout(loadMissingMessages)
                   // TODO shall we add `useRovingTabindex` here as well?
-                  return (
-                    <div className='info-message' id={String(messageId.msg_id)}>
-                      <div
-                        className='bubble'
-                        style={{
-                          backgroundColor: 'rgba(55,0,0,0.5)',
-                        }}
-                      >
-                        Loading Message {messageId.msg_id}
-                      </div>
-                    </div>
-                  )
+                  return <MessageLoading messageId={messageId} />
                 }
               }
             })}
@@ -876,6 +858,45 @@ export const MessageListInner = React.memo(
     return areEqual
   }
 )
+
+function MessageLoadingError({
+  messageId,
+  message,
+}: {
+  messageId: T.MessageListItem & { kind: 'message' }
+  message: T.MessageLoadResult
+}) {
+  return (
+    <div className='info-message' id={String(messageId.msg_id)}>
+      <div
+        className='bubble'
+        style={{
+          backgroundColor: 'rgba(55,0,0,0.5)',
+        }}
+      >
+        loading message {messageId.msg_id} failed: {message.error}
+      </div>
+    </div>
+  )
+}
+function MessageLoading({
+  messageId,
+}: {
+  messageId: T.MessageListItem & { kind: 'message' }
+}) {
+  return (
+    <div className='info-message' id={String(messageId.msg_id)}>
+      <div
+        className='bubble'
+        style={{
+          backgroundColor: 'rgba(55,0,0,0.5)',
+        }}
+      >
+        Loading Message {messageId.msg_id}
+      </div>
+    </div>
+  )
+}
 
 function JumpDownButton({
   countUnreadMessages,

--- a/packages/frontend/src/components/message/MessageMarkdown.tsx
+++ b/packages/frontend/src/components/message/MessageMarkdown.tsx
@@ -30,7 +30,13 @@ SettingsStoreInstance.subscribe(newState => {
   }
 })
 
-function renderElement(elm: ParsedElement, key?: number): JSX.Element {
+function renderElement(
+  elm: ParsedElement,
+  tabindexForInteractiveContents: -1 | 0,
+  key?: number
+): JSX.Element {
+  const mapFn = (elm: ParsedElement, index: number) =>
+    renderElement(elm, tabindexForInteractiveContents, index)
   switch (elm.t) {
     case 'CodeBlock':
       return (
@@ -48,20 +54,32 @@ function renderElement(elm: ParsedElement, key?: number): JSX.Element {
       )
 
     case 'StrikeThrough':
-      return <s key={key}>{elm.c.map(renderElement)}</s>
+      return <s key={key}>{elm.c.map(mapFn)}</s>
 
     case 'Italics':
-      return <i key={key}>{elm.c.map(renderElement)}</i>
+      return <i key={key}>{elm.c.map(mapFn)}</i>
 
     case 'Bold':
-      return <b key={key}>{elm.c.map(renderElement)}</b>
+      return <b key={key}>{elm.c.map(mapFn)}</b>
 
     case 'Tag':
-      return <TagLink key={key} tag={elm.c} />
+      return (
+        <TagLink
+          key={key}
+          tag={elm.c}
+          tabIndex={tabindexForInteractiveContents}
+        />
+      )
 
     case 'Link': {
       const { destination } = elm.c
-      return <Link destination={destination} key={key} />
+      return (
+        <Link
+          destination={destination}
+          key={key}
+          tabIndex={tabindexForInteractiveContents}
+        />
+      )
     }
 
     case 'LabeledLink':
@@ -69,18 +87,31 @@ function renderElement(elm: ParsedElement, key?: number): JSX.Element {
         <span key={key}>
           <LabeledLink
             destination={elm.c.destination}
-            label={<>{elm.c.label.map(renderElement)}</>}
+            label={<>{elm.c.label.map(mapFn)}</>}
+            tabIndex={tabindexForInteractiveContents}
           />{' '}
         </span>
       )
 
     case 'EmailAddress': {
       const email = elm.c
-      return <EmailLink key={key} email={email} />
+      return (
+        <EmailLink
+          key={key}
+          email={email}
+          tabIndex={tabindexForInteractiveContents}
+        />
+      )
     }
 
     case 'BotCommandSuggestion':
-      return <BotCommandSuggestion key={key} suggestion={elm.c} />
+      return (
+        <BotCommandSuggestion
+          key={key}
+          suggestion={elm.c}
+          tabIndex={tabindexForInteractiveContents}
+        />
+      )
 
     case 'Linebreak':
       return <span key={key}>{'\n'}</span>
@@ -147,13 +178,25 @@ function renderElementPreview(elm: ParsedElement, key?: number): JSX.Element {
   }
 }
 
-export function message2React(message: string, preview: boolean): JSX.Element {
+export function message2React(
+  message: string,
+  preview: boolean,
+  /**
+   * Has no effect `{@link preview} === true`, because there should be
+   * no interactive elements in the first place
+   */
+  tabindexForInteractiveContents: -1 | 0
+): JSX.Element {
   try {
     const elements = parseMessage(message)
     return preview ? (
       <div className='truncated'>{elements.map(renderElementPreview)}</div>
     ) : (
-      <>{elements.map(renderElement)}</>
+      <>
+        {elements.map((el, index) =>
+          renderElement(el, tabindexForInteractiveContents, index)
+        )}
+      </>
     )
   } catch (error) {
     log.error('parseMessage failed:', { input: message, error })
@@ -161,7 +204,13 @@ export function message2React(message: string, preview: boolean): JSX.Element {
   }
 }
 
-function EmailLink({ email }: { email: string }): JSX.Element {
+function EmailLink({
+  email,
+  tabIndex,
+}: {
+  email: string
+  tabIndex: -1 | 0
+}): JSX.Element {
   const accountId = selectedAccountId()
   const createChatByEmail = useCreateChatByEmail()
   const { selectChat } = useChat()
@@ -179,13 +228,14 @@ function EmailLink({ email }: { email: string }): JSX.Element {
       x-not-a-link='email'
       x-target-email={email}
       onClick={handleClick}
+      tabIndex={tabIndex}
     >
       {email}
     </a>
   )
 }
 
-function TagLink({ tag }: { tag: string }) {
+function TagLink({ tag, tabIndex }: { tag: string; tabIndex: -1 | 0 }) {
   const setSearch = () => {
     log.debug(
       `Clicked on a hastag, this should open search for the text "${tag}"`
@@ -199,13 +249,19 @@ function TagLink({ tag }: { tag: string }) {
   }
 
   return (
-    <a href={'#'} x-not-a-link='tag' onClick={setSearch}>
+    <a href={'#'} x-not-a-link='tag' onClick={setSearch} tabIndex={tabIndex}>
       {tag}
     </a>
   )
 }
 
-function BotCommandSuggestion({ suggestion }: { suggestion: string }) {
+function BotCommandSuggestion({
+  suggestion,
+  tabIndex,
+}: {
+  suggestion: string
+  tabIndex: -1 | 0
+}) {
   const openConfirmationDialog = useConfirmationDialog()
   const messageDisplay = useContext(MessagesDisplayContext)
   const accountId = selectedAccountId()
@@ -281,7 +337,12 @@ function BotCommandSuggestion({ suggestion }: { suggestion: string }) {
   }
 
   return (
-    <a href='#' x-not-a-link='bcs' onClick={applySuggestion}>
+    <a
+      href='#'
+      x-not-a-link='bcs'
+      onClick={applySuggestion}
+      tabIndex={tabIndex}
+    >
       {suggestion}
     </a>
   )

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -16,6 +16,7 @@ type Props = {
   timestamp: number
   hasLocation?: boolean
   onClickError?: () => void
+  tabindexForInteractiveContents: -1 | 0
   viewType: T.Viewtype
 }
 
@@ -31,6 +32,7 @@ export default function MessageMetaData(props: Props) {
     timestamp,
     hasLocation,
     onClickError,
+    tabindexForInteractiveContents,
     viewType,
   } = props
 
@@ -63,6 +65,7 @@ export default function MessageMetaData(props: Props) {
           className={classNames('status-icon', status)}
           aria-label={tx(`a11y_delivery_status_${status}`)}
           disabled={status !== 'error'}
+          tabIndex={status === 'error' ? tabindexForInteractiveContents : -1}
           onClick={status === 'error' ? onClickError : undefined}
         />
       )}


### PR DESCRIPTION
https://github.com/user-attachments/assets/76391400-a379-45ac-bc6b-940b7a864853

Closes https://github.com/deltachat/deltachat-desktop/issues/2141.
Together with other previously merged MRs, closes https://github.com/deltachat/deltachat-desktop/issues/4127.

Basically what this commit comes down to:
1. Apply `useRovingTabindex` for message items
2. Set `tabindex="-1"` on all the interactive items
    inside every message that is currently not the active one,
    so that they do no have tab stops.

TODO:
- [x] Address the TODOs in the code
- [ ] Manage what's gonna be the initially active message,
    because initially they're all active, so
    tabbing to the messages list from the top selects
    the first rendered one as the active one.
    https://github.com/deltachat/deltachat-desktop/pull/4292
    could help with this.
    And remember that the messages list is dynamic (a new message can arrive), so simply setting the last one as active once won't cut it.
    This is also not great for performance: changing `tabindex`
    on a bunch of messages makes them all re-render.
    And otherwise, we probably want to update which one is
    the active one as new messages arrive.
    Perhaps we can simply implement the "End" shortcut as sort of a workaround for now: https://github.com/deltachat/deltachat-desktop/pull/4438
- [ ] Some `jumpToMessage` calls probably ought to focus the message. For example, when jumping to a message through a click on a quote, or a webxdc info message. But not all `jumpToMessage` should change focus. For example, receiving a new message shouldn't do it. This probably requires that we add a `focus` parameter to `jumpToMessage`. Perhaps even 2 parameters: whether to set the message as the active one in the messages list (without focusing it), and whether to focus it. But consider the fact that then the composer will be blurred and will have to be manually focused.
    This can be done in further MRs.
- [x] The interactive items with `onClick` must be actual semantic
    `<button>`s.
    See https://github.com/deltachat/deltachat-desktop/pull/4210
    for reference.
    Namely, this goes for [`Attachment`](https://github.com/deltachat/deltachat-desktop/blob/d1a3f8dbebe4cfa9f74ec4e53e29637eb1e7c573/packages/frontend/src/components/attachment/messageAttachment.tsx#L34), and all the `onClick` listeners in `Message.ts`.
    Update: here is an MR: https://github.com/deltachat/deltachat-desktop/pull/4429
- [x] Set `tabindex` on `<video>` and `<audio>`
- [x] Does `onFocus` work? Does clicking something inside a message make that message the active one?
- [x] Same for `onKeyDown`. Does pressing an arrow key when a child element is focused switch the active message?
- [x] Some interactive contents, namely videos and audios, utilize arrow keys, i.e. for seeking, changing volume. We must not invoke our onKeyDown handler in such cases, switching focus to a different message.
  FYI This also applies to audios in gallery, see https://github.com/deltachat/deltachat-desktop/pull/4376
- [ ] Shift + F10 on a webxdc info message, then "Reply" causes the webxdc app to open. This is similar (or the same?) as https://github.com/deltachat/deltachat-desktop/issues/4242
- [ ] Looks like we need to set `role` attributes so that things like NVDA don't override the arrow key presses to manage focus on their own. See ["How do I disable NVDA's arrow key navigation"](https://stackoverflow.com/questions/41473174/how-do-i-disable-nvdas-arrow-key-navigation). `role` is also mentioned in https://www.w3.org/WAI/ARIA/apg/patterns/listbox/.
  The example that [MDN links to](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets#technique_1_roving_tabindex) uses `role="application"` on the list. I tried setting `role="application"` on our `<ul>` that contains the messages and it started working, but I am not sure if this is correct.
  I created a separate issue: https://github.com/deltachat/deltachat-desktop/issues/4444
- [ ] As mentioned below, "react" doesn't work: you can't navigate the reaction picker with keyboard, and cannot close it.