### PR TITLE
refactor: apply `disableWidth` to `<AutoSizer>`s

### DIFF
--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -333,14 +333,14 @@ export default class Gallery extends Component<
 
             {currentTab === 'files' && (
               <>
-                <AutoSizer>
-                  {({ width, height }) => (
+                <AutoSizer disableWidth>
+                  {({ height }) => (
                     <RovingTabindexProvider
                       wrapperElementRef={this.galleryItemsRef}
                       direction='vertical'
                     >
                       <FileTable
-                        width={width}
+                        width={'100%'}
                         height={height}
                         mediaLoadResult={mediaLoadResult}
                         mediaMessageIds={filteredMediaMessageIds}
@@ -528,7 +528,7 @@ function FileTable({
   mediaLoadResult,
   queryText,
 }: {
-  width: number
+  width: number | string
   height: number
   mediaMessageIds: number[]
   mediaLoadResult: Record<number, Type.MessageLoadResult>

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -66,7 +66,7 @@ export function ChatListPart({
   isRowLoaded: (index: number) => boolean
   loadMoreRows: (startIndex: number, stopIndex: number) => Promise<any>
   rowCount: number
-  width: number
+  width: number | string
   children: ComponentType<ListChildComponentProps<any>>
   height: number
   itemKey: ListItemKeySelector<any>
@@ -342,10 +342,10 @@ export default function ChatList(props: {
     return (
       <>
         <div className='chat-list'>
-          <AutoSizer>
-            {({ width, height }) => (
+          <AutoSizer disableWidth>
+            {({ height }) => (
               <div ref={tabindexWrapperElement}>
-                <div className='search-result-divider' style={{ width: width }}>
+                <div className='search-result-divider'>
                   {tx('search_in', searchChatInfo.name)}
                   {messageResultIds.length !== 0 &&
                     ': ' + translate_n('n_messages', messageResultIds.length)}
@@ -357,7 +357,7 @@ export default function ChatList(props: {
                     isRowLoaded={isMessageLoaded}
                     loadMoreRows={loadMessages}
                     rowCount={messageResultIds.length}
-                    width={width}
+                    width={'100%'}
                     height={
                       /* take remaining space */
                       height - DIVIDER_HEIGHT
@@ -380,11 +380,11 @@ export default function ChatList(props: {
   return (
     <>
       <div className='chat-list'>
-        <AutoSizer>
-          {({ width, height }) => (
+        <AutoSizer disableWidth>
+          {({ height }) => (
             <div ref={tabindexWrapperElement}>
               {isSearchActive && (
-                <div className='search-result-divider' style={{ width: width }}>
+                <div className='search-result-divider'>
                   {translate_n('n_chats', chatListIds.length)}
                 </div>
               )}
@@ -398,7 +398,7 @@ export default function ChatList(props: {
                   isRowLoaded={isChatLoaded}
                   loadMoreRows={loadChats}
                   rowCount={chatListIds.length}
-                  width={width}
+                  width={'100%'}
                   height={chatsHeight(height)}
                   setListRef={(ref: List<any> | null) =>
                     ((listRefRef.current as any) = ref)
@@ -411,17 +411,14 @@ export default function ChatList(props: {
                 </ChatListPart>
                 {isSearchActive && (
                   <>
-                    <div
-                      className='search-result-divider'
-                      style={{ width: width }}
-                    >
+                    <div className='search-result-divider'>
                       {translate_n('n_contacts', contactIds.length)}
                     </div>
                     <ChatListPart
                       isRowLoaded={isContactLoaded}
                       loadMoreRows={loadContact}
                       rowCount={contactIds.length}
-                      width={width}
+                      width={'100%'}
                       height={contactsHeight(height)}
                       itemKey={index => 'key' + contactIds[index]}
                       itemData={contactlistData}
@@ -432,26 +429,19 @@ export default function ChatList(props: {
                     {contactIds.length === 0 &&
                       chatListIds.length === 0 &&
                       queryStrIsValidEmail && (
-                        <div style={{ width: width }}>
-                          <PseudoListItemAddContact
-                            queryStr={queryStr?.trim() || ''}
-                            queryStrIsEmail={queryStrIsValidEmail}
-                            onClick={addContactOnClick}
-                          />
-                        </div>
+                        <PseudoListItemAddContact
+                          queryStr={queryStr?.trim() || ''}
+                          queryStrIsEmail={queryStrIsValidEmail}
+                          onClick={addContactOnClick}
+                        />
                       )}
                     {showPseudoListItemAddContactFromInviteLink && (
-                      <div style={{ width: width }}>
-                        <PseudoListItemAddContactOrGroupFromInviteLink
-                          inviteLink={queryStr!}
-                          accountId={accountId}
-                        />
-                      </div>
+                      <PseudoListItemAddContactOrGroupFromInviteLink
+                        inviteLink={queryStr!}
+                        accountId={accountId}
+                      />
                     )}
-                    <div
-                      className='search-result-divider'
-                      style={{ width: width }}
-                    >
+                    <div className='search-result-divider'>
                       {translated_messages_label(messageResultIds.length)}
                     </div>
 
@@ -459,7 +449,7 @@ export default function ChatList(props: {
                       isRowLoaded={isMessageLoaded}
                       loadMoreRows={loadMessages}
                       rowCount={messageResultIds.length}
-                      width={width}
+                      width={'100%'}
                       height={
                         // take remaining space
                         messagesHeight(height)

--- a/packages/frontend/src/components/dialogs/SelectChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectChat/index.tsx
@@ -61,13 +61,13 @@ export default function SelectChat(props: Props) {
               <PseudoListItemNoSearchResults queryStr={queryStr} />
             )}
             <div style={{ height: noResults ? '0px' : '100%' }}>
-              <AutoSizer>
-                {({ width, height }) => (
+              <AutoSizer disableWidth>
+                {({ height }) => (
                   <ChatListPart
                     isRowLoaded={isChatLoaded}
                     loadMoreRows={loadChats}
                     rowCount={chatListIds.length}
-                    width={width}
+                    width={'100%'}
                     height={height}
                     itemKey={index => 'key' + chatListIds[index]}
                     itemHeight={CHATLISTITEM_CHAT_HEIGHT}

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -34,7 +34,6 @@ import type { T } from '@deltachat/jsonrpc-client'
 import type { DialogProps } from '../../contexts/DialogContext'
 import ImageCropper from '../ImageCropper'
 import { AddMemberDialog } from './AddMember/AddMemberDialog'
-import AutoSizer from 'react-virtualized-auto-sizer'
 import { RovingTabindexProvider } from '../../contexts/RovingTabindex'
 import { ChatListItemRowChat } from '../chat/ChatListItemRow'
 
@@ -244,32 +243,26 @@ function ViewGroupInner(
                   <RovingTabindexProvider
                     wrapperElementRef={relatedChatsListWrapperRef}
                   >
-                    <AutoSizer disableHeight>
-                      {({ width }) => (
-                        <ChatListPart
-                          isRowLoaded={isChatLoaded}
-                          loadMoreRows={loadChats}
-                          rowCount={chatListIds.length}
-                          // We cannot just set the width to the width
-                          // of the dialog, because scrollbars might have width.
-                          width={width}
-                          height={CHATLISTITEM_CHAT_HEIGHT * chatListIds.length}
-                          itemKey={index => 'key' + chatListIds[index]}
-                          itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                          itemData={{
-                            chatCache,
-                            chatListIds,
-                            onChatClick,
+                    <ChatListPart
+                      isRowLoaded={isChatLoaded}
+                      loadMoreRows={loadChats}
+                      rowCount={chatListIds.length}
+                      width={'100%'}
+                      height={CHATLISTITEM_CHAT_HEIGHT * chatListIds.length}
+                      itemKey={index => 'key' + chatListIds[index]}
+                      itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                      itemData={{
+                        chatCache,
+                        chatListIds,
+                        onChatClick,
 
-                            selectedChatId: null,
-                            activeContextMenuChatId: null,
-                            openContextMenu: async () => {},
-                          }}
-                        >
-                          {ChatListItemRowChat}
-                        </ChatListPart>
-                      )}
-                    </AutoSizer>
+                        selectedChatId: null,
+                        activeContextMenuChatId: null,
+                        openContextMenu: async () => {},
+                      }}
+                    >
+                      {ChatListItemRowChat}
+                    </ChatListPart>
                   </RovingTabindexProvider>
                 </div>
               </>

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -321,13 +321,13 @@ export function ViewProfileInner({
             style={{ flexGrow: 1, minHeight: mutualChatsMinHeight }}
           >
             <RovingTabindexProvider wrapperElementRef={mutualChatsListRef}>
-              <AutoSizer>
-                {({ width, height }) => (
+              <AutoSizer disableWidth>
+                {({ height }) => (
                   <ChatListPart
                     isRowLoaded={isChatLoaded}
                     loadMoreRows={loadChats}
                     rowCount={chatListIds.length}
-                    width={width}
+                    width={'100%'}
                     height={height}
                     itemKey={index => 'key' + chatListIds[index]}
                     itemHeight={CHATLISTITEM_CHAT_HEIGHT}


### PR DESCRIPTION
Apparently it's not really necessary for vertical lists.
And we're already utilizing `disableWidth` in some other places.
So let's apply it to the rest where it's applicable,
in hopes to reduce code complexity.

After a bit of testing, this does not appear to affect behavior.

#skip-changelog