### PR TITLE
fix: scrollbar flickering in "Send to..." dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - fix clicking on message search result or "reply privately" quote not jumping to the message on first click #4510
 - fix messages from wrong chat being shown after clicking on "jump down" button after revealing a message from a "Reply Privately" quote #4511
 - accessibility: fix VCards (share contact) being tab-stops even in inactive messages #4519
+- fix flickering in "Send to..." appearing on some zoom levels #4534
 
 <a id="1_51_0"></a>
 

--- a/packages/frontend/src/components/dialogs/SelectChat/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/SelectChat/styles.module.scss
@@ -7,4 +7,10 @@
   display: flex;
   flex-direction: column;
   padding-bottom: 0px;
+
+  // This prevents constantly flickering scrollbars caused by <AutoSizer>
+  // on certain DPR (zoom) levels.
+  // It's fine to apply `overflow: hidden;` because we do not expect
+  // the dialog to overflow: the stuff inside of it is scrollable anyway.
+  overflow: hidden;
 }


### PR DESCRIPTION
Caused by \<AutoSizer\>.
Similar commit: c746a1cc309ac3c3e088899f28141de8ce69a0c8.
