### PR TITLE
fix: `jumpToMessage` not working sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixed
 - fix cancelation of account deletion when canceling clicking outside of the dialog
 - fix unread counter on "jump to bottom" button showing incorrect count (taking the count from other chats) #4500
+- fix clicking on message search result or "reply privately" quote not jumping to the message on first click #4510
 
 <a id="1_51_0"></a>
 

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -211,12 +211,9 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
     }
   }, [])
 
-  useEffect(() => {
-    window.__internal_jump_to_message = jumpToMessage
-    return () => {
-      window.__internal_jump_to_message = undefined
-    }
-  }, [jumpToMessage])
+  // TODO perf: to save memory, maybe set to `undefined` when unmounting,
+  // but be sure not to unset it if the new component render already set it.
+  window.__internal_jump_to_message = jumpToMessage
 
   const pendingProgrammaticSmoothScrollTo = useRef<null | number>(null)
   const pendingProgrammaticSmoothScrollTimeout = useRef<number>(-1)


### PR DESCRIPTION
...when the chatId of the message is different
from the currently open chat.

Closes https://github.com/deltachat/deltachat-desktop/issues/4508.
This is probably related to the React upgrade,
which changed the behaviour of `useEffect`.

The issue was that we called `window.__internal_jump_to_message`
_before_ `MessageListStore` has been reinstantiated,
so we'd call it on an old instance.

I think there might still be cases where this bug appears,
but at least this makes it appear less often.
