### PR TITLE
style: fix reactions to stickers overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - accessibility: make more items in messages list keyboard-accessible #4429
 - fix "incoming message background color" being used for quotes of outgoing sticker messages #4456
 - fix stickers being smaller than they're supposed to be #4432
+- fix reactions to sticker messages overlapping with next message #4433
 
 ## [1.50.1] - 2024-12-18
 

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -259,7 +259,11 @@
   .message-attachment-media {
     background-color: transparent;
     & > .attachment-content {
-      margin-bottom: 20px;
+      // Make space for the footer, which is `position: absolute;`.
+      // However, this does not account for the case
+      // where the footer text wraps.
+      margin-bottom: 26px;
+
       cursor: default;
     }
   }
@@ -267,7 +271,6 @@
   .metadata {
     float: right;
     padding: 4px 8px 1px 8px;
-    margin-bottom: -7px;
     background-color: #01010159;
     border-radius: 4px;
     color: black;


### PR DESCRIPTION
This is based on #4432.

Before / after 
![image](https://github.com/user-attachments/assets/4abf5c2d-526c-45c3-b7da-b2f4ab884496) ![image](https://github.com/user-attachments/assets/2a659de6-c5da-4d2c-a88b-322c0e45a9a7)

Apparently this `margin-bottom: -7px` is a residue
from copy pasting it from `.metadata` for regular text messages.
We have `marin: 0` set for image-only messages,
so we should set `margin: 0` for sticker messages as well.