### PR TITLE
improvement: better shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - shortcut improvements:
   - Ctrl + F now focuses search, instead of Ctrl + K
   - Ctrl + M now focuses composer, instead of Ctrl + N
+  - Ctrl + N now opens "New Chat" dialog
   - Pressing "Enter" or "Arrow Down" in the search focuses the first item
     (from which point arrow keys can be used to navigate items)
     instead of opening the first chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - shortcut improvements:
   - Ctrl + F now focuses search, instead of Ctrl + K
+  - Ctrl + M now focuses composer, instead of Ctrl + N
   - Pressing "Enter" or "Arrow Down" in the search focuses the first item
     (from which point arrow keys can be used to navigate items)
     instead of opening the first chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@
 - highlight the first unread message upon opening a chat #4525
 
 ### Changed
-- Ctrl + F now focuses search, instead of Ctrl + K
+- shortcut improvements:
+  - Ctrl + F now focuses search, instead of Ctrl + K
+  - Pressing "Enter" or "Arrow Down" in the search focuses the first item
+    (from which point arrow keys can be used to navigate items)
+    instead of opening the first chat
 - Improve backup transfer dialog (different message for connection step, timed message to tell user to check out troubleshooting, button to link to trouble shooting) #4476
 - store last used account in accounts.toml managed by core #4569
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - highlight the first unread message upon opening a chat #4525
 
 ### Changed
+- Ctrl + F now focuses search, instead of Ctrl + K
 - Improve backup transfer dialog (different message for connection step, timed message to tell user to check out troubleshooting, button to link to trouble shooting) #4476
 - store last used account in accounts.toml managed by core #4569
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Pressing "Enter" or "Arrow Down" in the search focuses the first item
     (from which point arrow keys can be used to navigate items)
     instead of opening the first chat
+  - Focusing the search input with a shortcut now doesn't clear it
 - Improve backup transfer dialog (different message for connection step, timed message to tell user to check out troubleshooting, button to link to trouble shooting) #4476
 - store last used account in accounts.toml managed by core #4569
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - shortcut improvements:
   - Ctrl + F now focuses search, instead of Ctrl + K
