### PR TITLE
fix: arrow-key navigation behavior in search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ## Added
-- accessibility: arrow-key navigation for the list of chats, list of accounts #4224, #4291
+- accessibility: arrow-key navigation for the list of chats, list of accounts #4224, #4291, #4361
 - Add "Learn More" button to "Disappearing Messages" dialog #4330
 - new icon for Mac users
 - smooth-scroll to newly arriving messages instead of jumping instantly #4125

--- a/packages/frontend/src/contexts/RovingTabindex.tsx
+++ b/packages/frontend/src/contexts/RovingTabindex.tsx
@@ -18,6 +18,9 @@ import React, {
  * https://developer.mozilla.org/en-US/docs/Web/Accessibility/Keyboard-navigable_JavaScript_widgets#technique_1_roving_tabindex
  * ).
  *
+ * It is OK to use this outside of `RovingTabindexContext`.
+ * In this case it will simply always return `tabIndex === 0`.
+ *
  * This is similar to https://www.npmjs.com/package/react-roving-tabindex, but
  * - it handles elements changing their order in DOM:
  *   'ArrowDown' will always focus the element that is next in DOM,


### PR DESCRIPTION
The "contacts" section items were not included
in the roving tabindex winget: they all had individual tab stops,
which is very confusing.

Before:

https://github.com/user-attachments/assets/05f11ce0-c7a2-44c0-b698-557f9b624e1c

After (it is not clear, but I have to press Tab to get to the "Contacts" section):

https://github.com/user-attachments/assets/60cef514-5fb4-433a-8043-adc8e720fc6e

