### PR TITLE
feat: experiment: webxdc.getMemberList api and also allow webxc to access avatars

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -580,6 +580,18 @@ If you think that's a bug and you need that permission, then please open an issu
       this.rpc.leaveWebxdcRealtime(accountId, msgId)
     })
 
+    ipcMain.handle('webxdc.getMemberList', async event => {
+      const key = Object.keys(open_apps).find(
+        key => open_apps[key].win.webContents === event.sender
+      )
+      if (!key) {
+        log.error('webxdc.getMemberList, app not found in list of open ones')
+        return
+      }
+      const { accountId, msgId } = open_apps[key]
+      return this.rpc.getWebxdcMemberlist(accountId, msgId)
+    })
+
     ipcMain.handle(
       'webxdc.sendToChat',
       (

--- a/packages/target-electron/static/webxdc-preload.js
+++ b/packages/target-electron/static/webxdc-preload.js
@@ -112,6 +112,7 @@ class RealtimeListener {
   const api = {
     selfAddr: '?Setup Missing?',
     selfName: '?Setup Missing?',
+    getMemberList: () => ipcRenderer.invoke('webxdc.getMemberList'),
     setUpdateListener: (cb, start_serial = 0) => {
       last_serial = start_serial
       callback = cb


### PR DESCRIPTION
(the part of allowing to access avatars is done by core, so see the core pr for that)

requires core with https://github.com/deltachat/deltachat-core-rust/pull/6429
