### PR TITLE
move "Save" and "Save as" together

### DIFF
--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -321,6 +321,11 @@ function buildContextMenu(
         }
       },
     },
+    // Save attachment as
+    showAttachmentOptions && {
+      label: tx('save_as'),
+      action: onDownload.bind(null, message),
+    },
     // copy link
     link !== '' &&
       isLink && {
@@ -359,11 +364,6 @@ function buildContextMenu(
           message.id,
           tx('saved')
         ),
-    },
-    // Download attachment
-    showAttachmentOptions && {
-      label: tx('save_as'),
-      action: onDownload.bind(null, message),
     },
     // Resend Message
     showResend && {


### PR DESCRIPTION
> this PR is the outcome of some one to one discussions

even though "Save" saves to saved messages
and "Save As" saves a file to some other place,
user may not think much about that,
and it is more confusing if they are not listed together as usual.

background: there are other ideas around,
eg. to reword "Saved Messages" to "Bookmarks"
(which would have the disadvantage to change a known UI element, and it would not fit that nicely to adding things manually, and it would not reflect the presistence).
another idea is to use "Export" instead,
however that was used before  https://github.com/deltachat/deltachat-desktop/pull/2546/ and probably cahnged for $reasons
(also cmp. https://github.com/deltachat/deltachat-desktop/pull/2160 ) so, all in all, the simple moving of the option seems to be a good first approach, we can iterate if ppl at scale are confused (and not only us devs :)

<img width="196" alt="Screenshot 2025-03-01 at 16 24 31" src="https://github.com/user-attachments/assets/dc95f979-fe4a-4b4b-9045-f78a9158bf95" />
<img width="196" alt="Screenshot 2025-03-01 at 16 22 38" src="https://github.com/user-attachments/assets/b4c511e2-e603-4639-ad74-37fdcf8cd7df" />

#skip-changelog