### PR TITLE
style: stickers being smaller than needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 ## Fixed
 - accessibility: make more items in messages list keyboard-accessible #4429
 - fix "incoming message background color" being used for quotes of outgoing sticker messages #4456
+- fix stickers being smaller than they're supposed to be #4432
 
 ## [1.50.1] - 2024-12-18
 

--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -83,15 +83,6 @@
   }
 }
 
-.message.type-sticker {
-  .message-attachment-media {
-    & > .attachment-content {
-      max-height: 200px;
-      max-width: 80%;
-    }
-  }
-}
-
 .message-attachment-broken-media {
   @include button-reset;
   display: block;


### PR DESCRIPTION
Before / after:
![image](https://github.com/user-attachments/assets/33c2c672-4745-4234-909d-5b749d5bef31) ![image](https://github.com/user-attachments/assets/2b29458d-38bb-4f9d-8529-98f0fcddafac)

Because of `max-width: 80%`, which refers to 80% of the wrapper
square, and not the chat section
(the later was apparently the intention).
This has been introduced in https://github.com/deltachat/deltachat-desktop/pull/4315,
which has later been sort of reverted, but not completely, in
https://github.com/deltachat/deltachat-desktop/pull/4407.
So, let's remove the residuals, especially that stickers also have
fixed `height: 200px`, so `max-height` doesn't make sense.
