### PR TITLE
refactor: fix Electron type error

### DIFF
--- a/packages/target-electron/bin/printCheckWarning.js
+++ b/packages/target-electron/bin/printCheckWarning.js
@@ -2,3 +2,7 @@ console.log('\x1b[31mHint:\x1b[0m')
 console.log(
   '\x1b[33mIf there are many errors and/or you just packaged deltachat-desktop-electron, then try resetting node_modules with "\x1b[1m\x1b[36mpnpm -w run reset:node_modules\x1b[0m"'
 )
+
+// This file is only executed on error, so let's make sure the entire command
+// also gives an error.
+process.exitCode = -1

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -287,7 +287,7 @@ app.on('activate', () => {
   }
 })
 app.on('before-quit', e => quit(e))
-app.on('window-all-closed', (e: Electron.Event) => quit(e))
+app.on('window-all-closed', () => quit())
 
 app.on('web-contents-created', (_ev, contents) => {
   const is_webxdc =


### PR DESCRIPTION
Looks like the event never passed an argument:
https://github.com/electron/electron/blob/624b6b97626d9baef48f60b67d84031b0a614870/docs/api/app.md?plain=1#L32-L39.
So this change does not affect behavior and only has to do with types.

This became an error after the recent Electron 32 -> 34 upgrade.

The first commit ("don't ignore Electron `check:types` err") makes sure that such errors don't get ignored.

#skip-changelog
