### PR TITLE
Pass in default size instead of booleans

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -282,7 +282,6 @@ export default class DCWebxdc {
 
       const app_icon = icon_blob && nativeImage?.createFromBuffer(icon_blob)
 
-      const lastBounds = await this.getLastBounds(accountId, msg_id)
       const webxdcWindow = new BrowserWindow({
         webPreferences: {
           partition: partitionFromAccountId(accountId),
@@ -301,9 +300,16 @@ export default class DCWebxdc {
         show: false,
       })
       setContentProtection(webxdcWindow)
+
       // reposition the window to last position (or default)
-      const bounds = adjustBounds(lastBounds || defaultSize)
+      const lastBounds: Bounds | null = await this.getLastBounds(
+        accountId,
+        msg_id
+      )
+      const size: Size = adjustSize(lastBounds || defaultSize)
+      const bounds: Partial<Bounds> = { ...(lastBounds || {}), ...size }
       webxdcWindow.setBounds(bounds, true)
+
       // show after repositioning to avoid blinking
       webxdcWindow.show()
       open_apps[`${accountId}.${msg_id}`] = {
@@ -923,10 +929,9 @@ export async function webxdcStartUpCleanup() {
 }
 
 /**
- * Make sure a default size doesn't extend the size
- * of the primary display work area.
+ * Make sure a default size doesn't extend the primary display work area.
  */
-function adjustBounds(size: Size): Size {
+function adjustSize(size: Size): Size {
   const { height: screenHeight, width: screenWidth } =
     screen.getPrimaryDisplay().workAreaSize
   return {

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -302,7 +302,7 @@ export default class DCWebxdc {
       })
       setContentProtection(webxdcWindow)
       // reposition the window to last position (or default)
-      const bounds = lastBounds || adjustDefaultSize(defaultSize)
+      const bounds = adjustBounds(lastBounds || defaultSize)
       webxdcWindow.setBounds(bounds, true)
       // show after repositioning to avoid blinking
       webxdcWindow.show()
@@ -926,7 +926,7 @@ export async function webxdcStartUpCleanup() {
  * Make sure a default size doesn't extend the size
  * of the primary display work area.
  */
-function adjustDefaultSize(size: Size): Size {
+function adjustBounds(size: Size): Size {
   const { height: screenHeight, width: screenWidth } =
     screen.getPrimaryDisplay().workAreaSize
   return {

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -929,7 +929,7 @@ export async function webxdcStartUpCleanup() {
 }
 
 /**
- * Make sure a default size doesn't extend the primary display work area.
+ * Make sure a size doesn't extend the primary display work area.
  */
 function adjustSize(size: Size): Size {
   const { height: screenHeight, width: screenWidth } =

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -86,16 +86,16 @@ const BOUNDS_UI_CONFIG_PREFIX = 'ui.desktop.webxdcBounds'
 
 type Size = { width: number; height: number }
 
-export default class DCWebxdc {
-  private DEFAULT_SIZE_WEBXDC: Size = defaultSize({
-    width: 375,
-    height: 667,
-  })
-  private DEFAULT_SIZE_MAP: Size = defaultSize({
-    width: 1000,
-    height: 800,
-  })
+const DEFAULT_SIZE_WEBXDC: Size = {
+  width: 375,
+  height: 667,
+}
+const DEFAULT_SIZE_MAP: Size = {
+  width: 1000,
+  height: 800,
+}
 
+export default class DCWebxdc {
   constructor(private controller: DeltaChatController) {
     // icon protocol
     app.whenReady().then(() => {
@@ -125,7 +125,7 @@ export default class DCWebxdc {
       _ev: IpcMainInvokeEvent,
       msg_id: number,
       p: DcOpenWebxdcParameters,
-      defaultSize: Size = this.DEFAULT_SIZE_WEBXDC
+      defaultSize: Size = DEFAULT_SIZE_WEBXDC
     ) => {
       const { webxdcInfo, chatName, displayname, accountId, href } = p
       const addr = webxdcInfo.selfAddr
@@ -302,7 +302,8 @@ export default class DCWebxdc {
       })
       setContentProtection(webxdcWindow)
       // reposition the window to last position (or default)
-      webxdcWindow.setBounds(lastBounds || defaultSize, true)
+      const bounds = lastBounds || adjustDefaultSize(defaultSize)
+      webxdcWindow.setBounds(bounds, true)
       // show after repositioning to avoid blinking
       webxdcWindow.show()
       open_apps[`${accountId}.${msg_id}`] = {
@@ -762,7 +763,7 @@ export default class DCWebxdc {
               },
               // special behaviour for the map dc integration,
               // (in this case bigger landscape window)
-              this.DEFAULT_SIZE_MAP
+              DEFAULT_SIZE_MAP
             )
           }
         }
@@ -921,12 +922,16 @@ export async function webxdcStartUpCleanup() {
   }
 }
 
-function defaultSize(default_size: Size): Size {
+/**
+ * Make sure a default size doesn't extend the size
+ * of the primary display work area.
+ */
+function adjustDefaultSize(size: Size): Size {
   const { height: screenHeight, width: screenWidth } =
     screen.getPrimaryDisplay().workAreaSize
   return {
-    width: Math.min(default_size.width, screenWidth),
-    height: Math.min(default_size.height, screenHeight),
+    width: Math.min(size.width, screenWidth),
+    height: Math.min(size.height, screenHeight),
   }
 }
 

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -760,6 +760,8 @@ export default class DCWebxdc {
                 webxdcInfo: messageWithMap.webxdcInfo,
                 href: '',
               },
+              // special behaviour for the map dc integration,
+              // (in this case bigger landscape window)
               this.DEFAULT_SIZE_MAP
             )
           }


### PR DESCRIPTION
A slightly different approach.

* Pass a default size (note, a `Size` that only has `width` and `height`) instead of a boolean
* Compute the default size for webxdc and map at startup, based on the primary display, instead of putting it into `getLastBounds()`
* `getLastBounds()` returns a bounds if there were any, if this wasn't the case, use the `defaultSize` which already is adjusted to to the size of the primary display

Tweak to https://github.com/deltachat/deltachat-desktop/pull/4683

#skip-changelog PR to a PR