### PR TITLE
improvement: a11y: `aria-label` for unread count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 - keep the order of contacts when calling getContactsByIds #4651
 
+### Fixed
+- accessibility: add `aria-label`s to unread counters
+
 <a id="1_54_0"></a>
 
 ## [1.54.0] - 2025-02-15

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -178,6 +178,13 @@ export default function AccountItem({
         className={classNames(styles.accountBadgeIcon, {
           [styles.muted]: muted,
         })}
+        // Looking at the string key, this might be interprented that
+        // it only applies to a single chat.
+        // But it's good enough I guess.
+        // Maybe we could also use `n_messages_in_m_chats` instead.
+        aria-label={tx('chat_n_new_messages', String(unreadCount), {
+          quantity: unreadCount,
+        })}
       >
         {unreadCount}
       </div>

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -13,12 +13,24 @@ import { InlineVerifiedIcon } from '../VerifiedIcon'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { message2React } from '../message/MessageMarkdown'
 import { useRovingTabindex } from '../../contexts/RovingTabindex'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 const log = getLogger('renderer/chatlist/item')
 
 function FreshMessageCounter({ counter }: { counter: number }) {
+  const tx = useTranslationFunction()
+
   if (counter === 0) return null
-  return <div className='fresh-message-counter'>{counter}</div>
+  return (
+    <span
+      className='fresh-message-counter'
+      aria-label={tx('chat_n_new_messages', String(counter), {
+        quantity: counter,
+      })}
+    >
+      {counter}
+    </span>
+  )
 }
 
 type ChatListItemType = Type.ChatListItemFetchResult & {

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -985,6 +985,8 @@ function JumpDownButton({
   >['store']['effect']['jumpToMessage']
   jumpToMessageStack: number[]
 }) {
+  const tx = useTranslationFunction()
+
   const countUnreadMessages = useUnreadCount(accountId, chat)
 
   let countToShow: string = countUnreadMessages.toString()
@@ -1000,6 +1002,11 @@ function JumpDownButton({
             'counter',
             countToShow.length === 3 && 'counter-3digits'
           )}
+          // Even though this is not focusable as of the time of writing,
+          // let's still apply label, for future-proofing.
+          aria-label={tx('chat_n_new_messages', String(countUnreadMessages), {
+            quantity: countUnreadMessages,
+          })}
           style={countUnreadMessages === 0 ? { visibility: 'hidden' } : {}}
         >
           {countToShow}


### PR DESCRIPTION
In:
- Chat list items.
- Account list items.
- "Jump down" button badge.
