### PR TITLE
feat: display past chat members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
   - implement experimental setting: content protection
   - api to change language
   - help window localisation
+- display past members in the group member list #4531
 
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.155.3`

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -142,7 +142,9 @@ function ViewGroupInner(
       .then(pastContacts => {
         setPastContacts(Object.values(pastContacts))
       })
+  }, [accountId, group.pastContactIds])
 
+  useEffect(() => {
     return onDCEvent(accountId, 'ContactsChanged', () => {
       BackendRemote.rpc
         .getContactsByIds(accountId, group.contactIds)


### PR DESCRIPTION
Since the core now has a new group consistency algorithm, the list of past members who left the group in the last 90 days is sent around in the (encrypted) header. Displaying it makes users aware that this happens and past members are known even to the new members. Besides "security" aspect, the feature is just occasionally useful to check "have I removed the bot from the group already, or just cannot find it in the huge member list?".

For use together with https://github.com/deltachat/deltachat-core-rust/pull/6442