### PR TITLE
perf: faster `jumpToMessage` in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 ## Changed
+- improve performance a little #4334
 
 ## Fixed
 - "Disappearing Messages" dialog not reflecting the actual current value #4327

--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -125,6 +125,7 @@ export const ChatListItemRowMessage = React.memo<{
             jumpToMessage({
               accountId,
               msgId: msrId,
+              msgChatId: messageSearchResult.chatId,
               scrollIntoViewArg: { block: 'center' },
             })
           }}


### PR DESCRIPTION
Follow-up to d085f8a6299817bd6b39603e7c2f1379760a18bc.
`.chatId` was added just recently in core. See https://github.com/deltachat/deltachat-core-rust/pull/6120.
