### PR TITLE
fix: a11y: arrow-key navigation stopping working after ~10 keypresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ## Fixed
 - fix chat "scrolls up" right after switching (rev 2) #4431
 - when deleting a message from gallery, update gallery items to remove the respective item #4457
+- accessibility: fix arrow-key navigation stopping working after ~10 key presses #4441
 - accessibility: make more items in messages list keyboard-accessible #4429
 - fix "incoming message background color" being used for quotes of outgoing sticker messages #4456
 - fix stickers being smaller than they're supposed to be #4432

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -422,32 +422,16 @@ export default class Gallery extends Component<
                           }
                           this.updateFirstVisibleMessage(message)
                         }}
-                      >
-                        {({ columnIndex, rowIndex, style }) => {
-                          const msgId =
-                            mediaMessageIds[
-                              rowIndex * itemsPerRow + columnIndex
-                            ]
-                          const message = mediaLoadResult[msgId]
-                          if (!message) {
-                            return null
-                          }
-                          return (
-                            <div
-                              style={{ ...style }}
-                              className='item'
-                              key={msgId}
-                            >
-                              <this.state.element
-                                messageId={msgId}
-                                loadResult={message}
-                                openFullscreenMedia={this.openFullscreenMedia.bind(
-                                  this
-                                )}
-                              />
-                            </div>
-                          )
+                        itemData={{
+                          Component: this.state.element,
+                          mediaMessageIds,
+                          mediaLoadResult,
+                          openFullscreenMedia:
+                            this.openFullscreenMedia.bind(this),
+                          itemsPerRow,
                         }}
+                      >
+                        {GalleryGridCell}
                       </FixedSizeGrid>
                     </RovingTabindexProvider>
                   )
@@ -459,6 +443,46 @@ export default class Gallery extends Component<
       </div>
     )
   }
