### PR TITLE
improvement: push "jump down" stack on webxdc info

### DIFF
--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -365,6 +365,7 @@ function buildContextMenu(
             // but let's not pass `chatId` here, for future-proofing.
             msgChatId: undefined,
             highlight: true,
+            msgParentId: message.id,
             scrollIntoViewArg: { block: 'center' },
           })
         }


### PR DESCRIPTION
This makes "jump down" button go to the webxdc info message
after going to the original webxdc app message
through the "Show in chat" context menu item.

In 6664e64ac1c60127ea9eb864b22d051940c358c5 we started opening
the webxdc app on info message click instead of going to the
app's original message, then later brough back this "go to message"
feature in 88de19ff2628bafdcc68efe4e51f29d4ee6f1ea8,
but forgot to add `msgParentId`.
