### PR TITLE
Show paste button in qr scanner dialog

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -80,5 +80,8 @@
   },
   "react_more_emojis": {
     "message": "More emojis…"
+  },
+  "paste": {
+    "message": "Paste"
   }
 }

--- a/packages/e2e-tests/tests/basic-functionality.spec.ts
+++ b/packages/e2e-tests/tests/basic-functionality.spec.ts
@@ -94,13 +94,7 @@ test('start chat with user', async ({ page, context, browserName }) => {
 
   await page.getByTestId('show-qr-scan').click()
 
-  await page.getByTestId('qr-reader-settings').click()
-
-  const item = page.getByTestId('paste-from-clipboard')
-
-  expect(await item.isVisible()).toBeTruthy()
-
-  await item.click()
+  await page.getByTestId('paste').click()
 
   const t = await page
     .locator('.styles_module_dialog')

--- a/packages/frontend/src/components/QrReader/helper.ts
+++ b/packages/frontend/src/components/QrReader/helper.ts
@@ -1,0 +1,88 @@
+import scanQrCode, { QRCode } from 'jsqr'
+import { Runtime } from '@deltachat-desktop/runtime-interface'
+
+/**
+ * Convert file data to base64 encoded data URL string.
+ */
+export async function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    try {
+      reader.addEventListener(
+        'load',
+        () => {
+          resolve(reader.result as string)
+        },
+        false
+      )
+
+      reader.readAsDataURL(file)
+    } catch (error) {
+      reject(error)
+    }
+  })
+}
+
+/**
+ * Convert base64-encoded blob string into image data.
+ */
+export async function base64ToImageData(base64: string): Promise<ImageData> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+
+    image.addEventListener('load', () => {
+      try {
+        const canvas = document.createElement('canvas')
+        const context = canvas.getContext('2d')
+        canvas.width = image.width
+        canvas.height = image.height
+
+        if (!context) {
+          return
+        }
+
+        context.drawImage(image, 0, 0)
+
+        const imageData = context.getImageData(0, 0, image.width, image.height)
+        resolve(imageData)
+      } catch (error) {
+        reject(error)
+      }
+    })
+
+    image.src = base64
+  })
+}
+
+/**
+ * @throws Error (no data in clipboard)
+ */
+export async function qrCodeFromClipboard(runtime: Runtime): Promise<string> {
+  // Try interpreting the clipboard data as an image
+  const base64 = await runtime.readClipboardImage()
+  if (base64) {
+    const imageData = await base64ToImageData(base64)
+    const result = scanQrCode(imageData.data, imageData.width, imageData.height)
+    if (result?.data) {
+      return result.data
+    } else {
+      throw new Error('no data in clipboard image')
+    }
+  }
+
+  // .. otherwise return non-image data from clipboard directly
+  const data = await runtime.readClipboardText()
+  if (!data) {
+    throw new Error('no data in clipboard')
+  }
+  // trim whitespaces because user might copy them by accident when sending over other messengers
+  // see https://github.com/deltachat/deltachat-desktop/issues/4161#issuecomment-2390428338
+  return data.trim()
+}
+
+export async function qrCodeFromImage(file: File): Promise<QRCode | null> {
+  const base64 = await fileToBase64(file)
+  const imageData = await base64ToImageData(base64)
+  return scanQrCode(imageData.data, imageData.width, imageData.height)
+}

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -120,7 +120,7 @@ export default function QrReader({ onError, onScanSuccess }: Props) {
         if (result) {
           onScanSuccess(result.data)
         } else {
-          throw Error(`${tx('qrscan_failed')}: no data in image`)
+          throw Error(`no data in image`)
         }
       } catch (error: any) {
         handleError(error)
@@ -132,7 +132,7 @@ export default function QrReader({ onError, onScanSuccess }: Props) {
         inputRef.current.value = ''
       }
     },
-    [handleError, tx, onScanSuccess]
+    [handleError, onScanSuccess]
   )
 
   // Show a context menu with different video input options to the user.

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -13,6 +13,7 @@ import Spinner from '../Spinner'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { ContextMenuContext } from '../../contexts/ContextMenuContext'
 import { ScreenContext } from '../../contexts/ScreenContext'
+import { runtime, Runtime } from '@deltachat-desktop/runtime-interface'
 
 // @ts-ignore:next-line: We're importing a worker here with the help of the
 // "esbuild-plugin-inline-worker" plugin
@@ -22,8 +23,6 @@ import styles from './styles.module.scss'
 
 import type { ContextMenuItem } from '../ContextMenu'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
