### PR TITLE
style: outgoing bg color for outgoing stickers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - Allow empty `To` field for self-sent messages.
 
 ## Fixed
+- fix "incoming message background color" being used for quotes of outgoing sticker messages #4456
 
 ## [1.50.1] - 2024-12-18
 

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -167,6 +167,7 @@
 
   .msg-container {
     background-color: var(--messageIncomingBg);
+    --messageBg: var(--messageIncomingBg);
 
     &,
     .message-attachment-media {
@@ -213,6 +214,7 @@
 
   .msg-container {
     background-color: var(--messageOutgoingBg);
+    --messageBg: var(--messageOutgoingBg);
 
     &,
     .message-attachment-media {
@@ -231,7 +233,10 @@
     }
 
     .quote-background {
-      background: var(--messageIncomingBg);
+      // `.msg-container` background is transparent,
+      // so let's explicitly apply the color just for the quote.
+      background: var(--messageBg);
+
       padding: 5px;
       padding-left: 6px;
       border-radius: 7px;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/24d505a0-5aac-4d0f-aba3-0015661c5fc0) ![image](https://github.com/user-attachments/assets/e5f1bd00-f01f-4d24-b9a3-b7ccaddcbcf0)

After:
![image](https://github.com/user-attachments/assets/1bf5eeeb-c853-430f-986d-ca910e54df46) ![image](https://github.com/user-attachments/assets/670b7c1c-be0b-4b49-a587-0430712cacc4)

For incoming messages the color is also respective:

![image](https://github.com/user-attachments/assets/6747a24a-829c-4f45-bdb9-b3c14003c1b5) ![image](https://github.com/user-attachments/assets/c7f024de-22f0-4f4b-b25c-4facfb718a62)

Closes https://github.com/deltachat/deltachat-desktop/issues/4453.
The bug (if you can call it that) was introduced in f83ce46cbf80a4c019d3be02222b164a8d58fe56.
Similar commit: 8259aad97.

CI failures are to be fixed in https://github.com/deltachat/deltachat-desktop/pull/4426.
