### PR TITLE
fix: keep the order of contacts when calling getContactsByIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Changed
 
+- keep the order of contacts when calling getContactsByIds #4651
+
 <a id="1_54_0"></a>
 
 ## [1.54.0] - 2025-02-15

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -140,7 +140,7 @@ function ViewGroupInner(
     BackendRemote.rpc
       .getContactsByIds(accountId, group.pastContactIds)
       .then(pastContacts => {
-        setPastContacts(Object.values(pastContacts))
+        setPastContacts(group.pastContactIds.map(id => pastContacts[id]))
       })
   }, [accountId, group.pastContactIds])
 
@@ -151,13 +151,13 @@ function ViewGroupInner(
         .then(contacts => {
           // update contacts in case a contact changed
           // while this dialog is open (e.g. contact got blocked)
-          group.contacts = Object.values(contacts)
+          group.contacts = group.contactIds.map(id => contacts[id])
         })
 
       BackendRemote.rpc
         .getContactsByIds(accountId, group.pastContactIds)
         .then(pastContacts => {
-          setPastContacts(Object.values(pastContacts))
+          setPastContacts(group.pastContactIds.map(id => pastContacts[id]))
         })
     })
   }, [accountId, group])


### PR DESCRIPTION
Otherwise contacts are sorted in arbitrary order
because getContactsByIds stores them in a Rust HashMap.