### PR TITLE
fix: treat numpad "Enter" as regular "Enter"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- numpad "Enter" not working as regular "Enter" #4546
 
 <a id="1_52_0"></a>
 

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -279,7 +279,7 @@ export function ContextMenu(props: {
             keyboardFocus.current = 0
           }
         }
-      } else if (ev.code == 'Enter') {
+      } else if (ev.key == 'Enter') {
         if (current) {
           ;(current as HTMLDivElement)?.click()
         }

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -148,10 +148,10 @@ export default class ComposerMessageInput extends React.Component<
     const enterKeySends = this.props.enterKeySends
 
     // ENTER + CTRL
-    if (e.code === 'Enter' && (e.ctrlKey || e.metaKey)) {
+    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
       return 'SEND'
       // ENTER
-    } else if (e.code === 'Enter' && !e.shiftKey) {
+    } else if (e.key === 'Enter' && !e.shiftKey) {
       return enterKeySends ? 'SEND' : undefined
     }
   }

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberInnerDialog.tsx
@@ -159,7 +159,7 @@ export function AddMemberInnerDialog({
   const itemCount = contactIds.length + (needToRenderAddContact ? 1 : 0)
 
   const addContactOnKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
-    if (ev.code == 'Enter') {
+    if (ev.key == 'Enter') {
       // TODO refactor: this is fragile.
       ;(
         contactListRef.current?.querySelector(

--- a/packages/frontend/src/components/screens/AccountSetupScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountSetupScreen.tsx
@@ -57,7 +57,7 @@ export default function AccountSetupScreen({
   // and not an explicit keyboard handling
   const onKeyDown = useCallback(
     (ev: KeyboardEvent) => {
-      if (ev.code === 'Enter') {
+      if (ev.key === 'Enter') {
         ev.stopPropagation()
         ev.preventDefault()
         if (hasOpenDialogs) {

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -113,7 +113,7 @@ export function keyDownEvent2Action(
         return KeybindAction.Composer_CancelReply
       }
     } else if (
-      ev.code === 'Enter' &&
+      ev.key === 'Enter' &&
       (ev.target as any).id === 'chat-list-search'
     ) {
       return KeybindAction.ChatList_SearchSelectFirstChat


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4543.

This partially reverts 9e7830f3d7793f9985cd774ec0f66a3a1f06f429
(https://github.com/deltachat/deltachat-desktop/pull/4140)
and
23a0791dbe582105f53fd05d7e6b48bf6b2d2a58
(https://github.com/deltachat/deltachat-desktop/pull/4140).
