### PR TITLE
fix: chat "scrolling up" because of imgs loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Allow empty `To` field for self-sent messages.
 
 ## Fixed
+- fix chat "scrolls up" right after switching (rev 2) #4431
 - when deleting a message from gallery, update gallery items to remove the respective item #4457
 - accessibility: make more items in messages list keyboard-accessible #4429
 - fix "incoming message background color" being used for quotes of outgoing sticker messages #4456

--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -23,6 +23,8 @@
    *
    * for higher values (than 200px) we have to add media queries otherwise
    * messages with images get strange paddings on small windows
+   *
+   * The same goes for `.quoted-image`.
    */
   & > .attachment-content {
     object-fit: scale-down;

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -495,8 +495,21 @@
   }
 
   img.quoted-image {
+    // Remember that width and height need to be set prior to the image
+    // getting actually loaded by the browser, to avoid content shifts.
+    // Same goes for messages' `.attachment-content`.
+    // See https://github.com/deltachat/deltachat-desktop/issues/4404.
+    //
+    // Setting just the height is not enough, because there might be text
+    // displayed beside the image, which might wrap and thus change height.
+    //
+    // In addition, really short and wide images could make the message
+    // overflow the chat container, for non-self-sent messages at least.
     height: var(--quote-img-size);
-    // do not set width, to keep the aspect ratio (see https://github.com/deltachat/deltachat-desktop/issues/3931)
+    width: var(--quote-img-size);
+    object-fit: scale-down;
+    object-position: center;
+
     margin-left: 6px;
   }
 


### PR DESCRIPTION
Visual aspect, before / after: 
![image](https://github.com/user-attachments/assets/b038b271-93b4-4c06-b40f-b2a60792ec03) ![image](https://github.com/user-attachments/assets/320f4b3e-55c5-4a7d-81e8-ef8d566c11d4)

This, together with https://github.com/deltachat/deltachat-desktop/pull/4407,
should close https://github.com/deltachat/deltachat-desktop/issues/4404.

The bug was introduced in https://github.com/deltachat/deltachat-desktop/pull/3999.
Pior to that we used to have fixed width on quoted images as well.
This commmit practically reverts that MR, but also adds
`object-fit` and `object-position`, and is now in line with
message attachment images