### PR TITLE
test: always upload E2E test artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,7 +104,10 @@ jobs:
     - name: Run e2e tests
       run: pnpm e2e --project Chrome
     - uses: actions/upload-artifact@v4
-      if: ${{ failure() && !cancelled() }}
+      # We may want to not upload artifacts if tests pass,
+      # (`if: ${{ failure() && !cancelled() }}`)
+      # but we want to debug flaky tests, so let's always upload them.
+      if: ${{ !cancelled() }}
       with:
         name: e2e-report
         path: packages/e2e-tests/playwright-report


### PR DESCRIPTION
So that we can debug flaky tests, because they _are_ pretty flaky
as of now.
