### PR TITLE
New webxdc api

### DIFF
--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -59,7 +59,7 @@ const contextMenuFactory = (
     },
     viewType === 'Webxdc' && {
       label: tx('start_app'),
-      action: openWebxdc.bind(null, message.id),
+      action: openWebxdc.bind(null, message),
     },
     {
       label: tx('save_as'),
@@ -577,7 +577,7 @@ export function WebxdcAttachment({
       <button
         className='media-attachment-webxdc'
         onContextMenu={openContextMenu}
-        onClick={openWebxdc.bind(null, loadResult.id)}
+        onClick={openWebxdc.bind(null, loadResult)}
       >
         <img
           className='icon'

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -835,7 +835,6 @@ function WebxdcMessageContent({ message }: { message: T.Message }) {
     name: 'INFO MISSING!',
     document: undefined,
     summary: 'INFO MISSING!',
-    internetAccess: false,
   }
 
   return (
@@ -853,12 +852,6 @@ function WebxdcMessageContent({ message }: { message: T.Message }) {
         {truncateText(info.name, 42)}
       </div>
       <div>{info.summary}</div>
-      {info.internetAccess && (
-        <div className='experimental'>
-          <b>EXPERIMENTAL</b> Webxdc that has full internet access, be careful!
-          (only works in saved messages)
-        </div>
-      )}
       <Button
         className={styles.startWebxdcButton}
         styling='primary'

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -358,7 +358,6 @@ export default function Message(props: {
   const privateReply = usePrivateReply()
   const { openContextMenu } = useContext(ContextMenuContext)
   const openViewProfileDialog = useOpenViewProfileDialog()
-  const { jumpToMessage } = useMessage()
   const { joinVideoChat } = useVideoChat()
 
   const showContextMenu = useCallback(
@@ -459,15 +458,9 @@ export default function Message(props: {
     let onClick
     if (isInteractive) {
       onClick = async () => {
-        if (isWebxdcInfo && message.parentId) {
-          jumpToMessage({
-            accountId,
-            msgId: message.parentId,
-            msgChatId: undefined,
-            highlight: true,
-            msgParentId: message.id,
-            scrollIntoViewArg: { block: 'center' },
-          })
+        if (isWebxdcInfo) {
+          // open or focus the webxdc app
+          openWebxdc(message)
         } else if (isProtectionBrokenMsg) {
           const { name } = await BackendRemote.rpc.getBasicChatInfo(
             selectedAccountId(),
@@ -850,7 +843,7 @@ function WebxdcMessageContent({ message }: { message: T.Message }) {
       <img
         src={runtime.getWebxdcIconURL(selectedAccountId(), message.id)}
         alt={`icon of ${info.name}`}
-        onClick={() => openWebxdc(message.id)}
+        onClick={() => openWebxdc(message)}
       />
       <div
         className='name'
@@ -869,7 +862,7 @@ function WebxdcMessageContent({ message }: { message: T.Message }) {
       <Button
         className={styles.startWebxdcButton}
         styling='primary'
-        onClick={() => openWebxdc(message.id)}
+        onClick={() => openWebxdc(message)}
       >
         {tx('start_app')}
       </Button>

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -141,7 +141,7 @@ export async function downloadFullMessage(messageId: number) {
   await BackendRemote.rpc.downloadFullMessage(selectedAccountId(), messageId)
 }
 
-export async function openWebxdc(messageId: number) {
+export async function openWebxdc(message: Type.Message) {
   const accountId = selectedAccountId()
-  internalOpenWebxdc(accountId, messageId)
+  internalOpenWebxdc(accountId, message)
 }

--- a/packages/frontend/src/system-integration/webxdc.ts
+++ b/packages/frontend/src/system-integration/webxdc.ts
@@ -2,7 +2,7 @@
 // because it opens new "independent" windows
 // and heavily uses the events
 
-import { BackendRemote } from '../backend-com'
+import { BackendRemote, Type } from '../backend-com'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 
 export function initWebxdc() {
@@ -20,24 +20,40 @@ export function initWebxdc() {
   })
 }
 
-export async function internalOpenWebxdc(accountId: number, messageId: number) {
-  const message = await BackendRemote.rpc.getMessage(accountId, messageId)
+/**
+ * open a webxdc window or focus to an existing one
+ * parameter "message" might be of viewType Webxdc or
+ * systemMessageType WebxdcInfoMessage
+ */
+export async function internalOpenWebxdc(
+  accountId: number,
+  message: Type.Message
+) {
+  let href = ''
+  let messageId = message.id
+  if (message.systemMessageType === 'WebxdcInfoMessage' && message.parentId) {
+    // if we have a webxdc info message, the webxdc app is attached to the parent message
+    href = message.webxdcHref ?? ''
+    messageId = message.parentId
+  }
   if (!message.webxdcInfo) {
-    throw new Error('no webxdc info for message ' + messageId)
+    // we can open only messages with webxdc info
+    throw new Error('no webxdc info for message ' + message)
   }
   const chatName = (
     await BackendRemote.rpc.getBasicChatInfo(accountId, message.chatId)
   ).name
-  const { addr, displayname } = await BackendRemote.rpc.batchGetConfig(
+  const displayname = await BackendRemote.rpc.getConfig(
     accountId,
-    ['addr', 'displayname']
+    'displayname'
   )
+
   runtime.openWebxdc(messageId, {
     accountId,
-    addr,
     displayname,
     chatName,
     webxdcInfo: message.webxdcInfo,
+    href,
   })
 }
 

--- a/packages/frontend/src/system-integration/webxdc.ts
+++ b/packages/frontend/src/system-integration/webxdc.ts
@@ -32,9 +32,10 @@ export async function internalOpenWebxdc(
   let href = ''
   let messageId = message.id
   if (message.systemMessageType === 'WebxdcInfoMessage' && message.parentId) {
-    // if we have a webxdc info message, the webxdc app is attached to the parent message
     href = message.webxdcHref ?? ''
+    // if we have a webxdc info message, the webxdcInfo is attached to the parent message
     messageId = message.parentId
+    message = await BackendRemote.rpc.getMessage(accountId, messageId)
   }
   if (!message.webxdcInfo) {
     // we can open only messages with webxdc info

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -109,9 +109,9 @@ export interface DcNotification {
 export interface DcOpenWebxdcParameters {
   accountId: number
   displayname: string | null
-  addr: string | null
   webxdcInfo: T.WebxdcMessageInfo
   chatName: string
+  href: string
 }
 
 export interface RuntimeOpenDialogOptions {

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -94,7 +94,8 @@ export default class DCWebxdc extends SplitOut {
       msg_id: number,
       p: DcOpenWebxdcParameters
     ) => {
-      const { webxdcInfo, chatName, displayname, addr, accountId } = p
+      const { webxdcInfo, chatName, displayname, accountId } = p
+      const addr = webxdcInfo.selfAddr || ''
       if (open_apps[`${accountId}.${msg_id}`]) {
         log.warn(
           'webxdc instance for this app is already open, trying to focus it',
@@ -115,7 +116,6 @@ export default class DCWebxdc extends SplitOut {
         await this.rpc.getWebxdcBlob(accountId, msg_id, icon),
         'base64'
       )
-
       const ses = sessionFromAccountId(accountId)
       const appURL = `webxdc://${accountId}.${msg_id}.webxdc`
 

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -72,7 +72,7 @@ export default class DCWebxdc extends SplitOut {
     // icon protocol
     app.whenReady().then(() => {
       protocol.handle('webxdc-icon', async request => {
-        const [a, m] = request.url.substr(12).split('.')
+        const [a, m] = request.url.substring(12).split('.')
         const [accountId, messageId] = [Number(a), Number(m)]
         try {
           const { icon } = await this.rpc.getWebxdcInfo(accountId, messageId)
@@ -99,6 +99,12 @@ export default class DCWebxdc extends SplitOut {
       p: DcOpenWebxdcParameters
     ) => {
       const { webxdcInfo, chatName, displayname, accountId, href } = p
+      const removeLeadingSlash = (s: string) => {
+        if (s.startsWith('/')) {
+          return s.substring(1)
+        }
+        return s
+      }
       const addr = webxdcInfo.selfAddr
       let base64EncodedHref = ''
       const appURL = `webxdc://${accountId}.${msg_id}.webxdc`
@@ -110,9 +116,9 @@ export default class DCWebxdc extends SplitOut {
           log.warn('href is not relative, ignoring', { href })
         } else {
           // make href eval safe
-          base64EncodedHref = Buffer.from(appURL + '/' + href).toString(
-            'base64'
-          )
+          base64EncodedHref = Buffer.from(
+            appURL + '/' + removeLeadingSlash(href)
+          ).toString('base64')
         }
       }
       if (open_apps[`${accountId}.${msg_id}`]) {
@@ -193,11 +199,9 @@ export default class DCWebxdc extends SplitOut {
           let filename = url.pathname
           // remove leading / trailing "/"
           if (filename.endsWith('/')) {
-            filename = filename.substr(0, filename.length - 1)
+            filename = filename.substring(0, filename.length - 1)
           }
-          if (filename.startsWith('/')) {
-            filename = filename.substr(1)
-          }
+          filename = removeLeadingSlash(filename)
 
           let mimeType: string | undefined = Mime.lookup(filename) || ''
           // Make sure that the browser doesn't open files in the PDF viewer.

--- a/packages/target-electron/static/webxdc-preload.js
+++ b/packages/target-electron/static/webxdc-preload.js
@@ -46,7 +46,14 @@ class RealtimeListener {
 //@ts-check
 ;(() => {
   const { contextBridge, ipcRenderer } = require('electron')
+  // setup is finished
   let is_ready = false
+
+  // used to replace the location.href of the iframe if
+  // setLocation was called before all connections were filled
+  let locationUrl = ''
+
+  let connectionsFilled = false
 
   /**
    * @type {Parameters<import('@webxdc/types').Webxdc["setUpdateListener"]>[0]|null}
@@ -291,15 +298,27 @@ class RealtimeListener {
           ipcRenderer.invoke('webxdc.exit')
         } catch (error) {
           loadingDiv.remove()
-          iframe.src = 'index.html'
+          iframe.src = locationUrl !== '' ? locationUrl : 'index.html'
           iframe.contentWindow.window.addEventListener(
             'keydown',
             keydown_handler
           )
+          connectionsFilled = true
         }
       } catch (error) {
         console.log('error loading, should crash/close window', error)
         ipcRenderer.invoke('webxdc.exit')
+      }
+    },
+    /**
+     * called via webContents.executeJavaScript
+     */
+    setLocationUrl(href) {
+      locationUrl = Buffer.from(href, 'base64').toString('utf8')
+      if (locationUrl && locationUrl !== '' && connectionsFilled) {
+        // if connectionsFilled is false, the url is loaded after
+        // the connections are filled
+        window.frames[0].window.location = locationUrl
       }
     },
   })
@@ -313,9 +332,11 @@ class RealtimeListener {
   window.addEventListener('keydown', keydown_handler)
   window.onload = () => {
     const frame = document.getElementById('frame')
-    if (frame)
+    if (frame) {
       frame.contentWindow.window.addEventListener('keydown', keydown_handler)
-    else console.log('attaching F12 handler failed, frame not found')
+    } else {
+      console.log('attaching F12 handler failed, frame not found')
+    }
   }
 
   contextBridge.exposeInMainWorld('webxdc_custom', {

--- a/packages/target-electron/static/webxdc-preload.js
+++ b/packages/target-electron/static/webxdc-preload.js
@@ -313,8 +313,8 @@ class RealtimeListener {
     /**
      * called via webContents.executeJavaScript
      */
-    setLocationUrl(href) {
-      locationUrl = Buffer.from(href, 'base64').toString('utf8')
+    setLocationUrl(base64EncodedHref) {
+      locationUrl = Buffer.from(base64EncodedHref, 'base64').toString('utf8')
       if (locationUrl && locationUrl !== '' && connectionsFilled) {
         // if connectionsFilled is false, the url is loaded after
         // the connections are filled


### PR DESCRIPTION
resolves (partly) to #4366 

Main changes: 
 - openWebxdc in frontend expects a message as first argument instead a messageId
 - selfAddr in webxdcInfo holds not the users address anymore
 - WebxdcInfo message has a new optional property webxdc_href
 - click on WebxdcInfo message directly opens the map and sets a event related location.url in iFrame (optional)
