### PR TITLE
fix: devmode: fix logging and counting jsonrpc requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - fix stickers being smaller than they're supposed to be #4432
 - fix reactions to sticker messages overlapping with next message #4433
 - fix: "Enter" not adding the first contact in "Add Members" dialog #4439
+- fix: devmode: fix logging and counting jsonrpc requests
 
 ## [1.50.1] - 2024-12-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - fix stickers being smaller than they're supposed to be #4432
 - fix reactions to sticker messages overlapping with next message #4433
 - fix: "Enter" not adding the first contact in "Add Members" dialog #4439
-- fix: devmode: fix logging and counting jsonrpc requests
+- fix: devmode: fix logging and counting jsonrpc requests #4458
 
 ## [1.50.1] - 2024-12-18
 

--- a/packages/frontend/src/backend-com.ts
+++ b/packages/frontend/src/backend-com.ts
@@ -1,6 +1,5 @@
 import { BaseDeltaChat, DcEvent } from '@deltachat/jsonrpc-client'
 import { runtime } from '@deltachat-desktop/runtime-interface'
-import { hasDebugEnabled } from '../../shared/logger'
 import { clearNotificationsForChat } from './system-integration/notifications'
 import { countCall } from './debug-tools'
 

--- a/packages/frontend/src/backend-com.ts
+++ b/packages/frontend/src/backend-com.ts
@@ -7,7 +7,7 @@ import { countCall } from './debug-tools'
 export { T as Type } from '@deltachat/jsonrpc-client'
 
 export const BackendRemote: BaseDeltaChat<any> =
-  runtime.createDeltaChatConnection(hasDebugEnabled(), countCall)
+  runtime.createDeltaChatConnection(countCall)
 
 /** Functions with side-effects */
 export namespace EffectfulBackendActions {

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -23,7 +23,6 @@ export interface Runtime {
   createDeltaChatConnection(
     callCounterFunction: (label: string) => void
   ): BaseDeltaChat<any>
-  setLogJsonrpcConnection(enabled: boolean): void
   /**
    * open html message, in dedicated window or in system browser
    * @param window_id unique id that we know if it's already open, should be accountid+"-"+msgid

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -21,9 +21,9 @@ export interface Runtime {
   emitUIFullyReady(): void
   emitUIReady(): void
   createDeltaChatConnection(
-    hasDebugEnabled: boolean,
     callCounterFunction: (label: string) => void
   ): BaseDeltaChat<any>
+  setLogJsonrpcConnection(enabled: boolean): void
   /**
    * open html message, in dedicated window or in system browser
    * @param window_id unique id that we know if it's already open, should be accountid+"-"+msgid

--- a/packages/shared/logger.ts
+++ b/packages/shared/logger.ts
@@ -81,10 +81,6 @@ export function setLogHandler(
   rc = rcObject
 }
 
-export function hasDebugEnabled() {
-  return rc['log-debug']
-}
-
 function log(
   { channel, isMainProcess }: Logger,
   level: number,


### PR DESCRIPTION
This was likely broken by me during refactoring when changing apis and initialisation to make the browser version possible.
The problem was that the comandline flags were checked before they were loaded.


Now the jsonrpc request are logged again in devmode. (write `-jsonrpc` in the filter to not be annoyed from it)
And you can now do `exp.printCallCounterResult()` again:
<img width="1028" alt="Bildschirmfoto 2025-01-08 um 04 41 16" src="https://github.com/user-attachments/assets/3ae961df-cdd6-47de-8081-bc30fddb9415" />