-import { runtime, Runtime } from '@deltachat-desktop/runtime-interface'
-import QrCode from '../dialogs/QrCode'
 
 type Props = {
   onError: (error: string) => void
@@ -65,7 +64,7 @@ async function fileToBase64(file: File): Promise<string> {
 /**
  * Convert base64-encoded blob string into image data.
  */
-export async function base64ToImageData(base64: string): Promise<ImageData> {
+async function base64ToImageData(base64: string): Promise<ImageData> {
   return new Promise((resolve, reject) => {
     const image = new Image()
 

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -174,6 +174,26 @@ export default function QrReader({ onError, onScan }: Props) {
     [onScan]
   )
 
+  const handlePasteFromClipboard = useCallback(async () => {
+    try {
+      const result = await processClipBoard(runtime)
+      if (typeof result === 'string') {
+        onScan(result)
+      } else {
+        try {
+          handleScanResult(result)
+        } catch (error) {
+          console.error('Error while processing clipboard content:', error)
+        }
+      }
+    } catch (error) {
+      userFeedback({
+        type: 'error',
+        text: `${tx('qrscan_failed')}: ${error}`,
+      })
+    }
+  }, [handleScanResult, onScan, tx, userFeedback])
+
   // General handler for errors which might occur during scanning.
   const handleError = useCallback(
     (error: any) => {
@@ -259,6 +279,11 @@ export default function QrReader({ onError, onScan }: Props) {
           action: handleImportImage,
           dataTestid: 'load-qr-code-as-image',
         },
+        {
+          label: tx('paste_from_clipboard'),
+          action: handlePasteFromClipboard,
+          dataTestid: 'paste-from-clipboard',
+        },
       ]
 
       openContextMenu({
@@ -266,7 +291,14 @@ export default function QrReader({ onError, onScan }: Props) {
         items,
       })
     },
-    [deviceId, handleImportImage, openContextMenu, tx, videoDevices]
+    [
+      deviceId,
+      handleImportImage,
+      openContextMenu,
+      tx,
+      videoDevices,
+      handlePasteFromClipboard,
+    ]
   )
 
   // Whenever a camera was (automatically or manually) selected we attempt

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -26,7 +26,7 @@ import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 
 type Props = {
   onError: (error: string) => void
-  onScan: (data: string) => void
+  onScanSuccess: (data: string) => void
 }
 
 type ImageDimensions = {
@@ -38,7 +38,7 @@ const SCAN_QR_INTERVAL_MS = 250
 
 const worker = new Worker()
 
-export default function QrReader({ onError, onScan }: Props) {
+export default function QrReader({ onError, onScanSuccess }: Props) {
   const tx = useTranslationFunction()
   const { openContextMenu } = useContext(ContextMenuContext)
 
@@ -89,11 +89,11 @@ export default function QrReader({ onError, onScan }: Props) {
   const handlePasteFromClipboard = useCallback(async () => {
     try {
       const result = await qrCodeFromClipboard(runtime)
-      onScan(result)
+      onScanSuccess(result)
     } catch (error) {
       handleError(error)
     }
-  }, [onScan, handleError])
+  }, [onScanSuccess, handleError])
 
   // Read data from an external image file.
   //
@@ -118,7 +118,7 @@ export default function QrReader({ onError, onScan }: Props) {
         const result = await qrCodeFromImage(file)
 
         if (result) {
-          onScan(result.data)
+          onScanSuccess(result.data)
         } else {
           throw Error(`${tx('qrscan_failed')}: no data in image`)
         }
@@ -132,7 +132,7 @@ export default function QrReader({ onError, onScan }: Props) {
         inputRef.current.value = ''
       }
     },
-    [handleError, tx, onScan]
+    [handleError, tx, onScanSuccess]
   )
 
   // Show a context menu with different video input options to the user.
@@ -172,10 +172,10 @@ export default function QrReader({ onError, onScan }: Props) {
     [
       deviceId,
       handleImportImage,
+      handlePasteFromClipboard,
       openContextMenu,
       tx,
       videoDevices,
-      handlePasteFromClipboard,
     ]
   )
 
@@ -275,7 +275,7 @@ export default function QrReader({ onError, onScan }: Props) {
 
     const handleWorkerMessage = (event: MessageEvent) => {
       if (event.data) {
-        onScan(event.data)
+        onScanSuccess(event.data)
       }
     }
 
@@ -317,7 +317,7 @@ export default function QrReader({ onError, onScan }: Props) {
       worker.removeEventListener('message', handleWorkerMessage)
       window.clearInterval(interval)
     }
-  }, [handleError, onScan])
+  }, [handleError, onScanSuccess])
 
   return (
     <div className={styles.qrReader}>

--- a/packages/frontend/src/components/dialogs/QrCode.tsx
+++ b/packages/frontend/src/components/dialogs/QrCode.tsx
@@ -239,7 +239,7 @@ export function QrCodeScanQrInner({
           await processQr(accountId, data, onDone)
         } catch (error: any) {
           log.errorWithoutStackTrace('QrReader process error: ', error)
-          handleError
+          handleError(error)
         }
         processingQrCode.current = false
       } else if (processingQrCode.current === true) {

--- a/packages/frontend/src/components/dialogs/QrCode.tsx
+++ b/packages/frontend/src/components/dialogs/QrCode.tsx
@@ -226,7 +226,7 @@ export function QrCodeScanQrInner({
     (error: any) => {
       const errorMessage = error?.message || error.toString()
       openAlertDialog({
-        message: `${tx('qrscan_failed')}: ${errorMessage}`,
+        message: `${tx('qrscan_failed')} ${errorMessage}`,
       })
     },
     [openAlertDialog, tx]
@@ -248,7 +248,6 @@ export function QrCodeScanQrInner({
     },
     [accountId, processQr, onDone, handleError]
   )
-
 
   const pasteClipboard = useCallback(async () => {
     try {

--- a/packages/frontend/src/components/dialogs/QrCodeScanner.tsx
+++ b/packages/frontend/src/components/dialogs/QrCodeScanner.tsx
@@ -6,6 +6,11 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../contexts/DialogContext'
 
+/**
+ * used to scan a QR code in other context
+ * than the invitation qr code dialog
+ * - UseOtherServerDialog
+ */
 export default function QrCodeScanner({ onClose }: DialogProps) {
   const tx = useTranslationFunction()
 

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
@@ -38,10 +38,10 @@ export function ReceiveBackupDialog({ onClose }: Props & DialogProps) {
       log.errorWithoutStackTrace('QrReader process error: ', error)
       const errorMessage = error?.message || error.toString()
       openAlertDialog({
-        message: errorMessage,
+        message: `${tx('qrscan_failed')} ${errorMessage}`,
       })
     },
-    [openAlertDialog]
+    [openAlertDialog, tx]
   )
 
   const handleScan = useCallback(

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
@@ -33,6 +33,17 @@ export function ReceiveBackupDialog({ onClose }: Props & DialogProps) {
     processingQrCode.current = false
   }, [onClose])
 
+  const handleError = useCallback(
+    (error: any) => {
+      log.errorWithoutStackTrace('QrReader process error: ', error)
+      const errorMessage = error?.message || error.toString()
+      openAlertDialog({
+        message: errorMessage,
+      })
+    },
+    [openAlertDialog]
+  )
+
   const handleScan = useCallback(
     async (data: string) => {
       if (data && !processingQrCode.current) {
@@ -41,21 +52,15 @@ export function ReceiveBackupDialog({ onClose }: Props & DialogProps) {
           await processQr(accountId, data, onDone)
         } catch (error: any) {
           log.errorWithoutStackTrace('QrReader process error: ', error)
-          openAlertDialog({
-            message: error.message || error.toString(),
-          })
+          handleError(error)
         }
         processingQrCode.current = false
       } else if (processingQrCode.current === true) {
         log.debug('Already processing a qr code')
       }
     },
-    [accountId, processQr, onDone, openAlertDialog]
+    [accountId, processQr, onDone, handleError]
   )
-
-  const handleError = (err: string) => {
-    log.error('QrReader error: ' + err)
-  }
 
   return (
     <DialogWithHeader
@@ -68,7 +73,7 @@ export function ReceiveBackupDialog({ onClose }: Props & DialogProps) {
           <br />
           {tx('multidevice_experimental_hint')}
         </p>
-        <QrReader onScan={handleScan} onError={handleError} />
+        <QrReader onScanSuccess={handleScan} onError={handleError} />
       </DialogBody>
       <DialogFooter>
         <FooterActions align='spaceBetween'>


### PR DESCRIPTION
resolves #3936

move "paste from clipboard" from settings context menu to own button

![image](https://github.com/user-attachments/assets/9330c0d1-822d-4351-8d69-ac02e2e7765e)

Another option would be: name the paste button "Import" and show the context menu onClick with the 2 options: 'load QR Code image' or 'paste from clipboard'
But buttons that show a context menu on click are a bit unusual