### PR TITLE
fix: unclosable webxdc apps (`beforeunload`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - Update local help (2025-03-01)
 
 ### Fixed
+- fix webxdc apps being unclosable, when using `beforeunload` event #4728
 - message list being empty when double-clicking the chat before it has loaded (again) #4647
 - accessibility: improve tab order of the app #4672
 - other minor accessibility improvements #4675

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -21,6 +21,12 @@
   "pref_current_account": {
     "message": "Current Profile"
   },
+  "webxdc_beforeunload_dialog_title": {
+    "message": "Close app?"
+  },
+  "webxdc_beforeunload_dialog_message": {
+    "message": "This app is asking you to confirm that you want to close it.\nChanges you made may not be saved."
+  },
   "camera_access_failed": {
     "message": "Could not access video camera. You might want to check your video permissions or if the camera is used already by another program"
   },

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -446,6 +446,27 @@ export default class DCWebxdc {
         ev.preventDefault()
       })
 
+      // Otherwise the app can make itself uncloseable.
+      // See https://github.com/deltachat/deltachat-desktop/issues/4726
+      // The code is taken from
+      // https://www.electronjs.org/docs/latest/api/web-contents#event-will-prevent-unload
+      webxdcWindow.webContents.on('will-prevent-unload', ev => {
+        const choice = dialog.showMessageBoxSync(webxdcWindow, {
+          type: 'question',
+          // Chromium shows "Close" and "Cancel",
+          // Gecko (Firefox) shows "Leave page" and "Stay on page".
+          buttons: [tx('close_window'), tx('cancel')],
+          title: tx('webxdc_beforeunload_dialog_title'),
+          message: tx('webxdc_beforeunload_dialog_message'),
+          defaultId: 0,
+          cancelId: 1,
+        })
+        const close = choice === 0
+        if (close) {
+          ev.preventDefault()
+        }
+      })
+
       // we would like to make `mailto:`-links work,
       // but https://github.com/electron/electron/pull/34418 is not merged yet.
 


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4726.

Here is an example of an app that uses `beforeunload`:

https://github.com/user-attachments/assets/02d6ac25-4f1e-4438-8995-1a42d6e643e8

