### PR TITLE
fix: arrow-key nav widgets being unfocusble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - accessibility: some context menu items not working with keyboard navigation #4578
 - fix messages sent to "Saved Messages" not being displayed sometimes #4582
 - fix clicking on message search result or "Reply Privately" quote not jumping to the message on first click sometimes, again #4554
+- accessibility: not being able to focus arrow-key navigable widgets that contain disabled items with disabled elements (such as in the "add contacts to group" widget)
 - fix jumping to message in a different chat momentarily opening the new chat scrolled to bottom before scrolling it to the desired message #4562
 - fix log format for logging core events #4572
 - fix dragging files out

--- a/packages/frontend/src/components/contact/ContactListItem.tsx
+++ b/packages/frontend/src/components/contact/ContactListItem.tsx
@@ -103,10 +103,10 @@ export function ContactListItem(props: {
         // still want to keep it focusable so that the context menu can be
         // activated, and for screen-readers.
         aria-disabled={disabled}
+        // Keep in mind that we have to be careful with disabled elements
+        // that are also part of the roving tabindex widget,
+        // because `tabindex="0"` does _not_ make disabled elements focusable.
         disabled={disabled && !onContextMenu}
-        // FYI this makes this element keyboard-navigarble
-        // regardless of whether it is disabled.
-        // This is probably fine.
         tabIndex={rovingTabindex.tabIndex}
         onClick={() => {
           if (disabled) return

--- a/packages/frontend/src/components/helpers/PseudoListItem.tsx
+++ b/packages/frontend/src/components/helpers/PseudoListItem.tsx
@@ -38,6 +38,8 @@ export function PseudoListItem(
         ref={buttonRef}
         className={'contact-list-item-button ' + rovingTabindex.className}
         onClick={onClick}
+        // Keep in mind that `tabIndex="0"` will _not_
+        // make the element focusable.
         disabled={!onClick}
         style={style}
         tabIndex={rovingTabindex.tabIndex}


### PR DESCRIPTION
Reproduction steps:
1. Create a group with one more contact.
2. Open the "View Group" dialog.
3. Click "Add Members"
4. Arrow-key navigate to the member that is already
  part of the group.
  You'll notice that you pressed the arrow key,
  but the focus didn't change.
5. Press Tab.

Now you will not be able to focus the widget with Shift + Tab,
because the "active element"
(the only element that doesn't have tabindex="-1") is not focusable.
