### PR TITLE
fix: "disappearing messages" dialog wrong value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## Changed
 
 ## Fixed
+- "Disappearing Messages" dialog not reflecting the actual current value #4327
 
 <a id="1_48_0"></a>
 

--- a/packages/frontend/src/components/Radio.tsx
+++ b/packages/frontend/src/components/Radio.tsx
@@ -32,9 +32,12 @@ export default function Radio({
         id={id}
         name={name}
         type='radio'
-        onClick={() => onSelect && onSelect()}
+        // > change event fires
+        // > When a <input type="radio"> element is checked
+        // > (but not when unchecked);
+        onChange={() => onSelect && onSelect()}
         value={value}
-        defaultChecked={Boolean(selected)}
+        checked={Boolean(selected)}
       />
       <label
         htmlFor={id}

--- a/packages/frontend/src/components/Settings/Appearance.tsx
+++ b/packages/frontend/src/components/Settings/Appearance.tsx
@@ -79,7 +79,7 @@ export default function Appearance({
 
     openDialog(SmallSelectDialog, {
       values,
-      selectedValue: activeTheme,
+      initialSelectedValue: activeTheme,
       title: tx('pref_theme'),
       onSelect,
       onCancel,

--- a/packages/frontend/src/components/Settings/Autodelete.tsx
+++ b/packages/frontend/src/components/Settings/Autodelete.tsx
@@ -97,7 +97,7 @@ export default function Autodelete({
       values: fromServer
         ? AUTODELETE_DURATION_OPTIONS_SERVER
         : AUTODELETE_DURATION_OPTIONS_DEVICE,
-      selectedValue: fromServer
+      initialSelectedValue: fromServer
         ? settingsStore.settings['delete_server_after']
         : settingsStore.settings['delete_device_after'],
       title: fromServer

--- a/packages/frontend/src/components/Settings/Communication.tsx
+++ b/packages/frontend/src/components/Settings/Communication.tsx
@@ -45,7 +45,7 @@ export default function Communication({ settingsStore }: Props) {
 
     openDialog(SmallSelectDialog, {
       values,
-      selectedValue: String(settingsStore.settings['show_emails']),
+      initialSelectedValue: String(settingsStore.settings['show_emails']),
       title: tx('pref_show_emails'),
       onSave: (show: string) => {
         SettingsStoreInstance.effect.setCoreSetting('show_emails', show)

--- a/packages/frontend/src/components/Settings/DownloadOnDemand.tsx
+++ b/packages/frontend/src/components/Settings/DownloadOnDemand.tsx
@@ -35,7 +35,7 @@ export default function DownloadOnDemand(props: {
       values: options.map(
         ({ label, value }) => [String(value), label] as SelectDialogOption
       ),
-      selectedValue: String(Number(settings['download_limit'])),
+      initialSelectedValue: String(Number(settings['download_limit'])),
       title: tx('auto_download_messages'),
       onSave: async (bytes: string) => {
         const seconds = Number(bytes)

--- a/packages/frontend/src/components/Settings/OutgoingMediaQuality.tsx
+++ b/packages/frontend/src/components/Settings/OutgoingMediaQuality.tsx
@@ -26,7 +26,7 @@ export default function OutgoingMediaQuality(props: {
       values: options.map(
         ({ label, value }) => [String(value), label] as SelectDialogOption
       ),
-      selectedValue: String(Number(settings['media_quality'])),
+      initialSelectedValue: String(Number(settings['media_quality'])),
       title: tx('pref_outgoing_media_quality'),
       onSave: async (option: string) => {
         SettingsStoreInstance.effect.setCoreSetting(

--- a/packages/frontend/src/components/SmallSelectDialog.tsx
+++ b/packages/frontend/src/components/SmallSelectDialog.tsx
@@ -18,7 +18,7 @@ export type SelectDialogOption = [value: string, label: string]
 
 type Props = {
   title: string
-  selectedValue: string
+  initialSelectedValue: string
   values: SelectDialogOption[]
   onSave?: (selectedValue: string) => void
   onSelect?: (selectedValue: string) => void
@@ -26,7 +26,7 @@ type Props = {
 } & DialogProps
 
 export default function SmallSelectDialog({
-  selectedValue,
+  initialSelectedValue,
   values,
   onSave,
   title,
@@ -36,8 +36,8 @@ export default function SmallSelectDialog({
 }: Props) {
   const tx = useTranslationFunction()
 
-  const [actualSelectedValue, setActualSelectedValue] =
-    useState<string>(selectedValue)
+  const [selectedValue, setActualSelectedValue] =
+    useState<string>(initialSelectedValue)
 
   const onChange = (value: string) => {
     setActualSelectedValue(value)
@@ -45,7 +45,7 @@ export default function SmallSelectDialog({
   }
 
   const saveAndClose = () => {
-    onSave && onSave(actualSelectedValue)
+    onSave && onSave(selectedValue)
     onClose()
   }
 
@@ -56,7 +56,7 @@ export default function SmallSelectDialog({
         <DialogContent>
           <RadioGroup
             onChange={onChange}
-            selectedValue={actualSelectedValue}
+            selectedValue={selectedValue}
             name='small-dialog-value'
           >
             {values.map((element, index) => {

--- a/packages/frontend/src/components/dialogs/MuteChat.tsx
+++ b/packages/frontend/src/components/dialogs/MuteChat.tsx
@@ -49,7 +49,7 @@ export default function MuteChat({ onClose, chatId }: Props & DialogProps) {
     <SmallSelectDialog
       title={tx('menu_mute')}
       values={MUTE_DURATION_OPTIONS}
-      selectedValue={'0'} // first option selected by default which is "not muted"
+      initialSelectedValue={'0'} // first option selected by default which is "not muted"
       onSave={onSave}
       onClose={onClose}
     />


### PR DESCRIPTION
The bug was introduced in https://github.com/deltachat/deltachat-desktop/commit/0e0d0b80d598802ebb972c8d6c05b593bd896f24,
where we switched from the Blueprint's `RadioGroup` to our
custom `RadioGroup`, which had the bug where it would not
reflect the actual value if it was changed programmatically.
This commit fixes that bug.

The bug in `Radio` existed ever since its introduction.
The reason for using `defaultChecked` instead of `checked`
probably was the fact that React would complain that
"input doesn't have `onChange` listener set,
use `defaultChecked` instead".

I have ligtly checked that "disappearing messages"
is the only affected place.