### PR TITLE
fix: don't show error on empty chat double click

### DIFF
--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -958,13 +958,9 @@ function JumpDownButton({
 }: {
   accountId: number
   chat: Parameters<typeof useUnreadCount>[1]
-  jumpToMessage: (params: {
-    msgId: number | undefined
-    highlight?: boolean
-    addMessageIdToStack?: undefined | number
-    scrollIntoViewArg?: Parameters<HTMLElement['scrollIntoView']>[0]
-    focus: boolean
-  }) => Promise<void>
+  jumpToMessage: ReturnType<
+    typeof useMessageList
+  >['store']['effect']['jumpToMessage']
   jumpToMessageStack: number[]
 }) {
   const countUnreadMessages = useUnreadCount(accountId, chat)

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -78,6 +78,7 @@ export const ChatProvider = ({
       }
 
       // Jump to last message if user clicked chat twice
+      // Remember that there might be no messages in the chat.
       // @TODO: We probably want this to be part of the UI logic instead
       if (nextChatId === chatId) {
         window.__internal_jump_to_message_asap = {

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -465,7 +465,8 @@ class MessageListStore extends Store<MessageListState> {
      * `MessageListStore` when `chatId` or `accountId` changes.
      *
      * @param msgId - when `undefined`, pop the jump stack, or,
-     * if the stack is empty, jump to last message.
+     * if the stack is empty, jump to last message
+     * if there _is_ a last message.
      * @param addMessageIdToStack the ID of the message to remember,
      * to later go back to it, using the "jump down" button.
      * The message with the specified ID must belong to the chat with ID
@@ -527,6 +528,16 @@ class MessageListStore extends Store<MessageListState> {
                 m.kind === 'message' ? m.msg_id : C.DC_MSG_ID_LAST_SPECIAL
               )
               .filter(msgId => msgId !== C.DC_MSG_ID_LAST_SPECIAL)
+
+            if (items.length <= 0) {
+              // This can happen when clicking the chat in the chat list twice,
+              // which is supposed to jump to the last message.
+
+              // Since we haven't changed `viewState`, `MessageList` won't
+              // call `unlockScroll()`, so let's unlock it now.
+              return false
+            }
+
             jumpToMessageId = items[items.length - 1]
             chatId =
               chatIdPreset ??


### PR DESCRIPTION
1. Open a chat with no messages.
2. Click on the currently open chat in the chat list.

The messages list will display an error
"cannot read toString of undefined" on MessageList.ts line 374.

The bug was surfaced by 28aa40a515a5d4ac3ff4d792007da57b401c0d93.
The bug existed before, but we wouldn't show error:
`jumpToMessage` would simply throw on `await getMessage()` instead.

#skip-changelog because the bug has not been released.
