### PR TITLE
fix: chat list & chat view desync, again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- fix chat list showing the chat that is different from the currently selected chat when switching chats rapidly, again #4628
 
 <a id="1_53_0"></a>
 


### PR DESCRIPTION
This is a follow-up to
https://github.com/deltachat/deltachat-desktop/issues/4501
(166ee8acf0c479728210f6d3d37367d3032b41e5).

The issue now is that `cancelPendingSetChat.current = undefined`
unsets the cancel function for a different `selectChat()` call.

This happens when you selectChat more than 2 times
in a quick succession. And can go like this:

1. set cancelPendingSetChat for chat 1
2. set cancelPendingSetChat for chat 2
3. chat loaded 1
4. unset cancelPendingSetChat, from chat 1
5. set cancelPendingSetChat for chat 3
6. chat loaded 3
7. unset cancelPendingSetChat, from chat 3
8. chat loaded 2
9. unset cancelPendingSetChat, from chat 2

As you can see, when we called `selectChat(2)`,
it set cancelPendingSetChat (entry 2), but chat 1 loaded first,
and it unset cancelPendingSetChat (entry 4).
So when we called `selectChat(3)` (entry 5), it thought that
there is nothing to cancel, so it didn't actually cancel
the loading of the previous chat 2.
Chat 2 loaded last, but its `cancelled` was `false`
so it replaced the state.
But it should not have happened, because `selectChat(3)`
was called last.

Basically, as you can see from the code,
this commit ensures that one `selectChat` cannot reset
`cancelPendingSetChat.current` if it belongs to a different
`selectChat()` call.
