### PR TITLE
fix: potential crash due to `Component({ ...props`

### DIFF
--- a/packages/frontend/src/components/contact/ContactList.tsx
+++ b/packages/frontend/src/components/contact/ContactList.tsx
@@ -44,17 +44,20 @@ export function ContactList(props: {
         if (disabledContacts !== undefined) {
           disabled = disabledContacts.indexOf(contact.id) !== -1
         }
-        return ContactListItem({
-          contact,
-          onClick,
-          showCheckbox: showCheckbox || false,
-          checked,
-          onCheckboxClick,
-          showRemove: showRemove || false,
-          onRemoveClick,
-          disabled,
-          onContextMenu: onContactContextMenu?.bind(null, contact),
-        })
+        return (
+          <ContactListItem
+            key={contact.id}
+            contact={contact}
+            onClick={onClick}
+            showCheckbox={showCheckbox || false}
+            checked={checked}
+            onCheckboxClick={onCheckboxClick}
+            showRemove={showRemove || false}
+            onRemoveClick={onRemoveClick}
+            disabled={disabled}
+            onContextMenu={onContactContextMenu?.bind(null, contact)}
+          />
+        )
       })}
     </div>
   )

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
@@ -229,10 +229,13 @@ export function AddMemberInnerDialog({
         <div className={styles.AddMemberChipsWrapper}>
           <div className={styles.AddMemberChips}>
             {contactIdsToAdd.map(contact => {
-              return AddMemberChip({
-                contact,
-                onRemoveClick: toggleMember,
-              })
+              return (
+                <AddMemberChip
+                  key={contact.id}
+                  contact={contact}
+                  onRemoveClick={toggleMember}
+                />
+              )
             })}
             <input
               ref={inputRef}


### PR DESCRIPTION
We already had similar fixes in the past.
I have looked through the code and have found no more of such calls.

Without this we get an error in the console after pressing "OK"
in the "Add Members" dialog in "Create Group":
`Warning: React has detected a change in the order of Hooks called by ContactList`.
