### PR TITLE
feat: show "edited" in message status line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
+- show "Edited" in the message's status line (if it's edited) #4697
 - add "learn more"-button to manage-key section that links to local help #4684
 - add a search field to help page #4691
 - update local help (2025-02-21)

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -169,7 +169,8 @@
       );
     }
 
-    & > .date {
+    & > .date,
+    & > .edited {
       color: var(--messageMetadataIncoming);
     }
   }
@@ -192,7 +193,8 @@
   margin-right: 0;
 
   .metadata:not(.with-image-no-caption) {
-    & > .date {
+    & > .date,
+    & > .edited {
       color: var(--messageOutgoingStatusColor);
     }
 
@@ -278,7 +280,8 @@
   }
 
   .metadata {
-    & > .date {
+    & > .date,
+    & > .edited {
       font-size: 11px;
       color: white;
     }
@@ -626,7 +629,8 @@
         @include color-svg('./images/map-marker.svg', white, 100%);
       }
 
-      & > .date {
+      & > .date,
+      & > .edited {
         color: white;
       }
     }

--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -13,7 +13,8 @@
     border-radius: 4px;
     font-weight: bold;
 
-    & > .date {
+    & > .date,
+    & > .edited {
       color: white;
     }
 
@@ -30,12 +31,20 @@
     margin-bottom: 2px;
   }
 
-  & > .date {
+  & > .date,
+  & > .edited {
     font-size: 11.5px;
     line-height: 16px;
     letter-spacing: 0.3px;
     color: var(--messageMetadataDate);
+  }
+  & > .date {
     text-transform: uppercase;
+  }
+  & > .edited {
+    text-transform: lowercase;
+    // Assumes that there is always a date after it.
+    margin-inline-end: 0.5ch;
   }
 
   & > .spacer {

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -677,6 +677,7 @@ export default function Message(props: {
             fileMime={(!isSetupmessage && message.fileMime) || null}
             direction={direction}
             status={status}
+            isEdited={message.isEdited}
             hasText={text !== null && text !== ''}
             hasLocation={hasLocation}
             timestamp={message.timestamp * 1000}
@@ -858,6 +859,7 @@ export default function Message(props: {
               fileMime={fileMime}
               direction={direction}
               status={status}
+              isEdited={message.isEdited}
               hasText={hasText}
               hasLocation={hasLocation}
               timestamp={message.timestamp * 1000}

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -12,6 +12,7 @@ type Props = {
   fileMime: string | null
   direction?: 'incoming' | 'outgoing'
   status: msgStatus
+  isEdited: boolean
   hasText: boolean
   timestamp: number
   hasLocation?: boolean
@@ -28,6 +29,7 @@ export default function MessageMetaData(props: Props) {
     fileMime,
     direction,
     status,
+    isEdited,
     hasText,
     timestamp,
     hasLocation,
@@ -53,6 +55,7 @@ export default function MessageMetaData(props: Props) {
         />
       )}
       {hasLocation && <span className={'location-icon'} />}
+      {isEdited && <span className='edited'>{tx('edited')}</span>}
       <Timestamp
         timestamp={timestamp}
         extended


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4694.
Depends on (hence draft):
- [x] https://github.com/deltachat/deltachat-core-rust/pull/6560.
- [x] Translations update.

![image](https://github.com/user-attachments/assets/35ebcca9-e225-423f-9b4d-96e3f4327ee3)

![image](https://github.com/user-attachments/assets/aed8d328-f0e1-4ad2-bea8-f0a602eacfc5)

~~skip-changelog~~ because:
- [x] We'll probably have an entry for the core upgrade. Check if it's the case prior to merging.