### PR TITLE
fix: update unread badge on read from other device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - fix chat scrolling up a bit when quoting a message or adding attachment to draft (rev 2) #4529
 - fix cancelation of account deletion when canceling clicking outside of the dialog
 - fix unread counter on "jump to bottom" button showing incorrect count (taking the count from other chats) #4500
+- fix unread counter on app's badge not updating when reading messages from other device #4539
 - fix clicking on message search result or "reply privately" quote not jumping to the message on first click #4510
 - fix messages from wrong chat being shown after clicking on "jump down" button after revealing a message from a "Reply Privately" quote #4511
 - accessibility: fix VCards (share contact) being tab-stops even in inactive messages #4519

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -70,6 +70,12 @@ export default function AccountItem({
     const cleanup = [
       onDCEvent(accountId, 'AccountsItemChanged', updateAccount),
 
+      // FYI we have 3 places where we watch the number of unread messages:
+      // - App's badge counter
+      // - Per-account badge counter in accounts list
+      // - useUnreadCount
+      // Make sure to update all the places if you update one of them.
+
       onDCEvent(accountId, 'IncomingMsg', updateUnread),
       // IncomingMsg doesn't listen for added device messages,
       // so we also listen to `ChatlistChanged` because it is a good indicator and not emitted too often

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -66,6 +66,9 @@ const onWindowFocus = (accountId: number) => {
       `window was focused: marking ${messageIdsToMarkAsRead.length} visible messages as read`,
       messageIdsToMarkAsRead
     )
+    // FYI we also listen for `MsgsNoticed` event
+    // to update the badge counter,
+    // so `.then(debouncedUpdateBadgeCounter)` is probably not necessary.
     BackendRemote.rpc
       .markseenMsgs(accountId, messageIdsToMarkAsRead)
       .then(debouncedUpdateBadgeCounter)
@@ -91,6 +94,11 @@ function useUnreadCount(
       }
     }
 
+    // FYI we have 3 places where we watch the number of unread messages:
+    // - App's badge counter
+    // - Per-account badge counter in accounts list
+    // - useUnreadCount
+    // Make sure to update all the places if you update one of them.
     const cleanup = [
       onDCEvent(accountId, 'IncomingMsg', update),
       onDCEvent(accountId, 'MsgRead', update),
@@ -182,6 +190,9 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
       if (messageIdsToMarkAsRead.length > 0) {
         const chatId = chat?.id
         if (!chatId) return
+        // FYI we also listen for `MsgsNoticed` event
+        // to update the badge counter,
+        // so `.then(debouncedUpdateBadgeCounter)` is probably not necessary.
         BackendRemote.rpc
           .markseenMsgs(accountId, messageIdsToMarkAsRead)
           .then(debouncedUpdateBadgeCounter)

--- a/packages/frontend/src/system-integration/badge-counter.ts
+++ b/packages/frontend/src/system-integration/badge-counter.ts
@@ -34,7 +34,18 @@ export const debouncedUpdateBadgeCounter = debounce(
 )
 
 export function initBadgeCounter() {
+  // FYI we have 3 places where we watch the number of unread messages:
+  // - App's badge counter
+  // - Per-account badge counter in accounts list
+  // - useUnreadCount
+  // Make sure to update all the places if you update one of them.
   BackendRemote.on('IncomingMsg', _ => {
+    debouncedUpdateBadgeCounter()
+  })
+  BackendRemote.on('ChatlistChanged', _ => {
+    debouncedUpdateBadgeCounter()
+  })
+  BackendRemote.on('MsgsNoticed', _ => {
     debouncedUpdateBadgeCounter()
   })
   BackendRemote.on('ChatModified', _ => {


### PR DESCRIPTION
We used to only update the count when calling
`BackendRemote.rpc.markseenMsgs()` or
`BackendRemote.rpc.marknoticedChat()`.
