### PR TITLE
fix: message list being empty on chat double click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- message list being empty when double-clicking the chat before it has loaded (again) #4647
 
 <a id="1_54_1"></a>
 

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -956,7 +956,6 @@ class MessageListStore extends Store<MessageListState> {
     let oldestFetchedMessageListItemIndex = -1
     let newestFetchedMessageListItemIndex = -1
     let newMessageCache: MessageListState['messageCache'] = {}
-    const half_page_size = Math.ceil(PAGE_SIZE / 2)
     if (messageListItems.length !== 0) {
       if (jumpToMessageIndex == undefined) {
         // To be fair, it's expected that we could jump to a message
@@ -970,6 +969,8 @@ class MessageListStore extends Store<MessageListState> {
         )
         jumpToMessageIndex = messageListItems.length - 1
       }
+
+      const half_page_size = Math.ceil(PAGE_SIZE / 2)
 
       oldestFetchedMessageListItemIndex = Math.max(
         jumpToMessageIndex - half_page_size,

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -797,7 +797,7 @@ class MessageListStore extends Store<MessageListState> {
    * (it will internally casue this function to be invoked).
    *
    * @param msgId - when `undefined`, pop the jump stack, or,
-   * if the stack is empty, jump to last message
+   * if the stack is empty, jump to last message of the `this.chatId` chat
    * if there _is_ a last message.
    * @param addMessageIdToStack the ID of the message to remember,
    * to later go back to it, using the "jump down" button.
@@ -869,10 +869,11 @@ class MessageListStore extends Store<MessageListState> {
         }
 
         jumpToMessageId = items[items.length - 1]
-        chatId =
-          chatIdPreset ??
-          (await BackendRemote.rpc.getMessage(accountId, jumpToMessageId))
-            .chatId
+        // Since `jumpToMessageId` is coming from
+        // `this.state.messageListItems`, it's guaranteed to belong
+        // to the current chat. No need to
+        // `(await rpc.getMessage(accountId, jumpToMessageId)).chatId`
+        chatId = chatIdPreset ?? this.chatId
         jumpToMessageStack = []
         highlight = false
       }


### PR DESCRIPTION
- **refactor: simplify jumpToMessage**
- **refactor: jumpToMessage more type safety, comments**
- **refactor: move var declaration in `jumpToMessage`**
- **fix: message list being empty on chat double click**

The important commit is the last one. Reviewing commit-by-commit should be easier for full understanding.

To reproduce, simply double click on a chat in the chat list
really fast.
Or:

```javascript
item = document.querySelector(
  '.chat-list-item:not(.archive-link-item):not(.selected)'
);
chatListItem.click();
// Let React re-render, then click again.
setTimeout(() => chatListItem.click());
```

https://github.com/user-attachments/assets/23ce7b0b-f05d-49a8-a29e-8504ac077e91

The problem is, in `selectChat` we have code that is supposed to
jump to the last message when the currently selected chat
gets clicked again.
However, if the chat has not loaded yet, and thus a new instance
of `MessageListStore` has not been created yet, and thus its
`loadChat()` has not been called yet,
then, when `loadChat()` does get called eventually,
it will see that `__internal_jump_to_message_asap` is set,
and so it will call `__jumpToMessage`, with `msgId: undefined`.
But, it turns out, `__jumpToMessage` cannot handle this case.
It would try to look up the last message in
`this.state.messageListItems`, but it is empty
(see the `items.length <= 0` line), so `__jumpToMessage()`
would simply return and do nothing, resulting in an empty chat.
But `messageListItems` is empty not because
there are really no messages in the chat,
but because `MessageListStore` has not loaded anything yet,
because, as you remember, `loadChat()` delegated its responsibility
to `__jumpToMessage()`.

This commit ensures that `__jumpToMessage()` handles the case where
`MessageListStore` has not loaded anything yet,
and where `msgId === undefined`.

It appears that the reproduction steps above is the only way
this bug can occur, because it's pretty much the only way
to have `msgId: undefined` (except for the "jump down" button).
So this commit probably doesn't fix any other current bugs.

The issue that this commit fixes was likely introduced in
https://github.com/deltachat/deltachat-desktop/pull/4562
(https://github.com/deltachat/deltachat-desktop/commit/637497c8da528af403c33050e19f5d091b6ca479).