### PR TITLE
fix: webxdc: Await calls to setUpdateListener() callback

### DIFF
--- a/packages/target-electron/static/webxdc-preload.js
+++ b/packages/target-electron/static/webxdc-preload.js
@@ -71,7 +71,7 @@ class RealtimeListener {
     )
     for (const update of updates) {
       last_serial = update.max_serial
-      callback(update)
+      await callback(update)
     }
     if (setUpdateListenerPromise) {
       setUpdateListenerPromise()


### PR DESCRIPTION
This allows an async callback to be passed to `webxdc.setUpdateListener()`.

Let me illustrate with an example by taking the simplest example from the webxdc.org page and tweaking it a bit. So imagine this app:

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8"/>
    <script src="webxdc.js"></script>
  </head>
  <body>
    <input id="input" type="text"/>
    <a href="" onclick="sendMsg(); return false;">Send</a>
    <p id="output"></p>
    <script>
      const numbers = []

      function sendMsg() {
        msg = document.getElementById("input").value;
        window.webxdc.sendUpdate({payload: msg}, 'Someone typed "'+msg+'".');
      }

      async function somethingReallyAsync () {
        return new Promise((resolve) => {
          setTimeout(() => {
            resolve()
          }, 100)
        })
      }

      async function doSomething (update) {
        const n = update.payload
        console.log('number payload', n)
        if (!numbers.includes(n)) {
          await somethingReallyAsync()
          numbers.push(n)
          document.getElementById('output').innerHTML += update.payload + "<br>";
        }
      }

      window.webxdc.setUpdateListener(async (update) => {
        await doSomething(update)
      }, 0);
    </script>
  </body>
</html>
```

It allows you to input numbers but only shows the ones you haven't already put in. So you can type like `1` and hit send a couple of times, then you just see a single `1`, then you type a `2` maybe and hit send a couple of times. It works.

Now, when you refresh the browser, it'll show everything you have put in. This means you can't have local state (this is just a javascript array) and do something async while updating that state (exemplified by `somethingReallyAsync()`).

If you instead `await callback()` this works.

Note that if you run this in the browser and you're using the local `webxdc.js` variant, the `setUpdateListener` method needs to change to something like:

![image](https://github.com/user-attachments/assets/0a694490-4849-439f-adfc-8b915c88714f)
