### PR TITLE
build: add "electron" to pnpm onlyBuiltDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
         "ia32",
         "arm64"
       ]
-    }
+    },
+    "onlyBuiltDependencies": [
+      "electron"
+    ]
   },
   "devDependencies": {
     "@types/ignore-walk": "^4.0.3",


### PR DESCRIPTION
Otherwise install script for electron is not started with pnpm 10.0.0 and the resulting build does not work.

Closes #4490