### PR TITLE
fix: improve `__jump_to_message` reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - fix changelog message left unread not in the selected account as it should be but in another account. #4569
 - accessibility: some context menu items not working with keyboard navigation #4578
+- fix clicking on message search result or "Reply Privately" quote not jumping to the message on first click sometimes, again #4554
 - fix log format for logging core events #4572
 - fix dragging files out
 - memory leak when opening and closing emoji picker #4567

--- a/packages/frontend/src/components/RuntimeAdapter.tsx
+++ b/packages/frontend/src/components/RuntimeAdapter.tsx
@@ -55,12 +55,19 @@ export default function RuntimeAdapter({
           clearNotificationsForChat(notificationAccountId, chatId)
         }
         if (msgId) {
-          window.__internal_jump_to_message?.({
-            msgId,
-            scrollIntoViewArg: { block: 'center' },
-            // We probably want the composer to be focused.
-            focus: false,
-          })
+          window.__internal_jump_to_message_asap = {
+            accountId: notificationAccountId,
+            chatId,
+            jumpToMessageArgs: [
+              {
+                msgId,
+                scrollIntoViewArg: { block: 'center' },
+                // We probably want the composer to be focused.
+                focus: false,
+              },
+            ],
+          }
+          window.__internal_check_jump_to_message?.()
         }
       }
     )

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -222,9 +222,19 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
     }
   }, [])
 
+  const maybeJumpToMessageHack = () => {
+    if (
+      window.__internal_jump_to_message_asap?.accountId === accountId &&
+      window.__internal_jump_to_message_asap.chatId === chat.id
+    ) {
+      jumpToMessage(...window.__internal_jump_to_message_asap.jumpToMessageArgs)
+      window.__internal_jump_to_message_asap = undefined
+    }
+  }
+  maybeJumpToMessageHack()
   // TODO perf: to save memory, maybe set to `undefined` when unmounting,
   // but be sure not to unset it if the new component render already set it.
-  window.__internal_jump_to_message = jumpToMessage
+  window.__internal_check_jump_to_message = maybeJumpToMessageHack
 
   const pendingProgrammaticSmoothScrollTo = useRef<null | number>(null)
   const pendingProgrammaticSmoothScrollTimeout = useRef<number>(-1)

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -80,14 +80,21 @@ export const ChatProvider = ({
       // Jump to last message if user clicked chat twice
       // @TODO: We probably want this to be part of the UI logic instead
       if (nextChatId === chatId) {
-        window.__internal_jump_to_message?.({
-          msgId: undefined,
-          highlight: false,
-          focus: false,
-          addMessageIdToStack: undefined,
-          // `scrollIntoViewArg:` doesn't really have effect when
-          // jumping to the last message.
-        })
+        window.__internal_jump_to_message_asap = {
+          accountId,
+          chatId: nextChatId,
+          jumpToMessageArgs: [
+            {
+              msgId: undefined,
+              highlight: false,
+              focus: false,
+              addMessageIdToStack: undefined,
+              // `scrollIntoViewArg:` doesn't really have effect when
+              // jumping to the last message.
+            },
+          ],
+        }
+        window.__internal_check_jump_to_message?.()
       }
 
       // Already set known state

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -8,6 +8,16 @@ import { getLogger } from '../../../../shared/logger'
 import type { T } from '@deltachat/jsonrpc-client'
 
 export type JumpToMessage = (params: {
+  // "not from a different account" because apparently
+  // `selectAccount` throws if `nextAccountId` is not the same
+  // as the current account ID.
+  //
+  // TODO refactor: can't we just remove this property then?
+  /**
+   * The ID of the currently selected account.
+   * jumpToMessage from `useMessage()` _cannot_ jump to messages
+   * of different accounts.
+   */
   accountId: number
   msgId: number
   /**
@@ -154,6 +164,14 @@ export default function useMessage() {
   )
 
   return {
+    /**
+     * Makes the currently rendered MessageList component instance
+     * load and scroll the message with the specified `msgId` into view.
+     *
+     * The specified message may be a message from a different chat,
+     * but _not_ from a different account,
+     * see {@link JumpToMessage['accountId']}.
+     */
     jumpToMessage,
     sendMessage,
     forwardMessage,

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -98,15 +98,20 @@ export default function useMessage() {
       setChatView(ChatView.MessageList)
 
       // Workaround to actual jump to message in regarding mounted component view
-      setTimeout(() => {
-        window.__internal_jump_to_message?.({
-          msgId,
-          highlight,
-          focus,
-          addMessageIdToStack: msgParentId,
-          scrollIntoViewArg,
-        })
-      }, 0)
+      window.__internal_jump_to_message_asap = {
+        accountId,
+        chatId: msgChatId,
+        jumpToMessageArgs: [
+          {
+            msgId,
+            highlight,
+            focus,
+            addMessageIdToStack: msgParentId,
+            scrollIntoViewArg,
+          },
+        ],
+      }
+      window.__internal_check_jump_to_message?.()
     },
     [chatId, selectChat, setChatView]
   )

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -410,6 +410,13 @@ class MessageListStore extends Store<MessageListState> {
      * reloading `messageListItems` if the message is missing from there,
      * and showing the message in a chat other than `this.chatId`.
      *
+     * Currently this function (as well as the MessageListStore)
+     * is only directly used by the MessageList component.
+     * To jump to a message without having a reference to the
+     * `MessageListStore`, and with an option to jump to message
+     * from a different chat, use `const { jumpToMessage } = useMessage()`,
+     * (it will internally casue this function to be invoked).
+     *
      * The latter (showing the message from a different chat), however,
      * should not be used, because, as of 2025-01-19, we re-create
      * `MessageListStore` when `chatId` or `accountId` changes.


### PR DESCRIPTION
Follow-up to 6a656f968ac2bc2f67d6b9fbc1aba15d3851f053
(https://github.com/deltachat/deltachat-desktop/pull/4510).
Partially addresses https://github.com/deltachat/deltachat-desktop/issues/4508.
Why partially? Because the bug appears to still happen sometimes.
But this commit should make it more reliable, or at least be a refactor.

This should also improve performance in some cases,
thanks to the removal of `setTimeout()`.
