### PR TITLE
improvement: add arrow-key nav everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ## Added
-- accessibility: arrow-key navigation for the list of chats, list of accounts, list of contacts in the "New Chat" dialog #4224, #4291, #4361, #4362
+- accessibility: arrow-key navigation for the list of chats, list of accounts, lists of contacts #4224, #4291, #4361, #4362, #4369
 - Add "Learn More" button to "Disappearing Messages" dialog #4330
 - new icon for Mac users
 - smooth-scroll to newly arriving messages instead of jumping instantly #4125

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
@@ -22,6 +22,7 @@ import InfiniteLoader from 'react-window-infinite-loader'
 import { AddMemberChip } from './AddMemberDialog'
 import styles from './styles.module.scss'
 import classNames from 'classnames'
+import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 
 export function AddMemberInnerDialog({
   onCancel,
@@ -275,58 +276,61 @@ export function AddMemberInnerDialog({
                 // minimumBatchSize={100}
               >
                 {({ onItemsRendered, ref }) => (
-                  // Not using 'react-window' results in ~5 second rendering time
-                  // if the user has 5000 contacts.
-                  // (see https://github.com/deltachat/deltachat-desktop/issues/1830)
-                  <FixedSizeList
-                    itemData={contactIds}
-                    itemCount={itemCount}
-                    itemKey={(index, contactIds) => {
-                      const isExtraItem = index >= contactIds.length
-                      return isExtraItem ? 'addContact' : contactIds[index]
-                    }}
-                    onItemsRendered={onItemsRendered}
-                    ref={ref}
-                    height={height}
-                    width='100%'
-                    // TODO fix: The size of each item is determined
-                    // by `--local-avatar-size` and `--local-avatar-vertical-margin`,
-                    // which might be different, e.g. currently they're smaller for
-                    // "Rocket Theme", which results in gaps between the elements.
-                    itemSize={64}
-                  >
-                    {({ index, style, data: contactIds }) => {
-                      const isExtraItem = index >= contactIds.length
-                      if (isExtraItem) {
-                        return renderAddContact()
-                      }
+                  <RovingTabindexProvider wrapperElementRef={contactListRef}>
+                    {/* Not using 'react-window' results in ~5 second rendering time
+                    if the user has 5000 contacts.
+                    (see https://github.com/deltachat/deltachat-desktop/issues/1830) */}
+                    <FixedSizeList
+                      itemData={contactIds}
+                      itemCount={itemCount}
+                      itemKey={(index, contactIds) => {
+                        const isExtraItem = index >= contactIds.length
+                        return isExtraItem ? 'addContact' : contactIds[index]
+                      }}
+                      onItemsRendered={onItemsRendered}
+                      ref={ref}
+                      height={height}
+                      width='100%'
+                      // TODO fix: The size of each item is determined
+                      // by `--local-avatar-size` and `--local-avatar-vertical-margin`,
+                      // which might be different, e.g. currently they're smaller for
+                      // "Rocket Theme", which results in gaps between the elements.
+                      itemSize={64}
+                    >
+                      {({ index, style, data: contactIds }) => {
+                        const isExtraItem = index >= contactIds.length
+                        if (isExtraItem) {
+                          return renderAddContact()
+                        }
 
-                      const contact = contactCache[contactIds[index]]
-                      if (!contact) {
-                        // Not loaded yet
-                        return <div style={style}></div>
-                      }
+                        const contact = contactCache[contactIds[index]]
+                        if (!contact) {
+                          // Not loaded yet
+                          return <div style={style}></div>
+                        }
 
-                      return (
-                        <div style={style}>
-                          <ContactListItem
-                            contact={contact}
-                            showCheckbox
-                            checked={
-                              contactIdsToAdd.some(c => c.id === contact.id) ||
-                              contactIdsInGroup.includes(contact.id)
-                            }
-                            disabled={
-                              contactIdsInGroup.includes(contact.id) ||
-                              contact.id === C.DC_CONTACT_ID_SELF
-                            }
-                            onCheckboxClick={toggleMember}
-                            showRemove={false}
-                          />
-                        </div>
-                      )
-                    }}
-                  </FixedSizeList>
+                        return (
+                          <div style={style}>
+                            <ContactListItem
+                              contact={contact}
+                              showCheckbox
+                              checked={
+                                contactIdsToAdd.some(
+                                  c => c.id === contact.id
+                                ) || contactIdsInGroup.includes(contact.id)
+                              }
+                              disabled={
+                                contactIdsInGroup.includes(contact.id) ||
+                                contact.id === C.DC_CONTACT_ID_SELF
+                              }
+                              onCheckboxClick={toggleMember}
+                              showRemove={false}
+                            />
+                          </div>
+                        )
+                      }}
+                    </FixedSizeList>
+                  </RovingTabindexProvider>
                 )}
               </InfiniteLoader>
             )}

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -419,6 +419,8 @@ export function CreateGroup(props: CreateGroupProps) {
   const [errorMissingGroupName, setErrorMissingGroupName] = useState(false)
   const [groupContacts, setGroupContacts] = useState<Type.Contact[]>([])
 
+  const groupMemberContactListWrapperRef = useRef<HTMLDivElement>(null)
+
   useMemo(() => {
     BackendRemote.rpc
       .getContactsByIds(accountId, groupMembers)
@@ -459,18 +461,25 @@ export function CreateGroup(props: CreateGroupProps) {
             quantity: groupMembers.length,
           })}
         </div>
-        <div className='group-member-contact-list-wrapper'>
-          <PseudoListItemAddMember
-            onClick={showAddMemberDialog}
-            isBroadcast={false}
-          />
-          <ContactList
-            contacts={groupContacts}
-            showRemove
-            onRemoveClick={c => {
-              removeGroupMember(c)
-            }}
-          />
+        <div
+          className='group-member-contact-list-wrapper'
+          ref={groupMemberContactListWrapperRef}
+        >
+          <RovingTabindexProvider
+            wrapperElementRef={groupMemberContactListWrapperRef}
+          >
+            <PseudoListItemAddMember
+              onClick={showAddMemberDialog}
+              isBroadcast={false}
+            />
+            <ContactList
+              contacts={groupContacts}
+              showRemove
+              onRemoveClick={c => {
+                removeGroupMember(c)
+              }}
+            />
+          </RovingTabindexProvider>
         </div>
       </DialogBody>
       <DialogFooter>
@@ -524,6 +533,8 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
   )
 
   const [broadcastContacts, setBroadcastContacts] = useState<Type.Contact[]>([])
+
+  const groupMemberContactListWrapperRef = useRef<HTMLDivElement>(null)
 
   useMemo(() => {
     BackendRemote.rpc
@@ -585,18 +596,25 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
               })}
             </div>
           )}
