### PR TITLE
Revert "add task to realease doc to document appstore releases centrally on pages repo

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,8 +49,6 @@
   - [ ] arch
   - [ ] nix
   - [ ] (community) snap
-  after all appstores are done:
-  - [ ] add/update entry on https://github.com/deltachat/deltachat-pages/blob/main/releases.md
   ```
   See [example](https://github.com/deltachat/deltachat-desktop/issues/3582)
 


### PR DESCRIPTION
This reverts https://github.com/deltachat/deltachat-desktop/pull/4251 ; `releases.md` does no longer exist, see https://github.com/deltachat/deltachat-pages/pull/994