### PR TITLE
fix: always allow to edit the draft if it is not empty

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -325,7 +325,13 @@ const Composer = forwardRef<
         </button>
       </div>
     )
-  } else if (!selectedChat.canSend) {
+  } else if (
+    !selectedChat.canSend &&
+    draftState.text === '' &&
+    draftState.file === null &&
+    draftState.quote === null &&
+    draftState.vcardContact === null
+  ) {
     return null
   } else {
     return (
@@ -377,12 +383,14 @@ const Composer = forwardRef<
           >
             <span />
           </button>
-          <div className='send-button-wrapper' onClick={composerSendMessage}>
-            <button
-              aria-label={tx('menu_send')}
-              aria-keyshortcuts={ariaSendShortcut}
-            />
-          </div>
+          {selectedChat.canSend && (
+            <div className='send-button-wrapper' onClick={composerSendMessage}>
+              <button
+                aria-label={tx('menu_send')}
+                aria-keyshortcuts={ariaSendShortcut}
+              />
+            </div>
+          )}
         </div>
         {showEmojiPicker && (
           <EmojiAndStickerPicker


### PR DESCRIPTION
Otherwise if you leave the group or get removed from the group, the draft stays forever and is shown in summary,
but it is not possible to edit it or get rid of it.

This builds on top of #4340 because there is a non-working "send" button.