### PR TITLE
macOS: make area under traffic lights dragable and slightly larger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix random crashes on quote reply #4337
 - avoid drafts in readonly chats #4349
 - fullscreen images getting cropped a little #4402, #4385
+- macOS: make area under traffic lights dragable and slightly larger
 
 <a id="1_49_0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - fix random crashes on quote reply #4337
 - avoid drafts in readonly chats #4349
 - fullscreen images getting cropped a little #4402, #4385
-- macOS: make area under traffic lights dragable and slightly larger #4408
+- macOS: make area under traffic lights dragable and fix the bug that its size changed based on profile acount and window height #4408
 
 <a id="1_49_0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - fix random crashes on quote reply #4337
 - avoid drafts in readonly chats #4349
 - fullscreen images getting cropped a little #4402, #4385
-- macOS: make area under traffic lights dragable and slightly larger
+- macOS: make area under traffic lights dragable and slightly larger #4408
 
 <a id="1_49_0"></a>
 

--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -139,7 +139,9 @@ export default function AccountListSidebar({
   return (
     <div className={styles.accountListSidebar}>
       {runtime.getRuntimeInfo().isMac && !smallScreenMode && (
-        <div className={classNames(styles.macOSTrafficLightBackground, 'drag')} />
+        <div
+          className={classNames(styles.macOSTrafficLightBackground, 'drag')}
+        />
       )}
       <div
         ref={accountsListRef}

--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -139,7 +139,7 @@ export default function AccountListSidebar({
   return (
     <div className={styles.accountListSidebar}>
       {runtime.getRuntimeInfo().isMac && !smallScreenMode && (
-        <div className={styles.macOSTrafficLightBackground} />
+        <div className={classNames(styles.macOSTrafficLightBackground, 'drag')} />
       )}
       <div
         ref={accountsListRef}

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -152,7 +152,8 @@
 }
 
 .macOSTrafficLightBackground {
-  height: 56px;
+  height: 20px;
+  flex-shrink: 0;
 }
 
 .buttonsContainer {

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -152,7 +152,7 @@
 }
 
 .macOSTrafficLightBackground {
-  height: 40px;
+  height: 56px;
 }
 
 .buttonsContainer {


### PR DESCRIPTION
raiden suggested this change to me in a private message.

| Before | After |
|--------|------|
| <img width="147" alt="Bildschirmfoto 2024-12-12 um 21 51 37" src="https://github.com/user-attachments/assets/b287628a-de58-47b6-b482-57f948a5defa" /> |  <img width="147" alt="Bildschirmfoto 2024-12-12 um 21 51 09" src="https://github.com/user-attachments/assets/b9eeeb9c-898e-4ec1-aed5-190875754e79" /> |

also fix the bug that size of that area changed based on profile acount and window height