### PR TITLE
ignore generated folders of tauri target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ deltachat-rpc-server-aarch64-macos
 .direnv
 .envrc
 default.nix
+
+packages/target-tauri/src-tauri/target
+packages/target-tauri/src-tauri/gen/schemas


### PR DESCRIPTION
I need this already so my editors git support does not freeze because of the many untracked files in the target folder (build artifacts of rust).
