### PR TITLE
fix: enable attach to node process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,16 +2,12 @@
     "version": "0.2.0",
     "configurations": [
         {
-        "name": "Debug Main Process",
         "type": "node",
-        "request": "launch",
-        "cwd": "${workspaceRoot}",
-        "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
-        "windows": {
-            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
-        },
-        "args" : ["."],
-        "outputCapture": "std"
+        "request": "attach",
+        "name": "Debug Main Process",
+        "sourceMaps": true,
+        "restart": true,
+        "port": 9229,
         }
     ]
 }


### PR DESCRIPTION
To be reviewed by someone who uses VScode.

Electron has to be started with pnpm debug:electron