+}
+function GalleryGridCell({
+  columnIndex,
+  rowIndex,
+  style,
+  data,
+}: {
+  columnIndex: number
+  rowIndex: number
+  style: React.CSSProperties
+  data: {
+    Component: GalleryElement
+    mediaMessageIds: number[]
+    mediaLoadResult: Record<number, Type.MessageLoadResult>
+    openFullscreenMedia: (message: Type.Message) => void
+    itemsPerRow: number
+  }
+}) {
+  const {
+    Component,
+    mediaMessageIds,
+    mediaLoadResult,
+    openFullscreenMedia,
+    itemsPerRow,
+  } = data
+
+  const msgId = mediaMessageIds[rowIndex * itemsPerRow + columnIndex]
+  const message = mediaLoadResult[msgId]
+  if (!message) {
+    return null
+  }
+  return (
+    <div style={{ ...style }} className='item' key={msgId}>
+      <Component
+        messageId={msgId}
+        loadResult={message}
+        openFullscreenMedia={openFullscreenMedia}
+      />
+    </div>
+  )
 }
 
 function GalleryTab(props: {

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -512,24 +512,43 @@ function FileTable({
       itemSize={60}
       itemCount={mediaMessageIds.length}
       overscanCount={10}
-      itemData={mediaMessageIds}
-    >
-      {({ index, style, data }) => {
-        const msgId = data[index]
-        const message = mediaLoadResult[msgId]
-        if (!message) {
-          return null
-        }
-        return (
-          <div style={style} className='item' key={msgId}>
-            <FileAttachmentRow
-              messageId={msgId}
-              loadResult={message}
-              queryText={queryText}
-            />
-          </div>
-        )
+      itemData={{
+        mediaMessageIds,
+        mediaLoadResult,
+        queryText,
       }}
+    >
+      {FileAttachmentRowWrapper}
     </FixedSizeList>
+  )
+}
+
+function FileAttachmentRowWrapper({
+  index,
+  style,
+  data,
+}: {
+  index: number
+  style: React.CSSProperties
+  data: {
+    mediaMessageIds: number[]
+    mediaLoadResult: Record<number, Type.MessageLoadResult>
+    queryText: string
+  }
+}) {
+  const { mediaMessageIds, mediaLoadResult, queryText } = data
+  const msgId = mediaMessageIds[index]
+  const message = mediaLoadResult[msgId]
+  if (!message) {
+    return null
+  }
+  return (
+    <div style={style} className='item' key={msgId}>
+      <FileAttachmentRow
+        messageId={msgId}
+        loadResult={message}
+        queryText={queryText}
+      />
+    </div>
   )
 }

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -71,10 +71,7 @@ export function ChatListPart({
   height: number
   itemKey: ListItemKeySelector<any>
   setListRef?: (ref: List<any> | null) => void
-  itemData?:
-    | ChatListItemData
-    | ContactChatListItemData
-    | MessageChatListItemData
+  itemData: ChatListItemData | ContactChatListItemData | MessageChatListItemData
   itemHeight: number
 }) {
   const infiniteLoaderRef = useRef<InfiniteLoader | null>(null)

--- a/packages/frontend/src/components/dialogs/SelectChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectChat/index.tsx
@@ -1,7 +1,7 @@
 import AutoSizer from 'react-virtualized-auto-sizer'
 import React, { useRef, useState } from 'react'
 
-import ChatListItem from '../../chat/ChatListItem'
+import { ChatListItemRowChat } from '../../chat/ChatListItemRow'
 import { PseudoListItemNoSearchResults } from '../../helpers/PseudoListItem'
 import { ChatListPart, useLogicVirtualChatList } from '../../chat/ChatList'
 import { useChatList } from '../../chat/ChatListHelpers'
@@ -70,18 +70,17 @@ export default function SelectChat(props: Props) {
                     height={height}
                     itemKey={index => 'key' + chatListIds[index]}
                     itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                  >
-                    {({ index, style }) => {
-                      const chatId = chatListIds[index]
-                      return (
-                        <div style={style}>
-                          <ChatListItem
-                            chatListItem={chatCache[chatId] || undefined}
-                            onClick={props.onChatClick.bind(null, chatId)}
-                          />
-                        </div>
-                      )
+                    itemData={{
+                      chatCache,
+                      chatListIds,
+                      onChatClick: props.onChatClick,
+
+                      selectedChatId: null,
+                      activeContextMenuChatId: null,
+                      openContextMenu: async () => {},
                     }}
+                  >
+                    {ChatListItemRowChat}
                   </ChatListPart>
                 )}
               </AutoSizer>

--- a/packages/frontend/src/components/dialogs/SelectContact/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectContact/index.tsx
@@ -90,6 +90,11 @@ export default function SelectContactDialog({
                   >
                     <FixedSizeList
                       itemCount={contactIds.length}
+                      itemData={{
+                        onContactClick: onOk,
+                        contactIds,
+                        contactCache,
+                      }}
                       itemKey={index => contactIds[index]}
                       onItemsRendered={onItemsRendered}
                       ref={ref}
@@ -97,27 +102,13 @@ export default function SelectContactDialog({
                       width='100%'
                       itemSize={64}
                     >
-                      {({ index, style }) => {
-                        const el = (() => {
-                          const item = contactCache[contactIds[index]]
-                          if (!item) {
-                            // It's not loaded yet
-                            return null
-                          }
-                          const contact: T.Contact = item
-                          return (
-                            <ContactListItem
-                              contact={contact}
-                              onClick={onOk}
-                              showCheckbox={false}
-                              checked={false}
-                              showRemove={false}
-                            />
-                          )
-                        })()
-
-                        return <div style={style}>{el}</div>
-                      }}
+                      {/* Remember that the renderer function
+                      must not be defined _inline_.
+                      Otherwise when the component re-renders,
+                      item elements get replaces with fresh ones,
+                      and we lose focus.
+                      See https://github.com/bvaughn/react-window/issues/420#issuecomment-585813335 */}
+                      {SelectContactDialogRow}
                     </FixedSizeList>
                   </RovingTabindexProvider>
                 )}
@@ -135,4 +126,40 @@ export default function SelectContactDialog({
       </DialogFooter>
     </Dialog>
   )
+}
+
+function SelectContactDialogRow({
+  index,
+  style,
+  data,
+}: {
+  index: number
+  style: React.CSSProperties
+  data: {
+    onContactClick: (contact: T.Contact) => void
+    contactIds: Array<T.Contact['id']>
+    contactCache: ReturnType<typeof useLazyLoadedContacts>['contactCache']
+  }
+}) {
+  const { onContactClick, contactIds, contactCache } = data
+
+  const el = (() => {
+    const item = contactCache[contactIds[index]]
+    if (!item) {
+      // It's not loaded yet
+      return null
+    }
+    const contact: T.Contact = item
+    return (
+      <ContactListItem
+        contact={contact}
+        onClick={onContactClick}
+        showCheckbox={false}
+        checked={false}
+        showRemove={false}
+      />
+    )
+  })()
+
+  return <div style={style}>{el}</div>
 }

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
-import ChatListItem from '../chat/ChatListItem'
 import { QrCodeShowQrInner } from './QrCode'
 import { useThemeCssVar } from '../../ThemeManager'
 import { ContactList } from '../contact/ContactList'
@@ -37,6 +36,7 @@ import ImageCropper from '../ImageCropper'
 import { AddMemberDialog } from './AddMember/AddMemberDialog'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { RovingTabindexProvider } from '../../contexts/RovingTabindex'
+import { ChatListItemRowChat } from '../chat/ChatListItemRow'
 
 export default function ViewGroup(
   props: {
@@ -256,18 +256,17 @@ function ViewGroupInner(
                           height={CHATLISTITEM_CHAT_HEIGHT * chatListIds.length}
                           itemKey={index => 'key' + chatListIds[index]}
                           itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                        >
-                          {({ index, style }) => {
-                            const chatId = chatListIds[index]
-                            return (
-                              <div style={style}>
-                                <ChatListItem
-                                  chatListItem={chatCache[chatId] || undefined}
-                                  onClick={onChatClick.bind(null, chatId)}
-                                />
-                              </div>
-                            )
+                          itemData={{
+                            chatCache,
+                            chatListIds,
+                            onChatClick,
+
+                            selectedChatId: null,
+                            activeContextMenuChatId: null,
+                            openContextMenu: async () => {},
                           }}
+                        >
+                          {ChatListItemRowChat}
                         </ChatListPart>
                       )}
                     </AutoSizer>

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect, useRef } from 'react'
 import moment from 'moment'
 import { C } from '@deltachat/jsonrpc-client'
 
-import ChatListItem from '../../chat/ChatListItem'
 import { useChatList } from '../../chat/ChatListHelpers'
 import { useLogicVirtualChatList, ChatListPart } from '../../chat/ChatList'
 import MessageBody from '../../message/MessageBody'
@@ -29,6 +28,7 @@ import styles from './styles.module.scss'
 import type { DialogProps } from '../../../contexts/DialogContext'
 import type { T } from '@deltachat/jsonrpc-client'
 import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
+import { ChatListItemRowChat } from '../../chat/ChatListItemRow'
 
 const log = getLogger('renderer/dialogs/ViewProfile')
 
@@ -331,18 +331,17 @@ export function ViewProfileInner({
                     height={height}
                     itemKey={index => 'key' + chatListIds[index]}
                     itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                  >
-                    {({ index, style }) => {
-                      const chatId = chatListIds[index]
-                      return (
-                        <div style={style}>
-                          <ChatListItem
-                            chatListItem={chatCache[chatId] || undefined}
-                            onClick={onChatClick.bind(null, chatId)}
-                          />
-                        </div>
-                      )
+                    itemData={{
+                      chatCache,
+                      chatListIds,
+                      onChatClick,
+
+                      selectedChatId: null,
+                      activeContextMenuChatId: null,
+                      openContextMenu: async () => {},
                     }}
+                  >
+                    {ChatListItemRowChat}
                   </ChatListPart>
                 )}
               </AutoSizer>


### PR DESCRIPTION
Reviewing commit-by-commit should be a bit easier. But basically what this does is it un-inlines the renderer functions, addressing this issue: https://github.com/bvaughn/react-window/issues/420#issuecomment-585813335.
You can check this behavior by arrow-key navigating the contact list in "new chat", as long as your contact list is at least ~30 items long. When new items get loaded (with 'react-infinite-loader'), the parent component re-renders, and all items' DOM get re-created, losing focus.

I am not 100% sure whether we should squash the commits. They're all quite similar, but it might not be easy to see separate logical changes when squashed.