### PR TITLE
fix: draft not clearing after sending message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ## Fixed
 - fix draft not getting cleared after sending the message #4493
+- fix draft not getting saved after inserting an emoji #4493
 - fix chat "scrolls up" right after switching (rev 2) #4431
 - when deleting a message from gallery, update gallery items to remove the respective item #4457
 - accessibility: fix arrow-key navigation stopping working after ~10 key presses #4441

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - update `@deltachat/message_parser_wasm` from `0.11.0` to `0.12.0` #4477
 
 ## Fixed
+- fix draft not getting cleared after sending the message #4493
 - fix chat "scrolls up" right after switching (rev 2) #4431
 - when deleting a message from gallery, update gallery items to remove the respective item #4457
 - accessibility: fix arrow-key navigation stopping working after ~10 key presses #4441

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -96,10 +96,6 @@ export default class ComposerMessageInput extends React.Component<
     return this.state.text
   }
 
-  clearText() {
-    this.setState({ text: '' })
-  }
-
   componentDidUpdate(
     _prevProps: ComposerMessageInputProps,
     prevState: ComposerMessageInputState

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -32,7 +32,7 @@ export default class ComposerMessageInput extends React.Component<
   composerSize: number
   setCursorPosition: number | false
   textareaRef: React.RefObject<HTMLTextAreaElement>
-  saveDraft: ReturnType<typeof throttle>
+  throttledSaveDraft: ReturnType<typeof throttle>
   constructor(props: ComposerMessageInputProps) {
     super(props)
     this.state = {
@@ -49,7 +49,7 @@ export default class ComposerMessageInput extends React.Component<
     this.insertStringAtCursorPosition =
       this.insertStringAtCursorPosition.bind(this)
 
-    this.saveDraft = throttle((text, chatId) => {
+    this.throttledSaveDraft = throttle((text, chatId) => {
       if (this.state.chatId === chatId) {
         this.props.updateDraftText(text.trim() === '' ? '' : text, chatId)
       }
@@ -132,7 +132,7 @@ export default class ComposerMessageInput extends React.Component<
   onChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const text = e.target.value
     this.setState({ text /*error: false*/ })
-    this.saveDraft(text, this.state.chatId)
+    this.throttledSaveDraft(text, this.state.chatId)
   }
 
   keyEventToAction(e: React.KeyboardEvent<HTMLTextAreaElement>) {

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -217,6 +217,7 @@ export default class ComposerMessageInput extends React.Component<
     this.setCursorPosition = textareaElem.selectionStart + str.length
 
     this.setState({ text: updatedText })
+    this.throttledSaveDraft(updatedText, this.state.chatId)
   }
 
   render() {

--- a/packages/shared/util.ts
+++ b/packages/shared/util.ts
@@ -22,7 +22,7 @@ export function throttle<R, A extends any[]>(
   let inThrottle: boolean,
     timeout: ReturnType<typeof setTimeout>,
     lastTime: number
-  return (...args: A) => {
+  const ret = (...args: A) => {
     if (!inThrottle) {
       fn(...args)
       lastTime = performance.now()
@@ -38,4 +38,8 @@ export function throttle<R, A extends any[]>(
       )
     }
   }
+  ret.cancel = () => {
+    clearTimeout(timeout)
+  }
+  return ret
 }


### PR DESCRIPTION
Commit-by-commit review should be easier, though anyway there are not many changes.

Closes https://github.com/deltachat/deltachat-desktop/issues/4430.

The bug was introduced in https://github.com/deltachat/deltachat-desktop/pull/4144.
There we made `throttle` accept the `text` argument
instead of reading `this.state.text`, and `this.state.text`
would get set to `''` after the message has been sent,
but then we'd still invoke the throttled function,
with the text from the last `onChange` event.

This probably doesn't address _all_ the "draft not cleared" issues,
e.g. https://github.com/deltachat/deltachat-desktop/issues/3586
could be a different issue.

This also fixes https://github.com/deltachat/deltachat-desktop/pull/4144#discussion_r1861963395.