### PR TITLE
fix mergeable.yml

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -7,7 +7,27 @@ mergeable:
         validate:
           - do: dependent
             changed:
-              file: 'src/**'
+              file: 'packages/frontend/**'
+              required: ['CHANGELOG.md']
+          - do: dependent
+            changed:
+              file: 'packages/runtime/**'
+              required: ['CHANGELOG.md']
+          - do: dependent
+            changed:
+              file: 'packages/shared/**'
+              required: ['CHANGELOG.md']
+          - do: dependent
+            changed:
+              file: 'packages/target-browser/**'
+              required: ['CHANGELOG.md']
+          - do: dependent
+            changed:
+              file: 'packages/target-electron/**'
+              required: ['CHANGELOG.md']
+          - do: dependent
+            changed:
+              file: 'packages/target-tauri/**'
               required: ['CHANGELOG.md']
           - do: dependent
             changed:


### PR DESCRIPTION
I forgot to update it while the monorepo conversion.

this should ignore changes to e2e tests, as IMO they don't need to always have a changelog entry - but we can debate that