### PR TITLE
fix: freshly sent "Saved Messages" not displaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - fix changelog message left unread not in the selected account as it should be but in another account. #4569
 - accessibility: some context menu items not working with keyboard navigation #4578
+- fix messages sent to "Saved Messages" not being displayed sometimes #4582
 - fix clicking on message search result or "Reply Privately" quote not jumping to the message on first click sometimes, again #4554
 - fix log format for logging core events #4572
 - fix dragging files out

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -276,6 +276,27 @@ class MessageListStore extends Store<MessageListState> {
       }, 'messageChanged')
     },
     setMessageState: (messageId: number, messageState: number) => {
+      const messageLoaded = this.state.messageCache[messageId] != undefined
+      if (!messageLoaded) {
+        // This may happen when sending a message to "Saved Messages"
+        // on a new Chatmail account, where `MsgDelivered` would fire
+        // almost instantly after the send, even before `jumpToMessage`
+        // finishes for the new message.
+        // This results in jumpToMessage thinking that the message
+        // is already loaded, but in fact it would be just a husk
+        // of a Message object, with only the `state` property present.
+        //
+        // TODO should we handle it differently? Should we
+        // schedule a full message list re-fetch, or would it always
+        // be loaded later by other event listeners?
+        this.log.warn(
+          `setMessageState called for message ${messageId}, ` +
+            `state ${messageState}, but it's not loaded. ` +
+            "Ignoring, in hopes that we'll automatically load it later."
+        )
+        return
+      }
+
       this.setState(state => {
         const modifiedState: MessageListState = {
           ...state,

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -276,8 +276,7 @@ class MessageListStore extends Store<MessageListState> {
       }, 'messageChanged')
     },
     setMessageState: (messageId: number, messageState: number) => {
-      const messageLoaded = this.state.messageCache[messageId] != undefined
-      if (this.state.messageCache[messageId] === undefined) {
+      if (this.state.messageCache[messageId] == undefined) {
         // This may happen when sending a message to "Saved Messages"
         // on a new Chatmail account, where `MsgDelivered` would fire
         // almost instantly after the send, even before `jumpToMessage`

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -277,7 +277,7 @@ class MessageListStore extends Store<MessageListState> {
     },
     setMessageState: (messageId: number, messageState: number) => {
       const messageLoaded = this.state.messageCache[messageId] != undefined
-      if (!messageLoaded) {
+      if (this.state.messageCache[messageId] === undefined) {
         // This may happen when sending a message to "Saved Messages"
         // on a new Chatmail account, where `MsgDelivered` would fire
         // almost instantly after the send, even before `jumpToMessage`


### PR DESCRIPTION
It sometimes momentarily shows "loading message" before
displaying the message properly, and sometimes,
if you send a lot of messages rapidly, doesn't load the messages
at all until you re-open the chat
or reload the message list otherwise.

Before:

https://github.com/user-attachments/assets/438bd0b9-65d2-4652-b648-0ad1d607ac81

After:

https://github.com/user-attachments/assets/0a242f20-11b8-4ec6-8543-2c077d16180f

This has probably been surfaced by the last core upgrade,
i.e. the thing that also introduced
https://github.com/deltachat/deltachat-core-rust/issues/6468.
