### PR TITLE
Drop 95vw limitation of video in FullscreenMedia

### DIFF
--- a/packages/frontend/scss/gallery/_attachment-view.scss
+++ b/packages/frontend/scss/gallery/_attachment-view.scss
@@ -14,10 +14,6 @@
     object-fit: contain;
     user-select: none;
   }
-
-  video {
-    width: 95vw;
-  }
 }
 
 .btn-wrapper {


### PR DESCRIPTION
@WofWca brought this up in private conversation. There's a limit to video width of 95vw but at the same time it's not centered. That was introduced 5 years ago, maybe to cover up for left-right navigation buttons, but they're wider than 5vw together. I tried to remove that and it seems to work fine in all scenarios.

As a further work we might want to handle video player events and hide arrows while video is playing, bringing them back on pause or video ending. I have no idea if video API is solid for this to be a straightforward implementation though.