### PR TITLE
Show parts of new URL instead incoming values

### DIFF
--- a/packages/frontend/src/components/message/Link.tsx
+++ b/packages/frontend/src/components/message/Link.tsx
@@ -144,7 +144,7 @@ function LabeledLinkConfirmationDialog(
                 .then(() => props.onClose())
             }}
           >
-            {tx('copy')}
+            {tx('global_menu_edit_copy_desktop')}
           </FooterActionButton>
           <FooterActionButton onClick={props.onClose}>
             {tx('cancel')}

--- a/packages/frontend/src/components/message/Link.tsx
+++ b/packages/frontend/src/components/message/Link.tsx
@@ -106,7 +106,7 @@ function LabeledLinkConfirmationDialog(
   const openLinkSafely = useOpenLinkSafely()
   const [isChecked, setIsChecked] = useState(false)
   const toggleIsChecked = () => setIsChecked(checked => !checked)
-
+  const url = new URL(props.target)
   return (
     <Dialog onClose={props.onClose}>
       <DialogBody>
@@ -119,7 +119,7 @@ function LabeledLinkConfirmationDialog(
               maxHeight: '50vh',
             }}
           >
-            {props.realUrl}
+            {url.href}
           </p>
           <div style={{ display: 'flex' }}>
             <DeltaCheckbox checked={isChecked} onClick={toggleIsChecked} />
@@ -128,7 +128,7 @@ function LabeledLinkConfirmationDialog(
                 tx('open_external_url_trust_domain', '$$hostname$$'),
                 '$$hostname$$',
                 () => (
-                  <i>{props.hostName}</i>
+                  <i>{url.hostname}</i>
                 )
               )}
             </div>
@@ -181,6 +181,7 @@ export const Link = ({
   const processQr = useProcessQr()
   const asciiUrl = punycode ? punycode.punycode_encoded_url : target
 
+  const constructedUrl = new URL(target)
   const onClick = (ev: any) => {
     ev.preventDefault()
     ev.stopPropagation()
@@ -195,6 +196,15 @@ export const Link = ({
         originalHostname: punycode.original_hostname,
         asciiHostname: punycode.ascii_hostname,
         asciiUrl: punycode.punycode_encoded_url,
+      })
+    } else if (
+      destination.hostname?.toLowerCase() !==
+      constructedUrl.hostname.toLowerCase()
+    ) {
+      openDialog(PunycodeUrlConfirmationDialog, {
+        originalHostname: destination.hostname ?? '',
+        asciiHostname: constructedUrl.hostname,
+        asciiUrl: constructedUrl.href,
       })
     } else {
       openLinkSafely(accountId, target)


### PR DESCRIPTION
resolves partly #4559 

This PR fixes two issues:

- punycode is shown to the user
- detect capital letters looking similar to other lower case letters like capital i looking like lower case L in some font-types (l != I)  and show a warning

It does not fix the issue that message parser is too greedy and adds some characters to domain names. (https://github.com/deltachat/message-parser/issues/91)

Before: opening a markup link with trailing )

![image](https://github.com/user-attachments/assets/b5f4044e-e00e-469d-9bbf-d8b7d5a5beb4)

After:

![image](https://github.com/user-attachments/assets/b4098ef8-c433-4213-8cb4-46fb0eaa1d2b)


Clicking a link like https://deIta.chat just opened https://deita.chat

Now:

![image](https://github.com/user-attachments/assets/e9c28f4c-13f2-4415-9ccc-fa9f7d1beb3e)


#skip-changelog