### PR TITLE
refactor: fix message list potentially being empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix dragging files out
 - memory leak when opening and closing emoji picker #4567
 - fix selected account not getting scrolled into view in accounts bar on app start #4542
+- message list being empty sometimes when a chat gets opened #4556
 - improve performance a little #4561
 
 <a id="1_52_1"></a>

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -106,6 +106,7 @@ export function useMessageList(accountId: number, chatId: number) {
   const [state, setState] = useState(store.getState())
 
   useEffect(() => {
+    setState(store.getState())
     store.subscribe(setState)
     return () => store.unsubscribe(setState)
   }, [store])

--- a/packages/frontend/src/stores/store.ts
+++ b/packages/frontend/src/stores/store.ts
@@ -6,7 +6,10 @@ export function useStore<T extends Store<any>>(
 ): [T extends Store<infer S> ? S : any, T['dispatch']] {
   const [state, setState] = useState(StoreInstance.getState())
 
-  useEffect(() => StoreInstance.subscribe(setState), [StoreInstance])
+  useEffect(() => {
+    setState(StoreInstance.getState())
+    return StoreInstance.subscribe(setState)
+  }, [StoreInstance])
   // TODO: better return an object to allow destructuring
   return [state, StoreInstance.dispatch.bind(StoreInstance)]
 }


### PR DESCRIPTION
...sometimes.
And maybe sometimes showing messages from previous chat.

I have not been able to confirm whether this fixes
an actual bug.
But at least in my understanding this fixes a semantic error.

The presence of the error is obvious if you make
`store.effect.loadChat()` synchronous.
So, what could be happening is that `loadChat` finishes _before_
we subscribe to the new store instance,
and thus the state never gets updated,
at least not until the next store update, which could be e.g.
`fetchMoreMessagesTop`.

The second commit also appears to be just a refactor.
