### PR TITLE
chore: upgrade Electron from 32 to 34

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+> Due to the Electron update, macOS 10.15 (Catalina)
+> is no longer supported, macOS 11 (Big Sur) or later
+> is the new requirement.
+
 ### Added
 - highlight the first unread message upon opening a chat #4525
 - enable notifications on mentions in muted chats #4538
@@ -22,6 +26,7 @@
 - Improve backup transfer dialog (different message for connection step, timed message to tell user to check out troubleshooting, button to link to trouble shooting) #4476
 - store last used account in accounts.toml managed by core #4569
 - update help menu URLs #4598
+- upgrade Electron from `32.1.0` to `34.0.1` #4568
 
 ### Fixed
 - fix changelog message left unread not in the selected account as it should be but in another account. #4569

--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -75,7 +75,7 @@
     "chai": "^5.1.1",
     "chokidar": "^3.6.0",
     "debounce": "^1.2.0",
-    "electron": "^32.1.0",
+    "electron": "^34.0.1",
     "electron-builder": "^24.13.3",
     "esbuild": "^0.19.8",
     "mocha": "^10.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,8 +385,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.1
       electron:
-        specifier: ^32.1.0
-        version: 32.1.0
+        specifier: ^34.0.1
+        version: 34.0.1
       electron-builder:
         specifier: ^24.13.3
         version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
@@ -2066,8 +2066,8 @@ packages:
   electron-publish@24.13.1:
     resolution: {integrity: sha512-2ZgdEqJ8e9D17Hwp5LEq5mLQPjqU3lv/IALvgp+4W8VeNhryfGhYEQC/PgDPMrnWUp+l60Ou5SJLsu+k4mhQ8A==}
 
-  electron@32.1.0:
-    resolution: {integrity: sha512-4etE3K6vPUkHihf7nvawngbB5+jLuUJgZh31f9ki1Gfveo0qwNDkLv/doabw+4zFFWKUXI+uFUpyOpL5+RwS+Q==}
+  electron@34.0.1:
+    resolution: {integrity: sha512-aArw5tAM80i3CKwEREnyZSM1SkARf5Jd1yBMTIdOL4pB1M+p/oDeyWSFI9Dl+vujyfJKiK4SS5+j19wna1onMw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5170,7 +5170,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@32.1.0:
+  electron@34.0.1:
     dependencies:
       '@electron/get': 2.0.2
       '@types/node': 20.14.15


### PR DESCRIPTION
FYI breaking changes. Nothing much appears to apply to us, except perhaps macOS. Please re-check:
- https://www.electronjs.org/blog/electron-33-0#breaking-changes
- https://www.electronjs.org/blog/electron-34-0#breaking-changes

Closes https://github.com/deltachat/deltachat-desktop/issues/3416.

Appears to work after some basic testing.

