### PR TITLE
tauri: add support for sticker picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - add "learn more"-button to manage-key section that links to local help #4684
+- tauri: add support for sticker picker
 
 ### Changed
 - open map in landscape orientation and with a bigger window #4683

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -92,7 +92,7 @@ function StickersListItem(props: { filePath: string; onClick: () => void }) {
       onKeyDown={rovingTabindex.onKeydown}
       onFocus={rovingTabindex.setAsActiveElement}
     >
-      <img src={filePath} />
+      <img src={runtime.transformStickerURL(filePath)} />
     </button>
   )
 }

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -75,6 +75,7 @@ export interface Runtime {
   showOpenFileDialog(options: RuntimeOpenDialogOptions): Promise<string[]>
   downloadFile(pathToSource: string, filename: string): Promise<void>
   transformBlobURL(blob: string): string
+  transformStickerURL(sticker_path: string): string
   readClipboardText(): Promise<string>
   /**
    * @returns promise that resolves into base64 encoded image string

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -106,6 +106,7 @@ export type RuntimeInfo = {
     scheme: {
       blobs: string
       webxdcIcon: string
+      stickers: string
     }
   }
 }

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -617,6 +617,9 @@ class BrowserRuntime implements Runtime {
     }
     return ''
   }
+  transformStickerURL(_sticker_path: string): string {
+    throw new Error('sticker picker is not implemented yet for browser')
+  }
   async showOpenFileDialog(
     options: RuntimeOpenDialogOptions
   ): Promise<string[]> {

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -318,6 +318,9 @@ class ElectronRuntime implements Runtime {
       return blob
     }
   }
+  transformStickerURL(sticker_path: string): string {
+    return sticker_path
+  }
   async showOpenFileDialog(
     options: RuntimeOpenDialogOptions
   ): Promise<string[]> {

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -331,6 +331,27 @@ class TauriRuntime implements Runtime {
     }
     return ''
   }
+  transformStickerURL(sticker_path: string): string {
+    const matches = sticker_path.match(/.*(:?\\|\/)(.+?)\1stickers\1(.*)/)
+    // this.log.info({ transformStickerURL: sticker_path, matches })
+
+    if (matches) {
+      let filename = matches[3]
+      if (decodeURIComponent(filename) === filename) {
+        // if it is not already encoded then encode it.
+        filename = encodeURIComponent(filename)
+      }
+      return `${this.runtime_info?.tauriSpecific?.scheme.stickers}${matches[2]}/${matches[3]}`
+    }
+    if (sticker_path !== '') {
+      this.log.error('transformStickerURL wrong url format', sticker_path)
+    } else {
+      this.log.debug(
+        'transformStickerURL called with empty string for sticker_path'
+      )
+    }
+    return ''
+  }
   readClipboardText(): Promise<string> {
     return readText()
   }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -13,6 +13,7 @@ mod i18n;
 mod runtime_info;
 mod settings;
 mod state;
+mod stickers;
 mod temp_file;
 mod webxdc;
 
@@ -116,6 +117,7 @@ pub fn run() {
         ])
         .register_asynchronous_uri_scheme_protocol("webxdc-icon", webxdc::webxdc_icon_protocol)
         .register_asynchronous_uri_scheme_protocol("dcblob", blobs::delta_blobs_protocol)
+        .register_asynchronous_uri_scheme_protocol("dcsticker", stickers::delta_stickers_protocol)
         .setup(move |app| {
             // Create missing directories for iOS (quick fix, better fix this upstream in tauri)
             #[cfg(target_os = "ios")]

--- a/packages/target-tauri/src-tauri/src/runtime_info.rs
+++ b/packages/target-tauri/src-tauri/src/runtime_info.rs
@@ -27,6 +27,7 @@ struct BuildInfo {
 pub(crate) struct TauriSpecificScheme {
     blobs: &'static str,
     webxdc_icon: &'static str,
+    stickers: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -62,11 +63,13 @@ pub fn get_runtime_info() -> RuntimeInfo {
         scheme: TauriSpecificScheme {
             blobs: "dcblob://",
             webxdc_icon: "webxdc-icon://",
+            stickers: "dcsticker://",
         },
         #[cfg(any(target_os = "windows", target_os = "android"))]
         scheme: TauriSpecificScheme {
             blobs: "http://dcblob.localhost/",
             webxdc_icon: "http://webxdc-icon.localhost/",
+            stickers: "http://dcsticker.localhost/",
         },
     };
 

--- a/packages/target-tauri/src-tauri/src/stickers.rs
+++ b/packages/target-tauri/src-tauri/src/stickers.rs
@@ -1,0 +1,112 @@
+use anyhow::Context;
+use log::error;
+use percent_encoding::percent_decode_str;
+use tauri::{Manager, UriSchemeContext, UriSchemeResponder};
+use tokio::fs;
+
+use crate::state::deltachat::DeltaChatAppState;
+
+pub(crate) fn delta_stickers_protocol<R: tauri::Runtime>(
+    ctx: UriSchemeContext<'_, R>,
+    request: http::Request<Vec<u8>>,
+    responder: UriSchemeResponder,
+) {
+    // info!("dcsticker {}", request.uri());
+
+    // URI format is dcsticker://<account folder name>/<sticker pack>/<sticker filename>
+
+    let app_state_deltachat = {
+        ctx.app_handle()
+            .state::<DeltaChatAppState>()
+            .deltachat
+            .clone()
+    };
+
+    tauri::async_runtime::spawn(async move {
+        // workaround for not yet available try_blocks feature
+        // https://doc.rust-lang.org/beta/unstable-book/language-features/try-blocks.html
+        let result: anyhow::Result<()> = async {
+            // parse url (account folder name, sticker pack folder and sticker filename)
+            let parsed = {
+                let mut splited = request.uri().path().split('/');
+                #[cfg(not(any(target_os = "windows", target_os = "android")))]
+                {
+                    (request.uri().host(), splited.nth(1), splited.next())
+                }
+                #[cfg(any(target_os = "windows", target_os = "android"))]
+                {
+                    (splited.nth(1), splited.next(), splited.next())
+                }
+            };
+
+            if let (Some(account_folder), Some(pack_folder), Some(file_name)) = parsed {
+                // trace!("dcsticker {account_folder} {pack_folder} {file_name}");
+
+                if matches!(pack_folder, ".." | "." | "") {
+                    anyhow::bail!("path escape attempt detected")
+                }
+
+                // get delta chat
+                let dc = app_state_deltachat.read().await;
+
+                let account = dc
+                    .get_all()
+                    .into_iter()
+                    .find_map(|id| {
+                        dc.get_account(id).filter(|account| {
+                            account
+                                .get_blobdir()
+                                .parent()
+                                .map(|p| p.ends_with(account_folder))
+                                .unwrap_or(false)
+                        })
+                    })
+                    .context("account not found")?;
+
+                let decoded_packname = percent_decode_str(pack_folder).decode_utf8()?.into_owned();
+                let decoded_filename = percent_decode_str(file_name).decode_utf8()?.into_owned();
+                let file_path = account
+                    .get_blobdir()
+                    .join("../stickers")
+                    .join(decoded_packname)
+                    .join(decoded_filename);
+                // trace!("file_path: {file_path:?}");
+
+                match fs::read(&file_path).await {
+                    Ok(blob) => {
+                        responder.respond(
+                            http::Response::builder()
+                                .status(http::StatusCode::OK)
+                                .body(blob)?,
+                        );
+                    }
+                    Err(err) => {
+                        error!("dcsticker loading error: {err:#} {file_path:?}");
+                        responder.respond(
+                            http::Response::builder()
+                                .status(http::StatusCode::INTERNAL_SERVER_ERROR)
+                                .header(http::header::CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
+                                .body(
+                                    "failed to load, look inside logfile for more info"
+                                        .as_bytes()
+                                        .to_vec(),
+                                )?,
+                        );
+                    }
+                }
+            } else {
+                responder.respond(
+                    http::Response::builder()
+                        .status(http::StatusCode::BAD_REQUEST)
+                        .header(http::header::CONTENT_TYPE, mime::TEXT_PLAIN.essence_str())
+                        .body("failed to parse requested url".as_bytes().to_vec())?,
+                );
+            }
+            Ok(())
+        }
+        .await;
+        if let Err(err) = result {
+            error!("Failed to build reply for dcsticker protocol: {err:#}")
+        }
+    });
+}


### PR DESCRIPTION
Before this pr the stickers where shown in the picker, but failed to load, this pr adds the `dcsticker://` scheme to fix that.
