### PR TITLE
[fix for regression] remove button and input again from no-drag

### DIFF
--- a/packages/frontend/scss/main_screen/_navbar_wrapper.scss
+++ b/packages/frontend/scss/main_screen/_navbar_wrapper.scss
@@ -56,9 +56,7 @@
   -webkit-app-region: drag;
 }
 
-.no-drag,
-input,
-button {
+.no-drag {
   -webkit-app-region: no-drag;
 }
 


### PR DESCRIPTION
it's more reliably to mark buttons and inout fields as no drag manually.

fixes #4370

changelog entry is not needed because bug was not released yet.