### PR TITLE
fix: showing wrong chat ("Reply Privately" quote)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix cancelation of account deletion when canceling clicking outside of the dialog
 - fix unread counter on "jump to bottom" button showing incorrect count (taking the count from other chats) #4500
 - fix clicking on message search result or "reply privately" quote not jumping to the message on first click #4510
+- fix messages from wrong chat being shown after clicking on "jump down" button after revealing a message from a "Reply Privately" quote #4511
 - accessibility: fix VCards (share contact) being tab-stops even in inactive messages #4519
 
 <a id="1_51_0"></a>

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -18,6 +18,16 @@ export type JumpToMessage = (params: {
    */
   msgChatId?: number
   highlight?: boolean
+  /**
+   * The ID of the message to remember,
+   * to later go back to it, using the "jump down" button.
+   *
+   * This has no effect if `msgId` and `msgParentId` belong to different chats.
+   * Because otherwise if the user pops the stack
+   * by clicking the "jump down" button,
+   * we'll erroneously show messages from the previous chat
+   * without actually switching to that chat.
+   */
   msgParentId?: number
   /**
    * `behavior: 'smooth'` should not be used due to "scroll locking":
@@ -79,6 +89,9 @@ export default function useMessage() {
       // Check if target message is in same chat, if not switch first
       if (msgChatId !== chatId) {
         await selectChat(accountId, msgChatId)
+
+        // See `msgParentId` docstring.
+        msgParentId = undefined
       }
       setChatView(ChatView.MessageList)
 

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -412,6 +412,13 @@ class MessageListStore extends Store<MessageListState> {
      *
      * @param msgId - when `undefined`, pop the jump stack, or,
      * if the stack is empty, jump to last message.
+     * @param addMessageIdToStack the ID of the message to remember,
+     * to later go back to it, using the "jump down" button.
+     * The message with the specified ID must belong to the chat with ID
+     * `MessageListStore.chatId`.
+     * For example, this must be ensured for message quotes,
+     * because they might belong to a different chat due to the
+     * "Reply Privately" feature.
      */
     jumpToMessage: this.scheduler.lockedQueuedEffect(
       'scroll',

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -401,9 +401,15 @@ class MessageListStore extends Store<MessageListState> {
     ),
     /**
      * Loads and shows the message in the messages list.
-     * It can handle showing the message in a chat other than `this.chatId`,
-     * loading the message if it is missing from `this.state.messageCache`,
-     * and reloading `messageListItems` if the message is missing from there.
+     * It can handle loading the message if it is missing
+     * from `this.state.messageCache`,
+     * reloading `messageListItems` if the message is missing from there,
+     * and showing the message in a chat other than `this.chatId`.
+     *
+     * The latter (showing the message from a different chat), however,
+     * should not be used, because, as of 2025-01-19, we re-create
+     * `MessageListStore` when `chatId` or `accountId` changes.
+     *
      * @param msgId - when `undefined`, pop the jump stack, or,
      * if the stack is empty, jump to last message.
      */
@@ -492,6 +498,15 @@ class MessageListStore extends Store<MessageListState> {
 
         const isMessageInCurrentChat =
           this.accountId === accountId && this.chatId === chatId
+        if (!isMessageInCurrentChat) {
+          this.log.error(
+            'Tried to show messages from a different chat.\n' +
+              `this.accountId === ${this.accountId}, ` +
+              `this.chatId === ${this.chatId}, ` +
+              `target IDs: ${accountId}, ${chatId}. ` +
+              `jumpToMessageId === ${jumpToMessageId}`
+          )
+        }
 
         let messageListItems = this.state.messageListItems
         const findMessageIndex = (): number =>


### PR DESCRIPTION
1. "Reply Privately" to a message in a group.
2. Click on the quote. This will open the original chat.
3. Click the "jump down" button.

This will load the messages from the private chat,
but still show the original group chat in the chat header.