### PR TITLE
fullscreen media view: improve drag behaviour and remove visible scrollbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - do not clear the draft if sending failed. #4340
 - "Search in \<chat name\>" divider overflowing for long chat names #4375
 - fix startup delay on linux #4379
-- fix: remove visible scrollbars in fullscreen media view 
+- fix: remove visible scrollbars in fullscreen media view #4385
 
 
 <a id="1_48_0"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - do not clear the draft if sending failed. #4340
 - "Search in \<chat name\>" divider overflowing for long chat names #4375
 - fix startup delay on linux #4379
+- fix: remove visible scrollbars in fullscreen media view 
 
 
 <a id="1_48_0"></a>

--- a/packages/frontend/scss/gallery/_attachment-view.scss
+++ b/packages/frontend/scss/gallery/_attachment-view.scss
@@ -29,6 +29,14 @@
   padding: 5px;
 }
 
+.attachment-view-drag-bar {
+  background-color: transparent;
+  position: absolute;
+  top: 0px;
+  width: 100vw;
+  height: 50px;
+}
+
 .media-previous-button,
 .media-next-button {
   position: absolute;

--- a/packages/frontend/scss/gallery/_attachment-view.scss
+++ b/packages/frontend/scss/gallery/_attachment-view.scss
@@ -6,6 +6,7 @@
   align-items: center;
   justify-content: center;
   background-color: rgba(49, 49, 49, 1);
+  overflow: hidden;
 
   img,
   video {

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -261,6 +261,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
   return (
     <Dialog unstyled onClose={onClose}>
       <div className='attachment-view'>{elm}</div>
+      {runtime.getRuntimeInfo().isMac && <div className='attachment-view-drag-bar drag'></div>}
       {elm && (
         <div className='btn-wrapper no-drag'>
           <IconButton

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -261,7 +261,9 @@ export default function FullscreenMedia(props: Props & DialogProps) {
   return (
     <Dialog unstyled onClose={onClose}>
       <div className='attachment-view'>{elm}</div>
-      {runtime.getRuntimeInfo().isMac && <div className='attachment-view-drag-bar drag'></div>}
+      {runtime.getRuntimeInfo().isMac && (
+        <div className='attachment-view-drag-bar drag'></div>
+      )}
       {elm && (
         <div className='btn-wrapper no-drag'>
           <IconButton


### PR DESCRIPTION
- **fix drag area problem in fullscreen media view**
- **fix: remove visible scrollbars in fullscreen media view**

closes #4368 (I know we could do even better, but this invisible drag area where the navbar would be already fixes the bug in my eyes)

The scrollbar problem: (those scrollbars are just a visual bug, they don't really do anything as far as I understood it)
<img width="263" alt="Bildschirmfoto 2024-12-04 um 15 48 47" src="https://github.com/user-attachments/assets/090bbb6f-b674-4005-9d03-cb6e1631fcbd">

The drag area:
| before| after|
|-------|-----|
|<img width="1151" alt="Bildschirmfoto 2024-12-04 um 15 51 01" src="https://github.com/user-attachments/assets/bb62e074-3317-43ee-b3a8-2ac7aca3e1bd">|<img width="1151" alt="Bildschirmfoto 2024-12-04 um 15 51 42" src="https://github.com/user-attachments/assets/a0ae7660-feee-4445-b839-165556e72c47">|