### PR TITLE
Release v1.50.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@
 ## Added
 
 ## Changed
+
+## Fixed
+
+## [1.50.1] - 2024-12-18
+
+## Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.152.1`
 
 ## Fixed
 - downgrade rust in core to avoid wrong Windows malware detection https://github.com/deltachat/deltachat-core-rust/issues/6338
 
-## [1.50.0] - 17.12.2024
+## [1.50.0] - 2024-12-17
 
 ## Added
 - show specific notifications for webxdc events #4400
@@ -3027,7 +3033,9 @@ This section is only relevant to contributors.
 
 **Historical Note 2** We removed the older changelog, you can look at the git history to get it. (version numbers made hallmark crazy)
 
-[unreleased]: https://github.com/deltachat/deltachat-desktop/compare/v1.50.0...HEAD
+[unreleased]: https://github.com/deltachat/deltachat-desktop/compare/v1.50.1...HEAD
+
+[1.50.1]: https://github.com/deltachat/deltachat-desktop/compare/v1.50.0...v1.50.1
 
 [1.50.0]: https://github.com/deltachat/deltachat-desktop/compare/v1.49.0...v1.50.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": "true",
   "name": "deltachat-desktop",
   "type": "module",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "scripts": {
     "preinstall": "node ./bin/check-nodejs-version.js",
     "check": "pnpm check:types && pnpm check:lint && pnpm check:format && pnpm check:target-versions && pnpm check:log-conventions",

--- a/packages/target-browser/package.json
+++ b/packages/target-browser/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "@deltachat-desktop/target-browser",
   "type": "module",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "check:types": "tsc --noEmit && tsc --noEmit -p runtime-browser",

--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "type": "module",
   "name": "@deltachat-desktop/target-electron",
-  "version": "1.50.0",
+  "version": "1.50.1",
   "description": "Desktop Application for delta.chat",
   "repository": {
     "type": "git",

--- a/packages/target-tauri/package.json
+++ b/packages/target-tauri/package.json
@@ -3,5 +3,5 @@
   "name": "deltachat-desktop-tauri",
   "type": "module",
   "license": "GPL-3.0-or-later",
-  "version": "1.50.0"
+  "version": "1.50.1"
 }


### PR DESCRIPTION
This release is only to address  https://github.com/deltachat/deltachat-core-rust/issues/6338 - it has a a new core with downgraded rust version to avoid wrong malware alerts on Windows