### PR TITLE
WIP: add background color for read/noticed/fresh

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -310,6 +310,17 @@
   }
 }
 
+.message {
+  transition: background-color 2s;
+  &.status_in_fresh {
+    background-color: #88ff8860;
+  }
+  &.status_in_noticed {
+    background-color: #8888ff30;
+  }
+  // &.status_in_seen {}
+}
+
 .message.forwarded {
   .forwarded-indicator {
     font-weight: bold;

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -84,12 +84,12 @@ const Message = React.memo<
   summaryPreviewImage,
   lastMessageId,
 }) {
-  const wasReceived =
+  const isIncoming =
     summaryStatus === C.DC_STATE_IN_FRESH ||
     summaryStatus === C.DC_STATE_IN_SEEN ||
     summaryStatus === C.DC_STATE_IN_NOTICED
 
-  const status = wasReceived ? '' : mapCoreMsgStatus2String(summaryStatus)
+  const status = isIncoming ? '' : mapCoreMsgStatus2String(summaryStatus)
 
   const iswebxdc = summaryPreviewImage === 'webxdc-icon://last-msg-id'
 

--- a/packages/frontend/src/components/helpers/MapMsgStatus.ts
+++ b/packages/frontend/src/components/helpers/MapMsgStatus.ts
@@ -16,11 +16,11 @@ export function mapCoreMsgStatus2String(state: number): msgStatus {
     case C.DC_STATE_OUT_MDN_RCVD:
       return 'read'
     case C.DC_STATE_IN_FRESH:
-      return 'delivered'
+      return 'in_fresh'
     case C.DC_STATE_IN_SEEN:
-      return 'delivered'
+      return 'in_seen'
     case C.DC_STATE_IN_NOTICED:
-      return 'read'
+      return 'in_noticed'
     default:
       return '' // to display no icon on unknown state
   }

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -754,6 +754,7 @@ export default function Message(props: {
           [styles.withReactions]: message.reactions && !isSetupmessage,
           'type-sticker': viewType === 'Sticker',
           error: status === 'error',
+          [`status_${status}`]: true,
           forwarded: message.isForwarded,
           'has-html': hasHtml,
         }

--- a/packages/frontend/src/types-app.d.ts
+++ b/packages/frontend/src/types-app.d.ts
@@ -27,4 +27,7 @@ export type msgStatus =
   | 'delivered'
   | 'read'
   | 'sent'
+  | 'in_fresh'
+  | 'in_seen'
+  | 'in_noticed'
   | ''


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/0805c43a-4c92-4908-bbfa-6eafa94bd8dc)


This does not work though because we do not listen
for the relevant events.
The displayed status does not reflect the status shown in the
"Message Info" dialog.

This was supposed to be mainly to help debug issues like:
- https://github.com/deltachat/deltachat-desktop/issues/2975
- https://github.com/deltachat/deltachat-desktop/issues/3978
- https://github.com/deltachat/deltachat-desktop/issues/3072

And potentially as a visual enhancement.
