### PR TITLE
[Tauri] Menu bars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,6 +1755,7 @@ dependencies = [
  "tauri-plugin-devtools",
  "tauri-plugin-dialog",
  "tauri-plugin-log",
+ "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
@@ -8412,6 +8413,28 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.11",
  "time 0.3.37",
+]
+
+[[package]]
+name = "tauri-plugin-opener"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635ed7c580dc3cdc61c94097d38ef517d749ffc0141c806d904e68e4b0cf1c2a"
+dependencies = [
+ "dunce",
+ "glob",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "open",
+ "schemars",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.11",
+ "url",
+ "windows 0.58.0",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1680,8 +1680,8 @@ dependencies = [
  "sha2",
  "shadowsocks",
  "smallvec",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "tagger",
  "textwrap",
  "thiserror 2.0.11",
@@ -1749,6 +1749,8 @@ dependencies = [
  "png",
  "serde",
  "serde_json",
+ "strum 0.27.0",
+ "strum_macros 0.27.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -4006,7 +4008,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "smallvec",
- "strum",
+ "strum 0.26.3",
  "stun-rs",
  "thiserror 2.0.11",
  "tokio",
@@ -7950,14 +7952,33 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
 
 [[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/packages/target-tauri/package.json
+++ b/packages/target-tauri/package.json
@@ -20,7 +20,8 @@
     "@tauri-apps/api": "^2.2.0",
     "@tauri-apps/plugin-log": "^2.2.0",
     "@tauri-apps/plugin-shell": "^2.2.0",
-    "@tauri-apps/plugin-store": "^2.2.0"
+    "@tauri-apps/plugin-store": "^2.2.0",
+    "plugin-opener@~2": "link:tauri-apps/plugin-opener@~2"
   },
   "devDependencies": {
     "@deltachat-desktop/runtime-interface": "link:../runtime",

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -256,6 +256,16 @@ class TauriRuntime implements Runtime {
     listen<string>('locale_reloaded', event => {
       this.onChooseLanguage?.(event.payload)
     })
+
+    listen<string>('showAboutDialog', () => {
+      this.onShowDialog?.("about")
+    });
+    listen<string>('showSettingsDialog', () => {
+      this.onShowDialog?.("settings")
+    });
+    listen<string>('showKeybindingsDialog', () => {
+      this.onShowDialog?.("keybindings")
+    });
   }
   reloadWebContent(): void {
     // for now use the browser method as long as it is sufficient

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -42,6 +42,8 @@ png = "0.*"
 base64 = "0.*"
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-opener = "2"
+strum = "0.27"
+strum_macros = "0.27"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ thiserror = "2.0.11"
 png = "0.*"
 base64 = "0.*"
 uuid = { version = "1", features = ["v4"] }
+tauri-plugin-opener = "2"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/packages/target-tauri/src-tauri/src/help_window.rs
+++ b/packages/target-tauri/src-tauri/src/help_window.rs
@@ -1,5 +1,5 @@
 use log::warn;
-use tauri::{Manager, WebviewWindow};
+use tauri::{Manager, Runtime};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum Error {
@@ -17,8 +17,8 @@ impl serde::Serialize for Error {
 }
 
 #[tauri::command]
-pub(crate) fn open_help_window(
-    app: tauri::AppHandle,
+pub(crate) fn open_help_window<A: Runtime>(
+    app: tauri::AppHandle<A>,
     locale: &str,
     anchor: Option<&str>,
 ) -> Result<(), Error> {
@@ -30,7 +30,7 @@ pub(crate) fn open_help_window(
 
     let app_url = tauri::WebviewUrl::App(url.into());
 
-    let mut help_window: WebviewWindow = if let Some(help_window) = app.get_webview_window("help") {
+    let mut help_window = if let Some(help_window) = app.get_webview_window("help") {
         help_window
     } else {
         tauri::WebviewWindowBuilder::new(&app, "help", app_url.clone()).build()?

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -1,8 +1,8 @@
 use std::time::SystemTime;
 
 use clipboard::copy_image_to_clipboard;
-use settings::load_and_apply_desktop_settings_on_startup;
 use menus::main_menu::create_main_menu;
+use settings::load_and_apply_desktop_settings_on_startup;
 use state::{app::AppState, deltachat::DeltaChatAppState};
 use tauri::Manager;
 mod app_path;

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -191,14 +191,6 @@ pub fn run() {
                 webview.set_title("")?;
             }
 
-            let zoom_factor = app
-                .handle()
-                .get_store("config.json")
-                .and_then(|store| store.get(ZOOM_FACTOR_KEY))
-                .and_then(|f| f.as_f64())
-                .unwrap_or(1.0);
-
-            set_zoom(&app.handle(), zoom_factor, "main")?;
             app.set_menu(create_main_menu(app.handle())?)?;
             app.on_menu_event(handle_menu_event);
 

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -71,6 +71,7 @@ pub fn run() {
     let startup_timestamp = SystemTime::now();
 
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::new().build())
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ use std::time::SystemTime;
 
 use clipboard::copy_image_to_clipboard;
 use settings::load_and_apply_desktop_settings_on_startup;
+use menus::main_menu::create_main_menu;
 use state::{app::AppState, deltachat::DeltaChatAppState};
 use tauri::Manager;
 mod app_path;
@@ -10,6 +11,7 @@ mod clipboard;
 mod file_dialogs;
 mod help_window;
 mod i18n;
+mod menus;
 mod runtime_info;
 mod settings;
 mod state;
@@ -86,6 +88,8 @@ pub fn run() {
                     .set_focus();
             }));
     }
+
+    builder = create_main_menu(builder);
 
     builder
         .invoke_handler(tauri::generate_handler![

--- a/packages/target-tauri/src-tauri/src/menus/help_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/help_menu.rs
@@ -1,0 +1,73 @@
+use super::HelpMenuAction;
+use tauri::{
+    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
+    AppHandle, Runtime,
+};
+
+pub(crate) fn create_help_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Result<Menu<A>> {
+    let menu = Menu::with_items(
+        handle,
+        &[
+            &Submenu::with_items(
+                handle,
+                "File",
+                true,
+                &[&MenuItem::with_id(
+                    handle,
+                    HelpMenuAction::HelpQuit,
+                    "Quit",
+                    true,
+                    None::<&str>,
+                )?],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::copy(handle, Some("Copy"))?,
+                    &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "View",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::ResetZoom,
+                        "Actual Size",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::ZoomIn,
+                        "Zoom In",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::ZoomOut,
+                        "Zoom Out",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::HelpFloatOnTop,
+                        "Float on Top",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::fullscreen(handle, Some("Toggle Full Screen"))?,
+                ],
+            )?,
+        ],
+    )?;
+
+    Ok(menu)
+}

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -1,0 +1,91 @@
+use tauri::{
+    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
+    Builder, Runtime,
+};
+
+pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
+    let builder = builder.menu(|handle| {
+        Menu::with_items(
+            handle,
+            &[
+                &Submenu::with_items(
+                    handle,
+                    "File",
+                    true,
+                    &[
+                        &PredefinedMenuItem::quit(handle, Some("Quit"))?,
+                        #[cfg(target_os = "macos")]
+                        &MenuItem::new(handle, "Hello", true, None::<&str>)?,
+                        &MenuItem::new(handle, "Settings", true, None::<&str>)?,
+                    ],
+                )?,
+                &Submenu::with_items(
+                    handle,
+                    "Edit",
+                    true,
+                    &[
+                        &PredefinedMenuItem::undo(handle, Some("Undo"))?,
+                        &PredefinedMenuItem::redo(handle, Some("Redo"))?,
+                        &PredefinedMenuItem::separator(handle)?,
+                        &PredefinedMenuItem::cut(handle, Some("Cut"))?,
+                        &PredefinedMenuItem::copy(handle, Some("Copy"))?,
+                        &PredefinedMenuItem::paste(handle, Some("Paste"))?,
+                        // &PredefinedMenuItem::delete(handle, Some("Select All"))?,
+                        &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
+                    ],
+                )?,
+                &Submenu::with_items(
+                    handle,
+                    "View",
+                    true,
+                    &[
+                        &MenuItem::new(handle, "Float on Top", true, None::<&str>)?,
+                        &Submenu::with_items(
+                            handle,
+                            "Zoom",
+                            true,
+                            &[
+                                &MenuItem::new(handle, "0.6x Extra Small", true, None::<&str>)?,
+                                &MenuItem::new(handle, "0.8x Small", true, None::<&str>)?,
+                                &MenuItem::new(handle, "1.0x Normal", true, None::<&str>)?,
+                                &MenuItem::new(handle, "1.2x Large", true, None::<&str>)?,
+                                &MenuItem::new(handle, "1.4x Extra Large", true, None::<&str>)?,
+                            ],
+                        )?,
+                        &Submenu::with_items(
+                            handle,
+                            "Developer",
+                            true,
+                            &[
+                                &MenuItem::new(handle, "Open Developer Tools", true, None::<&str>)?,
+                                &MenuItem::new(handle, "Open the Log Folder", true, None::<&str>)?,
+                                &MenuItem::new(
+                                    handle,
+                                    "Open Current Log File",
+                                    true,
+                                    None::<&str>,
+                                )?,
+                            ],
+                        )?,
+                    ],
+                )?,
+                &Submenu::with_items(
+                    handle,
+                    "Help",
+                    true,
+                    &[
+                        &MenuItem::new(handle, "Help", true, None::<&str>)?,
+                        &MenuItem::new(handle, "Keybindings", true, None::<&str>)?,
+                        &MenuItem::new(handle, "Learn More About Deltachat", true, None::<&str>)?,
+                        &MenuItem::new(handle, "Contribute on Github", true, None::<&str>)?,
+                        &MenuItem::new(handle, "Report an Issue", true, None::<&str>)?,
+                        &MenuItem::new(handle, "About Delta Chat", true, None::<&str>)?,
+                    ],
+                )?,
+            ],
+        )
+    });
+    builder.on_menu_event(|_app, event| {
+        println!("menu event: {:?}", event);
+    })
+}

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -160,6 +160,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                             true,
                             &[
                                 // Use `with_id` instead of new, add new parameter after `handle`
+                                #[cfg(feature = "crabnebula_extras")]
                                 &MenuItem::with_id(
                                     handle,
                                     "dev_tools",
@@ -245,9 +246,10 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
             }
             MenuAction::Delete => { /* Not supported by Tauri */ }
             MenuAction::FloatOnTop => {
-                /* Not supported by Tauri
-                https://docs.rs/tauri/latest/tauri/window/struct.Window.html#method.set_visible_on_all_workspaces
-                */
+                app.get_webview_window("main")
+                    .unwrap()
+                    .set_always_on_top(true)
+                    .ok();
             }
             MenuAction::Zoom(0.6) => {
                 app.menu()

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -115,7 +115,6 @@ pub(crate) fn create_main_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Res
                         "Developer",
                         true,
                         &[
-                            // Use `with_id` instead of new, add new parameter after `handle`
                             #[cfg(feature = "crabnebula_extras")]
                             &MenuItem::with_id(
                                 handle,

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -1,7 +1,12 @@
+use log::info;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
-    Builder, Runtime,
+    AppHandle, Builder, Emitter, Manager, Runtime,
 };
+use tauri_plugin_opener::OpenerExt;
+use tauri_plugin_store::StoreExt;
+
+use crate::help_window::open_help_window;
 
 pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
     let builder = builder.menu(|handle| {
@@ -13,10 +18,8 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                     "File",
                     true,
                     &[
-                        &PredefinedMenuItem::quit(handle, Some("Quit"))?,
-                        #[cfg(target_os = "macos")]
-                        &MenuItem::new(handle, "Hello", true, None::<&str>)?,
-                        &MenuItem::new(handle, "Settings", true, None::<&str>)?,
+                        &MenuItem::with_id(handle, "quit", "Quit", true, None::<&str>)?,
+                        &MenuItem::with_id(handle, "settings", "Settings", true, None::<&str>)?,
                     ],
                 )?,
                 &Submenu::with_items(
@@ -30,7 +33,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                         &PredefinedMenuItem::cut(handle, Some("Cut"))?,
                         &PredefinedMenuItem::copy(handle, Some("Copy"))?,
                         &PredefinedMenuItem::paste(handle, Some("Paste"))?,
-                        // &PredefinedMenuItem::delete(handle, Some("Select All"))?,
+                        &MenuItem::with_id(handle, "delete", "Delete", true, None::<&str>)?,
                         &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
                     ],
                 )?,
@@ -39,17 +42,54 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                     "View",
                     true,
                     &[
-                        &MenuItem::new(handle, "Float on Top", true, None::<&str>)?,
+                        &MenuItem::with_id(
+                            handle,
+                            "float_on_top",
+                            "Float on Top",
+                            true,
+                            None::<&str>,
+                        )?,
                         &Submenu::with_items(
                             handle,
                             "Zoom",
                             true,
                             &[
-                                &MenuItem::new(handle, "0.6x Extra Small", true, None::<&str>)?,
-                                &MenuItem::new(handle, "0.8x Small", true, None::<&str>)?,
-                                &MenuItem::new(handle, "1.0x Normal", true, None::<&str>)?,
-                                &MenuItem::new(handle, "1.2x Large", true, None::<&str>)?,
-                                &MenuItem::new(handle, "1.4x Extra Large", true, None::<&str>)?,
+                                &MenuItem::with_id(
+                                    handle,
+                                    "zoom_06",
+                                    "0.6x Extra Small",
+                                    true,
+                                    None::<&str>,
+                                )?,
+                                // Also use with_id here:
+                                &MenuItem::with_id(
+                                    handle,
+                                    "zoom_08",
+                                    "0.8x Small",
+                                    true,
+                                    None::<&str>,
+                                )?,
+                                &MenuItem::with_id(
+                                    handle,
+                                    "zoom_10",
+                                    "1.0x Normal",
+                                    true,
+                                    None::<&str>,
+                                )?,
+                                &MenuItem::with_id(
+                                    handle,
+                                    "zoom_12",
+                                    "1.2x Large",
+                                    true,
+                                    None::<&str>,
+                                )?,
+                                &MenuItem::with_id(
+                                    handle,
+                                    "zoom_14",
+                                    "1.4x Extra Large",
+                                    true,
+                                    None::<&str>,
+                                )?,
                             ],
                         )?,
                         &Submenu::with_items(
@@ -57,10 +97,24 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                             "Developer",
                             true,
                             &[
-                                &MenuItem::new(handle, "Open Developer Tools", true, None::<&str>)?,
-                                &MenuItem::new(handle, "Open the Log Folder", true, None::<&str>)?,
-                                &MenuItem::new(
+                                // Use `with_id` instead of new, add new parameter after `handle`
+                                &MenuItem::with_id(
                                     handle,
+                                    "dev_tools",
+                                    "Open Developer Tools",
+                                    true,
+                                    None::<&str>,
+                                )?,
+                                &MenuItem::with_id(
+                                    handle,
+                                    "log_folder",
+                                    "Open the Log Folder",
+                                    true,
+                                    None::<&str>,
+                                )?,
+                                &MenuItem::with_id(
+                                    handle,
+                                    "current_log_file",
                                     "Open Current Log File",
                                     true,
                                     None::<&str>,
@@ -74,18 +128,92 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                     "Help",
                     true,
                     &[
-                        &MenuItem::new(handle, "Help", true, None::<&str>)?,
-                        &MenuItem::new(handle, "Keybindings", true, None::<&str>)?,
-                        &MenuItem::new(handle, "Learn More About Deltachat", true, None::<&str>)?,
-                        &MenuItem::new(handle, "Contribute on Github", true, None::<&str>)?,
-                        &MenuItem::new(handle, "Report an Issue", true, None::<&str>)?,
-                        &MenuItem::new(handle, "About Delta Chat", true, None::<&str>)?,
+                        &MenuItem::with_id(handle, "help", "Help", true, None::<&str>)?,
+                        &MenuItem::new(handle, "keybindings", true, None::<&str>)?,
+                        &MenuItem::new(handle, "learn", true, None::<&str>)?,
+                        &MenuItem::new(handle, "contribute", true, None::<&str>)?,
+                        &MenuItem::new(handle, "report", true, None::<&str>)?,
+                        &MenuItem::new(handle, "about", true, None::<&str>)?,
                     ],
                 )?,
             ],
         )
     });
-    builder.on_menu_event(|_app, event| {
+    builder.on_menu_event(|app, event| {
         println!("menu event: {:?}", event);
+
+        match event.id().as_ref() {
+            "settings" => {
+                app.emit("open:settings", None::<String>);
+            }
+            "help" => {
+                open_help_window(app.clone(), "", None);
+            }
+            "quit" => {
+                app.exit(0);
+            }
+            "delete" => {
+                app.emit("delete", None::<()>);
+            }
+            "float_on_top" => {}
+            "zoom_06" => {
+                set_zoom(app, 0.6);
+            }
+            "zoom_08" => {
+                set_zoom(app, 0.8);
+            }
+            "zoom_10" => {
+                set_zoom(app, 1.0);
+            }
+            "zoom_12" => {
+                set_zoom(app, 1.2);
+            }
+
+            "zoom_14" => {
+                set_zoom(app, 1.4);
+            }
+            "dev_tools" => {
+                app.get_webview_window("main").unwrap().open_devtools();
+            }
+            "log_folder" => {
+                // app.get_store()
+            }
+            "current_log_file" => {}
+            "keybindings" => {
+                app.emit("open:keybindings", None::<String>).unwrap();
+            }
+            "learn" => {
+                app.opener();
+            }
+            "contribute" => {
+                app.opener()
+                    .open_url(
+                        "https://github.com/deltachat/deltachat-desktop",
+                        None::<String>,
+                    )
+                    .unwrap();
+            }
+            "report" => {
+                app.opener()
+                    .open_url(
+                        "https://github.com/deltachat/deltachat-desktop/issues",
+                        None::<String>,
+                    )
+                    .unwrap();
+            }
+            "about" => {
+                app.opener()
+                    .open_url("https://delta.chat/de/", None::<String>)
+                    .unwrap();
+            }
+            _ => {
+                info!("menu event not handled: {:?}", event.id());
+            }
+        }
     })
+}
+
+fn set_zoom<A: Runtime>(app: &AppHandle<A>, zoom: f64) {
+    let webview = app.get_webview_window("main").unwrap();
+    webview.set_zoom(zoom).unwrap();
 }

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -56,10 +56,11 @@ pub(crate) fn create_main_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Res
                 "View",
                 true,
                 &[
-                    &MenuItem::with_id(
+                    &CheckMenuItem::with_id(
                         handle,
                         MainMenuAction::FloatOnTop,
                         "Float on Top",
+                        true,
                         false,
                         None::<&str>,
                     )?,

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -195,9 +195,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
             "quit" => {
                 app.exit(0);
             }
-            "delete" => {
-                app.emit("delete", None::<()>).ok();
-            }
+            "delete" => { /* Not supported by Tauri */ }
             "float_on_top" => {
                 /* Not supported by Tauri
                 https://docs.rs/tauri/latest/tauri/window/struct.Window.html#method.set_visible_on_all_workspaces

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -1,205 +1,198 @@
-use super::{handle_event, MainMenuAction};
+use super::MainMenuAction;
+use crate::settings::ZOOM_FACTOR_KEY;
 use tauri::{
     menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
-    Builder, Runtime,
+    AppHandle, Runtime,
 };
+use tauri_plugin_store::StoreExt;
 
-pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
-    let builder = builder.menu(|handle| {
-        // let store = handle.get_store("config.json")?;
+pub(crate) fn create_main_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Result<Menu<A>> {
+    let zoom_factor = handle
+        .get_store("config.json")
+        .and_then(|store| store.get(ZOOM_FACTOR_KEY))
+        .and_then(|f| f.as_f64())
+        .unwrap_or(1.0);
 
-        // let zoom_factor: f64 = store
-        //     .get(ZOOM_FACTOR_KEY)
-        //     .and_then(|f| f.as_f64())
-        //     .unwrap_or(10.0);
-
-        let zoom_factor = 1.0;
-        Menu::with_items(
-            handle,
-            &[
-                &Submenu::with_items(
-                    handle,
-                    "File",
-                    true,
-                    &[
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::Quit,
-                            MainMenuAction::Quit,
-                            true,
-                            None::<&str>,
-                        )?,
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::Settings,
-                            MainMenuAction::Settings,
-                            true,
-                            None::<&str>,
-                        )?,
-                    ],
-                )?,
-                &Submenu::with_items(
-                    handle,
-                    "Edit",
-                    true,
-                    &[
-                        &PredefinedMenuItem::undo(handle, Some("Undo"))?,
-                        &PredefinedMenuItem::redo(handle, Some("Redo"))?,
-                        &PredefinedMenuItem::separator(handle)?,
-                        &PredefinedMenuItem::cut(handle, Some("Cut"))?,
-                        &PredefinedMenuItem::copy(handle, Some("Copy"))?,
-                        &PredefinedMenuItem::paste(handle, Some("Paste"))?,
-                        &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
-                    ],
-                )?,
-                &Submenu::with_items(
-                    handle,
-                    "View",
-                    true,
-                    &[
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::FloatOnTop,
-                            "Float on Top",
-                            false,
-                            None::<&str>,
-                        )?,
-                        &Submenu::with_items(
-                            handle,
-                            "Zoom",
-                            true,
-                            &[
-                                &CheckMenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::Zoom06,
-                                    "0.6x Extra Small",
-                                    true,
-                                    zoom_factor == 0.6,
-                                    None::<&str>,
-                                )?,
-                                &CheckMenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::Zoom08,
-                                    "0.8x Small",
-                                    true,
-                                    zoom_factor == 0.8,
-                                    None::<&str>,
-                                )?,
-                                &CheckMenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::Zoom10,
-                                    "1.0x Normal",
-                                    true,
-                                    zoom_factor == 1.0,
-                                    None::<&str>,
-                                )?,
-                                &CheckMenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::Zoom12,
-                                    "1.2x Large",
-                                    true,
-                                    zoom_factor == 1.2,
-                                    None::<&str>,
-                                )?,
-                                &CheckMenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::Zoom14,
-                                    "1.4x Extra Large",
-                                    true,
-                                    zoom_factor == 1.4,
-                                    None::<&str>,
-                                )?,
-                            ],
-                        )?,
-                        &Submenu::with_items(
-                            handle,
-                            "Developer",
-                            true,
-                            &[
-                                // Use `with_id` instead of new, add new parameter after `handle`
-                                #[cfg(feature = "crabnebula_extras")]
-                                &MenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::DevTools,
-                                    "Open Developer Tools",
-                                    true,
-                                    None::<&str>,
-                                )?,
-                                &MenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::LogFolder,
-                                    "Open the Log Folder",
-                                    true,
-                                    None::<&str>,
-                                )?,
-                                &MenuItem::with_id(
-                                    handle,
-                                    MainMenuAction::CurrentLogFile,
-                                    "Open Current Log File",
-                                    true,
-                                    None::<&str>,
-                                )?,
-                            ],
-                        )?,
-                    ],
-                )?,
-                &Submenu::with_items(
-                    handle,
-                    "Help",
-                    true,
-                    &[
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::Help,
-                            MainMenuAction::Help,
-                            true,
-                            None::<&str>,
-                        )?,
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::Keybindings,
-                            "Keybindings",
-                            true,
-                            None::<&str>,
-                        )?,
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::Learn,
-                            "Learn more about Delta Chat",
-                            true,
-                            None::<&str>,
-                        )?,
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::Contribute,
-                            "Contribute on Github",
-                            true,
-                            None::<&str>,
-                        )?,
-                        &PredefinedMenuItem::separator(handle)?,
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::Report,
-                            "Report an Issue",
-                            true,
-                            None::<&str>,
-                        )?,
-                        &MenuItem::with_id(
-                            handle,
-                            MainMenuAction::About,
-                            "About Delta Chat",
-                            true,
-                            None::<&str>,
-                        )?,
-                    ],
-                )?,
-            ],
-        )
-    });
-
-    builder.on_menu_event(|app, event| {
-        if let Err(e) = handle_event(&app, event) {
-            log::error!("Error handling menu event: {:?}", e);
-        }
-    })
+    Menu::with_items(
+        handle,
+        &[
+            &Submenu::with_items(
+                handle,
+                "File",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Quit,
+                        MainMenuAction::Quit,
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Settings,
+                        MainMenuAction::Settings,
+                        true,
+                        None::<&str>,
+                    )?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(handle, Some("Undo"))?,
+                    &PredefinedMenuItem::redo(handle, Some("Redo"))?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &PredefinedMenuItem::cut(handle, Some("Cut"))?,
+                    &PredefinedMenuItem::copy(handle, Some("Copy"))?,
+                    &PredefinedMenuItem::paste(handle, Some("Paste"))?,
+                    &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "View",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::FloatOnTop,
+                        "Float on Top",
+                        false,
+                        None::<&str>,
+                    )?,
+                    &Submenu::with_items(
+                        handle,
+                        "Zoom",
+                        true,
+                        &[
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom06,
+                                "0.6x Extra Small",
+                                true,
+                                zoom_factor == 0.6,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom08,
+                                "0.8x Small",
+                                true,
+                                zoom_factor == 0.8,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom10,
+                                "1.0x Normal",
+                                true,
+                                zoom_factor == 1.0,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom12,
+                                "1.2x Large",
+                                true,
+                                zoom_factor == 1.2,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom14,
+                                "1.4x Extra Large",
+                                true,
+                                zoom_factor == 1.4,
+                                None::<&str>,
+                            )?,
+                        ],
+                    )?,
+                    &Submenu::with_items(
+                        handle,
+                        "Developer",
+                        true,
+                        &[
+                            // Use `with_id` instead of new, add new parameter after `handle`
+                            #[cfg(feature = "crabnebula_extras")]
+                            &MenuItem::with_id(
+                                handle,
+                                MainMenuAction::DevTools,
+                                "Open Developer Tools",
+                                true,
+                                None::<&str>,
+                            )?,
+                            &MenuItem::with_id(
+                                handle,
+                                MainMenuAction::LogFolder,
+                                "Open the Log Folder",
+                                true,
+                                None::<&str>,
+                            )?,
+                            &MenuItem::with_id(
+                                handle,
+                                MainMenuAction::CurrentLogFile,
+                                "Open Current Log File",
+                                true,
+                                None::<&str>,
+                            )?,
+                        ],
+                    )?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "Help",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Help,
+                        MainMenuAction::Help,
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Keybindings,
+                        "Keybindings",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Learn,
+                        "Learn more about Delta Chat",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Contribute,
+                        "Contribute on Github",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Report,
+                        "Report an Issue",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::About,
+                        "About Delta Chat",
+                        true,
+                        None::<&str>,
+                    )?,
+                ],
+            )?,
+        ],
+    )
+    .map_err(anyhow::Error::from)
 }

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -3,8 +3,8 @@ use std::str::FromStr;
 use log::info;
 use strum_macros::{AsRefStr, EnumString};
 use tauri::{
-    menu::{CheckMenuItem, Menu, MenuId, MenuItem, PredefinedMenuItem, Submenu},
-    AppHandle, Builder, Emitter, Manager, Runtime,
+    menu::{CheckMenuItem, Menu, MenuEvent, MenuId, MenuItem, PredefinedMenuItem, Submenu},
+    AppHandle, Builder, Emitter, Manager, Runtime, WebviewWindow,
 };
 use tauri_plugin_opener::OpenerExt;
 
@@ -30,19 +30,21 @@ enum MenuAction {
 
 impl From<MenuAction> for MenuId {
     fn from(action: MenuAction) -> Self {
-        MenuId::new(action.as_ref())
+        MenuId::new(action)
     }
 }
 
-impl From<&MenuId> for MenuAction {
-    fn from(item: &MenuId) -> Self {
-        MenuAction::from_str(item.as_ref()).expect("conversion error")
+impl TryFrom<&MenuId> for MenuAction {
+    type Error = anyhow::Error;
+
+    fn try_from(item: &MenuId) -> Result<Self, Self::Error> {
+        MenuAction::from_str(item.as_ref()).map_err(|e| e.into())
     }
 }
 
 pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
     let builder = builder.menu(|handle| {
-        // let store = handle.get_store("config.json").unwrap();
+        // let store = handle.get_store("config.json")?;
 
         // let zoom_factor: f64 = store
         //     .get(ZOOM_FACTOR_KEY)
@@ -61,14 +63,14 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                         &MenuItem::with_id(
                             handle,
                             MenuAction::Quit,
-                            MenuAction::Quit.as_ref(),
+                            MenuAction::Quit,
                             true,
                             None::<&str>,
                         )?,
                         &MenuItem::with_id(
                             handle,
                             MenuAction::Settings,
-                            MenuAction::Settings.as_ref(),
+                            MenuAction::Settings,
                             true,
                             None::<&str>,
                         )?,
@@ -87,8 +89,8 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                         &PredefinedMenuItem::paste(handle, Some("Paste"))?,
                         &MenuItem::with_id(
                             handle,
-                            MenuAction::Delete.as_ref(),
-                            "Delete",
+                            MenuAction::Delete,
+                            MenuAction::Delete,
                             true,
                             None::<&str>,
                         )?,
@@ -102,8 +104,8 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                     &[
                         &MenuItem::with_id(
                             handle,
-                            "float_on_top",
-                            "Float on Top",
+                            MenuAction::FloatOnTop,
+                            MenuAction::FloatOnTop,
                             false,
                             None::<&str>,
                         )?,
@@ -114,7 +116,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                             &[
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    "zoom_06",
+                                    MenuAction::Zoom(0.6),
                                     "0.6x Extra Small",
                                     true,
                                     zoom_factor == 0.6,
@@ -122,7 +124,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    "zoom_08",
+                                    MenuAction::Zoom(0.8),
                                     "0.8x Small",
                                     true,
                                     zoom_factor == 0.8,
@@ -130,7 +132,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    "zoom_10",
+                                    MenuAction::Zoom(1.0),
                                     "1.0x Normal",
                                     true,
                                     zoom_factor == 1.0,
@@ -138,7 +140,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    "zoom_12",
+                                    MenuAction::Zoom(1.2),
                                     "1.2x Large",
                                     true,
                                     zoom_factor == 1.2,
@@ -146,7 +148,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    "zoom_14",
+                                    MenuAction::Zoom(1.4),
                                     "1.4x Extra Large",
                                     true,
                                     zoom_factor == 1.4,
@@ -163,22 +165,22 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 #[cfg(feature = "crabnebula_extras")]
                                 &MenuItem::with_id(
                                     handle,
-                                    "dev_tools",
-                                    "Open Developer Tools",
+                                    MenuAction::DevTools,
+                                    MenuAction::DevTools,
                                     true,
                                     None::<&str>,
                                 )?,
                                 &MenuItem::with_id(
                                     handle,
-                                    "log_folder",
-                                    "Open the Log Folder",
+                                    MenuAction::LogFolder,
+                                    MenuAction::LogFolder,
                                     true,
                                     None::<&str>,
                                 )?,
                                 &MenuItem::with_id(
                                     handle,
-                                    "current_log_file",
-                                    "Open Current Log File",
+                                    MenuAction::CurrentLogFile,
+                                    MenuAction::CurrentLogFile,
                                     true,
                                     None::<&str>,
                                 )?,
@@ -191,40 +193,46 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                     "Help",
                     true,
                     &[
-                        &MenuItem::with_id(handle, "help", "Help", true, None::<&str>)?,
                         &MenuItem::with_id(
                             handle,
-                            "keybindings",
-                            "Keybindings",
+                            MenuAction::Help,
+                            MenuAction::Help,
                             true,
                             None::<&str>,
                         )?,
                         &MenuItem::with_id(
                             handle,
-                            "learn",
-                            "Learn more about Delta Chat",
+                            MenuAction::Keybindings,
+                            MenuAction::Keybindings,
                             true,
                             None::<&str>,
                         )?,
                         &MenuItem::with_id(
                             handle,
-                            "contribute",
-                            "Contribute on Github",
+                            MenuAction::Learn,
+                            MenuAction::Learn,
+                            true,
+                            None::<&str>,
+                        )?,
+                        &MenuItem::with_id(
+                            handle,
+                            MenuAction::Contribute,
+                            MenuAction::Contribute,
                             true,
                             None::<&str>,
                         )?,
                         &PredefinedMenuItem::separator(handle)?,
                         &MenuItem::with_id(
                             handle,
-                            "report",
-                            "Report an Issue",
+                            MenuAction::Report,
+                            MenuAction::Report,
                             true,
                             None::<&str>,
                         )?,
                         &MenuItem::with_id(
                             handle,
-                            "about",
-                            "About Delta Chat",
+                            MenuAction::About,
+                            MenuAction::About,
                             true,
                             None::<&str>,
                         )?,
@@ -234,95 +242,94 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
         )
     });
     builder.on_menu_event(|app, event| {
-        match MenuAction::from(event.id()) {
-            MenuAction::Settings => {
-                app.emit("showSettingsDialog", None::<String>).ok();
-            }
-            MenuAction::Help => {
-                open_help_window(app.clone(), "", None).ok();
-            }
-            MenuAction::Quit => {
-                app.exit(0);
-            }
-            MenuAction::Delete => { /* Not supported by Tauri */ }
-            MenuAction::FloatOnTop => {
-                app.get_webview_window("main")
-                    .unwrap()
-                    .set_always_on_top(true)
-                    .ok();
-            }
-            MenuAction::Zoom(0.6) => {
-                app.menu()
-                    .unwrap()
-                    .get("zoom_06")
-                    .unwrap()
-                    .as_check_menuitem()
-                    .unwrap()
-                    .set_checked(true)
-                    .unwrap();
-                set_zoom(app, 0.6);
-            }
-            MenuAction::Zoom(0.8) => {
-                set_zoom(app, 0.8);
-            }
-            MenuAction::Zoom(1.0) => {
-                set_zoom(app, 1.0);
-            }
-            MenuAction::Zoom(1.2) => {
-                set_zoom(app, 1.2);
-            }
-            MenuAction::Zoom(1.4) => {
-                set_zoom(app, 1.4);
-            }
-            MenuAction::DevTools => {
-                app.get_webview_window("main").unwrap().open_devtools();
-            }
-            MenuAction::LogFolder => {
-                if let Ok(path) = &app.path().app_log_dir() {
-                    if let Some(path) = path.to_str() {
-                        app.opener().open_path(path, None::<String>).ok();
-                    }
-                }
-            }
-            MenuAction::CurrentLogFile => {
-                let path = || app.state::<AppState>().current_log_file_path.clone();
-                app.opener().open_path(path(), None::<String>).ok();
-            }
-            MenuAction::Keybindings => {
-                app.emit("showKeybindingsDialog", None::<String>).unwrap();
-            }
-            MenuAction::Contribute => {
-                app.opener()
-                    .open_url(
-                        "https://github.com/deltachat/deltachat-desktop",
-                        None::<String>,
-                    )
-                    .unwrap();
-            }
-            MenuAction::Report => {
-                app.opener()
-                    .open_url(
-                        "https://github.com/deltachat/deltachat-desktop/issues",
-                        None::<String>,
-                    )
-                    .unwrap();
-            }
-            MenuAction::Learn => {
-                app.opener()
-                    .open_url("https://delta.chat/de/", None::<String>)
-                    .unwrap();
-            }
-            MenuAction::About => {
-                app.emit("showAboutDialog", None::<String>).unwrap();
-            }
-            _ => {
-                info!("menu event not handled: {:?}", event.id());
-            }
+        if let Err(e) = handle_event(&app, event) {
+            log::error!("Error handling menu event: {:?}", e);
         }
     })
 }
 
-fn set_zoom<A: Runtime>(app: &AppHandle<A>, zoom: f64) {
-    let webview = app.get_webview_window("main").unwrap();
-    webview.set_zoom(zoom).unwrap();
+fn set_zoom<A: Runtime>(app: &AppHandle<A>, zoom: f64) -> anyhow::Result<()> {
+    let webview = app
+        .get_webview_window("main")
+        .ok_or(anyhow::anyhow!("webview not found"))?;
+    webview.set_zoom(zoom)?;
+    Ok(())
+}
+
+fn handle_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) -> anyhow::Result<()> {
+    match MenuAction::try_from(event.id())? {
+        MenuAction::Settings => {
+            app.emit("showSettingsDialog", None::<String>).ok();
+        }
+        MenuAction::Help => {
+            open_help_window(app.clone(), "", None).ok();
+        }
+        MenuAction::Quit => {
+            app.exit(0);
+        }
+        MenuAction::Delete => { /* Not supported by Tauri */ }
+        MenuAction::FloatOnTop => {
+            get_main_window(app)?.set_always_on_top(true).ok();
+        }
+        MenuAction::Zoom(0.6) => {
+            set_zoom(app, 0.6)?;
+        }
+        MenuAction::Zoom(0.8) => {
+            set_zoom(app, 0.8)?;
+        }
+        MenuAction::Zoom(1.0) => {
+            set_zoom(app, 1.0)?;
+        }
+        MenuAction::Zoom(1.2) => {
+            set_zoom(app, 1.2)?;
+        }
+        MenuAction::Zoom(1.4) => {
+            set_zoom(app, 1.4)?;
+        }
+        MenuAction::DevTools => {
+            get_main_window(&app)?.open_devtools();
+        }
+        MenuAction::LogFolder => {
+            if let Ok(path) = &app.path().app_log_dir() {
+                if let Some(path) = path.to_str() {
+                    app.opener().open_path(path, None::<String>).ok();
+                }
+            }
+        }
+        MenuAction::CurrentLogFile => {
+            let path = || app.state::<AppState>().current_log_file_path.clone();
+            app.opener().open_path(path(), None::<String>).ok();
+        }
+        MenuAction::Keybindings => {
+            app.emit("showKeybindingsDialog", None::<String>)?;
+        }
+        MenuAction::Contribute => {
+            app.opener().open_url(
+                "https://github.com/deltachat/deltachat-desktop",
+                None::<String>,
+            )?;
+        }
+        MenuAction::Report => {
+            app.opener().open_url(
+                "https://github.com/deltachat/deltachat-desktop/issues",
+                None::<String>,
+            )?;
+        }
+        MenuAction::Learn => {
+            app.opener()
+                .open_url("https://delta.chat/de/", None::<String>)?;
+        }
+        MenuAction::About => {
+            app.emit("showAboutDialog", None::<String>)?;
+        }
+        _ => {
+            info!("menu event not handled: {:?}", event.id());
+        }
+    }
+    Ok(())
+}
+
+fn get_main_window<A: Runtime>(app: &AppHandle<A>) -> anyhow::Result<WebviewWindow<A>> {
+    app.get_webview_window("main")
+        .ok_or(anyhow::anyhow!("main window not found"))
 }

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -104,8 +104,8 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                     &[
                         &MenuItem::with_id(
                             handle,
-                            MenuAction::FloatOnTop,
-                            MenuAction::FloatOnTop,
+                            "float_on_top",
+                            "Float on Top",
                             false,
                             None::<&str>,
                         )?,
@@ -116,7 +116,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                             &[
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    MenuAction::Zoom(0.6),
+                                    "zoom_06",
                                     "0.6x Extra Small",
                                     true,
                                     zoom_factor == 0.6,
@@ -124,7 +124,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    MenuAction::Zoom(0.8),
+                                    "zoom_08",
                                     "0.8x Small",
                                     true,
                                     zoom_factor == 0.8,
@@ -132,7 +132,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    MenuAction::Zoom(1.0),
+                                    "zoom_10",
                                     "1.0x Normal",
                                     true,
                                     zoom_factor == 1.0,
@@ -140,7 +140,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    MenuAction::Zoom(1.2),
+                                    "zoom_12",
                                     "1.2x Large",
                                     true,
                                     zoom_factor == 1.2,
@@ -148,7 +148,7 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 )?,
                                 &CheckMenuItem::with_id(
                                     handle,
-                                    MenuAction::Zoom(1.4),
+                                    "zoom_14",
                                     "1.4x Extra Large",
                                     true,
                                     zoom_factor == 1.4,
@@ -166,21 +166,21 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                                 &MenuItem::with_id(
                                     handle,
                                     MenuAction::DevTools,
-                                    MenuAction::DevTools,
+                                    "Open Developer Tools",
                                     true,
                                     None::<&str>,
                                 )?,
                                 &MenuItem::with_id(
                                     handle,
                                     MenuAction::LogFolder,
-                                    MenuAction::LogFolder,
+                                    "Open the Log Folder",
                                     true,
                                     None::<&str>,
                                 )?,
                                 &MenuItem::with_id(
                                     handle,
                                     MenuAction::CurrentLogFile,
-                                    MenuAction::CurrentLogFile,
+                                    "Open Current Log File",
                                     true,
                                     None::<&str>,
                                 )?,
@@ -193,31 +193,25 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                     "Help",
                     true,
                     &[
-                        &MenuItem::with_id(
-                            handle,
-                            MenuAction::Help,
-                            MenuAction::Help,
-                            true,
-                            None::<&str>,
-                        )?,
+                        &MenuItem::with_id(handle, "help", "Help", true, None::<&str>)?,
                         &MenuItem::with_id(
                             handle,
                             MenuAction::Keybindings,
-                            MenuAction::Keybindings,
+                            "Keybindings",
                             true,
                             None::<&str>,
                         )?,
                         &MenuItem::with_id(
                             handle,
                             MenuAction::Learn,
-                            MenuAction::Learn,
+                            "Learn more about Delta Chat",
                             true,
                             None::<&str>,
                         )?,
                         &MenuItem::with_id(
                             handle,
                             MenuAction::Contribute,
-                            MenuAction::Contribute,
+                            "Contribute on Github",
                             true,
                             None::<&str>,
                         )?,
@@ -225,14 +219,14 @@ pub(crate) fn create_main_menu<A: Runtime>(builder: Builder<A>) -> Builder<A> {
                         &MenuItem::with_id(
                             handle,
                             MenuAction::Report,
-                            MenuAction::Report,
+                            "Report an Issue",
                             true,
                             None::<&str>,
                         )?,
                         &MenuItem::with_id(
                             handle,
                             MenuAction::About,
-                            MenuAction::About,
+                            "About Delta Chat",
                             true,
                             None::<&str>,
                         )?,

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod main_menu;

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -1,1 +1,172 @@
+use crate::{help_window::open_help_window, AppState};
+use help_menu::create_help_menu;
+use std::str::FromStr;
+use strum_macros::{AsRefStr, EnumString};
+use tauri::menu::MenuId;
+use tauri::{menu::MenuEvent, AppHandle, Emitter, Manager, Runtime, WebviewWindow};
+use tauri_plugin_opener::OpenerExt;
+pub mod help_menu;
 pub(crate) mod main_menu;
+
+#[derive(Debug, AsRefStr, EnumString)]
+pub(crate) enum MainMenuAction {
+    Settings,
+    Help,
+    Quit,
+    FloatOnTop,
+    Zoom06,
+    Zoom08,
+    Zoom10,
+    Zoom12,
+    Zoom14,
+    DevTools,
+    LogFolder,
+    CurrentLogFile,
+    Keybindings,
+    Contribute,
+    Report,
+    Learn,
+    About,
+}
+
+impl From<MainMenuAction> for MenuId {
+    fn from(action: MainMenuAction) -> Self {
+        MenuId::new(action)
+    }
+}
+
+impl TryFrom<&MenuId> for MainMenuAction {
+    type Error = anyhow::Error;
+
+    fn try_from(item: &MenuId) -> Result<Self, Self::Error> {
+        MainMenuAction::from_str(item.as_ref()).map_err(|e| e.into())
+    }
+}
+
+#[derive(Debug, AsRefStr, EnumString)]
+pub(crate) enum HelpMenuAction {
+    HelpQuit,
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
+    HelpFloatOnTop,
+}
+
+impl TryFrom<&MenuId> for HelpMenuAction {
+    type Error = anyhow::Error;
+
+    fn try_from(item: &MenuId) -> Result<Self, Self::Error> {
+        HelpMenuAction::from_str(item.as_ref()).map_err(|e| e.into())
+    }
+}
+
+impl From<HelpMenuAction> for MenuId {
+    fn from(action: HelpMenuAction) -> Self {
+        MenuId::new(action)
+    }
+}
+
+fn handle_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) -> anyhow::Result<()> {
+    if let Ok(action) = MainMenuAction::try_from(event.id()) {
+        match action {
+            MainMenuAction::Settings => {
+                app.emit("showSettingsDialog", None::<String>).ok();
+            }
+            MainMenuAction::Help => {
+                open_help_window(app.clone(), "", None).ok();
+
+                let window = app
+                    .get_webview_window("help")
+                    .ok_or(anyhow::anyhow!("help window not found"))?;
+                window.set_menu(create_help_menu(&app)?)?;
+            }
+            MainMenuAction::Quit => {
+                app.exit(0);
+            }
+            MainMenuAction::FloatOnTop => {
+                get_main_window(app)?.set_always_on_top(true).ok();
+            }
+            MainMenuAction::Zoom06 => {
+                set_zoom(app, 0.6, "main")?;
+            }
+            MainMenuAction::Zoom08 => {
+                set_zoom(app, 0.8, "main")?;
+            }
+            MainMenuAction::Zoom10 => {
+                set_zoom(app, 1.0, "main")?;
+            }
+            MainMenuAction::Zoom12 => {
+                set_zoom(app, 1.2, "main")?;
+            }
+            MainMenuAction::Zoom14 => {
+                set_zoom(app, 1.4, "main")?;
+            }
+            MainMenuAction::DevTools => {
+                get_main_window(&app)?.open_devtools();
+            }
+            MainMenuAction::LogFolder => {
+                if let Ok(path) = &app.path().app_log_dir() {
+                    if let Some(path) = path.to_str() {
+                        app.opener().open_path(path, None::<String>).ok();
+                    }
+                }
+            }
+            MainMenuAction::CurrentLogFile => {
+                let path = || app.state::<AppState>().current_log_file_path.clone();
+                app.opener().open_path(path(), None::<String>).ok();
+            }
+            MainMenuAction::Keybindings => {
+                app.emit("showKeybindingsDialog", None::<String>)?;
+            }
+            MainMenuAction::Contribute => {
+                app.opener().open_url(
+                    "https://github.com/deltachat/deltachat-desktop",
+                    None::<String>,
+                )?;
+            }
+            MainMenuAction::Report => {
+                app.opener().open_url(
+                    "https://github.com/deltachat/deltachat-desktop/issues",
+                    None::<String>,
+                )?;
+            }
+            MainMenuAction::Learn => {
+                app.opener()
+                    .open_url("https://delta.chat/de/", None::<String>)?;
+            }
+            MainMenuAction::About => {
+                app.emit("showAboutDialog", None::<String>)?;
+            }
+        }
+    }
+
+    if let Ok(action) = HelpMenuAction::try_from(event.id()) {
+        match action {
+            HelpMenuAction::HelpQuit => {
+                let window = app
+                    .get_webview_window("help")
+                    .ok_or(anyhow::anyhow!("help window not found"))?;
+                window.close().ok();
+            }
+            HelpMenuAction::ZoomIn => {}
+            HelpMenuAction::ZoomOut => {}
+            HelpMenuAction::ResetZoom => {}
+            HelpMenuAction::HelpFloatOnTop => {}
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn get_main_window<A: Runtime>(app: &AppHandle<A>) -> anyhow::Result<WebviewWindow<A>> {
+    app.get_webview_window("main")
+        .ok_or(anyhow::anyhow!("main window not found"))
+}
+
+fn set_zoom<A: Runtime>(app: &AppHandle<A>, zoom: f64, window: &str) -> anyhow::Result<()> {
+    let webview = app
+        .get_webview_window(window)
+        .ok_or(anyhow::anyhow!("webview not found"))?;
+    webview.set_zoom(zoom)?;
+    Ok(())
+}

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -3,6 +3,7 @@ use crate::{help_window::open_help_window, AppState};
 use help_menu::create_help_menu;
 use main_menu::create_main_menu;
 use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
 use strum_macros::{AsRefStr, EnumString};
 use tauri::menu::MenuId;
 use tauri::{menu::MenuEvent, AppHandle, Emitter, Manager, Runtime, WebviewWindow};
@@ -12,6 +13,7 @@ pub mod help_menu;
 pub(crate) mod main_menu;
 
 const HELP_ZOOM_FACTOR_KEY: &str = "helpZoomFactor";
+static FLOATING: AtomicBool = AtomicBool::new(false);
 
 #[derive(Debug, AsRefStr, EnumString)]
 pub(crate) enum MainMenuAction {
@@ -188,7 +190,8 @@ pub fn handle_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) -> anyhow:
             }
             HelpMenuAction::HelpFloatOnTop => {
                 if let Some(window) = app.get_webview_window("help") {
-                    window.set_always_on_top(true)?;
+                    let previous = FLOATING.fetch_xor(true, Ordering::SeqCst);
+                    window.set_always_on_top(previous)?;
                 }
             }
         }

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -63,8 +63,6 @@
             "shell:allow-open",
             // Badge counter
             "core:window:allow-set-badge-count",
-            "core:menu:default",
-            "core:menu:allow-new"
           ]
         }
       ]

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -62,7 +62,9 @@
             // open current logfile & open links
             "shell:allow-open",
             // Badge counter
-            "core:window:allow-set-badge-count"
+            "core:window:allow-set-badge-count",
+            "core:menu:default",
+            "core:menu:allow-new"
           ]
         }
       ]
@@ -79,7 +81,7 @@
       "icons/icon.ico"
     ],
     "resources": {
-      "../../../_locales/*.json" : "_locales"
+      "../../../_locales/*.json": "_locales"
     },
     "iOS": {
       "minimumSystemVersion": "13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -417,6 +417,9 @@ importers:
       '@tauri-apps/plugin-store':
         specifier: ^2.2.0
         version: 2.2.0
+      plugin-opener@~2:
+        specifier: link:tauri-apps/plugin-opener@~2
+        version: link:tauri-apps/plugin-opener@~2
     devDependencies:
       '@deltachat-desktop/runtime-interface':
         specifier: link:../runtime
@@ -584,6 +587,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.0':
+    resolution: {integrity: sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.19.8':
     resolution: {integrity: sha512-B8JbS61bEunhfx8kasogFENgQfr/dIp+ggYXwTqdbMAgGDhRa3AaPpQMuQU0rNxDLECj6FhDzk1cF9WHMVwrtA==}
     engines: {node: '>=12'}
@@ -604,6 +613,12 @@ packages:
 
   '@esbuild/android-arm64@0.24.2':
     resolution: {integrity: sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.0':
+    resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -632,6 +647,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.0':
+    resolution: {integrity: sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.19.8':
     resolution: {integrity: sha512-rdqqYfRIn4jWOp+lzQttYMa2Xar3OK9Yt2fhOhzFXqg0rVWEfSclJvZq5fZslnz6ypHvVf3CT7qyf0A5pM682A==}
     engines: {node: '>=12'}
@@ -652,6 +673,12 @@ packages:
 
   '@esbuild/android-x64@0.24.2':
     resolution: {integrity: sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.0':
+    resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -680,6 +707,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.0':
+    resolution: {integrity: sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.19.8':
     resolution: {integrity: sha512-3sur80OT9YdeZwIVgERAysAbwncom7b4bCI2XKLjMfPymTud7e/oY4y+ci1XVp5TfQp/bppn7xLw1n/oSQY3/Q==}
     engines: {node: '>=12'}
@@ -700,6 +733,12 @@ packages:
 
   '@esbuild/darwin-x64@0.24.2':
     resolution: {integrity: sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.0':
+    resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -728,6 +767,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.0':
+    resolution: {integrity: sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.19.8':
     resolution: {integrity: sha512-ICvZyOplIjmmhjd6mxi+zxSdpPTKFfyPPQMQTK/w+8eNK6WV01AjIztJALDtwNNfFhfZLux0tZLC+U9nSyA5Zg==}
     engines: {node: '>=12'}
@@ -748,6 +793,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.24.2':
     resolution: {integrity: sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.0':
+    resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -776,6 +827,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.0':
+    resolution: {integrity: sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.19.8':
     resolution: {integrity: sha512-H4vmI5PYqSvosPaTJuEppU9oz1dq2A7Mr2vyg5TF9Ga+3+MGgBdGzcyBP7qK9MrwFQZlvNyJrvz6GuCaj3OukQ==}
     engines: {node: '>=12'}
@@ -796,6 +853,12 @@ packages:
 
   '@esbuild/linux-arm@0.24.2':
     resolution: {integrity: sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.0':
+    resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -824,6 +887,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.0':
+    resolution: {integrity: sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.19.8':
     resolution: {integrity: sha512-fHZWS2JJxnXt1uYJsDv9+b60WCc2RlvVAy1F76qOLtXRO+H4mjt3Tr6MJ5l7Q78X8KgCFudnTuiQRBhULUyBKQ==}
     engines: {node: '>=12'}
@@ -844,6 +913,12 @@ packages:
 
   '@esbuild/linux-loong64@0.24.2':
     resolution: {integrity: sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.0':
+    resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -872,6 +947,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.0':
+    resolution: {integrity: sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.19.8':
     resolution: {integrity: sha512-ETaW6245wK23YIEufhMQ3HSeHO7NgsLx8gygBVldRHKhOlD1oNeNy/P67mIh1zPn2Hr2HLieQrt6tWrVwuqrxg==}
     engines: {node: '>=12'}
@@ -892,6 +973,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.24.2':
     resolution: {integrity: sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.0':
+    resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -920,6 +1007,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.0':
+    resolution: {integrity: sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.19.8':
     resolution: {integrity: sha512-NPxbdmmo3Bk7mbNeHmcCd7R7fptJaczPYBaELk6NcXxy7HLNyWwCyDJ/Xx+/YcNH7Im5dHdx9gZ5xIwyliQCbg==}
     engines: {node: '>=12'}
@@ -940,6 +1033,12 @@ packages:
 
   '@esbuild/linux-s390x@0.24.2':
     resolution: {integrity: sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.0':
+    resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -968,8 +1067,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.0':
+    resolution: {integrity: sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.24.2':
     resolution: {integrity: sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -998,6 +1109,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.0':
+    resolution: {integrity: sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.0':
     resolution: {integrity: sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==}
     engines: {node: '>=18'}
@@ -1012,6 +1129,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.24.2':
     resolution: {integrity: sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.25.0':
+    resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1040,6 +1163,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.0':
+    resolution: {integrity: sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/sunos-x64@0.19.8':
     resolution: {integrity: sha512-9Lc4s7Oi98GqFA4HzA/W2JHIYfnXbUYgekUP/Sm4BG9sfLjyv6GKKHKKVs83SMicBF2JwAX6A1PuOLMqpD001w==}
     engines: {node: '>=12'}
@@ -1060,6 +1189,12 @@ packages:
 
   '@esbuild/sunos-x64@0.24.2':
     resolution: {integrity: sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.0':
+    resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1088,6 +1223,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.0':
+    resolution: {integrity: sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.19.8':
     resolution: {integrity: sha512-AIAbverbg5jMvJznYiGhrd3sumfwWs8572mIJL5NQjJa06P8KfCPWZQ0NwZbPQnbQi9OWSZhFVSUWjjIrn4hSw==}
     engines: {node: '>=12'}
@@ -1112,6 +1253,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.0':
+    resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.19.8':
     resolution: {integrity: sha512-bfZ0cQ1uZs2PqpulNL5j/3w+GDhP36k1K5c38QdQg+Swy51jFZWWeIkteNsufkQxp986wnqRRsb/bHbY1WQ7TA==}
     engines: {node: '>=12'}
@@ -1132,6 +1279,12 @@ packages:
 
   '@esbuild/win32-x64@0.24.2':
     resolution: {integrity: sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.0':
+    resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2139,6 +2292,11 @@ packages:
 
   esbuild@0.24.2:
     resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.25.0:
+    resolution: {integrity: sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3818,6 +3976,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.24.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.0':
+    optional: true
+
   '@esbuild/android-arm64@0.19.8':
     optional: true
 
@@ -3828,6 +3989,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.0':
     optional: true
 
   '@esbuild/android-arm@0.19.8':
@@ -3842,6 +4006,9 @@ snapshots:
   '@esbuild/android-arm@0.24.2':
     optional: true
 
+  '@esbuild/android-arm@0.25.0':
+    optional: true
+
   '@esbuild/android-x64@0.19.8':
     optional: true
 
@@ -3852,6 +4019,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.24.2':
+    optional: true
+
+  '@esbuild/android-x64@0.25.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.8':
@@ -3866,6 +4036,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.24.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.19.8':
     optional: true
 
@@ -3876,6 +4049,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.24.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.8':
@@ -3890,6 +4066,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.24.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.19.8':
     optional: true
 
@@ -3900,6 +4079,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.24.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.0':
     optional: true
 
   '@esbuild/linux-arm64@0.19.8':
@@ -3914,6 +4096,9 @@ snapshots:
   '@esbuild/linux-arm64@0.24.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.0':
+    optional: true
+
   '@esbuild/linux-arm@0.19.8':
     optional: true
 
@@ -3924,6 +4109,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.24.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.0':
     optional: true
 
   '@esbuild/linux-ia32@0.19.8':
@@ -3938,6 +4126,9 @@ snapshots:
   '@esbuild/linux-ia32@0.24.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.19.8':
     optional: true
 
@@ -3948,6 +4139,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.8':
@@ -3962,6 +4156,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.24.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.19.8':
     optional: true
 
@@ -3972,6 +4169,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.24.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.8':
@@ -3986,6 +4186,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.24.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.19.8':
     optional: true
 
@@ -3996,6 +4199,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.24.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.0':
     optional: true
 
   '@esbuild/linux-x64@0.19.8':
@@ -4010,7 +4216,13 @@ snapshots:
   '@esbuild/linux-x64@0.24.2':
     optional: true
 
+  '@esbuild/linux-x64@0.25.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.19.8':
@@ -4025,6 +4237,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.24.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.0':
     optional: true
 
@@ -4032,6 +4247,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.24.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.8':
@@ -4046,6 +4264,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.24.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.19.8':
     optional: true
 
@@ -4056,6 +4277,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.24.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.0':
     optional: true
 
   '@esbuild/win32-arm64@0.19.8':
@@ -4070,6 +4294,9 @@ snapshots:
   '@esbuild/win32-arm64@0.24.2':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.19.8':
     optional: true
 
@@ -4082,6 +4309,9 @@ snapshots:
   '@esbuild/win32-ia32@0.24.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.0':
+    optional: true
+
   '@esbuild/win32-x64@0.19.8':
     optional: true
 
@@ -4092,6 +4322,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.24.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -5218,7 +5451,7 @@ snapshots:
 
   esbuild-plugin-inline-worker@0.1.1:
     dependencies:
-      esbuild: 0.24.2
+      esbuild: 0.25.0
       find-cache-dir: 3.3.2
 
   esbuild@0.19.8:
@@ -5327,6 +5560,34 @@ snapshots:
       '@esbuild/win32-arm64': 0.24.2
       '@esbuild/win32-ia32': 0.24.2
       '@esbuild/win32-x64': 0.24.2
+
+  esbuild@0.25.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.0
+      '@esbuild/android-arm': 0.25.0
+      '@esbuild/android-arm64': 0.25.0
+      '@esbuild/android-x64': 0.25.0
+      '@esbuild/darwin-arm64': 0.25.0
+      '@esbuild/darwin-x64': 0.25.0
+      '@esbuild/freebsd-arm64': 0.25.0
+      '@esbuild/freebsd-x64': 0.25.0
+      '@esbuild/linux-arm': 0.25.0
+      '@esbuild/linux-arm64': 0.25.0
+      '@esbuild/linux-ia32': 0.25.0
+      '@esbuild/linux-loong64': 0.25.0
+      '@esbuild/linux-mips64el': 0.25.0
+      '@esbuild/linux-ppc64': 0.25.0
+      '@esbuild/linux-riscv64': 0.25.0
+      '@esbuild/linux-s390x': 0.25.0
+      '@esbuild/linux-x64': 0.25.0
+      '@esbuild/netbsd-arm64': 0.25.0
+      '@esbuild/netbsd-x64': 0.25.0
+      '@esbuild/openbsd-arm64': 0.25.0
+      '@esbuild/openbsd-x64': 0.25.0
+      '@esbuild/sunos-x64': 0.25.0
+      '@esbuild/win32-arm64': 0.25.0
+      '@esbuild/win32-ia32': 0.25.0
+      '@esbuild/win32-x64': 0.25.0
 
   escalade@3.1.1: {}
 


### PR DESCRIPTION
Add functionality for main menu in tauri backend.

- [x] Dialogs
- [x] Edit view
- [x] Developers
- [x] Show devtools open only if setting is set
- [x] Delete action 
  -  https://github.com/tauri-apps/tauri/issues/12718
- [x] Checkboxes for zoom level
- [x] Mac mainbar
- [x] Float on top

close https://github.com/deltachat/delta-tauri-todo/issues/7
close https://github.com/deltachat/delta-tauri-todo/issues/8

I currently have the problem that `config.json` store is not available during initialization and I can not check the proper value of the zoom level. Can we fix that @Simon-Laux or is it anyways not persisted? I think it would be nicer If we persisted it with actual managed state. I can also not check the mac mainbar.