### PR TITLE
refactor: remove dead code (`MetaData.username`)

### DIFF
--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -30,10 +30,6 @@
     margin-bottom: 2px;
   }
 
-  & > .username {
-    margin-right: 10px;
-  }
-
   & > .date {
     font-size: 11.5px;
     line-height: 16px;

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -9,7 +9,6 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 type Props = {
   padlock: boolean
-  username?: string
   fileMime: string | null
   direction?: 'incoming' | 'outgoing'
   status: msgStatus
@@ -25,7 +24,6 @@ export default function MessageMetaData(props: Props) {
 
   const {
     padlock,
-    username,
     fileMime,
     direction,
     status,
@@ -46,7 +44,6 @@ export default function MessageMetaData(props: Props) {
         ),
       })}
     >
-      {username && <div className='username'>{username}</div>}
       {padlock && (
         <div
           aria-label={tx('a11y_encryption_padlock')}


### PR DESCRIPTION
This is no longer used after 90f4047d2a77e16ad2f31bd5b53d803a37eaf583.
