### PR TITLE
make log additionally available at "Settings / Advanced / View Log"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - highlight the first unread message upon opening a chat #4525
 - enable notifications on mentions in muted chats #4538
 - always show accounts with unread messages, even when they're normally scrolled out of view #4536
+- make log additionally available at "Settings / Advanced / View Log" #4610
 
 ### Changed
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.155.2`

--- a/packages/frontend/src/components/Settings/Advanced.tsx
+++ b/packages/frontend/src/components/Settings/Advanced.tsx
@@ -11,6 +11,7 @@ import Communication from './Communication'
 import EditAccountAndPasswordDialog from '../dialogs/EditAccountAndPasswordDialog'
 import useDialog from '../../hooks/dialog/useDialog'
 import SettingsButton from './SettingsButton'
+import { runtime } from '@deltachat-desktop/runtime-interface'
 
 type Props = {
   settingsStore: SettingsStoreState
@@ -22,6 +23,9 @@ export default function Advanced({ settingsStore }: Props) {
 
   return (
     <>
+      <SettingsButton onClick={() => runtime.openLogFile()}>
+        {tx('pref_view_log')}
+      </SettingsButton>
       <Communication settingsStore={settingsStore} />
       <SettingsSeparator />
 


### PR DESCRIPTION
closes #4483