### PR TITLE
refactor: adjust send button HTML

### DIFF
--- a/packages/e2e-tests/tests/basic-functionality.spec.ts
+++ b/packages/e2e-tests/tests/basic-functionality.spec.ts
@@ -123,7 +123,7 @@ test('send message', async ({ page }) => {
     .click()
   const messageText = `Hello ${userB.name}!`
   page.locator('#composer-textarea').fill(messageText)
-  page.locator('.send-button-wrapper button').click()
+  page.locator('button.send-button').click()
   const badgeNumber = await page
     .getByTestId(`account-item-${userB.id}`)
     .locator('.styles_module_accountBadgeIcon')
@@ -187,7 +187,7 @@ test('create group', async ({ page, context, browserName }) => {
     .filter({ hasText: groupName })
   await expect(chatListItem).toBeVisible()
   page.locator('#composer-textarea').fill(`Hello group members!`)
-  page.locator('.send-button-wrapper button').click()
+  page.locator('button.send-button').click()
   const badgeNumber = await page
     .getByTestId(`account-item-${userB.id}`)
     .locator('.styles_module_accountBadgeIcon')
@@ -256,7 +256,7 @@ test('add app from picker to chat', async ({ page }) => {
   await page.getByTestId('add-app-to-chat').click()
   const appDraft = page.locator('.attachment-quote-section .text-part')
   await expect(appDraft).toContainText(appName)
-  await page.locator('.send-button-wrapper button').click()
+  await page.locator('button.send-button').click()
   const webxdcMessage = page.locator('.msg-body .webxdc')
   await webxdcMessage.isVisible()
   expect(webxdcMessage).toContainText(appName)

--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -93,13 +93,15 @@
       }
     }
 
-    .send-button-wrapper {
+    .send-button {
       width: 32px;
       height: 32px;
+      padding: 0;
       margin-top: 4px;
       margin-bottom: 4px;
       margin-right: 5px;
       background-color: var(--composerSendButton);
+      border: none;
       border-radius: 180px;
       cursor: pointer;
 
@@ -107,7 +109,7 @@
         outline: none;
       }
 
-      button {
+      .paper-plane {
         height: 24px;
         width: 24px;
         margin: 4px;
@@ -118,10 +120,6 @@
         background-position: 3px 1px;
         background-size: contain;
         vertical-align: middle;
-
-        &:focus:not(:focus-visible) {
-          outline: none;
-        }
       }
     }
 

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -426,12 +426,14 @@ const Composer = forwardRef<
               <span />
             </button>
           )}
-          <div className='send-button-wrapper' onClick={composerSendMessage}>
-            <button
-              aria-label={tx('menu_send')}
-              aria-keyshortcuts={ariaSendShortcut}
-            />
-          </div>
+          <button
+            className='send-button'
+            onClick={composerSendMessage}
+            aria-label={tx('menu_send')}
+            aria-keyshortcuts={ariaSendShortcut}
+          >
+            <div className='paper-plane'></div>
+          </button>
         </div>
         {showAppPicker && (
           <OutsideClickHelper onClick={() => setShowAppPicker(false)}>

--- a/packages/frontend/themes/dev_minimal.scss
+++ b/packages/frontend/themes/dev_minimal.scss
@@ -265,13 +265,13 @@ $scrollbarTransparency: 0.5;
   }
 }
 
-.composer .lower-bar .send-button-wrapper button {
+.composer .lower-bar .send-button .paper-plane {
   background-blend-mode: difference;
   background-repeat: no-repeat;
   background-color: white;
 }
 
-.composer .lower-bar .send-button-wrapper {
+.composer .lower-bar .send-button {
   background-color: transparent;
 }
 

--- a/packages/frontend/themes/dev_rocket.scss
+++ b/packages/frontend/themes/dev_rocket.scss
@@ -254,13 +254,13 @@ $scrollbarTransparency: 0.5;
   background-image: unset !important;
 }
 
-.composer .lower-bar .send-button-wrapper button {
+.composer .lower-bar .send-button .paper-plane {
   background-blend-mode: difference;
   background-repeat: no-repeat;
   background-color: white;
 }
 
-.composer .lower-bar .send-button-wrapper {
+.composer .lower-bar .send-button {
   background-color: transparent;
 }
 
@@ -482,7 +482,7 @@ div.group-image-wrapper div.group-image-edit-button {
 
     .emoji-button,
     .attachment-button,
-    .send-button-wrapper {
+    .send-button {
       width: 50px;
       display: flex;
       justify-content: center;
@@ -492,7 +492,7 @@ div.group-image-wrapper div.group-image-edit-button {
       order: 1;
     }
 
-    .send-button-wrapper {
+    .send-button {
       order: 3;
       display: none;
     }


### PR DESCRIPTION
Apply the `onClick` handler to the button itself
and not its container.

This should make it easier to apply `disabled` state to the button.

This also makes the `outline` style reflect the button circular shape,
which looks better.

#skip-changelog
