### PR TITLE
fix: a11y: `aria-hidden="true"` for some avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixed
 - fix unread count on "jump down" button not clearing when all messages are read #4648
 - keep the order of contacts when calling getContactsByIds #4651
-- improve accessibility #4655, #4656, #4662
+- improve accessibility #4655, #4656, #4661, #4662
 
 <a id="1_54_0"></a>
 

--- a/packages/frontend/src/components/Avatar/index.tsx
+++ b/packages/frontend/src/components/Avatar/index.tsx
@@ -43,6 +43,12 @@ export function Avatar(props: {
   wasSeenRecently?: boolean
   style?: htmlDivProps['style']
   onClick?: () => void
+  /**
+   * Consider setting this to `true` if the name
+   * of whoever the avatar belongs to is displayed somewhere near.
+   * Has no effect when `onClick` is set.
+   */
+  'aria-hidden'?: boolean
   tabIndex?: -1 | 0
   className?: string
 }) {
@@ -71,10 +77,16 @@ export function Avatar(props: {
     <div
       className={classNames(
         'avatar',
+        // Since `wasSeenRecently` is not exposed to accessibility API,
+        // it is safe to apply aria-hidden to the entire component.
+        // If at some point we make `wasSeenRecently` accessible,
+        // we should only apply `aria-hidden` to the avatar / initial itself
+        // (and perhaps rename the prop).
         { large, small, wasSeenRecently },
         className
       )}
       onClick={onClick}
+      aria-hidden={onClick ? undefined : props['aria-hidden']}
       tabIndex={tabIndex}
     >
       {content}
@@ -87,6 +99,10 @@ export function AvatarFromContact(
     contact: Type.Contact
     onClick?: (contact: Type.Contact) => void
     tabIndex?: -1 | 0
+    /**
+     * @see {@link Avatar}'s aria-hidden prop.
+     */
+    'aria-hidden'?: boolean
   },
   large?: boolean,
   small?: boolean

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -261,6 +261,7 @@ function ChatListItemError({
         {...{
           displayName: 'E',
           color: '',
+          'aria-hidden': true,
         }}
       />
       <div className='content'>
@@ -332,6 +333,10 @@ function ChatListItemNormal({
           avatarPath: chatListItem.avatarPath || undefined,
           color: chatListItem.color,
           wasSeenRecently: chatListItem.wasSeenRecently,
+          // Avatar is purely decorative here,
+          // and is redundant accessibility-wise,
+          // because we display the chat name below.
+          'aria-hidden': true,
         }}
       />
       <div className='content'>
@@ -445,7 +450,9 @@ export const ChatListItemMessageResult = React.memo<{
       onFocus={tabindexSetAsActiveElement}
       className={`pseudo-chat-list-item message-search-result ${tabindexClassName}`}
     >
-      <div className='avatars'>
+      {/* Avatars are purely decorative here, and are redundant
+      accessibility-wise, because we display the chat and author name below. */}
+      <div className='avatars' aria-hidden='true'>
         <Avatar
           className='big'
           avatarPath={msr.chatProfileImage}

--- a/packages/frontend/src/components/contact/Contact.tsx
+++ b/packages/frontend/src/components/contact/Contact.tsx
@@ -51,6 +51,10 @@ export default function Contact(props: {
           displayName,
           addr: address,
           wasSeenRecently,
+          // Avatar is purely decorative here,
+          // and is redundant accessibility-wise,
+          // because we display the contact name below.
+          'aria-hidden': true,
         }}
       />
       <ContactName
@@ -76,6 +80,10 @@ export function PseudoContact(
           avatarPath={undefined}
           color={'#505050'}
           displayName={cutoff || ''}
+          // Avatar is purely decorative here,
+          // and is redundant accessibility-wise,
+          // because we display the "contact name" below.
+          aria-hidden={true}
         />
       )}
       {!subText && (

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
@@ -76,6 +76,10 @@ export const AddMemberChip = (props: {
           avatarPath={contact.profileImage}
           color={contact.color}
           small={true}
+          // Avatar is purely decorative here,
+          // and is redundant accessibility-wise,
+          // because we display the contact name below.
+          aria-hidden={true}
         />
       </div>
       <div className={styles.DisplayName}>

--- a/packages/frontend/src/components/dialogs/MessageDetail/ReadReceipts.tsx
+++ b/packages/frontend/src/components/dialogs/MessageDetail/ReadReceipts.tsx
@@ -71,6 +71,10 @@ function ReadReceipt(props: { receipt: T.MessageReadReceipt }) {
         avatarPath={contact.profileImage}
         addr={contact.address}
         color={contact.color}
+        // Avatar is purely decorative here,
+        // and is redundant accessibility-wise,
+        // because we display the contact name below.
+        aria-hidden={true}
       />
       <div className={styles.ReadReceiptContactLabel}>
         <div>

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
@@ -146,7 +146,13 @@ function ReactionsDialogListItem(props: {
       onFocus={rovingTabindex.setAsActiveElement}
     >
       <div className={styles.reactionsDialogAvatar}>
-        <AvatarFromContact contact={contact} />
+        <AvatarFromContact
+          contact={contact}
+          // Avatar is purely decorative here,
+          // and is redundant accessibility-wise,
+          // because we display the contact name below.
+          aria-hidden={true}
+        />
       </div>
       <div className={styles.reactionsDialogContactName}>
         <ContactName displayName={contact.displayName} />

--- a/packages/frontend/src/components/screens/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen.tsx
@@ -369,6 +369,10 @@ function ChatHeading({ chat }: { chat: T.FullChat }) {
         avatarPath={chat.profileImage || undefined}
         small
         wasSeenRecently={chat.wasSeenRecently}
+        // Avatar is purely decorative here,
+        // and is redundant accessibility-wise,
+        // because we display the chat name below.
+        aria-hidden={true}
       />
       <div style={{ marginLeft: '7px', overflow: 'hidden' }}>
         <div className='navbar-chat-name'>


### PR DESCRIPTION
We can ignore them because contact / chat name is displayed
alongside the avatar, so avatars in this case are redundant.

This commit does not affect some clickable avatars,
e.g. in message list items in groups.
I am not sure how to approach those yet.
