### PR TITLE
fix: a11y: aria-live for draft quote & attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,10 @@ All notable changes to this project will be documented in this file.
 - Calls: add "P2P" / "non-P2P" text
 
 
+### Fixed
+- accessibility: announce when the draft's quoted message and attachments change (as a result of user actions) (make it a live region) #4693
+
+
 <a id="2_22_0"></a>
 
 ## [2.22.0] - 2025-10-17

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -591,7 +591,16 @@ const Composer = forwardRef<
           // (`id='chat-section-heading'`) is probably enough.
         }
       >
-        <div className='upper-bar'>
+        <section
+          // Keep in mind that this element also changes when switching
+          // between chats.
+          // We probably want such changes to be announced still.
+          aria-live='polite'
+          // Announce quote / editing / attachment _removals_
+          // as well as text changes and node insertions.
+          aria-relevant='all'
+          className='upper-bar'
+        >
           {!messageEditing.isEditingModeActive ? (
             <>
               {draftState.quote !== null && (
@@ -599,11 +608,22 @@ const Composer = forwardRef<
                   className='attachment-quote-section is-quote'
                   aria-label={tx('menu_reply')}
                 >
-                  {/* Check that this is a "full" quote.
-                  TODO it would be nice to show a placeholder otherwise. */}
-                  {'text' in draftState.quote && (
-                    <Quote quote={draftState.quote} tabIndex={0} />
-                  )}
+                  <div
+                    // When changing the quoted message, e.g. with the Ctrl + Up
+                    // shortcut, we should read the author's name
+                    // even if it didn't change.
+                    //
+                    // Note that `aria-atomic` doesn't appear to work,
+                    // at least with NVDA, when it's a _descendant_ of the
+                    // `aria-live` element.
+                    aria-atomic='true'
+                  >
+                    {/* Check that this is a "full" quote.
+                    TODO it would be nice to show a placeholder otherwise. */}
+                    {'text' in draftState.quote && (
+                      <Quote quote={draftState.quote} tabIndex={0} />
+                    )}
+                  </div>
                   <CloseButton
                     onClick={removeQuote}
                     aria-label={tx('remove_quote')}
@@ -683,7 +703,7 @@ const Composer = forwardRef<
               />
             </div>
           )}
-        </div>
+        </section>
         <div className='lower-bar'>
           {!messageEditing.isEditingModeActive && !recording && (
             <MenuAttachment

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -626,7 +626,14 @@ const Composer = forwardRef<
           // (`id='chat-section-heading'`) is probably enough.
         }
       >
-        <div className='upper-bar'>
+        <section
+          aria-live='polite'
+          // Announce quote / editing / attachment _removals_
+          // as well as text changes and node insertions.
+          aria-relevant='all'
+          aria-busy={draftIsLoading}
+          className='upper-bar'
+        >
           {!messageEditing.isEditingModeActive ? (
             <>
               {draftState.quote !== null && (
@@ -634,11 +641,22 @@ const Composer = forwardRef<
                   className='attachment-quote-section is-quote'
                   aria-label={tx('menu_reply')}
                 >
-                  {/* Check that this is a "full" quote.
-                  TODO it would be nice to show a placeholder otherwise. */}
-                  {'text' in draftState.quote && (
-                    <Quote quote={draftState.quote} tabIndex={0} />
-                  )}
+                  <div
+                    // When changing the quoted message, e.g. with the Ctrl + Up
+                    // shortcut, we should read the author's name
+                    // even if it didn't change.
+                    //
+                    // Note that `aria-atomic` doesn't appear to work,
+                    // at least with NVDA, when it's a _descendant_ of the
+                    // `aria-live` element.
+                    aria-atomic='true'
+                  >
+                    {/* Check that this is a "full" quote.
+                    TODO it would be nice to show a placeholder otherwise. */}
+                    {'text' in draftState.quote && (
+                      <Quote quote={draftState.quote} tabIndex={0} />
+                    )}
+                  </div>
                   <CloseButton
                     onClick={removeQuote}
                     aria-label={tx('remove_quote')}
@@ -718,7 +736,7 @@ const Composer = forwardRef<
               />
             </div>
           )}
-        </div>
+        </section>
         <div className='lower-bar'>
           {!messageEditing.isEditingModeActive && !recording && (
             <MenuAttachment


### PR DESCRIPTION
This is handy for the Ctrl + Up shortcut,
and also adds confirmation for when using the regular way,
i.e. context meny -> reply.
Same for attachments.

TODO:
- [ ] I'm testing with NVDA and it seems like `aria-atomic` doesn't work for some reason. It only announces the changes. E.g. if the author's name didn't change, it won't announce it.
- [ ] NVDA doesn't announce when the quote gets removed, when using the Ctrl + Down shortcut.
- [ ] We announce the changes, but don't announce that it's a draft quote. Can this MR still be considered an improvement?
- [ ] Consider alternatives, see comments below.