### PR TITLE
fix dragging files out and add fallback if image can not be loaded (so drag and drop will still work)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- fix dragging files out
 
 <a id="1_52_1"></a>
 


### PR DESCRIPTION
closes #4550