-          <div className='group-member-contact-list-wrapper'>
-            <PseudoListItemAddMember
-              onClick={showAddMemberDialog}
-              isBroadcast
-            />
-            <ContactList
-              contacts={broadcastContacts}
-              showRemove
-              onRemoveClick={c => {
-                removeBroadcastRecipient(c)
-              }}
-            />
+          <div
+            className='group-member-contact-list-wrapper'
+            ref={groupMemberContactListWrapperRef}
+          >
+            <RovingTabindexProvider
+              wrapperElementRef={groupMemberContactListWrapperRef}
+            >
+              <PseudoListItemAddMember
+                onClick={showAddMemberDialog}
+                isBroadcast
+              />
+              <ContactList
+                contacts={broadcastContacts}
+                showRemove
+                onRemoveClick={c => {
+                  removeBroadcastRecipient(c)
+                }}
+              />
+            </RovingTabindexProvider>
           </div>
         </DialogContent>
       </DialogBody>

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -1,5 +1,5 @@
 import AutoSizer from 'react-virtualized-auto-sizer'
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import ChatListItem from '../../chat/ChatListItem'
@@ -20,6 +20,7 @@ import styles from './styles.module.scss'
 
 import type { T } from '@deltachat/jsonrpc-client'
 import type { DialogProps } from '../../../contexts/DialogContext'
