### PR TITLE
refactor: improve styles in shortcut hint

### DIFF
--- a/packages/frontend/scss/misc/_keyboard_hint_box.scss
+++ b/packages/frontend/scss/misc/_keyboard_hint_box.scss
@@ -64,7 +64,7 @@
     flex-wrap: wrap;
     flex-direction: column;
     padding: 4px;
-    max-height: 80vH;
+    max-height: 80vh;
 
     .action {
       width: calc(50% - 15px);

--- a/packages/frontend/scss/misc/_keyboard_hint_box.scss
+++ b/packages/frontend/scss/misc/_keyboard_hint_box.scss
@@ -47,10 +47,9 @@
 }
 
 .keyboard-hint-cheatsheet-dialog {
-  width: 100% !important;
-  max-width: 840px !important;
+  width: 80% !important;
+  max-width: 560px !important;
   .keybinding {
-    flex-grow: 1;
     font-size: 0.84em;
   }
   h4 .keybinding {
@@ -63,13 +62,12 @@
   .keyboard-hint-dialog-body {
     display: flex;
     flex-wrap: wrap;
-    padding: 4px;
-    max-height: 80vh;
-
+    padding-left: 10px;
+    padding-bottom: 10px;
     .action {
       width: 260px;
-      margin: 7px;
-      padding: 10px;
+      margin: 4px;
+      padding: 7px;
     }
 
     h2 {

--- a/packages/frontend/scss/misc/_keyboard_hint_box.scss
+++ b/packages/frontend/scss/misc/_keyboard_hint_box.scss
@@ -47,7 +47,8 @@
 }
 
 .keyboard-hint-cheatsheet-dialog {
-  width: 70% !important;
+  width: 100% !important;
+  max-width: 840px !important;
   .keybinding {
     flex-grow: 1;
     font-size: 0.84em;
@@ -62,18 +63,17 @@
   .keyboard-hint-dialog-body {
     display: flex;
     flex-wrap: wrap;
-    flex-direction: column;
     padding: 4px;
     max-height: 80vh;
 
     .action {
-      width: calc(50% - 15px);
+      width: 260px;
       margin: 7px;
       padding: 10px;
     }
 
     h2 {
-      max-width: 240px;
+      max-width: 280px;
       font-size: 1.4em;
     }
   }

--- a/packages/frontend/scss/misc/_keyboard_hint_box.scss
+++ b/packages/frontend/scss/misc/_keyboard_hint_box.scss
@@ -48,7 +48,7 @@
 
 .keyboard-hint-cheatsheet-dialog {
   width: 80% !important;
-  max-width: 560px !important;
+  max-width: 570px !important;
   .keybinding {
     font-size: 0.84em;
   }
@@ -62,8 +62,8 @@
   .keyboard-hint-dialog-body {
     display: flex;
     flex-wrap: wrap;
-    padding-left: 10px;
     padding-bottom: 10px;
+    justify-content: space-evenly;
     .action {
       width: 260px;
       margin: 4px;

--- a/packages/frontend/scss/misc/_keyboard_hint_box.scss
+++ b/packages/frontend/scss/misc/_keyboard_hint_box.scss
@@ -3,7 +3,7 @@
 .keyboard-hint-cheatsheet-dialog {
   .keybinding {
     display: block;
-    margin-bottom: 7px;
+    padding: 7px 0;
 
     .key {
       background: var(--keybindingKeyBackground);
@@ -47,25 +47,29 @@
 }
 
 .keyboard-hint-cheatsheet-dialog {
+  width: 70% !important;
   .keybinding {
-    display: block;
     flex-grow: 1;
     font-size: 0.84em;
-    margin-bottom: 0;
+  }
+  h4 .keybinding {
+    flex: none;
+    margin-left: 20px;
+  }
+  .dialog-body {
+    padding-bottom: 0;
   }
   .keyboard-hint-dialog-body {
     display: flex;
     flex-wrap: wrap;
     flex-direction: column;
     padding: 4px;
-    max-height: 600px;
-    justify-content: space-evenly;
-    padding: 20px;
+    max-height: 80vH;
 
     .action {
-      max-width: 240px;
-      width: calc(50% - 7px);
-      margin-right: 7px;
+      width: calc(50% - 15px);
+      margin: 7px;
+      padding: 10px;
     }
 
     h2 {

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -199,9 +199,19 @@ function Shortcut(action: ShortcutAction): CheatSheetEntryType {
 
 export function CheatSheetKeyboardShortcut() {
   if (runtime.getRuntimeInfo().isMac) {
-    return <KeyboardShortcut elements={['Meta', '/']} />
+    return (
+      <>
+        <KeyboardShortcut elements={['Meta', '/']} />
+        <KeyboardShortcut elements={['Meta', '-']} />
+      </>
+    )
   } else {
-    return <KeyboardShortcut elements={['Control', '/']} />
+    return (
+      <>
+        <KeyboardShortcut elements={['Control', '/']} />
+        <KeyboardShortcut elements={['Control', '-']} />
+      </>
+    )
   }
 }
 

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -222,19 +222,10 @@ export function getKeybindings(
   const tx = window.static_translate
 
   return [
+    // Title(tx('desktop_keybindings_composer')),
+    ...enterKeySendsKeyboardShortcuts(settings['enterKeySends']).map(Shortcut),
     // Title(tx('desktop_keybindings_global')),
     ...[
-      {
-        title: tx('switch_between_chats'),
-        keyBindings: [
-          ['Alt', 'ArrowUp'],
-          ['Alt', 'ArrowDown'],
-          ['Control', 'PageUp'],
-          ['Control', 'PageDown'],
-          ['Control', 'Tab'],
-          ['Control', 'Shift', 'Tab'],
-        ],
-      },
       {
         title: tx('scroll_messages'),
         keyBindings: [['PageUp'], ['PageDown']],
@@ -256,14 +247,6 @@ export function getKeybindings(
         keyBindings: [['Control', 'M']],
       },
       {
-        title: tx('menu_reply'),
-        keyBindings: [
-          ['Control', 'ArrowUp'],
-          ['Control', 'ArrowDown'],
-          ['Esc'],
-        ],
-      },
-      {
         title: tx('menu_help'),
         keyBindings: [['F1']],
       },
@@ -275,8 +258,25 @@ export function getKeybindings(
         title: tx('force_refresh_network'),
         keyBindings: [['F5']],
       },
+      {
+        title: tx('switch_between_chats'),
+        keyBindings: [
+          ['Alt', 'ArrowUp'],
+          ['Alt', 'ArrowDown'],
+          ['Control', 'PageUp'],
+          ['Control', 'PageDown'],
+          ['Control', 'Tab'],
+          ['Control', 'Shift', 'Tab'],
+        ],
+      },
+      {
+        title: tx('menu_reply'),
+        keyBindings: [
+          ['Control', 'ArrowUp'],
+          ['Control', 'ArrowDown'],
+          ['Esc'],
+        ],
+      },
     ].map(Shortcut),
-    // Title(tx('desktop_keybindings_composer')),
-    ...enterKeySendsKeyboardShortcuts(settings['enterKeySends']).map(Shortcut),
   ]
 }

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -199,19 +199,9 @@ function Shortcut(action: ShortcutAction): CheatSheetEntryType {
 
 export function CheatSheetKeyboardShortcut() {
   if (runtime.getRuntimeInfo().isMac) {
-    return (
-      <>
-        <KeyboardShortcut elements={['Meta', '/']} />
-        <KeyboardShortcut elements={['Meta', '-']} />
-      </>
-    )
+    return <KeyboardShortcut elements={['Meta', '/']} />
   } else {
-    return (
-      <>
-        <KeyboardShortcut elements={['Control', '/']} />
-        <KeyboardShortcut elements={['Control', '-']} />
-      </>
-    )
+    return <KeyboardShortcut elements={['Control', '/']} />
   }
 }
 
@@ -222,9 +212,7 @@ export function getKeybindings(
   const tx = window.static_translate
 
   return [
-    // Title(tx('desktop_keybindings_composer')),
     ...enterKeySendsKeyboardShortcuts(settings['enterKeySends']).map(Shortcut),
-    // Title(tx('desktop_keybindings_global')),
     ...[
       {
         title: tx('scroll_messages'),

--- a/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
+++ b/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
@@ -33,7 +33,7 @@ export default function KeybindingCheatSheet(props: DialogProps) {
           <CheatSheetKeyboardShortcut />
         </DialogHeading>
       </DialogHeader>
-      <DialogBody>
+      <DialogBody className='dialog-body'>
         <div className='keyboard-hint-dialog-body'>
           {settingsStore &&
             getKeybindings(settingsStore.desktopSettings).map(entry => {


### PR DESCRIPTION
- add alternative shortcut to open shortcut hints


Before:

![image](https://github.com/user-attachments/assets/c18b224e-bad1-467f-85c4-304dbf89f7fd)


After:

![image](https://github.com/user-attachments/assets/7bd70cd7-4c99-4a41-b7eb-45b6ebe639ea)

#skip-changelog
