### PR TITLE
fix: `onEventMessagesChanged`: handle `msgId == 0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 ### Fixed
+- message list being empty when opening a chat in some cases #4555
 - numpad "Enter" not working as regular "Enter" #4546
 - improve performance a little
 

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -922,6 +922,7 @@ class MessageListStore extends Store<MessageListState> {
     onEventMessagesChanged: this.scheduler.queuedEffect(
       async (messageId: number) => {
         if (
+          messageId > C.DC_MSG_ID_LAST_SPECIAL &&
           this.state.messageListItems.findIndex(
             m => m.kind === 'message' && m.msg_id === messageId
           ) !== -1
@@ -954,6 +955,7 @@ class MessageListStore extends Store<MessageListState> {
           // perhaps by moving `getLastKnownScrollPosition()`
           // to the render function of `MessageList`.
           if (
+            messageId > C.DC_MSG_ID_LAST_SPECIAL &&
             (await BackendRemote.rpc.getMessage(this.accountId, messageId))
               .state === C.DC_STATE_OUT_DRAFT
           ) {


### PR DESCRIPTION
~~This could cause the message list to not update on some events, but I have not seen a concrete example.~~

The bug was introduced in 7a968b68cd0c6d586e4554f47dbf0f628555595a.
(https://github.com/deltachat/deltachat-desktop/pull/4529).

The added `messageId > C.DC_MSG_ID_LAST_SPECIAL` in the first `if`
is purely for consistency and performance.
It's the second one that matters.

Update: OK, this really does appear like this is causing the "empty chat issue". Reproduction steps are roughly as follows:
1. Create two accounts
2. On Alice, send ~20 messages to Bob.
3. Switch to Bob's account and open the chat with Alice. Do not scroll to bottom.
4. Switch to Alice account and send another message to Bob.
5. Switch to Bob's account and open the chat with Alice.

You will see the `Failed to load message Msg#0 for account` error in the console and the chat will be empty.

I apologize for such carelessness.