### PR TITLE
browser edition: add backup and key export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   - support for selecting custom chat wallpaper #4306
   - support for themes #4304
 - improve keyboard and screen-reader accessibility #4210
+- make backup and key export work in browser #4303
 
 ## Changed
 - style: avoid scrolling to account list items such that they're at the very edge of the list #4252

--- a/packages/frontend/src/components/Settings/ManageKeys.tsx
+++ b/packages/frontend/src/components/Settings/ManageKeys.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react'
+import { dirname, basename } from 'path'
 
 import { BackendRemote } from '../../backend-com'
 import { runtime } from '@deltachat-desktop/runtime-interface'
@@ -6,14 +7,20 @@ import { selectedAccountId } from '../../ScreenController'
 import SettingsButton from './SettingsButton'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useConfirmationDialog from '../../hooks/dialog/useConfirmationDialog'
-
 import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
-import { dirname } from 'path'
+
 import { RuntimeOpenDialogOptions } from '@deltachat-desktop/shared/shared-types'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+import { DcEventType } from '@deltachat/jsonrpc-client'
+import AlertDialog from '../dialogs/AlertDialog'
+import useDialog from '../../hooks/dialog/useDialog'
+
+const log = getLogger('renderer/Settings/ManageKeys')
 
 export default function ManageKeys() {
   const tx = useTranslationFunction()
   const openConfirmationDialog = useConfirmationDialog()
+  const { openDialog } = useDialog()
 
   const onKeysImport = useCallback(async () => {
     const { defaultPath, setLastPath } = rememberLastUsedPath(
@@ -54,25 +61,31 @@ export default function ManageKeys() {
   const onKeysExport = useCallback(async () => {
     // TODO: ask for the user's password and check it
 
-    const { defaultPath, setLastPath } = rememberLastUsedPath(
-      LastUsedSlot.KeyExport
-    )
-    const opts: RuntimeOpenDialogOptions = {
-      title: tx('pref_managekeys_export_secret_keys'),
-      defaultPath,
-      properties: ['openDirectory', 'createDirectory'],
-      buttonLabel: tx('select'),
+    let destination: string
+    if (runtime.getRuntimeInfo().target === 'browser') {
+      destination = '<BROWSER>' // gets replaced internally by browser runtime
+    } else {
+      const { defaultPath, setLastPath } = rememberLastUsedPath(
+        LastUsedSlot.KeyExport
+      )
+      const opts: RuntimeOpenDialogOptions = {
+        title: tx('pref_managekeys_export_secret_keys'),
+        defaultPath,
+        properties: ['openDirectory', 'createDirectory'],
+        buttonLabel: tx('select'),
+      }
+
+      const [chosen_destination] = await runtime.showOpenFileDialog(opts)
+      if (!chosen_destination) {
+        return
+      }
+      setLastPath(chosen_destination)
+      destination = chosen_destination
     }
 
-    const [destination] = await runtime.showOpenFileDialog(opts)
-    if (!destination) {
-      return
-    }
-    setLastPath(destination)
-
-    const title = tx('pref_managekeys_export_explain').replace(
-      '%1$s',
-      destination
+    const title = tx(
+      'pref_managekeys_export_explain',
+      runtime.getRuntimeInfo().target === 'browser' ? '(download)' : destination
     )
 
     const confirmed = await openConfirmationDialog({
@@ -82,16 +95,52 @@ export default function ManageKeys() {
     })
 
     if (confirmed) {
-      await BackendRemote.rpc.exportSelfKeys(
-        selectedAccountId(),
-        destination,
-        null
-      )
+      const listenForOutputFiles = ({
+        path,
+      }: DcEventType<'ImexFileWritten'>) => {
+        if (runtime.getRuntimeInfo().target === 'browser') {
+          if (!basename(path).startsWith('private-key')) {
+            return
+          }
+          const downloadLink = `/download-backup/${basename(path)}`
+          // this alert dialog is to make the opening of the link a user action, to prevent the popup warning
+          openDialog(AlertDialog, {
+            cb: () => window.open(downloadLink, '__blank'),
+            message: tx(
+              'pref_managekeys_secret_keys_exported_to_x',
+              downloadLink
+            ),
+            okBtnLabel: tx('open'),
+          })
+        }
+      }
+      const emitter = BackendRemote.getContextEvents(selectedAccountId())
+      emitter.on('ImexFileWritten', listenForOutputFiles)
 
-      window.__userFeedback({
-        type: 'success',
-        text: tx('pref_managekeys_secret_keys_exported_to_x', destination),
-      })
+      try {
+        await BackendRemote.rpc.exportSelfKeys(
+          selectedAccountId(),
+          destination,
+          null
+        )
+
+        if (runtime.getRuntimeInfo().target !== 'browser') {
+          window.__userFeedback({
+            type: 'success',
+            text: tx('pref_managekeys_secret_keys_exported_to_x', destination),
+          })
+        }
+      } catch (error) {
+        // TODO/QUESTION - how are errors shown to user?
+        log.error('backup-export failed:', error)
+      } finally {
+        if (runtime.getRuntimeInfo().target === 'browser') {
+          // event is slower than return of exportSelfKeys
+          // TODO find better solution
+          await new Promise(res => setTimeout(res, 1000))
+        }
+        emitter.off('ImexFileWritten', listenForOutputFiles)
+      }
     }
   }, [tx, openConfirmationDialog])
 

--- a/packages/frontend/src/components/Settings/ManageKeys.tsx
+++ b/packages/frontend/src/components/Settings/ManageKeys.tsx
@@ -142,7 +142,7 @@ export default function ManageKeys() {
         emitter.off('ImexFileWritten', listenForOutputFiles)
       }
     }
-  }, [tx, openConfirmationDialog])
+  }, [tx, openConfirmationDialog, openDialog])
 
   return (
     <>

--- a/packages/frontend/src/components/dialogs/AlertDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AlertDialog.tsx
@@ -15,9 +15,10 @@ import type { DialogProps } from '../../contexts/DialogContext'
 export type Props = {
   cb?: () => void
   message: string | ReactNode
+  okBtnLabel?: string
 } & DialogProps
 
-export default function AlertDialog({ message, onClose, cb }: Props) {
+export default function AlertDialog({ message, onClose, cb, okBtnLabel }: Props) {
   const tx = useTranslationFunction()
 
   const onClick = () => {
@@ -34,7 +35,7 @@ export default function AlertDialog({ message, onClose, cb }: Props) {
       </DialogBody>
       <DialogFooter>
         <FooterActions>
-          <FooterActionButton onClick={onClick}>{tx('ok')}</FooterActionButton>
+          <FooterActionButton onClick={onClick}>{okBtnLabel || tx('ok')}</FooterActionButton>
         </FooterActions>
       </DialogFooter>
     </Dialog>

--- a/packages/frontend/src/components/dialogs/AlertDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AlertDialog.tsx
@@ -18,7 +18,12 @@ export type Props = {
   okBtnLabel?: string
 } & DialogProps
 
-export default function AlertDialog({ message, onClose, cb, okBtnLabel }: Props) {
+export default function AlertDialog({
+  message,
+  onClose,
+  cb,
+  okBtnLabel,
+}: Props) {
   const tx = useTranslationFunction()
 
   const onClick = () => {
@@ -35,7 +40,9 @@ export default function AlertDialog({ message, onClose, cb, okBtnLabel }: Props)
       </DialogBody>
       <DialogFooter>
         <FooterActions>
-          <FooterActionButton onClick={onClick}>{okBtnLabel || tx('ok')}</FooterActionButton>
+          <FooterActionButton onClick={onClick}>
+            {okBtnLabel || tx('ok')}
+          </FooterActionButton>
         </FooterActions>
       </DialogFooter>
     </Dialog>

--- a/packages/target-browser/src/deltachat-rpc.ts
+++ b/packages/target-browser/src/deltachat-rpc.ts
@@ -167,11 +167,12 @@ export async function startDeltaChat(): Promise<
     ws.on('message', raw_data => {
       if (active_connection === ws) {
         const stringData = raw_data.toString('utf-8')
-        if (stringData.indexOf('export_backup') !== -1) {
+        if (stringData.indexOf('export') !== -1) {
           // modify backup export location
           const request = JSON.parse(stringData)
           if (
-            request.method === 'export_backup' &&
+            (request.method === 'export_backup' ||
+              request.method === 'export_self_keys') &&
             request.params[1] === '<BROWSER>'
           ) {
             request.params[1] = join(DC_ACCOUNTS_DIR, 'backups')


### PR DESCRIPTION
- alert dialog: add option to set alternative ok button label
- make backup export work in browser, import already worked
- browser: add ability to export secret key

TODO: 
- [x] changelog entry, wait for next release so we have less rebasing effort
