### PR TITLE
fix: show correct git version in build info

### DIFF
--- a/bin/lib/gather-version-info.js
+++ b/bin/lib/gather-version-info.js
@@ -21,7 +21,7 @@ async function getGitRef() {
 
   let git_describe, git_branch
   try {
-    git_describe = gatherProcessStdout('git', ['describe'])
+    git_describe = gatherProcessStdout('git', ['describe', '--tags'])
     try {
       const git_symbolic_ref =
         process.env.GITHUB_HEAD_REF ||


### PR DESCRIPTION
According to the docs: "By default (without --all or --tags) git describe only shows annotated tags"

But we want to search for any tag, not only annotated tags

#skip-changelog