### PR TITLE
improvement: focus message when jumping to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - settings: explain "Read Receipts" and adjust "Enter Key Sends" title #4524
+- accessibility: focus message when jumping to it in some cases (e.g. when clicking on a quote) #4547
 
 ### Changed
 

--- a/packages/frontend/src/components/RuntimeAdapter.tsx
+++ b/packages/frontend/src/components/RuntimeAdapter.tsx
@@ -58,6 +58,8 @@ export default function RuntimeAdapter({
           window.__internal_jump_to_message?.({
             msgId,
             scrollIntoViewArg: { block: 'center' },
+            // We probably want the composer to be focused.
+            focus: false,
           })
         }
       }

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -79,6 +79,7 @@ const contextMenuFactory = (
           accountId,
           msgId: message.id,
           msgChatId: message.chatId,
+          focus: true,
           scrollIntoViewArg: { block: 'center' },
         }),
     },

--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -126,6 +126,7 @@ export const ChatListItemRowMessage = React.memo<{
               accountId,
               msgId: msrId,
               msgChatId: messageSearchResult.chatId,
+              focus: false,
               scrollIntoViewArg: { block: 'center' },
             })
           }}

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -655,6 +655,7 @@ export function useDraft(
         msgId: messageId,
         msgChatId: chatId,
         highlight: true,
+        focus: false,
         // The message is usually already in view,
         // so let's not scroll at all if so.
         scrollIntoViewArg: { block: 'nearest' },

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -43,11 +43,15 @@ const DisplayedStickerPack = ({
 
   const onClickSticker = (fileName: string) => {
     const stickerPath = fileName.replace('file://', '')
-    BackendRemote.rpc
-      .sendSticker(accountId, chatId, stickerPath)
-      .then(msgId =>
-        jumpToMessage({ accountId, msgId, msgChatId: chatId, highlight: false })
-      )
+    BackendRemote.rpc.sendSticker(accountId, chatId, stickerPath).then(msgId =>
+      jumpToMessage({
+        accountId,
+        msgId,
+        msgChatId: chatId,
+        highlight: false,
+        focus: false,
+      })
+    )
     setShowEmojiPicker(false)
   }
 

--- a/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
@@ -51,6 +51,7 @@ function buildContextMenu(
             msgId: message.id,
             msgChatId: message.chatId,
             highlight: true,
+            focus: true,
             scrollIntoViewArg: { block: 'center' },
           })
         )
@@ -70,6 +71,7 @@ function buildContextMenu(
             // but let's not pass `chatId` here, for future-proofing.
             msgChatId: undefined,
             highlight: true,
+            focus: true,
             scrollIntoViewArg: { block: 'center' },
           })
         }

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -50,7 +50,12 @@ export default function ForwardMessage(props: ForwardMessageProps) {
         )
         const lastMessage = messageIds[messageIds.length - 1]
         if (lastMessage) {
-          jumpToMessage({ accountId, msgId: lastMessage, msgChatId: chatId })
+          jumpToMessage({
+            accountId,
+            msgId: lastMessage,
+            msgChatId: chatId,
+            focus: false,
+          })
         }
       } else {
         selectChat(accountId, message.chatId)

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -119,6 +119,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
           accountId,
           msgId: msg.id,
           msgChatId: msg.chatId,
+          focus: true,
           scrollIntoViewArg: { block: 'center' },
         })
         onClose()

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -365,6 +365,7 @@ function buildContextMenu(
             // but let's not pass `chatId` here, for future-proofing.
             msgChatId: undefined,
             highlight: true,
+            focus: true,
             msgParentId: message.id,
             scrollIntoViewArg: { block: 'center' },
           })
