### PR TITLE
fix: jumpToMessage flashing the bottom of new chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - fix changelog message left unread not in the selected account as it should be but in another account. #4569
 - accessibility: some context menu items not working with keyboard navigation #4578
 - fix clicking on message search result or "Reply Privately" quote not jumping to the message on first click sometimes, again #4554
+- fix jumping to message in a different chat momentarily opening the new chat scrolled to bottom before scrolling it to the desired message #4562
 - fix log format for logging core events #4572
 - fix dragging files out
 - memory leak when opening and closing emoji picker #4567

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -223,6 +223,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
   }, [])
 
   const maybeJumpToMessageHack = () => {
+    // FYI there is similar code in `messagelist.ts`.
     if (
       window.__internal_jump_to_message_asap?.accountId === accountId &&
       window.__internal_jump_to_message_asap.chatId === chat.id


### PR DESCRIPTION
~~This is based on https://github.com/deltachat/deltachat-desktop/pull/4561 and https://github.com/deltachat/deltachat-desktop/pull/4554. This MR is about just the last commit.~~

Before:

https://github.com/user-attachments/assets/19f2c7c4-e3ee-4cf8-ae58-9b83936deebf

After:

https://github.com/user-attachments/assets/41d2210d-727d-44cf-8ed7-40fddf443673

That is, when you jump to a message in a different chat
(e.g. by clicking on a notification, or from message search,
or from a "private reply" quote),
we would momentarily show the new chat scrolled to bottom
prior to jumping to the desired message.

Why this is bad:

- We mark the visible messages as read.
  In this case that would be the last messages in the chat.
  But they weren't actually read, the user did not intend
  to scroll to them.
- Extra layout shifting: not great visually.
- Bad for performance. Let's just load the part of the chat
  that we need right away.
  
Related:
- https://github.com/deltachat/deltachat-desktop/issues/4508
- https://github.com/deltachat/deltachat-desktop/pull/4510
- https://github.com/deltachat/deltachat-desktop/pull/4554