### PR TITLE
style: "Search in ..." divider overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - fix mac drag window issues #4300
 - the main window overflowing small screens, or/and if zoom level is high #4156
 - do not clear the draft if sending failed. #4340
+- "Search in \<chat name\>" divider overflowing for long chat names #4375
 
 
 <a id="1_48_0"></a>

--- a/packages/frontend/scss/chat/_chat-list.scss
+++ b/packages/frontend/scss/chat/_chat-list.scss
@@ -16,9 +16,7 @@
   overflow: hidden;
 
   .search-result-divider {
-    line-height: 43px;
-    height: 40px;
-    padding-left: 15px;
+    padding: 11px 15px;
     font-weight: 200;
     color: var(--globaltext);
     background: var(--cli-search-result-divider);


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/67e2fa52-5a58-4195-9523-15e8cb254f70)

After:

![image](https://github.com/user-attachments/assets/fea42f82-2627-4420-9a4f-0392c2fd9299)

Reported by @adbenitez 