### PR TITLE
add show_app_in_chat option to webxdc info message context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## Added
 - accessibility: arrow-key navigation for gallery #4376
 - accessibility: arrow-key navigation: handle "End" and "Home" keys to go to last / first item #4438
-- add show_app_in_chat option to webxdc info message context menu
+- add show_app_in_chat option to webxdc info message context menu #4459
 
 ## Changed
 - dev: upgrade react to v18 and react pinch pan zoom to v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 - accessibility: arrow-key navigation for gallery #4376
 - accessibility: arrow-key navigation: handle "End" and "Home" keys to go to last / first item #4438
+- add show_app_in_chat option to webxdc info message context menu
 
 ## Changed
 - dev: upgrade react to v18 and react pinch pan zoom to v3


### PR DESCRIPTION
To make it easy again to reach/jump-to the webxdc message. Since the notification webxdc info messages open the app directly on click.

<img width="243" alt="Bildschirmfoto 2025-01-08 um 05 26 40" src="https://github.com/user-attachments/assets/2d0a3244-f198-4d0f-87d2-e3c1c22e0d9f" />

