### PR TITLE
improvement: un-experimental Ctrl+Up to reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 ## Changed
+- enable Telegram-style Ctrl + ArrowUp to reply by default #4333
 - improve performance a little #4334
 
 ## Fixed

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -15,12 +15,6 @@
   "background_sync_disabled_explaination": {
     "message": "Background sync disabled, profile is only synced when selected"
   },
-  "pref_ctrl_up_down_to_reply": {
-    "message": "Ctrl + Up/Down to Reply"
-  },
-  "explain_ctrl_up_down_to_reply": {
-    "message": "Choose the message to reply to with this shortcut"
-  },
   "muted": {
     "message": "Muted"
   },

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -12,6 +12,10 @@ Search contact list: `ctrl + k`
 
 Focus message composer: `ctrl + n`
 
+Select a message to reply to: `ctrl + arrow up`, `ctrl + arrow down`
+
+Cancel reply (remove quote): `Esc`
+
 Open settings: `cmd ⌘ + ,` or `ctrl + ,`
 
 Open help: `F1`

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -238,6 +238,14 @@ export function getKeybindings(
         keyBindings: [['Control', 'N']],
       },
       {
+        title: tx('menu_reply'),
+        keyBindings: [
+          ['Control', 'ArrowUp'],
+          ['Control', 'ArrowDown'],
+          ['Esc'],
+        ],
+      },
+      {
         title: tx('menu_help'),
         keyBindings: [['F1']],
       },

--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -102,14 +102,6 @@ export function ExperimentalFeatures({ settingsStore }: Props) {
         // 853b584251a5dacf60ebc616f7fb10edffb5c5e5/src/main/index.ts#L12-L21
         description='Careful: opening developer tools on a malicious webxdc app could lead to the app getting access to the Internet'
       />
-      {/* If this stops being experimental, add it to the
-      Keyboard shortcuts help (Ctrl + /), and KEYBINDINGS.md.
-      And don't forget about "Esc" to cancel reply */}
-      <DesktopSettingsSwitch
-        settingsKey='enableCtrlUpToReplyShortcut'
-        label={tx('pref_ctrl_up_down_to_reply')}
-        description={tx('explain_ctrl_up_down_to_reply')}
-      />
     </>
   )
 }

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -567,23 +567,13 @@ export function useDraft(
     [inputRef, saveDraft]
   )
 
-  const settingsStore = useSettingsStore()[0]
   useKeyBindingAction(KeybindAction.Composer_SelectReplyToUp, () => {
-    if (settingsStore?.desktopSettings.enableCtrlUpToReplyShortcut !== true) {
-      return
-    }
     onSelectReplyToShortcut(KeybindAction.Composer_SelectReplyToUp)
   })
   useKeyBindingAction(KeybindAction.Composer_SelectReplyToDown, () => {
-    if (settingsStore?.desktopSettings.enableCtrlUpToReplyShortcut !== true) {
-      return
-    }
     onSelectReplyToShortcut(KeybindAction.Composer_SelectReplyToDown)
   })
   useKeyBindingAction(KeybindAction.Composer_CancelReply, () => {
-    if (settingsStore?.desktopSettings.enableCtrlUpToReplyShortcut !== true) {
-      return
-    }
     removeQuote()
   })
   const { jumpToMessage } = useMessage()

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -45,7 +45,6 @@ export interface DesktopSettingsType {
   galleryImageKeepAspectRatio: boolean
   /** whether to use system ui font */
   useSystemUIFont: boolean
-  enableCtrlUpToReplyShortcut: boolean
 }
 
 export interface RC_Config {

--- a/packages/shared/state.ts
+++ b/packages/shared/state.ts
@@ -31,6 +31,5 @@ export function getDefaultState(): DesktopSettingsType {
     enableRelatedChats: false,
     galleryImageKeepAspectRatio: false,
     useSystemUIFont: false,
-    enableCtrlUpToReplyShortcut: false,
   }
 }


### PR DESCRIPTION
The feature was introduced in cd80587ed79bb1a0723dc7c36002e88818cdfcb4.

With several performance improvements to `jumpToMessage`,
the fix to https://github.com/deltachat/deltachat-core-rust/issues/6036,
and some testing, it's time to release it.
