### PR TITLE
test: fix E2E test timing out on group creation

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['list'], ['html']],
   // timeout: 30 * 60 * 1000,
+  expect: {
+    // Our tests involve network interaction, so we want a higher timeout
+    // for assertions, such as receiving an invitation to a group.
+    timeout: 20_000,
+  },
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
Namely,
`expect(page.locator('.verified-icon-info-msg')).toBeVisible()`.

Looks like we should just wait for a bit longer.

#skip-changelog
