### PR TITLE
improvement: a11y: turn more elements into <button>s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Allow empty `To` field for self-sent messages.
 
 ## Fixed
+- accessibility: make more items in messages list keyboard-accessible #4429
 - fix "incoming message background color" being used for quotes of outgoing sticker messages #4456
 
 ## [1.50.1] - 2024-12-18

--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -30,7 +30,8 @@
         margin: 4px;
       }
 
-      button {
+      // The "remove attachment / quote" buttons.
+      button:not(.quote-background) {
         margin-left: auto;
       }
 

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -64,8 +64,13 @@
     padding-bottom: 10px;
 
     .msg-body {
-      &.msg-body--clickable > .text {
-        cursor: pointer;
+      &.msg-body--clickable {
+        @include button-reset;
+        display: block;
+
+        > .text {
+          cursor: pointer;
+        }
       }
 
       & > .text {

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -115,6 +115,8 @@
   }
 
   .show-html {
+    @include button-reset;
+
     border: none;
     background-color: transparent;
     padding-left: 0;
@@ -373,6 +375,8 @@
   }
 
   .bubble {
+    @include button-reset;
+
     display: inline-block;
     text-align: center;
     padding: 7px 14px;
@@ -396,7 +400,9 @@
   &.interactive > .bubble {
     cursor: pointer;
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:focus-within {
       opacity: 1;
     }
   }
@@ -562,6 +568,8 @@
 
     cursor: pointer;
     .join-button {
+      @include button-reset;
+
       font-weight: 100;
       margin-top: 5px;
     }

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -432,6 +432,8 @@
 // quote
 
 .quote-background {
+  @include button-reset;
+
   overflow: hidden;
   max-width: 100%;
 }

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -15,6 +15,8 @@
   align-items: stretch;
 
   & > .author-avatar {
+    @include button-reset;
+
     align-self: flex-end;
     bottom: 0px;
     position: static;
@@ -305,7 +307,9 @@
     margin-bottom: 3px;
     opacity: 0.86;
 
-    span {
+    .forwarded-indicator-button {
+      @include button-reset;
+
       cursor: pointer;
     }
   }
@@ -509,6 +513,8 @@
     display: none;
   }
   .author {
+    @include button-reset;
+
     display: inline-block;
     max-width: 40vw;
     font-size: 13px;

--- a/packages/frontend/scss/message/_status-icon.scss
+++ b/packages/frontend/scss/message/_status-icon.scss
@@ -8,6 +8,8 @@
 }
 
 .status-icon {
+  @include button-reset;
+
   width: 18px; // respect the 1.5:1 aspect ratio (dictated by delivered & seen icon)
   height: 12px;
   display: inline-block;

--- a/packages/frontend/src/components/Reactions/index.tsx
+++ b/packages/frontend/src/components/Reactions/index.tsx
@@ -7,6 +7,7 @@ import ReactionsDialog from '../dialogs/ReactionsDialog'
 import styles from './styles.module.scss'
 
 import type { T } from '@deltachat/jsonrpc-client'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 // With this constant we define how many max. different emojis we display
 // under each message.
@@ -20,6 +21,8 @@ type Props = {
 }
 
 export default function Reactions(props: Props) {
+  const tx = useTranslationFunction()
+
   const { openDialog } = useDialog()
   const { reactionsByContact, reactions } = props.reactions
 
@@ -30,7 +33,7 @@ export default function Reactions(props: Props) {
   }
 
   return (
-    <div className={styles.reactions} onClick={handleClick}>
+    <div className={styles.reactions}>
       {reactions
         .slice(0, SHOW_MAX_DIFFERENT_EMOJIS)
         .map(({ emoji, isFromSelf, count }) => {
@@ -49,6 +52,11 @@ export default function Reactions(props: Props) {
       {reactions.length > SHOW_MAX_DIFFERENT_EMOJIS && (
         <span className={classNames(styles.emoji, styles.showMore)} />
       )}
+      <button
+        className={styles.openReactionsListDialogButton}
+        aria-label={tx('more_info_desktop')}
+        onClick={handleClick}
+      ></button>
     </div>
   )
 }

--- a/packages/frontend/src/components/Reactions/styles.module.scss
+++ b/packages/frontend/src/components/Reactions/styles.module.scss
@@ -41,3 +41,11 @@
   margin-right: 1px;
   position: relative;
 }
+
+.openReactionsListDialogButton {
+  // Fill the parent.
+  position: absolute;
+  inset: 0;
+  border: none;
+  background: transparent;
+}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -854,6 +854,8 @@ function WebxdcMessageContent({ message }: { message: T.Message }) {
       <img
         src={runtime.getWebxdcIconURL(selectedAccountId(), message.id)}
         alt={`icon of ${info.name}`}
+        // No need to turn this element into a `<button>` for a11y,
+        // because there is a button below that does the same.
         onClick={() => openWebxdc(message)}
       />
       <div

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -479,6 +479,7 @@ export default function Message(props: {
       }
     }
 
+    const TagName = onClick ? 'button' : 'div'
     return (
       <div
         className={classNames(
@@ -488,7 +489,6 @@ export default function Message(props: {
         )}
         id={String(message.id)}
         onContextMenu={showContextMenu}
-        onClick={onClick}
       >
         {(isProtectionBrokenMsg || isProtectionEnabledMsg) && (
           <img
@@ -500,7 +500,7 @@ export default function Message(props: {
             }
           />
         )}
-        <div className='bubble'>
+        <TagName className='bubble' onClick={onClick}>
           {isWebxdcInfo && message.parentId && (
             <img
               src={runtime.getWebxdcIconURL(
@@ -517,7 +517,7 @@ export default function Message(props: {
                 aria-label={tx(`a11y_delivery_status_${status}`)}
               />
             )}
-        </div>
+        </TagName>
       </div>
     )
   }
@@ -549,11 +549,11 @@ export default function Message(props: {
           {direction === 'incoming'
             ? tx('videochat_contact_invited_hint', message.sender.displayName)
             : tx('videochat_you_invited_hint')}
-          <div className='join-button'>
+          <button className='join-button'>
             {direction === 'incoming'
               ? tx('videochat_tap_to_join')
               : tx('rejoin')}
-          </div>
+          </button>
         </div>
         <div className='break' />
         <div className='meta-data-container'>
@@ -688,12 +688,12 @@ export default function Message(props: {
           )}
           {content}
           {hasHtml && (
-            <div
+            <button
               onClick={openMessageHTML.bind(null, message.id)}
               className='show-html'
             >
               {tx('show_full_message')}
-            </div>
+            </button>
           )}
           <footer
             className={classNames(styles.messageFooter, {

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -541,6 +541,8 @@ export default function Message(props: {
         <div className='videochat-icon'>
           <span className='icon videocamera' />
         </div>
+        {/* FYI the clickable element is not a semantic button.
+        Here it's probably fine. */}
         <AvatarFromContact contact={message.sender} onClick={onContactClick} />
         <div className='break' />
         <div

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -747,23 +747,28 @@ export const Quote = ({
       ? {}
       : { borderLeftColor: quote.authorDisplayColor }
 
+  let onClick = undefined
+  if (quote.kind === 'WithMessage') {
+    onClick = () => {
+      jumpToMessage({
+        accountId,
+        msgId: quote.messageId,
+        msgChatId: undefined,
+        highlight: true,
+        msgParentId,
+        // Often times the quoted message is already in view,
+        // so let's not scroll at all if so.
+        scrollIntoViewArg: { block: 'nearest' },
+      })
+    }
+  }
+  // TODO a11y: we probably want a separate button
+  // with `aria-label="Jump to message"`.
+  // Having a button with so much content is probably not good.
+  const Tag = onClick ? 'button' : 'div'
+
   return (
-    <div
-      className='quote-background'
-      onClick={() => {
-        quote.kind === 'WithMessage' &&
-          jumpToMessage({
-            accountId,
-            msgId: quote.messageId,
-            msgChatId: undefined,
-            highlight: true,
-            msgParentId,
-            // Often times the quoted message is already in view,
-            // so let's not scroll at all if so.
-            scrollIntoViewArg: { block: 'nearest' },
-          })
-      }}
-    >
+    <Tag className='quote-background' onClick={onClick}>
       <div
         className={`quote ${hasMessage && 'has-message'}`}
         style={borderStyle}
@@ -822,7 +827,7 @@ export const Quote = ({
           />
         )}
       </div>
-    </div>
+    </Tag>
   )
 }
 

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -527,9 +527,11 @@ export default function Message(props: {
   }
 
   let onClickMessageBody
+  let MessageTagName: 'div' | 'button' = 'div'
   if (isSetupmessage) {
     onClickMessageBody = () =>
       openDialog(EnterAutocryptSetupMessage, { message })
+    MessageTagName = 'button'
   }
 
   let content
@@ -663,7 +665,7 @@ export default function Message(props: {
             />
           </div>
         )}
-        <div
+        <MessageTagName
           className={classNames('msg-body', {
             'msg-body--clickable': onClickMessageBody,
           })}
@@ -716,7 +718,7 @@ export default function Message(props: {
               <Reactions reactions={message.reactions} />
             )}
           </footer>
-        </div>
+        </MessageTagName>
       </div>
       <ShortcutMenu
         chat={props.chat}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -65,9 +65,9 @@ const Avatar = ({
 
   if (profileImage) {
     return (
-      <div className='author-avatar' onClick={onClick}>
+      <button className='author-avatar' onClick={onClick}>
         <img alt={displayName} src={runtime.transformBlobURL(profileImage)} />
-      </div>
+      </button>
     )
   } else {
     const codepoint = displayName && displayName.codePointAt(0)
@@ -75,7 +75,7 @@ const Avatar = ({
       ? String.fromCodePoint(codepoint).toUpperCase()
       : '#'
     return (
-      <div
+      <button
         className='author-avatar default'
         aria-label={displayName}
         onClick={onClick}
@@ -83,7 +83,7 @@ const Avatar = ({
         <div style={{ backgroundColor: color }} className='label'>
           {initial}
         </div>
-      </div>
+      </button>
     )
   }
 }
@@ -116,14 +116,14 @@ const AuthorName = ({
   }, [accountId, id])
 
   return (
-    <span
+    <button
       key='author'
       className='author'
       style={{ color }}
       onClick={() => onContactClick(contact)}
     >
       {getAuthorName(displayName, overrideSenderName)}
-    </span>
+    </button>
   )
 }
 
@@ -151,19 +151,23 @@ const ForwardedTitle = ({
           tx('forwarded_by', '$$forwarder$$'),
           '$$forwarder$$',
           () => (
-            <span
+            <button
+              className='forwarded-indicator-button'
               onClick={() => onContactClick(contact)}
               key='displayname'
               style={{ color: color }}
             >
               {overrideSenderName ? `~${overrideSenderName}` : displayName}
-            </span>
+            </button>
           )
         )
       ) : (
-        <span onClick={() => onContactClick(contact)}>
+        <button
+          onClick={() => onContactClick(contact)}
+          className='forwarded-indicator-button'
+        >
           {tx('forwarded_message')}
-        </span>
+        </button>
       )}
     </div>
   )

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -59,9 +59,10 @@ export default function MessageMetaData(props: Props) {
       />
       <span className='spacer' />
       {direction === 'outgoing' && (
-        <div
+        <button
           className={classNames('status-icon', status)}
           aria-label={tx(`a11y_delivery_status_${status}`)}
+          disabled={status !== 'error'}
           onClick={status === 'error' ? onClickError : undefined}
         />
       )}


### PR DESCRIPTION
- **improvement: turn clickable items into <button>s**
- **improvement: turn clickable items into <button>s**
- **improvement: a11y: turn quote into <button>**
- **refactor: add comment about a11y**
- **improvement: turn autocrypt msg into <button>**
- **improvement: turn delivery status into <button>**
