### PR TITLE
fix: context menu not working with keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Fixed
 - fix changelog message left unread not in the selected account as it should be but in another account. #4569
+- accessibility: some context menu items not working with keyboard navigation #4578
 - fix log format for logging core events #4572
 - fix dragging files out
 - memory leak when opening and closing emoji picker #4567

--- a/packages/frontend/scss/misc/_context_menu.scss
+++ b/packages/frontend/scss/misc/_context_menu.scss
@@ -42,6 +42,8 @@
     0 8px 24px rgba(16, 22, 26, 0.2);
 
   .item {
+    @include button-reset;
+    width: 100%;
     line-height: 20px;
     padding: 5px 12px;
     white-space: nowrap;

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -48,7 +48,7 @@ type ContextMenuLevel = {
  */
 export type OpenContextMenu = (args: showFnArguments) => Promise<void>
 
-const ScrollKeysToBlock = ['Space', 'PageUp', 'PageDown', 'End', 'Home']
+const ScrollKeysToBlock = ['PageUp', 'PageDown', 'End', 'Home']
 
 export function ContextMenuLayer({
   setShowFunction,
@@ -279,10 +279,6 @@ export function ContextMenu(props: {
             keyboardFocus.current = 0
           }
         }
-      } else if (ev.key == 'Enter') {
-        if (current) {
-          ;(current as HTMLDivElement)?.click()
-        }
       } else if (ev.code == 'Escape') {
         closeCallback()
         keyboardFocus.current = -1
@@ -320,7 +316,7 @@ export function ContextMenu(props: {
           }}
         >
           {level.items.map((item, index) => (
-            <div
+            <button
               className={classNames({
                 item: true,
                 selected: index === openSublevels[levelIdx],
@@ -354,7 +350,7 @@ export function ContextMenu(props: {
               {item.icon && <Icon className='left-icon' icon={item.icon} />}
               {item.label}
               {item.subitems && <div className='right-icon'></div>}
-            </div>
+            </button>
           ))}
         </div>
       ))}


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4242.

Based on https://github.com/deltachat/deltachat-desktop/pull/4577.

I tested various context menus (chat list, "three-dot menu",
messages' context menus) and found no issues with this change.
