### PR TITLE
hardening: disable `IsolateSandboxedIframes`

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -21,6 +21,8 @@ const hostRules = 'MAP * ~NOTFOUND, EXCLUDE *.openstreetmap.org'
 rawApp.commandLine.appendSwitch('host-resolver-rules', hostRules)
 rawApp.commandLine.appendSwitch('host-rules', hostRules)
 
+rawApp.commandLine.appendSwitch('disable-features', 'IsolateSandboxedIframes')
+
 if (rc['version'] === true || rc['v'] === true) {
   /* ignore-console-log */
   console.info(BuildInfo.VERSION)


### PR DESCRIPTION
This feature has been recently enabled by default in Chromium,
so let's toggle it back.
