### PR TITLE
fix: chat scrolling up on quoting sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - fix chat being scrolled up a little right after you switch to it (rev 3) #4521
+- fix chat scrolling up a bit when quoting a message or adding attachment to draft (rev 2) #4529
 - fix cancelation of account deletion when canceling clicking outside of the dialog
 - fix unread counter on "jump to bottom" button showing incorrect count (taking the count from other chats) #4500
 - fix clicking on message search result or "reply privately" quote not jumping to the message on first click #4510

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -938,6 +938,24 @@ class MessageListStore extends Store<MessageListState> {
             return
           }
         } else {
+          // The draft message does not affect the return value of
+          // `getMessageListItems()`.
+          // The main purpose of this check is not just reduced resource usage,
+          // but to fix the messages list "scrolling up"
+          // when you quote a message. See
+          // https://github.com/deltachat/deltachat-desktop/issues/3763#issuecomment-2602630507
+          //
+          // A more correct solution would perhaps be to reduce the delay
+          // between `getLastKnownScrollPosition()` and the actual scroll,
+          // perhaps by moving `getLastKnownScrollPosition()`
+          // to the render function of `MessageList`.
+          if (
+            (await BackendRemote.rpc.getMessage(this.accountId, messageId))
+              .state === C.DC_STATE_OUT_DRAFT
+          ) {
+            return
+          }
+
           this.log.debug(
             'DC_EVENT_MSGS_CHANGED',
             'changed message seems to be a new message, refetching messageIds'


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/3763 (again).
See https://github.com/deltachat/deltachat-desktop/issues/3763#issuecomment-2602630507.
Previous supposed fix: https://github.com/deltachat/deltachat-desktop/pull/4119.

Apparently the bug came back after the recent React upgrade, which was introduced in 1.51.0, so the bug is a regression.

I was unable to reproduce the bug on the Windows preview build from this MR.
