### PR TITLE
refactor: simplify jumpToMessage

### DIFF
--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -1109,7 +1109,7 @@ class MessageListStore extends Store<MessageListState> {
       messageCache: newMessageCache,
       messageListItems,
       oldestFetchedMessageListItemIndex,
-      newestFetchedMessageListItemIndex: newestFetchedMessageListItemIndex,
+      newestFetchedMessageListItemIndex,
       viewState: newViewState,
       jumpToMessageStack,
     })

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -952,7 +952,7 @@ class MessageListStore extends Store<MessageListState> {
     // calculate page indexes, so that jumpToMessageId is in the middle of the page
     let oldestFetchedMessageListItemIndex = -1
     let newestFetchedMessageListItemIndex = -1
-    let newMessageCache: MessageListState['messageCache'] = {}
+    let newMessageCache: MessageListState['messageCache']
     let newViewState: ChatViewState
     if (messageListItems.length === 0) {
       if (jumpToMessageId != undefined) {
@@ -962,6 +962,7 @@ class MessageListStore extends Store<MessageListState> {
         )
       }
 
+      newMessageCache = {}
       // Same as in `loadChat()`
       newViewState = ChatViewReducer.selectChat(this.state.viewState)
     } else {

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -950,8 +950,8 @@ class MessageListStore extends Store<MessageListState> {
     }
 
     // calculate page indexes, so that jumpToMessageId is in the middle of the page
-    let oldestFetchedMessageListItemIndex = -1
-    let newestFetchedMessageListItemIndex = -1
+    let oldestFetchedMessageListItemIndex: number
+    let newestFetchedMessageListItemIndex: number
     let newMessageCache: MessageListState['messageCache']
     let newViewState: ChatViewState
     if (messageListItems.length === 0) {
@@ -962,6 +962,8 @@ class MessageListStore extends Store<MessageListState> {
         )
       }
 
+      oldestFetchedMessageListItemIndex = -1
+      newestFetchedMessageListItemIndex = -1
       newMessageCache = {}
       // Same as in `loadChat()`
       newViewState = ChatViewReducer.selectChat(this.state.viewState)


### PR DESCRIPTION
- **refactor: simplify jumpToMessage**
- **refactor: simplify jumpToMessage 2**
- **refactor: simplify jumpToMessage 3**

This does not affect jumpToMessage behavior. TypeScript ensures that the vars are initialized eventually.

#skip-changelog