### PR TITLE
fix: chat "scrolling up" because of imgs, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - order search results by relevance in App Picker #4506
 
 ### Fixed
+- fix chat being scrolled up a little right after you switch to it (rev 3) #4521
 - fix cancelation of account deletion when canceling clicking outside of the dialog
 - fix unread counter on "jump to bottom" button showing incorrect count (taking the count from other chats) #4500
 - fix clicking on message search result or "reply privately" quote not jumping to the message on first click #4510

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -507,6 +507,13 @@
     // overflow the chat container, for non-self-sent messages at least.
     height: var(--quote-img-size);
     width: var(--quote-img-size);
+    // For some reason the image element can get shrunk
+    // while it's being loaded.
+    // This, however, is not the case for images with no `src` at all,
+    // god knows why.
+    // See https://github.com/deltachat/deltachat-desktop/issues/4404#issuecomment-2602438175
+    flex-shrink: 0;
+
     object-fit: scale-down;
     object-position: center;
 
@@ -514,8 +521,11 @@
   }
 
   img.quoted-webxdc-icon {
+    // The dimensions need to be fixed, same as for `.quoted-image`.
     height: var(--quote-img-size);
     width: var(--quote-img-size);
+    flex-shrink: 0;
+
     margin-left: 6px;
     border-radius: 7%;
   }


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4404,
again.
See https://github.com/deltachat/deltachat-desktop/issues/4404#issuecomment-2602438175.
