### PR TITLE
test: upgrade playwright to 1.50

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -76,10 +76,6 @@ env: # dummy certificates for testing
 
 jobs:
   test:
-    # Disable temporarily because they're not working
-    # at least 90% of the time.
-    if: false
-
     name: E2E Tests
     environment: test
     env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
       run: npm install -g pnpm && pnpm install
     - name: Install Playwright Browsers
       working-directory: ./packages/e2e-tests
-      run: npx playwright install --with-deps
+      run: npx playwright install --with-deps --only-shell chromium
     - name: create data dir
       run: mkdir -p packages/target-browser/data
     - name: Run e2e tests

--- a/docs/E2E-TESTING.md
+++ b/docs/E2E-TESTING.md
@@ -17,7 +17,7 @@ This package depends on the target-browser so make sure you prepared that to run
 But don't run the browser at the same time, it will be started inside the test routine.
 
 ```sh
-pnpm -w e2e --project <chromium | firefox | Chrome>
+pnpm -w e2e
 ```
 
 for headless usage
@@ -25,7 +25,7 @@ for headless usage
 or
 
 ```sh
-pnpm -w e2e --project <chromium | firefox | Chrome> --ui
+pnpm -w e2e --ui
 ```
 
 for [UI mode](https://playwright.dev/docs/test-ui-mode)

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "GPL-3.0-or-later",
   "devDependencies": {
-    "@playwright/test": "^1.48.1",
+    "@playwright/test": "^1.50.0",
     "@types/node": "^20.14.13"
   },
   "scripts": {

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [['list'], ['html']],
   // timeout: 30 * 60 * 1000,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
@@ -39,24 +39,17 @@ export default defineConfig({
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
+      name: 'Chrome',
       use: {
         ...devices['Desktop Chrome'],
       },
     },
-    {
-      name: 'firefox',
-      use: {
-        ...devices['Desktop Firefox'],
-      },
-    },
-    {
-      name: 'Chrome', // Google Chrome
-      use: {
-        ...devices['Desktop Chrome'],
-        channel: 'chrome',
-      },
-    },
+    // {
+    //   name: 'firefox',
+    //   use: {
+    //     ...devices['Desktop Firefox'],
+    //   },
+    // },
 
     // {
     //   name: 'webkit',

--- a/packages/e2e-tests/tests/basic-functionality.spec.ts
+++ b/packages/e2e-tests/tests/basic-functionality.spec.ts
@@ -170,7 +170,7 @@ test('send message', async ({ page }) => {
   expect(receivedMessageText).toEqual(messageText)
 })
 
-test('add app from picker to chat', async ({ page }) => {
+test.skip('add app from picker to chat', async ({ page }) => {
   const userA = existingProfiles[0]
   const userB = existingProfiles[1]
   await switchToProfile(page, userA.id)

--- a/packages/e2e-tests/tests/basic-functionality.spec.ts
+++ b/packages/e2e-tests/tests/basic-functionality.spec.ts
@@ -170,7 +170,7 @@ test('send message', async ({ page }) => {
   expect(receivedMessageText).toEqual(messageText)
 })
 
-test.skip('add app from picker to chat', async ({ page }) => {
+test('add app from picker to chat', async ({ page }) => {
   const userA = existingProfiles[0]
   const userB = existingProfiles[1]
   await switchToProfile(page, userA.id)

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -73,21 +73,26 @@ export function AppPicker({ className, onSelect, apps = [] }: Props) {
         }
       }
       const newIcons: { [key: string]: string } = {}
+      for (const app of apps) {
+        newIcons[app.app_id] = `./images/icons/image_outline.svg`
+      }
+      setIcons(newIcons)
       let count = 0
       for (const app of apps) {
-        const response = (await BackendRemote.rpc.getHttpResponse(
-          selectedAccountId(),
-          AppStoreUrl + app.icon_relname
-        )) as { blob: string }
-        if (response?.blob !== undefined) {
-          newIcons[app.app_id] = `data:image/png;base64,${response.blob}`
-        }
-        count++
-        if (count % 10 === 0) {
-          setIcons({ ...newIcons })
-        }
+        BackendRemote.rpc
+          .getHttpResponse(selectedAccountId(), AppStoreUrl + app.icon_relname)
+          .then((response: { blob: string }) => {
+            if (response?.blob !== undefined) {
+              newIcons[app.app_id] = `data:image/png;base64,${response.blob}`
+            }
+            count++
+            if (count === apps.length) {
+              setIcons({ ...newIcons })
+            } else if (count % 10 === 0) {
+              setIcons({ ...newIcons })
+            }
+          })
       }
-      setIcons({ ...newIcons })
     }
     loadIcons()
   }, [apps, isOffline])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,8 +81,8 @@ importers:
   packages/e2e-tests:
     devDependencies:
       '@playwright/test':
-        specifier: ^1.48.1
-        version: 1.48.1
+        specifier: ^1.50.0
+        version: 1.50.1
       '@types/node':
         specifier: ^20.14.13
         version: 20.14.15
@@ -1209,8 +1209,8 @@ packages:
     resolution: {integrity: sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.48.1':
-    resolution: {integrity: sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==}
+  '@playwright/test@1.50.1':
+    resolution: {integrity: sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2967,13 +2967,13 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
-  playwright-core@1.48.1:
-    resolution: {integrity: sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==}
+  playwright-core@1.50.1:
+    resolution: {integrity: sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.48.1:
-    resolution: {integrity: sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==}
+  playwright@1.50.1:
+    resolution: {integrity: sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4180,9 +4180,9 @@ snapshots:
 
   '@pkgr/core@0.1.1': {}
 
-  '@playwright/test@1.48.1':
+  '@playwright/test@1.50.1':
     dependencies:
-      playwright: 1.48.1
+      playwright: 1.50.1
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -6200,11 +6200,11 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
-  playwright-core@1.48.1: {}
+  playwright-core@1.50.1: {}
 
-  playwright@1.48.1:
+  playwright@1.50.1:
     dependencies:
-      playwright-core: 1.48.1
+      playwright-core: 1.50.1
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
Since current chrome has no builtin headless mode anymore we have to update playwright

The tests on Windows & MacOS are very flaky, so removed to have not too many false positives. in the CI pipeline

Our copy process also often fails, so needs some future improvements...

I tried to speed up the App picker loading, by not waiting for the icon load promises.

#skip-changelog