### PR TITLE
fix: scroll selected account into view on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - fix log format for logging core events #4572
 - fix dragging files out
 - memory leak when opening and closing emoji picker #4567
+- fix selected account not getting scrolled into view in accounts bar on app start #4542
 - improve performance a little #4561
 
 <a id="1_52_1"></a>

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -224,38 +224,29 @@ export default function AccountItem({
   // gets switched, e.g. via clicking on a message notification
   // for a different account, and upon initial render.
 
-  if (!account) {
-    return (
-      <button
-        className={classNames(styles.account, {
-          [styles.active]: isSelected,
-          [styles['context-menu-active']]: isContextMenuActive,
-        })}
-        disabled
-        aria-busy
-        ref={ref}
-      ></button>
-    )
-  }
-
   return (
     <button
       className={classNames(styles.account, rovingTabindex.className, {
         [styles.active]: isSelected,
         [styles['context-menu-active']]: isContextMenuActive,
       })}
+      aria-busy={!account}
       onClick={() => onSelectAccount(accountId)}
       onContextMenu={onContextMenu}
-      onMouseEnter={() => updateAccountForHoverInfo(account, true)}
-      onMouseLeave={() => updateAccountForHoverInfo(account, false)}
+      onMouseEnter={() => account && updateAccountForHoverInfo(account, true)}
+      onMouseLeave={() => account && updateAccountForHoverInfo(account, false)}
       x-account-sidebar-account-id={accountId}
-      data-testid={`account-item-${account.id}`}
+      data-testid={`account-item-${accountId}`}
       ref={ref}
       tabIndex={rovingTabindex.tabIndex}
       onFocus={rovingTabindex.setAsActiveElement}
       onKeyDown={rovingTabindex.onKeydown}
     >
-      {account.kind == 'Configured' ? (
+      {!account ? (
+        <div className={styles.avatar}>
+          <div className={styles.content}>⏳</div>
+        </div>
+      ) : account.kind == 'Configured' ? (
         <div className={styles.avatar}>
           {' '}
           {account.profileImage ? (


### PR DESCRIPTION
The feature was introduced in 46d98111b69764b278f15c3dfe300e794dd64dcc,
but then broken apparently in d13a36cd10bcdb3c51d4f6cb0bd77a1a85f526a3.

As a side-effect, this will also show "placeholder" acount list items
while the accounts are loading.

And it makes the account list items interactive
while they're loading, i.e. you can select one
or activate the context menu.

Another thing this fixes is roving tabindex
while the accounts are loading, but isn't really important.
