### PR TITLE
fix: message list freezes on selectChat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - "Show in Chat" in Gallery not working #4629
+- Fix ~3 second freeze after switching the chat #4638
 - fix chat list showing the chat that is different from the currently selected chat when switching chats rapidly, again #4628
 - fix a resource leak accumulating when opening media in full screen #4634
 

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -452,6 +452,9 @@ class MessageListStore extends Store<MessageListState> {
      * from `this.state.messageCache`,
      * reloading `messageListItems` if the message is missing from there,
      * and showing the message in a chat other than `this.chatId`.
+     * The latter (showing the message from a different chat), however,
+     * should not be used, because, as of 2025-01-19, we re-create
+     * `MessageListStore` when `chatId` or `accountId` changes.
      *
      * Currently this function (as well as the MessageListStore)
      * is only directly used by the MessageList component.
@@ -459,10 +462,6 @@ class MessageListStore extends Store<MessageListState> {
      * `MessageListStore`, and with an option to jump to message
      * from a different chat, use `const { jumpToMessage } = useMessage()`,
      * (it will internally casue this function to be invoked).
-     *
-     * The latter (showing the message from a different chat), however,
-     * should not be used, because, as of 2025-01-19, we re-create
-     * `MessageListStore` when `chatId` or `accountId` changes.
      *
      * @param msgId - when `undefined`, pop the jump stack, or,
      * if the stack is empty, jump to last message

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -13,6 +13,9 @@ import { ChatStoreScheduler } from './chat/chat_scheduler'
 import { useEffect, useMemo, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { debounce } from 'debounce'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+
+const log = getLogger('messagelist')
 
 const PAGE_SIZE = 11
 
@@ -1071,5 +1074,13 @@ async function loadMessages(
   )
     .map(m => (m.kind === 'message' ? m.msg_id : C.DC_MSG_ID_LAST_SPECIAL))
     .filter(msgId => msgId !== C.DC_MSG_ID_LAST_SPECIAL)
+
+  if (view.length > 100) {
+    log.error(
+      `loadMessages is loading too many (${view.length}) messages. ` +
+        'This is bad for performance.'
+    )
+  }
+
   return await BackendRemote.rpc.getMessages(accountId, view)
 }


### PR DESCRIPTION
FYI this moves the jumpToMessage function without changing it.

This should fix the bug where we'd try to load too many messages,
namely (almost) all messages of the chat.

The problem is that `loadChat` might return early,
to delegate its job to `effect.jumpToMessage`,
but there could already be other effects
(such as `fetchMoreMessagesTop`) already queued up,
so the `effect.jumpToMessage` would get added
to the back of the queue, resulting in other operations getting
executed prior to the `jumpToMessage`.
Those other operations do not work well with an uninitialized
store state, namely when
`oldestFetchedMessageListItemIndex` is `-1`.

In particular, `fetchMoreMessagesTop` would call `loadMessages`
with `newestFetchedMessageListItemIndex === -2` and
`oldestFetchedMessageListItemIndex === 0`, which, in turn,
would call `getMessages()` with the list of almost all message IDs.

Reproduction steps (not 100% reliable):
1. Open chat 1.
2. Receive a message in chat 2.
  Use a different device to send the message.
  It is preferable to keep the window focused.
3. Wait ~5 seconds (not sure why).
4. Click on chat 2 in the chat list.

Chat 2 will open, but with a much greater delay.

https://github.com/user-attachments/assets/32680a08-af8c-4773-93cc-138c7ec13711

This commit also has potential to fix the issue
where the messages list does not show any messages
when the chat gets opened.
And maybe other problems might get fixed, because this fixes
a race condition.

The problem has likely been surfaced by the recent "performance"
changes and bug fixes related to messagelist.ts.
Users report that it has become noticeable on 1.53.0, see diff:
https://github.com/deltachat/deltachat-desktop/compare/v1.52.1...v1.53.0

I tested this for ~15 minutes with various other `jumpToMessage`s (e.g. from gallery, from notification), and found no issues.