### PR TITLE
chore: disable E2E test workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,6 +76,10 @@ env: # dummy certificates for testing
 
 jobs:
   test:
+    # Disable temporarily because they're not working
+    # at least 90% of the time.
+    if: false
+
     name: E2E Tests
     environment: test
     env:


### PR DESCRIPTION
This is letting other workflow failures go unnoticed because you just assume that the workflows will fail.