### PR TITLE
feat: make unread accounts `position: sticky`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Added
 - highlight the first unread message upon opening a chat #4525
 - enable notifications on mentions in muted chats #4538
+- always show accounts with unread messages, even when they're normally scrolled out of view #4536
 
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.155.2`

--- a/packages/frontend/scss/_variables.scss
+++ b/packages/frontend/scss/_variables.scss
@@ -32,6 +32,7 @@ $z-index: (
   chatlist-scope-floating-action-button: 1,
   jump-down-button-scope-counter: 1,
   account-list-sidebar-scope-account-badge: 1,
+  account-list-sidebar-scope-sticky-account: 1,
 
   // Global Scope
   // ============

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -184,6 +184,8 @@ export default function AccountItem({
     )
   }
 
+  const isSticky = unreadCount > 0
+
   const ref = useRef<HTMLButtonElement>(null)
   useLayoutEffect(() => {
     if (!isSelected) {
@@ -216,8 +218,13 @@ export default function AccountItem({
     // TODO refactor: maybe just use `ResizeObserver`,
     // as we do with messages list:
     // https://github.com/deltachat/deltachat-desktop/pull/4119
+    //
+    // Also watching `isSticky` because the selected account might stop
+    // being sticky when the user reads its messages,
+    // and it would get out of view, so we'd want to get it back in view.
+    //
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSelected, window.__screen])
+  }, [isSelected, isSticky, window.__screen])
 
   const rovingTabindex = useRovingTabindex(ref)
   // TODO `rovingTabindex.setAsActiveElement()` when the active account
@@ -229,6 +236,7 @@ export default function AccountItem({
       className={classNames(styles.account, rovingTabindex.className, {
         [styles.active]: isSelected,
         [styles['context-menu-active']]: isContextMenuActive,
+        [styles.isSticky]: isSticky,
       })}
       aria-busy={!account}
       onClick={() => onSelectAccount(accountId)}

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -70,10 +70,27 @@
     text-align: start; // To align the "active" indicator
 
     height: var(--als-avatar-size);
+
     margin-bottom: var(--als-avatar-margin);
     margin-top: var(--als-avatar-margin);
-    scroll-margin-bottom: var(--als-avatar-margin);
-    scroll-margin-top: var(--als-avatar-margin);
+    // Adding extra `var(--als-avatar-size) + 2 * var(--als-avatar-margin)`
+    // to the margins so that
+    // if there is another `.isSticky` account, then that account does not
+    // cover the account that we want to scroll into view.
+    // And another extra `2 * var(--als-avatar-margin)` so that it's obvious that
+    // the other sticky account really is sticky, to make it obviously overlay
+    // on top of another account, and be positioned perfectly on top of it.
+    //
+    // TODO improvement: perhaps it makes sense to keep these at just
+    // `var(--als-avatar-margin)` in case there is no sticky account above.
+    // This should be achievable with CSS.
+    scroll-margin-bottom: calc(
+      5 * var(--als-avatar-margin) + var(--als-avatar-size)
+    );
+    scroll-margin-top: calc(
+      5 * var(--als-avatar-margin) + var(--als-avatar-size)
+    );
+
     position: relative;
     z-index: $z-index-new-local-scope;
 
@@ -87,6 +104,21 @@
       div.content,
       img.content {
         border-radius: 10%;
+      }
+    }
+
+    &.isSticky {
+      position: sticky;
+      bottom: var(--als-avatar-margin);
+      top: var(--als-avatar-margin);
+      // Only needed when this account is scrolled _above_ the visible region.
+      z-index: map-get($z-index, account-list-sidebar-scope-sticky-account);
+
+      .avatar {
+        opacity: 1;
+        .content {
+          box-shadow: 0px 0px 4px 2px #00000040;
+        }
       }
     }
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/ad38fad5-4a87-4c73-be80-8ff2af772193

This somewhat addresses the
"indicators on top and bottom
if there are unread accounts out of screen"
point in https://github.com/deltachat/deltachat-desktop/issues/3671.

An alternative would be to put "unread" accounts at the top of the list (sort). Or to just show a "jump down" button, similar to how we do it in messages.
But this is a simple change I came up with, and it's not too often anyway that people have a dozen of accounts (profiles).