@@ -914,6 +915,7 @@ export const Quote = ({
         msgId: quote.messageId,
         msgChatId: undefined,
         highlight: true,
+        focus: true,
         msgParentId,
         // Often times the quoted message is already in view,
         // so let's not scroll at all if so.

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -386,6 +386,21 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
 
       domElement.scrollIntoView(scrollTo.scrollIntoViewArg)
 
+      if (scrollTo.focus) {
+        const focusEl = domElement.getElementsByClassName(
+          'roving-tabindex'
+        )[0] as HTMLElement | undefined
+        if (!focusEl) {
+          log.error(
+            'scrollTo: failed to focus element:' +
+              'no child element with class "roving-tabindex" found',
+            domElement
+          )
+        } else {
+          focusEl.focus()
+        }
+      }
+
       if (scrollTo.highlight === true) {
         // Trigger highlight animation
 
@@ -934,6 +949,7 @@ function JumpDownButton({
     highlight?: boolean
     addMessageIdToStack?: undefined | number
     scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
+    focus: boolean
   }) => Promise<void>
   jumpToMessageStack: number[]
 }) {
@@ -964,6 +980,7 @@ function JumpDownButton({
               // When the stack is empty, we'll jump to last message,
               // and 'center' will make the chat scroll down all the way.
               scrollIntoViewArg: { block: 'center' },
+              focus: false,
             })
           }}
         >

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -78,6 +78,7 @@ export const ChatProvider = ({
         window.__internal_jump_to_message?.({
           msgId: undefined,
           highlight: false,
+          focus: false,
           addMessageIdToStack: undefined,
           // `scrollIntoViewArg:` doesn't really have effect when
           // jumping to the last message.

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -25,6 +25,7 @@ declare global {
       | undefined
       | ((params: {
           msgId: number | undefined
+          focus: boolean
           highlight?: boolean
           addMessageIdToStack?: undefined | number
           scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -18,6 +18,7 @@ export type JumpToMessage = (params: {
    */
   msgChatId?: number
   highlight?: boolean
+  focus: boolean
   /**
    * The ID of the message to remember,
    * to later go back to it, using the "jump down" button.
@@ -77,6 +78,7 @@ export default function useMessage() {
       msgId,
       msgChatId,
       highlight = true,
+      focus,
       msgParentId,
       scrollIntoViewArg,
     }) => {
@@ -100,6 +102,7 @@ export default function useMessage() {
         window.__internal_jump_to_message?.({
           msgId,
           highlight,
+          focus,
           addMessageIdToStack: msgParentId,
           scrollIntoViewArg,
         })
@@ -120,7 +123,13 @@ export default function useMessage() {
       })
 
       // Jump down on sending
-      jumpToMessage({ accountId, msgId, msgChatId: chatId, highlight: false })
+      jumpToMessage({
+        accountId,
+        msgId,
+        msgChatId: chatId,
+        highlight: false,
+        focus: false,
+      })
     },
     [jumpToMessage]
   )

--- a/packages/frontend/src/hooks/useVideoChat.ts
+++ b/packages/frontend/src/hooks/useVideoChat.ts
@@ -52,6 +52,7 @@ export default function useVideoChat() {
           msgId: messageId,
           msgChatId: chatId,
           highlight: false,
+          focus: false,
         })
         await joinVideoChat(accountId, messageId)
       } catch (error: todo) {

--- a/packages/frontend/src/stores/chat/chat_view_reducer.ts
+++ b/packages/frontend/src/stores/chat/chat_view_reducer.ts
@@ -10,6 +10,9 @@ interface ScrollToMessage {
   msgId: number
   scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
   highlight: boolean
+  focus: boolean
+  // TODO improvement: also add an option to make the message the "active" one
+  // in the "roving tabindex" widget, but not focus it.
 }
 
 /**
@@ -142,6 +145,7 @@ export class ChatViewReducer {
     prevState: ChatViewState,
     jumpToMessageId: number,
     highlight: boolean,
+    focus: boolean,
     scrollIntoViewArg: ScrollToMessage['scrollIntoViewArg']
   ): ChatViewState {
     return {
@@ -150,6 +154,7 @@ export class ChatViewReducer {
         type: 'scrollToMessage',
         msgId: jumpToMessageId,
         highlight,
+        focus,
         scrollIntoViewArg,
       },
     }

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -349,6 +349,7 @@ class MessageListStore extends Store<MessageListState> {
             this.effect.jumpToMessage({
               msgId: firstUnreadMsgId,
               highlight: false,
+              focus: false,
               // 'center' so that old messages are also shown, for context.
               // See https://github.com/deltachat/deltachat-desktop/issues/4284
               scrollIntoViewArg: { block: 'center' },
@@ -425,11 +426,13 @@ class MessageListStore extends Store<MessageListState> {
       async ({
         msgId: jumpToMessageId,
         highlight = true,
+        focus,
         addMessageIdToStack,
         scrollIntoViewArg,
       }: {
         msgId: number | undefined
         highlight?: boolean
+        focus: boolean
         addMessageIdToStack?: undefined | number
         scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
       }) => {
@@ -649,6 +652,7 @@ class MessageListStore extends Store<MessageListState> {
             this.state.viewState,
             jumpToMessageId,
             highlight,
+            focus,
             scrollIntoViewArg
           ),
           jumpToMessageStack,


### PR DESCRIPTION
Where appropriate. Most notably:
- When jumping to message from quote click
- When jump to webxdc app from "Show app in chat" context menu item
- After "Show in chat" from the gallery

Let's add `focus: true` only to the most basic cases for now,
and later consider expanding this, and perhaps even adding
some logic / settings as to whether to focus the message.
