### PR TITLE
fix: keep white-space in dialogs

### DIFF
--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -253,3 +253,8 @@ audio {
   padding: 0;
   border: 0;
 }
+
+// used in alert & confirmation dialogs
+p.whitespace {
+  white-space: break-spaces;
+}

--- a/packages/frontend/src/components/dialogs/AlertDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AlertDialog.tsx
@@ -9,12 +9,11 @@ import Dialog, {
 } from '../Dialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
-import type { ReactNode } from 'react'
 import type { DialogProps } from '../../contexts/DialogContext'
 
 export type Props = {
   cb?: () => void
-  message: string | ReactNode
+  message: string
   okBtnLabel?: string
 } & DialogProps
 

--- a/packages/frontend/src/components/dialogs/AlertDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AlertDialog.tsx
@@ -35,7 +35,7 @@ export default function AlertDialog({
     <Dialog width={350} onClose={onClose}>
       <DialogBody>
         <DialogContent paddingTop>
-          <p>{message}</p>
+          <p className='whitespace'>{message}</p>
         </DialogContent>
       </DialogBody>
       <DialogFooter>

--- a/packages/frontend/src/components/dialogs/ConfirmationDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfirmationDialog.tsx
@@ -49,7 +49,7 @@ export default function ConfirmationDialog({
       {header && <DialogHeader title={header} />}
       <DialogBody>
         <DialogContent paddingTop={header === undefined}>
-          <p>{message}</p>
+          <p className='whitespace'>{message}</p>
         </DialogContent>
       </DialogBody>
       <DialogFooter>


### PR DESCRIPTION
Should be carefully checked for unexpected side effects.

AlertDialogs sometimes show an error besides a translated message, which might look bad if it's a long error message with many line breaks.

I also removed the alternate message type ReactNode from AlertDialog since it was not used (according to type checks)

#skip-changelog