### PR TITLE
fix: MessageListStore logger name is Store

### DIFF
--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -146,7 +146,7 @@ class MessageListStore extends Store<MessageListState> {
     private readonly accountId: number,
     private readonly chatId: number
   ) {
-    super(defaultState())
+    super(defaultState(), 'MessageListStore')
   }
 
   get activeView() {


### PR DESCRIPTION
Before change:

![Screenshot from 2025-02-17 00-48-02](https://github.com/user-attachments/assets/0f6686ea-761d-4655-b4fd-441a14ae830f)

After change:

![Screenshot from 2025-02-17 00-48-42](https://github.com/user-attachments/assets/52ec2491-e2f8-4140-86a1-9e519ba76d8e)
