### PR TITLE
improvement: hide chat name for single chat search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - Use dedicated ID for sync messages affecting device chat.
   - Do not allow non-members to change ephemeral timer settings.
   - Show padlock when the message is not sent over the network.
+- when searching for messages in a single chat, do not show the redundant chat name in each search result #4696
 - html email view: migrate from deprecated `BrowserView` to `WebContentsView` #4689
 
 ### Fixed

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -333,8 +333,13 @@ export default function ChatList(props: {
   }, [contactCache, contactIds])
 
   const messagelistData = useMemo(() => {
-    return { messageResultIds, messageCache, queryStr }
-  }, [messageResultIds, messageCache, queryStr])
+    return {
+      messageResultIds,
+      messageCache,
+      queryStr,
+      isSingleChatSearch: queryChatId != null,
+    }
+  }, [messageResultIds, messageCache, queryStr, queryChatId])
 
   const [searchChatInfo, setSearchChatInfo] = useState<T.BasicChat | null>(null)
   useEffect(() => {

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -427,8 +427,21 @@ export const ChatListItemMessageResult = React.memo<{
   msr: T.MessageSearchResult
   onClick: () => void
   queryStr: string
+  /**
+   * Whether the user is searching for messages in just a single chat.
+   */
+  isSingleChatSearch: boolean
 }>(props => {
-  const { msr, onClick, queryStr } = props
+  const {
+    msr,
+    onClick,
+    queryStr,
+    /**
+     * When the user is searching for messages in just a single chat,
+     * we don't need to specify here which chat it belongs to.
+     */
+    isSingleChatSearch,
+  } = props
 
   const ref = useRef<HTMLButtonElement>(null)
 
@@ -453,18 +466,29 @@ export const ChatListItemMessageResult = React.memo<{
       {/* Avatars are purely decorative here, and are redundant
       accessibility-wise, because we display the chat and author name below. */}
       <div className='avatars' aria-hidden='true'>
-        <Avatar
-          className='big'
-          avatarPath={msr.chatProfileImage}
-          color={msr.chatColor}
-          displayName={msr.chatName}
-        />
-        {!(
-          msr.chatType === C.DC_CHAT_TYPE_SINGLE &&
-          msr.authorId !== C.DC_CONTACT_ID_SELF
-        ) && (
+        {!isSingleChatSearch ? (
+          <>
+            <Avatar
+              className='big'
+              avatarPath={msr.chatProfileImage}
+              color={msr.chatColor}
+              displayName={msr.chatName}
+            />
+            {!(
+              msr.chatType === C.DC_CHAT_TYPE_SINGLE &&
+              msr.authorId !== C.DC_CONTACT_ID_SELF
+            ) && (
+              <Avatar
+                className='small'
+                avatarPath={msr.authorProfileImage}
+                color={msr.authorColor}
+                displayName={msr.authorName}
+              />
+            )}
+          </>
+        ) : (
           <Avatar
-            className='small'
+            className='big'
             avatarPath={msr.authorProfileImage}
             color={msr.authorColor}
             displayName={msr.authorName}
@@ -475,8 +499,12 @@ export const ChatListItemMessageResult = React.memo<{
         <div className='header'>
           <div className='name'>
             <span>
-              <span className='truncated'>{msr.chatName}</span>
-              {msr.isChatProtected && <InlineVerifiedIcon />}
+              <span className='truncated'>
+                {!isSingleChatSearch ? msr.chatName : msr.authorName}
+              </span>
+              {!isSingleChatSearch && msr.isChatProtected && (
+                <InlineVerifiedIcon />
+              )}
             </span>
           </div>
           <div>
@@ -487,19 +515,21 @@ export const ChatListItemMessageResult = React.memo<{
             />
           </div>
         </div>
-        <div className='message-result-author-line'>
-          <div className='author-name'>{msr.authorName}</div>
-          {msr.isChatContactRequest && (
-            <div className='label'>
-              {window.static_translate('chat_request_label')}
-            </div>
-          )}
-          {msr.isChatArchived && (
-            <div className='label'>
-              {window.static_translate('chat_archived_label')}
-            </div>
-          )}
-        </div>
+        {!isSingleChatSearch && (
+          <div className='message-result-author-line'>
+            <div className='author-name'>{msr.authorName}</div>
+            {msr.isChatContactRequest && (
+              <div className='label'>
+                {window.static_translate('chat_request_label')}
+              </div>
+            )}
+            {msr.isChatArchived && (
+              <div className='label'>
+                {window.static_translate('chat_archived_label')}
+              </div>
+            )}
+          </div>
+        )}
         <div className='chat-list-item-message'>
           <div className='text'>{rMessage(msr.message, queryStr)}</div>
         </div>

--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -32,6 +32,10 @@ export type MessageChatListItemData = {
     [id: number]: T.MessageSearchResult | undefined
   }
   queryStr: string | undefined
+  /**
+   * Whether the user is searching for messages in just a single chat.
+   */
+  isSingleChatSearch: boolean
 }
 
 export type ContactChatListItemData = {
@@ -109,7 +113,7 @@ export const ChatListItemRowMessage = React.memo<{
   data: MessageChatListItemData
   style: React.CSSProperties
 }>(({ index, data, style }) => {
-  const { messageResultIds, messageCache, queryStr } = data
+  const { messageResultIds, messageCache, queryStr, isSingleChatSearch } = data
   const msrId = messageResultIds[index]
   const messageSearchResult = messageCache[msrId]
   const { jumpToMessage } = useMessage()
@@ -121,6 +125,7 @@ export const ChatListItemRowMessage = React.memo<{
         <ChatListItemMessageResult
           queryStr={queryStr || ''}
           msr={messageSearchResult}
+          isSingleChatSearch={isSingleChatSearch}
           onClick={() => {
             jumpToMessage({
               accountId,


### PR DESCRIPTION
Also hide the "Archived" and "Contact Request" status.
This info is redundant when searching in a particular single chat.

Before / after:
![image](https://github.com/user-attachments/assets/bb64eb11-7449-4d44-8910-baa2e9809a9e) ![image](https://github.com/user-attachments/assets/63bf6f07-43b8-44e0-a23b-d5236630a45e)