### PR TITLE
fix: unreadable quote text for sticker replies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - settings: chat background preview element not working for the default background image #4403
 - macOS: make area under traffic lights dragable and fix the bug that its size changed based on profile acount and window height #4408
 - fix chat "scrolls up" right after switching #4404
+- quote text being unreadable for sticker replies in light theme #4417
 
 <a id="1_49_0"></a>
 

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -238,11 +238,6 @@
 
       & > .quote {
         margin: 0;
-        color: white;
-
-        .quoted-text {
-          color: white;
-        }
       }
     }
   }


### PR DESCRIPTION
The background used to be transparent,
and the text color has been changed to white in e69fd47cfaa5aec38a6401fab01cd64f6b33d351,
but then we changed background color of the quote bubbles
to be the same as the message bubble color for regular messages
in f83ce46cbf80a4c019d3be02222b164a8d58fe56, so now
there is no need to override colors.

Before / after:
![image](https://github.com/user-attachments/assets/28602628-8cb8-4b29-9abc-dd9ed1f8fde4) ![image](https://github.com/user-attachments/assets/2f220b70-d5e6-4b34-bf01-c7ca1725a5fd)
