### PR TITLE
fix: a11y: 'tablist' role for gallery / chat view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 - message list being empty when double-clicking the chat before it has loaded (again) #4647
 - accessibility: improve tab order of the app #4672
+- other minor accessibility improvements #4675
 - improve performance a little #4512
 
 <a id="1_54_1"></a>

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -278,8 +278,18 @@ export default class Gallery extends Component<
     const showDateHeader =
       currentTab !== 'files' && currentTab !== 'webxdc_apps'
 
+    // FYI the role="tablist" element is not rendered when
+    // `props.chatId === 'all'`.
+    // Would be nice to DRY this somehow.
+    const isTabpanel = this.props.chatId !== 'all'
+
     return (
-      <div className='media-view'>
+      <div
+        role={isTabpanel ? 'tabpanel' : undefined}
+        aria-labelledby={isTabpanel ? 'tab-media-view' : undefined}
+        id='media-view'
+        className='media-view'
+      >
         <ul ref={this.tabListRef} className='tab-list .modifier' role='tablist'>
           <RovingTabindexProvider
             wrapperElementRef={this.tabListRef}

--- a/packages/frontend/src/components/NoChatSelected.tsx
+++ b/packages/frontend/src/components/NoChatSelected.tsx
@@ -13,7 +13,14 @@ export default function NoChatSelected() {
     : {}
 
   return (
-    <div className='message-list-and-composer' style={style}>
+    <div
+      role='tabpanel'
+      aria-labelledby='tab-message-list-view'
+      // The main MessageListAndComposer also has this ID and class.
+      id='message-list-and-composer'
+      className='message-list-and-composer'
+      style={style}
+    >
       <div
         className='message-list-and-composer__message-list'
         style={{ display: 'flex' }}

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -275,6 +275,10 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   return (
     <div
+      role='tabpanel'
+      aria-labelledby='tab-message-list-view'
+      // NoChatSelected also has this ID and class.
+      id='message-list-and-composer'
       className='message-list-and-composer'
       style={style}
       ref={conversationRef}

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -395,24 +395,41 @@ function ChatNavButtons() {
 
   return (
     <>
-      <span className='views' data-no-drag-region>
+      <span
+        role='tablist'
+        aria-orientation='horizontal'
+        className='views'
+        data-no-drag-region
+      >
         <Button
+          role='tab'
+          id='tab-message-list-view'
           onClick={() => setChatView(ChatView.MessageList)}
           active={activeView === ChatView.MessageList}
+          aria-selected={activeView === ChatView.MessageList}
+          // FYI there are 2 components that use this ID,
+          // but they're not supposed to be rendered at the same time.
+          aria-controls='message-list-and-composer'
           aria-label={tx('chat')}
           className='navbar-button'
         >
           <Icon coloring='navbar' icon='chats' size={18} />
         </Button>
         <Button
+          role='tab'
+          id='tab-media-view'
           onClick={() => setChatView(ChatView.Media)}
           active={activeView === ChatView.Media}
+          aria-selected={activeView === ChatView.Media}
+          aria-controls='media-view'
           aria-label={tx('media')}
           className='navbar-button'
         >
           <Icon coloring='navbar' icon='image' size={18} />
         </Button>
         {settingsStore?.desktopSettings.enableOnDemandLocationStreaming && (
+          // Yes, this is not marked as `role='tab'`.
+          // I'm not sure if this is alright.
           <Button
             onClick={() => openMapWebxdc(selectedAccountId(), chatId)}
             aria-label={tx('tab_map')}


### PR DESCRIPTION
if you listen to the screen-reader, it's not clear
what the buttons do, and how to change the active view.
This should fix it.
