### PR TITLE
improvement: mark bots as such in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.151.5`
+- mark bots as such in chat header and in contact view dialog #4405
 
 ## Fixed
 - handle double escape on Dialog #4365

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -90,7 +90,7 @@ export default function ViewProfile(
       className={styles.viewProfileDialog}
     >
       <DialogHeader
-        title={tx('contact')}
+        title={contact.isBot ? tx('bot') : tx('contact')}
         onClose={onClose}
         onClickBack={onBack}
       >

--- a/packages/frontend/src/components/screens/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen.tsx
@@ -280,6 +280,11 @@ function chatSubtitle(chat: Type.FullChat) {
       return tx('n_members', [String(chat.contacts.length)], {
         quantity: chat.contacts.length,
       })
+    } else if (
+      chat.chatType === C.DC_CHAT_TYPE_SINGLE &&
+      chat.contacts[0]?.isBot
+    ) {
+      return tx('bot')
     } else if (chat.chatType === C.DC_CHAT_TYPE_MAILINGLIST) {
       if (chat.mailingListAddress) {
         return `${tx('mailing_list')} – ${chat.mailingListAddress}`

--- a/packages/frontend/src/components/screens/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen.tsx
@@ -360,7 +360,7 @@ function ChatHeading({ chat }: { chat: T.FullChat }) {
           </div>
         </div>
         {subtitle && subtitle.length && (
-          <div className='navbar-chat-subtitle'>{chatSubtitle(chat)}</div>
+          <div className='navbar-chat-subtitle'>{subtitle}</div>
         )}
       </div>
     </button>


### PR DESCRIPTION
- **refactor: simplify `navbar-chat-subtitle`**
- **improvement: mark bots as such in UI**

Closes https://github.com/deltachat/deltachat-desktop/issues/4332.

Thanks @r10s for the detailed instructions in https://github.com/deltachat/deltachat-desktop/issues/4332!

Tested with a bot. Works.