### PR TITLE
logger: Add some more examples and mention Verbose in drop down

### DIFF
--- a/packages/shared/logger.ts
+++ b/packages/shared/logger.ts
@@ -67,16 +67,27 @@ export function printProcessLogLevelInfo() {
   )
   /* ignore-console-log */
   console.info(
-    `# Tips and Tricks for working with the browser console:
-## Use the search to filter the output like:
-space separate terms, exclude with -, if your term contains spaces you should exape it with "
+    `# Tips and Tricks for using the search filter in the browser console:
 
--👻                 don't show events from background accounts (not selected accounts)
--📡                 don't show any events
--[JSONRPC]   don't show jsonrpc messages
-[JSONRPC]    show only jsonrpc messages
+• Use space to separate search terms
+• Exclude search terms using -
+• If the search term contains spaces you should escape it with ""
+
+Examples:
+
+🕸️          only show debug messages
+-🕸️         don't show debug messages
+ℹ️          only show info messages
+-ℹ️         don't show info messages
+👻          only show events from background accounts (not selected accounts)
+-👻         don't show events from background accounts (not selected accounts)
+📡          only show events
+-📡         don't show any events
+[JSONRPC]   only show jsonrpc messages
+-[JSONRPC]  don't show jsonrpc messages
 
 Start deltachat with --devmode (or --log-debug and --log-to-console) argument to show full log output.
+If the log seems quiet, make sure the 'All levels' drop down has 'Verbose' checked.
   `
   )
 }


### PR DESCRIPTION
Just adding some more examples. This is a very nice feature!

Before change:

![Screenshot from 2025-02-17 19-35-27](https://github.com/user-attachments/assets/914836fc-143a-412f-9109-37c88426148d)

After change:

![Screenshot from 2025-02-17 19-47-21](https://github.com/user-attachments/assets/93b2597a-d475-4e19-bc03-67631208de17)

I'll update the `docs/LOGGING.md` file later in a separate PR.

#skip-changelog
