### PR TITLE
fix: tauri: build failing (base64 dependency)

### DIFF
--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -39,7 +39,7 @@ mime = "0.3.17"
 percent-encoding = "2"
 thiserror = "2.0.11"
 png = "0.*"
-base64 = "0.*"
+base64 = "0.22.1"
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]


### PR DESCRIPTION
Apparently it started failing after https://github.com/deltachat/deltachat-desktop/pull/4533.

#skip-changelog