+import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 
 type Props = {
   message: T.Message
@@ -41,6 +42,8 @@ export default function ForwardMessage(props: Props) {
   const { chatListIds } = useChatList(LIST_FLAGS, queryStr)
   const { isChatLoaded, loadChats, chatCache } =
     useLogicVirtualChatList(chatListIds)
+
+  const chatListRef = useRef<HTMLDivElement>(null)
 
   const onChatClick = async (chatId: number) => {
     const chat = await BackendRemote.rpc.getFullChatById(accountId, chatId)
@@ -96,37 +99,39 @@ export default function ForwardMessage(props: Props) {
             spellCheck={false}
           />
         </div>
-        <div className='forward-message-list-chat-list'>
-          {noResults && queryStr && (
-            <PseudoListItemNoSearchResults queryStr={queryStr} />
-          )}
-          <div style={{ height: noResults ? '0px' : '100%' }}>
-            <AutoSizer>
-              {({ width, height }) => (
-                <ChatListPart
-                  isRowLoaded={isChatLoaded}
-                  loadMoreRows={loadChats}
-                  rowCount={chatListIds.length}
-                  width={width}
-                  height={height}
-                  itemKey={index => 'key' + chatListIds[index]}
-                  itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                >
-                  {({ index, style }) => {
-                    const chatId = chatListIds[index]
-                    return (
-                      <div style={style}>
-                        <ChatListItem
-                          chatListItem={chatCache[chatId] || undefined}
-                          onClick={onChatClick.bind(null, chatId)}
-                        />
-                      </div>
-                    )
-                  }}
-                </ChatListPart>
-              )}
-            </AutoSizer>
-          </div>
+        <div className='forward-message-list-chat-list' ref={chatListRef}>
+          <RovingTabindexProvider wrapperElementRef={chatListRef}>
+            {noResults && queryStr && (
+              <PseudoListItemNoSearchResults queryStr={queryStr} />
+            )}
+            <div style={{ height: noResults ? '0px' : '100%' }}>
+              <AutoSizer>
+                {({ width, height }) => (
+                  <ChatListPart
+                    isRowLoaded={isChatLoaded}
+                    loadMoreRows={loadChats}
+                    rowCount={chatListIds.length}
+                    width={width}
+                    height={height}
+                    itemKey={index => 'key' + chatListIds[index]}
+                    itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                  >
+                    {({ index, style }) => {
+                      const chatId = chatListIds[index]
+                      return (
+                        <div style={style}>
+                          <ChatListItem
+                            chatListItem={chatCache[chatId] || undefined}
+                            onClick={onChatClick.bind(null, chatId)}
+                          />
+                        </div>
+                      )
+                    }}
+                  </ChatListPart>
+                )}
+              </AutoSizer>
+            </div>
+          </RovingTabindexProvider>
         </div>
       </DialogBody>
     </Dialog>

--- a/packages/frontend/src/components/dialogs/MailtoDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/MailtoDialog/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useRef, useState } from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { C } from '@deltachat/jsonrpc-client'
 
@@ -15,6 +15,7 @@ import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import styles from './styles.module.scss'
 
 import type { DialogProps } from '../../../contexts/DialogContext'
+import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 
 type Props = {
   messageText: string
@@ -31,6 +32,8 @@ export default function MailtoDialog(props: Props & DialogProps) {
   const { chatListIds } = useChatList(listFlags, queryStr)
   const { isChatLoaded, loadChats, chatCache } =
     useLogicVirtualChatList(chatListIds)
+
+  const resultsRef = useRef<HTMLDivElement>(null)
 
   const onChatClick = async (chatId: number) => {
     createDraftMessage(accountId, chatId, messageText)
@@ -65,32 +68,38 @@ export default function MailtoDialog(props: Props & DialogProps) {
             {noResults && queryStr && (
               <PseudoListItemNoSearchResults queryStr={queryStr} />
             )}
-            <div style={noResults ? { height: '0px' } : {}} className='results'>
-              <AutoSizer>
-                {({ width, height }) => (
-                  <ChatListPart
-                    isRowLoaded={isChatLoaded}
-                    loadMoreRows={loadChats}
-                    rowCount={chatListIds.length}
-                    width={width}
-                    height={height}
-                    itemKey={index => 'key' + chatListIds[index]}
-                    itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                  >
-                    {({ index, style }) => {
-                      const chatId = chatListIds[index]
-                      return (
-                        <div style={style}>
-                          <ChatListItem
-                            chatListItem={chatCache[chatId] || undefined}
-                            onClick={onChatClick.bind(null, chatId)}
-                          />
-                        </div>
-                      )
-                    }}
-                  </ChatListPart>
-                )}
-              </AutoSizer>
+            <div
+              ref={resultsRef}
+              style={noResults ? { height: '0px' } : {}}
+              className='results'
+            >
+              <RovingTabindexProvider wrapperElementRef={resultsRef}>
+                <AutoSizer>
+                  {({ width, height }) => (
+                    <ChatListPart
+                      isRowLoaded={isChatLoaded}
+                      loadMoreRows={loadChats}
+                      rowCount={chatListIds.length}
+                      width={width}
+                      height={height}
+                      itemKey={index => 'key' + chatListIds[index]}
+                      itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                    >
+                      {({ index, style }) => {
+                        const chatId = chatListIds[index]
+                        return (
+                          <div style={style}>
+                            <ChatListItem
+                              chatListItem={chatCache[chatId] || undefined}
+                              onClick={onChatClick.bind(null, chatId)}
+                            />
+                          </div>
+                        )
+                      }}
+                    </ChatListPart>
+                  )}
+                </AutoSizer>
+              </RovingTabindexProvider>
             </div>
           </div>
         </div>

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
@@ -91,34 +91,48 @@ function ReactionsDialogList({ reactionsByContact, onClose }: Props) {
 
   return (
     <ul className={styles.reactionsDialogList}>
-      {contacts.map(contact => {
-        const notFromSelf = C.DC_CONTACT_ID_SELF !== contact.id
-        return (
-          <li key={contact.id}>
-            <button
-              onClick={() => {
-                if (notFromSelf) {
-                  openViewProfileDialog(accountId, contact.id)
-                }
-              }}
-              // `aria-disabled` instead of just `disabled` because we probably
-              // still want to keep it focusable for screen-readers.
-              aria-disabled={!notFromSelf}
-              className={classNames(styles.reactionsDialogListItem, {
-                [styles.reactionsDialogListClickable]: notFromSelf,
-              })}
-            >
-              <div className={styles.reactionsDialogAvatar}>
-                <AvatarFromContact contact={contact} />
-              </div>
-              <div className={styles.reactionsDialogContactName}>
-                <ContactName displayName={contact.displayName} />
-              </div>
-              <div className={styles.reactionsDialogEmoji}>{contact.emoji}</div>
-            </button>
-          </li>
-        )
-      })}
+      {contacts.map(contact => (
+        <li key={contact.id}>
+          <ReactionsDialogListItem
+            contact={contact}
+            onClickNonSelf={contactId =>
+              openViewProfileDialog(accountId, contactId)
+            }
+          />
+        </li>
+      ))}
     </ul>
+  )
+}
+
+function ReactionsDialogListItem(props: {
+  contact: ContactWithReaction
+  onClickNonSelf: (contactId: number) => void
+}) {
+  const { contact, onClickNonSelf } = props
+  const notFromSelf = C.DC_CONTACT_ID_SELF !== contact.id
+
+  return (
+    <button
+      onClick={() => {
+        if (notFromSelf) {
+          onClickNonSelf(contact.id)
+        }
+      }}
+      // `aria-disabled` instead of just `disabled` because we probably
+      // still want to keep it focusable for screen-readers.
+      aria-disabled={!notFromSelf}
+      className={classNames(styles.reactionsDialogListItem, {
+        [styles.reactionsDialogListClickable]: notFromSelf,
+      })}
+    >
+      <div className={styles.reactionsDialogAvatar}>
+        <AvatarFromContact contact={contact} />
+      </div>
+      <div className={styles.reactionsDialogContactName}>
+        <ContactName displayName={contact.displayName} />
+      </div>
+      <div className={styles.reactionsDialogEmoji}>{contact.emoji}</div>
+    </button>
   )
 }

--- a/packages/frontend/src/components/dialogs/SelectContact/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectContact/index.tsx
@@ -16,6 +16,7 @@ import { ContactListItem } from '../../contact/ContactListItem'
 import { FixedSizeList } from 'react-window'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import InfiniteLoader from 'react-window-infinite-loader'
+import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 
 /**
  * display a dialog with a react-window of contacts
@@ -38,6 +39,8 @@ export default function SelectContactDialog({
     queryStr
   )
   const tx = useTranslationFunction()
+
+  const selectContactListRef = useRef<HTMLDivElement>(null)
 
   const infiniteLoaderRef = useRef<InfiniteLoader | null>(null)
   // By default InfiniteLoader assumes that each item's index in the list
@@ -66,7 +69,7 @@ export default function SelectContactDialog({
         />
       </DialogHeader>
       <DialogBody className={styles.selectContactDialogBody}>
-        <div className={styles.selectContactList}>
+        <div className={styles.selectContactList} ref={selectContactListRef}>
           <AutoSizer disableWidth>
             {({ height }) => (
               <InfiniteLoader
@@ -82,37 +85,41 @@ export default function SelectContactDialog({
                 // minimumBatchSize={100}
               >
                 {({ onItemsRendered, ref }) => (
-                  <FixedSizeList
-                    itemCount={contactIds.length}
-                    itemKey={index => contactIds[index]}
-                    onItemsRendered={onItemsRendered}
-                    ref={ref}
-                    height={height}
-                    width='100%'
-                    itemSize={64}
+                  <RovingTabindexProvider
+                    wrapperElementRef={selectContactListRef}
                   >
-                    {({ index, style }) => {
-                      const el = (() => {
-                        const item = contactCache[contactIds[index]]
-                        if (!item) {
-                          // It's not loaded yet
-                          return null
-                        }
-                        const contact: T.Contact = item
-                        return (
-                          <ContactListItem
-                            contact={contact}
-                            onClick={onOk}
-                            showCheckbox={false}
-                            checked={false}
-                            showRemove={false}
-                          />
-                        )
-                      })()
+                    <FixedSizeList
+                      itemCount={contactIds.length}
+                      itemKey={index => contactIds[index]}
+                      onItemsRendered={onItemsRendered}
+                      ref={ref}
+                      height={height}
+                      width='100%'
+                      itemSize={64}
+                    >
+                      {({ index, style }) => {
+                        const el = (() => {
+                          const item = contactCache[contactIds[index]]
+                          if (!item) {
+                            // It's not loaded yet
+                            return null
+                          }
+                          const contact: T.Contact = item
+                          return (
+                            <ContactListItem
+                              contact={contact}
+                              onClick={onOk}
+                              showCheckbox={false}
+                              checked={false}
+                              showRemove={false}
+                            />
+                          )
+                        })()
 
-                      return <div style={style}>{el}</div>
-                    }}
-                  </FixedSizeList>
+                        return <div style={style}>{el}</div>
+                      }}
+                    </FixedSizeList>
+                  </RovingTabindexProvider>
                 )}
               </InfiniteLoader>
             )}

--- a/packages/frontend/src/components/dialogs/UnblockContacts.tsx
+++ b/packages/frontend/src/components/dialogs/UnblockContacts.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import debounce from 'debounce'
 
 import { ContactList } from '../contact/ContactList'
@@ -9,6 +9,7 @@ import useConfirmationDialog from '../../hooks/dialog/useConfirmationDialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../contexts/DialogContext'
+import { RovingTabindexProvider } from '../../contexts/RovingTabindex'
 
 export default function UnblockContacts({ onClose }: DialogProps) {
   const [blockedContacts, setBlockedContacts] = useState<Type.Contact[] | null>(
@@ -41,6 +42,8 @@ export default function UnblockContacts({ onClose }: DialogProps) {
     }
   }
 
+  const wrapperRef = useRef<HTMLDivElement>(null)
+
   if (blockedContacts === null) return null
   return (
     <DialogWithHeader
@@ -53,16 +56,19 @@ export default function UnblockContacts({ onClose }: DialogProps) {
           {blockedContacts.length === 0 && <p>{tx('blocked_empty_hint')}</p>}
           {blockedContacts.length > 0 && (
             <div
+              ref={wrapperRef}
               style={{
                 overflow: 'scroll',
                 height: '100%',
                 backgroundColor: 'var(--bp4DialogBgPrimary)',
               }}
             >
-              <ContactList
-                contacts={blockedContacts}
-                onClick={onUnblockContact}
-              />
+              <RovingTabindexProvider wrapperElementRef={wrapperRef}>
+                <ContactList
+                  contacts={blockedContacts}
+                  onClick={onUnblockContact}
+                />
+              </RovingTabindexProvider>
             </div>
           )}
         </DialogContent>

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -1,5 +1,5 @@
 import AutoSizer from 'react-virtualized-auto-sizer'
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import moment from 'moment'
 import { C } from '@deltachat/jsonrpc-client'
 
@@ -28,6 +28,7 @@ import styles from './styles.module.scss'
 
 import type { DialogProps } from '../../../contexts/DialogContext'
 import type { T } from '@deltachat/jsonrpc-client'
+import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 
 const log = getLogger('renderer/dialogs/ViewProfile')
 
@@ -137,6 +138,8 @@ export function ViewProfileInner({
     label: string
     action?: () => void
   }>(null)
+
+  const mutualChatsListRef = useRef<HTMLDivElement>(null)
 
   const isDeviceChat = contact.id === C.DC_CONTACT_ID_DEVICE
   const isSelfChat = contact.id === C.DC_CONTACT_ID_SELF
@@ -313,34 +316,37 @@ export function ViewProfileInner({
         <>
           <div className='group-separator'>{tx('profile_shared_chats')}</div>
           <div
+            ref={mutualChatsListRef}
             className='mutual-chats'
             style={{ flexGrow: 1, minHeight: mutualChatsMinHeight }}
           >
-            <AutoSizer>
-              {({ width, height }) => (
-                <ChatListPart
-                  isRowLoaded={isChatLoaded}
-                  loadMoreRows={loadChats}
-                  rowCount={chatListIds.length}
-                  width={width}
-                  height={height}
-                  itemKey={index => 'key' + chatListIds[index]}
-                  itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                >
-                  {({ index, style }) => {
-                    const chatId = chatListIds[index]
-                    return (
-                      <div style={style}>
-                        <ChatListItem
-                          chatListItem={chatCache[chatId] || undefined}
-                          onClick={onChatClick.bind(null, chatId)}
-                        />
-                      </div>
-                    )
-                  }}
-                </ChatListPart>
-              )}
-            </AutoSizer>
+            <RovingTabindexProvider wrapperElementRef={mutualChatsListRef}>
+              <AutoSizer>
+                {({ width, height }) => (
+                  <ChatListPart
+                    isRowLoaded={isChatLoaded}
+                    loadMoreRows={loadChats}
+                    rowCount={chatListIds.length}
+                    width={width}
+                    height={height}
+                    itemKey={index => 'key' + chatListIds[index]}
+                    itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                  >
+                    {({ index, style }) => {
+                      const chatId = chatListIds[index]
+                      return (
+                        <div style={style}>
+                          <ChatListItem
+                            chatListItem={chatCache[chatId] || undefined}
+                            onClick={onChatClick.bind(null, chatId)}
+                          />
+                        </div>
+                      )
+                    }}
+                  </ChatListPart>
+                )}
+              </AutoSizer>
+            </RovingTabindexProvider>
           </div>
         </>
       )}

--- a/packages/frontend/src/components/dialogs/WebxdcSendToChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/WebxdcSendToChat/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useRef, useState } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import classNames from 'classnames'
@@ -26,6 +26,7 @@ import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import styles from './styles.module.scss'
 
 import type { DialogProps } from '../../../contexts/DialogContext'
+import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 
 type Props = {
   messageText: string | null
@@ -44,6 +45,8 @@ export default function WebxdcSaveToChatDialog(props: Props) {
   const { chatListIds } = useChatList(LIST_FLAGS, queryStr)
   const { isChatLoaded, loadChats, chatCache } =
     useLogicVirtualChatList(chatListIds)
+
+  const resultsRef = useRef<HTMLDivElement>(null)
 
   const onChatClick = async (chatId: number) => {
     let path = null
@@ -103,32 +106,38 @@ export default function WebxdcSaveToChatDialog(props: Props) {
         {noResults && queryStr && (
           <PseudoListItemNoSearchResults queryStr={queryStr} />
         )}
-        <div className='results' style={{ height: noResults ? '0px' : '100%' }}>
-          <AutoSizer>
-            {({ width, height }) => (
-              <ChatListPart
-                isRowLoaded={isChatLoaded}
-                loadMoreRows={loadChats}
-                rowCount={chatListIds.length}
-                width={width}
-                height={height}
-                itemKey={index => 'key' + chatListIds[index]}
-                itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-              >
-                {({ index, style }) => {
-                  const chatId = chatListIds[index]
-                  return (
-                    <div style={style}>
-                      <ChatListItem
-                        chatListItem={chatCache[chatId] || undefined}
-                        onClick={onChatClick.bind(null, chatId)}
-                      />
-                    </div>
-                  )
-                }}
-              </ChatListPart>
-            )}
-          </AutoSizer>
+        <div
+          ref={resultsRef}
+          className='results'
+          style={{ height: noResults ? '0px' : '100%' }}
+        >
+          <RovingTabindexProvider wrapperElementRef={resultsRef}>
+            <AutoSizer>
+              {({ width, height }) => (
+                <ChatListPart
+                  isRowLoaded={isChatLoaded}
+                  loadMoreRows={loadChats}
+                  rowCount={chatListIds.length}
+                  width={width}
+                  height={height}
+                  itemKey={index => 'key' + chatListIds[index]}
+                  itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                >
+                  {({ index, style }) => {
+                    const chatId = chatListIds[index]
+                    return (
+                      <div style={style}>
+                        <ChatListItem
+                          chatListItem={chatCache[chatId] || undefined}
+                          onClick={onChatClick.bind(null, chatId)}
+                        />
+                      </div>
+                    )
+                  }}
+                </ChatListPart>
+              )}
+            </AutoSizer>
+          </RovingTabindexProvider>
         </div>
       </DialogBody>
       <DialogFooter>


### PR DESCRIPTION
I have shallowly tested all the places where added it.

This completes arrow-key navigation for all the chat lists and contact lists, unless I missed something.

Follow up to #4224, #4291, #4361, #4362.

For easier review, hide white-space changes.  
This MR includes one small refactor commit, otherwise it's just boilerplate.

And about boilerplate: please tell me whether in general this looks like a good way to write this, or if this feels wrong and unmaintainable.