### PR TITLE
streamline help menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   - Focusing the search input with a shortcut now doesn't clear it
 - Improve backup transfer dialog (different message for connection step, timed message to tell user to check out troubleshooting, button to link to trouble shooting) #4476
 - store last used account in accounts.toml managed by core #4569
+- update help menu URLs #4598
 
 ### Fixed
 - fix changelog message left unread not in the selected account as it should be but in another account. #4569

--- a/packages/target-electron/src/menu.ts
+++ b/packages/target-electron/src/menu.ts
@@ -289,15 +289,15 @@ export function getHelpMenu(
         accelerator: isMac ? 'Cmd+/' : 'Ctrl+/',
       },
       {
-        label: tx('global_menu_help_learn_desktop'),
+        label: tx('delta_chat_homepage'),
         click: () => {
           shell.openExternal(homePageUrl)
         },
       },
       {
-        label: tx('global_menu_help_contribute_desktop'),
+        label: tx('contribute'),
         click: () => {
-          shell.openExternal(gitHubUrl)
+          shell.openExternal('https://delta.chat/contribute')
         },
       },
       {

--- a/packages/target-electron/src/menu.ts
+++ b/packages/target-electron/src/menu.ts
@@ -289,6 +289,9 @@ export function getHelpMenu(
         accelerator: isMac ? 'Cmd+/' : 'Ctrl+/',
       },
       {
+        type: 'separator',
+      },
+      {
         label: tx('delta_chat_homepage'),
         click: () => {
           shell.openExternal(homePageUrl)
@@ -301,13 +304,13 @@ export function getHelpMenu(
         },
       },
       {
-        type: 'separator',
-      },
-      {
         label: tx('global_menu_help_report_desktop'),
         click: () => {
           shell.openExternal(gitHubIssuesUrl)
         },
+      },
+      {
+        type: 'separator',
       },
       {
         label: tx('global_menu_help_about_desktop'),

--- a/packages/target-electron/src/menu.ts
+++ b/packages/target-electron/src/menu.ts
@@ -4,7 +4,6 @@ import { join } from 'path'
 
 import {
   gitHubIssuesUrl,
-  gitHubUrl,
   homePageUrl,
   appWindowTitle,
 } from '../../shared/constants.js'


### PR DESCRIPTION
- do not advertise "Github" in our menu, also, contributions can be translations, donations, whatnot. just link to our own "contribute" page

- change homepage title to "Delta Chat Homepage", the old "Learn more about ..." opened questions :)

- group "online" actions together; the old separator was a but random

with this PR, things are in sync again with android/iOS, see https://github.com/deltachat/deltachat-android/pull/3556 and https://github.com/deltachat/deltachat-ios/pull/2545


<img width="550" alt="Screenshot 2025-02-03 at 18 38 11" src="https://github.com/user-attachments/assets/00eca149-d0ed-4fc6-8658-0c988ae6dc5d" />

