### PR TITLE
build: allow to use pnpm 10.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "engineStrict": true,
   "engines": {
     "node": "^20",
-    "pnpm": "^9.6.0"
+    "pnpm": ">=9.6.0"
   },
   "pnpm": {
     "supportedArchitectures": {


### PR DESCRIPTION
Arch Linux packages pnpm 10.0.0 for some time already, so without this change I cannot run `pnpm install`.

Closes #4489