+  - Ctrl + Shift + F to search in chat
   - Ctrl + M now focuses composer, instead of Ctrl + N
   - Ctrl + N now opens "New Chat" dialog
   - Pressing "Enter" or "Arrow Down" in the search focuses the first item

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -10,6 +10,8 @@ Scroll active chat into view ~~`alt + arrow left`~~ _(disabled until we find a b
 
 Search contact list: `ctrl + f`
 
+Search in chat: `ctrl + f`
+
 Open "Create Chat" dialog: `ctrl + n`
 
 Focus message composer: `ctrl + m`

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -10,7 +10,7 @@ Scroll active chat into view ~~`alt + arrow left`~~ _(disabled until we find a b
 
 Search contact list: `ctrl + f`
 
-Focus message composer: `ctrl + n`
+Focus message composer: `ctrl + m`
 
 Select a message to reply to: `ctrl + arrow up`, `ctrl + arrow down`
 

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -10,6 +10,8 @@ Scroll active chat into view ~~`alt + arrow left`~~ _(disabled until we find a b
 
 Search contact list: `ctrl + f`
 
+Open "Create Chat" dialog: `ctrl + n`
+
 Focus message composer: `ctrl + m`
 
 Select a message to reply to: `ctrl + arrow up`, `ctrl + arrow down`

--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -8,7 +8,7 @@ Switch between chats: `alt + arrow down`, `alt + arrow up`,
 
 Scroll active chat into view ~~`alt + arrow left`~~ _(disabled until we find a better key combo, because this one collides with to mac system shortcut to move a word (see [#1796](https://github.com/deltachat/deltachat-desktop/issues/1796)))_
 
-Search contact list: `ctrl + k`
+Search contact list: `ctrl + f`
 
 Focus message composer: `ctrl + n`
 

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -231,7 +231,7 @@ export function getKeybindings(
       },
       {
         title: tx('focus_search_input'),
-        keyBindings: [['Control', 'K']],
+        keyBindings: [['Control', 'F']],
       },
       {
         title: tx('focus_message_input'),

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -234,6 +234,10 @@ export function getKeybindings(
         keyBindings: [['Control', 'F']],
       },
       {
+        title: tx('menu_new_chat'),
+        keyBindings: [['Control', 'N']],
+      },
+      {
         title: tx('focus_message_input'),
         keyBindings: [['Control', 'M']],
       },

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -234,6 +234,10 @@ export function getKeybindings(
         keyBindings: [['Control', 'F']],
       },
       {
+        title: tx('search_in_chat'),
+        keyBindings: [['Control', 'Shift', 'F']],
+      },
+      {
         title: tx('menu_new_chat'),
         keyBindings: [['Control', 'N']],
       },

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -235,7 +235,7 @@ export function getKeybindings(
       },
       {
         title: tx('focus_message_input'),
-        keyBindings: [['Control', 'N']],
+        keyBindings: [['Control', 'M']],
       },
       {
         title: tx('menu_reply'),

--- a/packages/frontend/src/components/SearchInput/index.tsx
+++ b/packages/frontend/src/components/SearchInput/index.tsx
@@ -51,6 +51,7 @@ export default function SearchInput(props: Props) {
         data-no-drag-region
         ref={props.inputRef}
         spellCheck={false}
+        // FYI there is also Ctrl + Shift + F to search in chat.
         aria-keyshortcuts='Control+F'
       />
       {hasValue && (

--- a/packages/frontend/src/components/SearchInput/index.tsx
+++ b/packages/frontend/src/components/SearchInput/index.tsx
@@ -51,7 +51,7 @@ export default function SearchInput(props: Props) {
         data-no-drag-region
         ref={props.inputRef}
         spellCheck={false}
-        aria-keyshortcuts='Control+K'
+        aria-keyshortcuts='Control+F'
       />
       {hasValue && (
         <SearchInputButton

--- a/packages/frontend/src/components/ThreeDotMenu.tsx
+++ b/packages/frontend/src/components/ThreeDotMenu.tsx
@@ -70,6 +70,10 @@ export function useThreeDotMenu(
       {
         label: tx('search_in_chat'),
         action: () => {
+          // Same as in with `KeybindAction.ChatList_SearchInChat`
+          //
+          // TODO improvement a11y: maybe we can add `aria-keyshortcuts=`
+          // to this menu item?
           window.__chatlistSetSearch?.('', selectedChat.id)
           setTimeout(
             () =>

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -178,6 +178,7 @@ export default function ChatList(props: {
   const { openDialog } = useDialog()
 
   const onCreateChat = () => {
+    // Same as `KeybindAction.NewChat_Open`.
     openDialog(CreateChat)
   }
 
@@ -481,6 +482,7 @@ export default function ChatList(props: {
                 onClick={onCreateChat}
                 id='new-chat-button'
                 aria-label={tx('menu_new_chat')}
+                aria-keyshortcuts='Control+N'
               >
                 <div
                   className='Icon'

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -161,6 +161,7 @@ export default function ChatList(props: {
   const createChatByContactId = useCreateChatByContactId()
   const { selectChat } = useChat()
 
+  const rovingTabindexItemsClassName = 'roving-tabindex'
   const tabindexWrapperElement = useRef<HTMLDivElement>(null)
 
   const addContactOnClick = async () => {
@@ -285,9 +286,19 @@ export default function ChatList(props: {
     }
   })
 
-  useKeyBindingAction(KeybindAction.ChatList_SelectFirstChat, () =>
-    selectFirstChat()
-  )
+  useKeyBindingAction(KeybindAction.ChatList_FocusItems, () => {
+    ;(
+      tabindexWrapperElement.current?.querySelector(
+        // Not just the first element, but the active one, i.e.
+        // if the user already interacted with the list we should not reset
+        // the current selection.
+        '.' + rovingTabindexItemsClassName + ':not([tabindex="-1"])'
+      ) as HTMLElement
+    )?.focus()
+  })
+  // useKeyBindingAction(KeybindAction.ChatList_SelectFirstChat, () =>
+  //   selectFirstChat()
+  // )
 
   const chatlistData = useMemo(() => {
     return {
@@ -352,6 +363,7 @@ export default function ChatList(props: {
                 </div>
                 <RovingTabindexProvider
                   wrapperElementRef={tabindexWrapperElement}
+                  classNameOfTargetElements={rovingTabindexItemsClassName}
                 >
                   <ChatListPart
                     isRowLoaded={isMessageLoaded}
@@ -393,6 +405,7 @@ export default function ChatList(props: {
               from DOM if scrolled out of view. */}
               <RovingTabindexProvider
                 wrapperElementRef={tabindexWrapperElement}
+                classNameOfTargetElements={rovingTabindexItemsClassName}
               >
                 <ChatListPart
                   isRowLoaded={isChatLoaded}

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -237,7 +237,7 @@ export default class ComposerMessageInput extends React.Component<
         disabled={this.state.loadingDraft}
         dir='auto'
         spellCheck={true}
-        aria-keyshortcuts='Control+N'
+        aria-keyshortcuts='Control+M'
       />
     )
   }

--- a/packages/frontend/src/components/screens/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen.tsx
@@ -126,6 +126,16 @@ export default function MainScreen({ accountId }: Props) {
     searchRef.current?.focus()
   })
 
+  useKeyBindingAction(KeybindAction.ChatList_SearchInChat, () => {
+    // Also see `search_in_chat` item in ThreeDotMenu.tsx
+    searchRef.current?.focus()
+    if (chatId == undefined) {
+      return
+    }
+    // Yes, preserve the search string. This might be nice.
+    searchChats(queryStr, chatId)
+  })
+
   useKeyBindingAction(KeybindAction.ChatList_ClearSearchInput, () => {
     handleSearchClear()
   })

--- a/packages/frontend/src/components/screens/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen.tsx
@@ -35,6 +35,7 @@ import { ChatView } from '../../contexts/ChatContext'
 import { ScreenContext } from '../../contexts/ScreenContext'
 
 import type { T } from '@deltachat/jsonrpc-client'
+import CreateChat from '../dialogs/CreateChat'
 
 type Props = {
   accountId?: number
@@ -127,6 +128,12 @@ export default function MainScreen({ accountId }: Props) {
 
   useKeyBindingAction(KeybindAction.ChatList_ClearSearchInput, () => {
     handleSearchClear()
+  })
+
+  const { openDialog } = useDialog()
+  useKeyBindingAction(KeybindAction.NewChat_Open, () => {
+    // Same as `onCreateChat` in ChatList.
+    openDialog(CreateChat)
   })
 
   useEffect(() => {

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -6,7 +6,12 @@ export enum KeybindAction {
   ChatList_SelectNextChat = 'chatlist:select-next-chat',
   ChatList_SelectPreviousChat = 'chatlist:select-previous-chat',
   ChatList_ScrollToSelectedChat = 'chatlist:scroll-to-selected-chat',
-  ChatList_SelectFirstChat = 'chatlist:select-first-chat',
+  /**
+   * "Items" instead of "Chats" because searching might show
+   * messages and contacts and not just chats.
+   */
+  ChatList_FocusItems = 'chatlist:focus-items',
+  // ChatList_SelectFirstChat = 'chatlist:select-first-chat',
   ChatList_FocusSearchInput = 'chatlist:focus-search',
   ChatList_ClearSearchInput = 'chatlist:clear-search',
   Composer_Focus = 'composer:focus',
@@ -27,7 +32,7 @@ export enum KeybindAction {
   // Composite Actions (actions that trigger other actions)
   ChatList_FocusAndClearSearchInput = 'chatlist:focus-and-clear-search',
   ChatList_ExitSearch = 'chatlist:exit-search',
-  ChatList_SearchSelectFirstChat = 'chatlist:search-select-first-chat',
+  // ChatList_SearchSelectFirstChat = 'chatlist:search-select-first-chat',
 
   // Debug
   Debug_MaybeNetwork = 'debug:maybe_network',
@@ -113,10 +118,11 @@ export function keyDownEvent2Action(
         return KeybindAction.Composer_CancelReply
       }
     } else if (
-      ev.key === 'Enter' &&
-      (ev.target as any).id === 'chat-list-search'
+      (ev.target as any).id === 'chat-list-search' &&
+      (ev.key === 'Enter' || ev.code === 'ArrowDown')
     ) {
-      return KeybindAction.ChatList_SearchSelectFirstChat
+      // return KeybindAction.ChatList_SearchSelectFirstChat
+      return KeybindAction.ChatList_FocusItems
     } else if (ev.code === 'F5') {
       return KeybindAction.Debug_MaybeNetwork
     } else if (ev.code === 'PageUp') {
@@ -167,10 +173,10 @@ ActionEmitter.registerHandler(KeybindAction.ChatList_ExitSearch, () => {
   ActionEmitter.emitAction(KeybindAction.Composer_Focus)
 })
 
-ActionEmitter.registerHandler(
-  KeybindAction.ChatList_SearchSelectFirstChat,
-  () => {
-    ActionEmitter.emitAction(KeybindAction.ChatList_SelectFirstChat)
-    ActionEmitter.emitAction(KeybindAction.Composer_Focus)
-  }
-)
+// ActionEmitter.registerHandler(
+//   KeybindAction.ChatList_SearchSelectFirstChat,
+//   () => {
+//     ActionEmitter.emitAction(KeybindAction.ChatList_SelectFirstChat)
+//     ActionEmitter.emitAction(KeybindAction.Composer_Focus)
+//   }
+// )

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -94,7 +94,7 @@ export function keyDownEvent2Action(
       //   return KeybindAction.ChatList_ScrollToSelectedChat
     } else if (ev.ctrlKey && ev.code === 'KeyF') {
       return KeybindAction.ChatList_FocusSearchInput
-    } else if (ev.ctrlKey && ev.code === 'KeyN') {
+    } else if (ev.ctrlKey && ev.code === 'KeyM') {
       return KeybindAction.Composer_Focus
     } else if (
       // Also consider adding this to `ev.repeat` when it stops being so sluggish

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -18,6 +18,7 @@ export enum KeybindAction {
   Composer_SelectReplyToUp = 'composer:select-reply-to-up',
   Composer_SelectReplyToDown = 'composer:select-reply-to-down',
   Composer_CancelReply = 'composer:cancel-reply',
+  NewChat_Open = 'new-chat:open',
   Settings_Open = 'settings:open',
   KeybindingCheatSheet_Open = 'keybindinginfo:open',
   MessageList_PageUp = 'msglist:pageup',
@@ -94,6 +95,8 @@ export function keyDownEvent2Action(
       //   return KeybindAction.ChatList_ScrollToSelectedChat
     } else if (ev.ctrlKey && ev.code === 'KeyF') {
       return KeybindAction.ChatList_FocusSearchInput
+    } else if (ev.ctrlKey && ev.code === 'KeyN') {
+      return KeybindAction.NewChat_Open
     } else if (ev.ctrlKey && ev.code === 'KeyM') {
       return KeybindAction.Composer_Focus
     } else if (

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -30,7 +30,7 @@ export enum KeybindAction {
   AboutDialog_Open = 'about:open',
 
   // Composite Actions (actions that trigger other actions)
-  ChatList_FocusAndClearSearchInput = 'chatlist:focus-and-clear-search',
+  // ChatList_FocusAndClearSearchInput = 'chatlist:focus-and-clear-search',
   ChatList_ExitSearch = 'chatlist:exit-search',
   // ChatList_SearchSelectFirstChat = 'chatlist:search-select-first-chat',
 
@@ -93,7 +93,7 @@ export function keyDownEvent2Action(
       // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
       //   return KeybindAction.ChatList_ScrollToSelectedChat
     } else if (ev.ctrlKey && ev.code === 'KeyF') {
-      return KeybindAction.ChatList_FocusAndClearSearchInput
+      return KeybindAction.ChatList_FocusSearchInput
     } else if (ev.ctrlKey && ev.code === 'KeyN') {
       return KeybindAction.Composer_Focus
     } else if (
@@ -160,13 +160,13 @@ export function keyDownEvent2Action(
 
 // Implementation of Composite Actions (actions that trigger other actions)
 
-ActionEmitter.registerHandler(
-  KeybindAction.ChatList_FocusAndClearSearchInput,
-  () => {
-    ActionEmitter.emitAction(KeybindAction.ChatList_FocusSearchInput)
-    ActionEmitter.emitAction(KeybindAction.ChatList_ClearSearchInput)
-  }
-)
+// ActionEmitter.registerHandler(
+//   KeybindAction.ChatList_FocusAndClearSearchInput,
+//   () => {
+//     ActionEmitter.emitAction(KeybindAction.ChatList_FocusSearchInput)
+//     ActionEmitter.emitAction(KeybindAction.ChatList_ClearSearchInput)
+//   }
+// )
 
 ActionEmitter.registerHandler(KeybindAction.ChatList_ExitSearch, () => {
   ActionEmitter.emitAction(KeybindAction.ChatList_ClearSearchInput)

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -13,6 +13,7 @@ export enum KeybindAction {
   ChatList_FocusItems = 'chatlist:focus-items',
   // ChatList_SelectFirstChat = 'chatlist:select-first-chat',
   ChatList_FocusSearchInput = 'chatlist:focus-search',
+  ChatList_SearchInChat = 'chatlist:search-in-chat',
   ChatList_ClearSearchInput = 'chatlist:clear-search',
   Composer_Focus = 'composer:focus',
   Composer_SelectReplyToUp = 'composer:select-reply-to-up',
@@ -94,6 +95,10 @@ export function keyDownEvent2Action(
       // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
       //   return KeybindAction.ChatList_ScrollToSelectedChat
     } else if (ev.ctrlKey && ev.code === 'KeyF') {
+      // https://github.com/deltachat/deltachat-desktop/issues/4579
+      if (ev.shiftKey) {
+        return KeybindAction.ChatList_SearchInChat
+      }
       return KeybindAction.ChatList_FocusSearchInput
     } else if (ev.ctrlKey && ev.code === 'KeyN') {
       return KeybindAction.NewChat_Open

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -87,7 +87,7 @@ export function keyDownEvent2Action(
       // } else if (ev.altKey && ev.code === 'ArrowLeft') {
       // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
       //   return KeybindAction.ChatList_ScrollToSelectedChat
-    } else if (ev.ctrlKey && ev.code === 'KeyK') {
+    } else if (ev.ctrlKey && ev.code === 'KeyF') {
       return KeybindAction.ChatList_FocusAndClearSearchInput
     } else if (ev.ctrlKey && ev.code === 'KeyN') {
       return KeybindAction.Composer_Focus


### PR DESCRIPTION
- **improvement: Ctrl + F to focus search**
- **improvement: Enter or ArrowDown to focus 1st item**
- **improvement: don't clear search on focus**
- **improvement: Ctrl+M to focus composer, not Ctrl+N**
- **feat: Ctrl + N to open "Create Chat"**
- **feat: add Ctrl + Shift + F to search in chat**
