### PR TITLE
chore: update old core repository to new one

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ If you found a bug, [report it on Github](https://github.com/deltachat/deltachat
 
 Project maintainers may transfer bugs that are not UI specific
 (e.g. related to network, database or encryption)
-to [Delta Chat Core](https://github.com/deltachat/deltachat-core-rust/issues).
+to [Delta Chat Core](https://github.com/chatmail/core/issues).
 If you believe the bug belongs to Core, you can report it there directly.
 
 Please search both open and closed issues to make sure your bug report is not a duplicate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1609,7 +1609,7 @@ dependencies = [
 [[package]]
 name = "deltachat"
 version = "1.156.2"
-source = "git+https://github.com/deltachat/deltachat-core-rust?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
+source = "git+https://github.com/chatmail/core?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1694,7 +1694,7 @@ dependencies = [
 [[package]]
 name = "deltachat-contact-tools"
 version = "0.0.0"
-source = "git+https://github.com/deltachat/deltachat-core-rust?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
+source = "git+https://github.com/chatmail/core?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1706,7 +1706,7 @@ dependencies = [
 [[package]]
 name = "deltachat-jsonrpc"
 version = "1.156.2"
-source = "git+https://github.com/deltachat/deltachat-core-rust?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
+source = "git+https://github.com/chatmail/core?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -1764,12 +1764,12 @@ dependencies = [
 [[package]]
 name = "deltachat-time"
 version = "1.0.0"
-source = "git+https://github.com/deltachat/deltachat-core-rust?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
+source = "git+https://github.com/chatmail/core?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
 
 [[package]]
 name = "deltachat_derive"
 version = "2.0.0"
-source = "git+https://github.com/deltachat/deltachat-core-rust?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
+source = "git+https://github.com/chatmail/core?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
 dependencies = [
  "quote",
  "syn 2.0.99",
@@ -2592,7 +2592,7 @@ dependencies = [
 [[package]]
 name = "format-flowed"
 version = "1.0.0"
-source = "git+https://github.com/deltachat/deltachat-core-rust?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
+source = "git+https://github.com/chatmail/core?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
 
 [[package]]
 name = "funty"
@@ -6621,7 +6621,7 @@ dependencies = [
 [[package]]
 name = "ratelimit"
 version = "1.0.0"
-source = "git+https://github.com/deltachat/deltachat-core-rust?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
+source = "git+https://github.com/chatmail/core?tag=v1.156.2#490171650ae8beb8440caa49a12f0dd7ecbcaccc"
 
 [[package]]
 name = "raw-cpuid"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@
 <details><summary>Click to expand</summary>
 
 - [Delta Chat Desktop ](#delta-chat-desktop-)
+  - [Editions](#editions)
   - [Documentation Links ](#documentation-links-)
+    - [For Users](#for-users)
+    - [For Developers](#for-developers)
   - [Table of Contents](#table-of-contents)
   - [Install ](#install-)
     - [Linux ](#linux-)
@@ -159,11 +162,11 @@ $ pnpm -w start:electron
 
 > `-w` means workspace root package, with this you don't need to have your current working directory at the repo-root to run those scripts.
 
-For development with local `deltachat-core-rust` read [`docs/UPDATE_CORE.md`](docs/UPDATE_CORE.md).
+For development with local `deltachat core` read [`docs/UPDATE_CORE.md`](docs/UPDATE_CORE.md).
 
 ### Troubleshooting <a id="troubleshooting"></a>
 
-- This module builds on top of [`deltachat-core-rust`](https://github.com/chatmail/core),
+- This module builds on top of [`deltachat core`](https://github.com/chatmail/core),
   which in turn has external dependencies. The instructions below assume a Linux system (e.g. Ubuntu 18.10).
 - Read the error, maybe it already tells you what you need to do. If not feel free to file an issue in this github repo.
 - Make sure that your nodejs version is `20.0.0` or newer.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ For development with local `deltachat-core-rust` read [`docs/UPDATE_CORE.md`](do
 
 ### Troubleshooting <a id="troubleshooting"></a>
 
-- This module builds on top of [`deltachat-core-rust`](https://github.com/deltachat/deltachat-core-rust),
+- This module builds on top of [`deltachat-core-rust`](https://github.com/chatmail/core),
   which in turn has external dependencies. The instructions below assume a Linux system (e.g. Ubuntu 18.10).
 - Read the error, maybe it already tells you what you need to do. If not feel free to file an issue in this github repo.
 - Make sure that your nodejs version is `20.0.0` or newer.

--- a/bin/link_core/link_local.sh
+++ b/bin/link_core/link_local.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 set -e
 
-export CORE_REPO_CHECKOUT="../core"
+if [ -z "$CORE_REPO_CHECKOUT" ]; then
+    if [ -d "../core" ]; then
+    CORE_REPO_CHECKOUT="../core"
+  elif [ -d "../deltachat-core-rust" ]; then
+    CORE_REPO_CHECKOUT="../deltachat-core-rust"
+  else
+    echo "No valid directory found for CORE_REPO_CHECKOUT"
+    exit 1
+  fi
+fi
 
 cd packages/target-electron
 pnpm add @deltachat/jsonrpc-client@link:../../$CORE_REPO_CHECKOUT/deltachat-jsonrpc/typescript \

--- a/bin/link_core/link_local.sh
+++ b/bin/link_core/link_local.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-export CORE_REPO_CHECKOUT="../deltachat-core-rust"
+export CORE_REPO_CHECKOUT="../core"
 
 cd packages/target-electron
 pnpm add @deltachat/jsonrpc-client@link:../../$CORE_REPO_CHECKOUT/deltachat-jsonrpc/typescript \

--- a/bin/link_core/link_version.js
+++ b/bin/link_core/link_version.js
@@ -34,7 +34,7 @@ execSync('./bin/link_core/link_catalog.sh', { stdio: 'inherit' })
 
 // cargo / tauri
 try {
-  execSync(`cargo add deltachat deltachat-jsonrpc --git https://github.com/deltachat/deltachat-core-rust --tag v${newVersion}`, {
+  execSync(`cargo add deltachat deltachat-jsonrpc --git https://github.com/chatmail/core.git --tag v${newVersion}`, {
     stdio: 'inherit',
     cwd: resolve('packages/target-tauri/src-tauri'),
   })

--- a/bin/link_core/link_version.js
+++ b/bin/link_core/link_version.js
@@ -34,7 +34,7 @@ execSync('./bin/link_core/link_catalog.sh', { stdio: 'inherit' })
 
 // cargo / tauri
 try {
-  execSync(`cargo add deltachat deltachat-jsonrpc --git https://github.com/chatmail/core.git --tag v${newVersion}`, {
+  execSync(`cargo add deltachat deltachat-jsonrpc --git https://github.com/chatmail/core --tag v${newVersion}`, {
     stdio: 'inherit',
     cwd: resolve('packages/target-tauri/src-tauri'),
   })

--- a/docs/UPDATE_CORE.md
+++ b/docs/UPDATE_CORE.md
@@ -37,7 +37,7 @@ DELTA_CHAT_RPC_SERVER=path/to/deltachat-rpc-server pnpm -w dev:electron --allow-
 You can easily get the deltachat-rpc-server binary for your pr by installing it with cargo install:
 
 ```
-cargo install --git https://github.com/chatmail/core.git --branch <your-branch> deltachat-rpc-server
+cargo install --git https://github.com/chatmail/core --branch <your-branch> deltachat-rpc-server
 ```
 
 Then you can run:

--- a/docs/UPDATE_CORE.md
+++ b/docs/UPDATE_CORE.md
@@ -1,6 +1,6 @@
 # Update core
 
-[DeltaChat core](https://github.com/deltachat/deltachat-core-rust) is the base library that all clients and bots build upon and is the heart of DeltaChat.
+[DeltaChat core](https://github.com/chatmail/core) is the base library that all clients and bots build upon and is the heart of DeltaChat.
 
 To update the desktop application to a new core you need to update the following dependencies:
 
@@ -16,7 +16,7 @@ Let's say the core version you want to upgrade to is `X.Y.Z`.
 
 If version `X.Y.Z` hasn't yet been published to `npm`, then ask another maintainer.
 
-GitHub CI builds and publishes [stdio-rpc-server](https://github.com/deltachat/deltachat-core-rust/actions/workflows/deltachat-rpc-server.yml) and [jsonrpc-client](https://github.com/deltachat/deltachat-core-rust/actions/workflows/jsonrpc-client-npm-package.yml) to npm.
+GitHub CI builds and publishes [stdio-rpc-server](https://github.com/chatmail/core/actions/workflows/deltachat-rpc-server.yml) and [jsonrpc-client](https://github.com/chatmail/core/actions/workflows/jsonrpc-client-npm-package.yml) to npm.
 
 > bash shortcut `node ./bin/link_core/link_version.js 1.142.2`
 
@@ -37,7 +37,7 @@ DELTA_CHAT_RPC_SERVER=path/to/deltachat-rpc-server pnpm -w dev:electron --allow-
 You can easily get the deltachat-rpc-server binary for your pr by installing it with cargo install:
 
 ```
-cargo install --git https://github.com/deltachat/deltachat-core-rust --branch <your-branch> deltachat-rpc-server
+cargo install --git https://github.com/chatmail/core.git --branch <your-branch> deltachat-rpc-server
 ```
 
 Then you can run:
@@ -64,10 +64,10 @@ But be aware: there might be **migrations** that are applied to your accounts da
 
 If you already have a core git checkout, you can skip the first step.
 
-1. clone the core repo, right next to your desktop repo folder: `git clone git@github.com:deltachat/deltachat-core-rust.git`
+1. clone the core repo, right next to your desktop repo folder: `git clone git@github.com:chatmail/core.git`
 2. go into your core checkout and run `git pull` to update it to the newest version, then create a branch for your changes
 3. run `python3 deltachat-rpc-server/npm-package/scripts/make_local_dev_version.py`
-4. run `npm i` and `npm run build` inside `../deltachat-core-rust/deltachat-jsonrpc/typescript/`
+4. run `npm i` and `npm run build` inside `../core/deltachat-jsonrpc/typescript/`
 5. go into your desktop repo and run `./bin/link_core/link_local.sh` [^1]
 
 Note that you need to run step 3 and 4 again after each change to core sourcecode.

--- a/docs/UPDATE_CORE.md
+++ b/docs/UPDATE_CORE.md
@@ -62,7 +62,7 @@ very useful for development.
 
 But be aware: there might be **migrations** that are applied to your accounts databases and there is no way back, unless you have a **backup**!
 
-If you already have a core git checkout, you can skip the first step.
+If you already have a core git checkout, you can skip the first step. Set the environment variable CORE_REPO_CHECKOUT to point to your core repository (as a relative path to deltachat-desktop) if it's not "../core" or "../deltachat-core-rust".
 
 1. clone the core repo, right next to your desktop repo folder: `git clone git@github.com:chatmail/core.git`
 2. go into your core checkout and run `git pull` to update it to the newest version, then create a branch for your changes

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -25,8 +25,8 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = "1.38.1"
-deltachat = { git = "https://github.com/deltachat/deltachat-core-rust", tag = "v1.156.2", version = "1.156.2" }
-deltachat-jsonrpc = { git = "https://github.com/deltachat/deltachat-core-rust", tag = "v1.156.2", version = "1.156.2" }
+deltachat = { git = "https://github.com/chatmail/core", tag = "v1.156.2", version = "1.156.2" }
+deltachat-jsonrpc = { git = "https://github.com/chatmail/core", tag = "v1.156.2", version = "1.156.2" }
 tauri-plugin-dialog = "2"
 tauri-plugin-clipboard-manager = "2.0.2"
 log = "0.4.22"

--- a/static/help/cs/help.html
+++ b/static/help/cs/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1240,7 +1240,7 @@ or read the <a href="https://delta.chat/assets/blog/MER-01-report.pdf">full repo
   </li>
   <li>
     <p>2020, <a href="https://includesecurity.com">Include Security</a> analyzed Delta
-Chat’s Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>,
+Chat’s Rust <a href="https://github.com/chatmail/core/">core</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a>, and
 <a href="https://github.com/async-email/async-native-tls">TLS</a> libraries.
@@ -1718,7 +1718,7 @@ program potřebuje heslo k tomu aby mohl posílat e-maily. Samozřejmě, že
 heslo je uloženo pouze na tvém přístroji. Heslo je přenášeno pouze při přihlašení
 k e-mailovému serveru, který má i beztak přístup k tvým e-mailům.</p>
 
-<p>Delta Chat má otevřený <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">zdrojový kód</a>,
+<p>Delta Chat má otevřený <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">zdrojový kód</a>,
 ze kterého lze ověřit, že program s osobními daty zachází bezpečně. Jsme rádi
 za každou odezvu, která udělá Delta Chat bezpečnější pro všechny.</p>
     
@@ -1894,7 +1894,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>Dobrý začátek je <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Standards used in Delta Chat</a>.</li>
+  <li>Dobrý začátek je <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Standards used in Delta Chat</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/de/help.html
+++ b/static/help/de/help.html
@@ -164,7 +164,7 @@ sicher gegen Netzwerk- und Serverangriffe.</p>
   </li>
   <li>
     <p>Freie und quelloffene Software, sowohl app- als auch serverseitig. 
-Basiert auf <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-Mail- und Web-Internet-Standards</a>, 
+Basiert auf <a href="https://github.com/chatmail/core/blob/master/standards.md">E-Mail- und Web-Internet-Standards</a>, 
 um das <a href="https://xkcd.com/927/">„Noch-ein-Standard-Syndrom“ (xkcd 927)</a> zu vermeiden.</p>
   </li>
 </ul>
@@ -1165,7 +1165,7 @@ Weitere Informationen finden Sie in unserem Blogbeitrag über <a href="https://d
     <p>Im März 2023 analysierte <a href="https://cure53.de">Cure53</a> sowohl die Transportverschlüsselung von Delta Chats Netzwerkverbindungen als auch das reproduzierbare Mailserver-Setup wie <a href="https://delta.chat/de/serverguide">auf dieser Seite empfohlen</a>. Sie können mehr über das Audit <a href="https://delta.chat/en/2023-03-27-third-independent-security-audit">in unserem Blog</a> lesen oder Sie lesen den <a href="https://delta.chat/assets/blog/MER-01-report.pdf">vollständigen Bericht hier</a>.</p>
   </li>
   <li>
-    <p>Im Jahr 2020 analysierte <a href="https://includesecurity.com">Include Security</a> Delta Chats Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>, <a href="https://github.com/async-email/async-imap">IMAP</a>,<a href="https://github.com/async-email/async-smtp">SMTP</a>, und <a href="https://github.com/async-email/async-native-tls">TLS</a> Bibliotheken.
+    <p>Im Jahr 2020 analysierte <a href="https://includesecurity.com">Include Security</a> Delta Chats Rust <a href="https://github.com/chatmail/core/">core</a>, <a href="https://github.com/async-email/async-imap">IMAP</a>,<a href="https://github.com/async-email/async-smtp">SMTP</a>, und <a href="https://github.com/async-email/async-native-tls">TLS</a> Bibliotheken.
 Es wurden keine kritischen oder hochgradig gefährlichen Probleme gefunden. Der Bericht wies auf einige Schwachstellen mittlerer Schwere hin - sie stellen für sich genommen keine Bedrohung für Delta-Chat-Benutzer dar, da sie von der Umgebung abhängen, in der Delta Chat verwendet wird. Aus Gründen der Benutzerfreundlichkeit und der Kompatibilität können wir nicht alle Schwachstellen beseitigen und haben beschlossen, Sicherheitsempfehlungen für bedrohte Benutzer zu geben. Sie können den <a href="https://delta.chat/assets/blog/2020-second-security-review.pdf">vollständigen Bericht hier</a> lesen.</p>
   </li>
   <li>
@@ -1555,7 +1555,7 @@ Allerdings benötigen einige Anbieter besondere Einstellungen, um ordnungsgemä�
 
 <p>Genau wie auch bei anderen E-Mail-Programmen (z. B. Thunderbird, K9-Mail oder Outlook) benötigt Delta Chat das Passwort, um E-Mails versenden zu können. Das Passwort wird nur auf Ihrem Gerät gespeichert und bei der Anmeldung an Ihren E-Mail-Anbieter gesendet.</p>
 
-<p>Da Delta Chat Open Source ist, können Sie den <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Quellcode</a> einsehen und sich davon überzeugen, dass Ihre Zugangsdaten sicher gehandhabt werden. Wir freuen uns über Feedback, das unsere App sicherer für all unsere NutzerInnen macht.</p>
+<p>Da Delta Chat Open Source ist, können Sie den <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Quellcode</a> einsehen und sich davon überzeugen, dass Ihre Zugangsdaten sicher gehandhabt werden. Wir freuen uns über Feedback, das unsere App sicherer für all unsere NutzerInnen macht.</p>
     
       <h3 id="welche-nachrichten-erscheinen-in-delta-chat">
         
@@ -1698,7 +1698,7 @@ Andernfalls könnten Sie unverschlüsselte Nachrichten aus diesen Gruppenchats e
       </h3>
 
 <ul>
-  <li>Siehe hierzu <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">in Delta Chat genutzte Standards</a>.</li>
+  <li>Siehe hierzu <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">in Delta Chat genutzte Standards</a>.</li>
 </ul>
     
       <h3 id="wo-können-meine-freunde-delta-chat-finden">

--- a/static/help/en/help.html
+++ b/static/help/en/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1246,7 +1246,7 @@ or read the <a href="https://delta.chat/assets/blog/MER-01-report.pdf">full repo
   </li>
   <li>
     <p>2020, <a href="https://includesecurity.com">Include Security</a> analyzed Delta
-Chat’s Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>,
+Chat’s Rust <a href="https://github.com/chatmail/core/">core</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a>, and
 <a href="https://github.com/async-email/async-native-tls">TLS</a> libraries.
@@ -1725,7 +1725,7 @@ program needs the password so you can use it to send and receive mails. Of cours
 password is stored only on your device. The password is only transmitted to
 your E-Mail provider (when you login), which has access to your mails anyway.</p>
 
-<p>As Delta Chat is Open Source, you can check the <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Source
+<p>As Delta Chat is Open Source, you can check the <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Source
 Code</a>
 if you want to verify that your credentials are handled securely. We are happy
 about feedback which makes the app more secure for all of our users.</p>
@@ -1903,7 +1903,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>See <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Standards used in Delta Chat</a>.</li>
+  <li>See <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Standards used in Delta Chat</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/es/help.html
+++ b/static/help/es/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1209,7 +1209,7 @@ or read the <a href="https://delta.chat/assets/blog/MER-01-report.pdf">full repo
   </li>
   <li>
     <p>2020, <a href="https://includesecurity.com">Include Security</a> analyzed Delta
-Chat’s Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>,
+Chat’s Rust <a href="https://github.com/chatmail/core/">core</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a>, and
 <a href="https://github.com/async-email/async-native-tls">TLS</a> libraries.
@@ -1848,7 +1848,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>Visita la página <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Estándares usados en Delta Chat</a>.</li>
+  <li>Visita la página <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Estándares usados en Delta Chat</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/fr/help.html
+++ b/static/help/fr/help.html
@@ -169,7 +169,7 @@ contre les attaques ciblées sur le réseau et les serveurs.</p>
   </li>
   <li>
     <p>Logiciel libre et open source, à la fois appli et côté serveur. 
-Construit sur des <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">Standards d’Internet et d’e-mail</a>, 
+Construit sur des <a href="https://github.com/chatmail/core/blob/master/standards.md">Standards d’Internet et d’e-mail</a>, 
 <a href="https://xkcd.com/927/">pour éviter le syndrome du “standard de plus” (xkcd 927)</a></p>
   </li>
 </ul>
@@ -1206,7 +1206,7 @@ Vous trouverez <a href="https://delta.chat/en/2023-05-22-webxdc-security">ici un
 Vous trouverez plus d’informations sur cet audit <a href="https://delta.chat/en/2023-03-27-third-independent-security-audit">sur notre blog</a> ou dans <a href="https://delta.chat/assets/blog/MER-01-report.pdf">le rapport complet ici</a>.</p>
   </li>
   <li>
-    <p>En 2020, <a href="https://includesecurity.com">Include Security</a> a analysé les <a href="https://github.com/deltachat/deltachat-core-rust/">bibliothèques principales</a> Rust de Delta Chat, ainsi que ses bibliothèques <a href="https://github.com/async-email/async-imap">IMAP</a>, <a href="https://github.com/async-email/async-smtp">SMTP</a> et <a href="https://github.com/async-email/async-native-tls">TLS</a>.
+    <p>En 2020, <a href="https://includesecurity.com">Include Security</a> a analysé les <a href="https://github.com/chatmail/core/">bibliothèques principales</a> Rust de Delta Chat, ainsi que ses bibliothèques <a href="https://github.com/async-email/async-imap">IMAP</a>, <a href="https://github.com/async-email/async-smtp">SMTP</a> et <a href="https://github.com/async-email/async-native-tls">TLS</a>.
 Aucun problème grave ou critique n’a été découvert.
 Le rapport a tout de même révélé quelques vulnérabilités de gravité moyenne, qui ne représentent pas une menace en elles-mêmes pour les utilisateurs et les utilisatrices de Delta Chat, car elles dépendent de l’environnement dans lequel Delta Chat est utilisé.
 Pour des raison de compatibilité et de facilité d’utilisation, nous ne pouvons pas les pallier toutes et avons préféré fournir des préconisations de sécurité aux personnes exposées.
@@ -1654,7 +1654,7 @@ Cependant, il faut activer des options spéciales pour que cela fonctionne corre
 <p>Comme pour les autres clients de courriel, Thunderbird, FairEmail, K9-Mail, Outlook, etc, celui-ci a besoin des identifiants / mots de passe pour recevoir et envoyer des courriels. 
 Bien sûr le mot de passe est uniquement stocké sur votre appareil. Et il est utilisé uniquement pour vous authentifier auprès de votre fournisseur de courriel, qui a, rappelons-le, accès à vos courriels non chiffrés.</p>
 
-<p>Comme Delta Chat est un logiciel libre, vous pouvez étudier le <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">code source</a> pour vérifier que vos identifiants / mots de passe sont utilisés de façon sécurisée. Nous sommes très heureux d’avoir des retours pour renforcer la sécurité de l’application.</p>
+<p>Comme Delta Chat est un logiciel libre, vous pouvez étudier le <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">code source</a> pour vérifier que vos identifiants / mots de passe sont utilisés de façon sécurisée. Nous sommes très heureux d’avoir des retours pour renforcer la sécurité de l’application.</p>
     
       <h3 id="quels-sont-les-messages-qui-apparaissent-dans-delta-chat-">
         
@@ -1810,7 +1810,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>Consultez les <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">standards utilisés dans Delta Chat</a>.</li>
+  <li>Consultez les <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">standards utilisés dans Delta Chat</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/id/help.html
+++ b/static/help/id/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1246,7 +1246,7 @@ or read the <a href="https://delta.chat/assets/blog/MER-01-report.pdf">full repo
   </li>
   <li>
     <p>2020, <a href="https://includesecurity.com">Include Security</a> analyzed Delta
-Chat’s Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>,
+Chat’s Rust <a href="https://github.com/chatmail/core/">core</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a>, and
 <a href="https://github.com/async-email/async-native-tls">TLS</a> libraries.
@@ -1725,7 +1725,7 @@ program membutuhkan kata sandi sehingga Anda dapat menggunakannya untuk mengirim
 kata sandi hanya disimpan di perangkat Anda. Kata sandi hanya dikirimkan ke
 penyedia E-Mail Anda (saat Anda login), yang tetap memiliki akses ke email Anda.</p>
 
-<p>Karena Delta Chat adalah Open Source, Anda dapat memeriksa file <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Source
+<p>Karena Delta Chat adalah Open Source, Anda dapat memeriksa file <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Source
 Code</a>
 jika Anda ingin memverifikasi bahwa kredensial Anda ditangani dengan aman. Kami bahagia
 tentang umpan balik yang membuat aplikasi lebih aman untuk semua pengguna kami.</p>
@@ -1903,7 +1903,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>See <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Standards used in Delta Chat</a>.</li>
+  <li>See <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Standards used in Delta Chat</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/it/help.html
+++ b/static/help/it/help.html
@@ -169,7 +169,7 @@ sicuro contro gli attacchi alla rete e al server.</p>
   </li>
   <li>
     <p>Software Libero e Open Source, sia lato app che lato server. 
-Basato su <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">Standard E-mail e Web Internet</a>, 
+Basato su <a href="https://github.com/chatmail/core/blob/master/standards.md">Standard E-mail e Web Internet</a>, 
 <a href="https://xkcd.com/927/">per evitare “l’ennesima sindrome standard (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1232,7 +1232,7 @@ o leggere il <a href="https://delta.chat/assets/blog/MER-01-report.pdf">rapporto
   </li>
   <li>
     <p>Nel 2020, <a href="https://includesecurity.com">Include Security</a> ha analizzato il Delta
-Chat’s Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>,
+Chat’s Rust <a href="https://github.com/chatmail/core/">core</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a> e
 <a href="https://github.com/async-email/async-native-tls">TLS</a> librerie.
@@ -1686,7 +1686,7 @@ programma ha bisogno della password in modo da poterla utilizzare per inviare ma
 password è memorizzata solo sul tuo dispositivo. La password viene trasmessa solo a
 il tuo fornitore E-Mail (quando effettui il login), che ha comunque accesso alla tua posta.</p>
 
-<p>Poiché Delta Chat è Open Source, puoi controllare il <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Codice
+<p>Poiché Delta Chat è Open Source, puoi controllare il <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Codice
 Sorgente</a>
 se vuoi verificare che le tue credenziali siano gestite in modo sicuro. Siamo felici dei feedback che rendono l’app più sicura per tutti i nostri utenti.</p>
     
@@ -1863,7 +1863,7 @@ Altrimenti potresti ricevere messaggi non decifrabili da quelle chat di gruppo.<
       </h3>
 
 <ul>
-  <li>Vedi <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Standard usati in Delta Chat</a>.</li>
+  <li>Vedi <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Standard usati in Delta Chat</a>.</li>
 </ul>
     
       <h3 id="dove-possono-trovare-delta-chat-i-miei-amici">

--- a/static/help/nl/help.html
+++ b/static/help/nl/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1239,7 +1239,7 @@ of in het <a href="https://delta.chat/assets/blog/MER-01-report.pdf">volledige v
   </li>
   <li>
     <p>In 2020 heeft <a href="https://includesecurity.com">Include Security</a> Delta Chats
-Rust-<a href="https://github.com/deltachat/deltachat-core-rust/">kern</a>,
+Rust-<a href="https://github.com/chatmail/core/">kern</a>,
 <a href="https://github.com/async-email/async-imap">imap-</a>,
 <a href="https://github.com/async-email/async-smtp">smtp-</a> en
 <a href="https://github.com/async-email/async-native-tls">tls-</a>bibliotheken geanalyseerd.
@@ -1713,7 +1713,7 @@ blog</a>.</li>
 
 <p>Delta Chat heeft, net zoals andere e-mailprogramma’s (Thunderbird, K9-Mail, Outlook, etc.), je wachtwoord nodig om berichten te versturen. Het wordt alleen opgeslagen op je apparaat en alleen uitgewisseld met je e-mailprovider, die toch al toegang heeft tot je mails.</p>
 
-<p>Delta Chat is open source. Dit betekent dat je de <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">bron-
+<p>Delta Chat is open source. Dit betekent dat je de <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">bron-
 code</a>
 kunt bekijken om er zeker van te zijn dat er veilig wordt omgegaan met je inloggegevens. We ontvangen graag feedback hierover.</p>
     
@@ -1889,7 +1889,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>Bekijk de pagina <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Door Delta Chat gebruikte standaarden</a>.</li>
+  <li>Bekijk de pagina <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Door Delta Chat gebruikte standaarden</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/pl/help.html
+++ b/static/help/pl/help.html
@@ -154,7 +154,7 @@
     <p><a href="#security-audits">Audytowne szyfrowanie end-to-end</a> zabezpieczające przed atakami sieciowymi i serwerowymi.</p>
   </li>
   <li>
-    <p>Bezpłatne i otwartoźródłowe oprogramowanie zarówno po stronie aplikacji, jak i serwera. Stworzone w oparciu o <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">standardy e-mail i internetowe</a>, <a href="https://xkcd.com/927/">aby uniknąć „kolejnego standardowego syndromu (xkcd 927)”</a>.</p>
+    <p>Bezpłatne i otwartoźródłowe oprogramowanie zarówno po stronie aplikacji, jak i serwera. Stworzone w oparciu o <a href="https://github.com/chatmail/core/blob/master/standards.md">standardy e-mail i internetowe</a>, <a href="https://xkcd.com/927/">aby uniknąć „kolejnego standardowego syndromu (xkcd 927)”</a>.</p>
   </li>
 </ul>
     
@@ -892,7 +892,7 @@ od najnowszych do najstarszych:</p>
     <p>W marcu 2023 r. firma <a href="https://cure53.de">Cure53</a> przeanalizowała zarówno szyfrowanie transportu połączeń sieciowych Delta Chat, jak i powtarzalną konfigurację serwera pocztowego zgodnie z <a href="https://delta.chat/pl/serverguide">zaleceniami na tej stronie</a>. Możesz przeczytać więcej o audycie <a href="https://delta.chat/en/2023-03-27-third-independent-security-audit">na naszym blogu</a> lub przeczytać pełny raport <a href="https://delta.chat/assets/blog/MER-01-report.pdf">tutaj</a>.</p>
   </li>
   <li>
-    <p>W 2020 r. firma <a href="https://includesecurity.com">Include Security</a> przeanalizowała biblioteki Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>, <a href="https://github.com/async-email/async-imap">IMAP</a>, <a href="https://github.com/async-email/async-smtp">SMTP</a> i <a href="https://github.com/async-email/async-native-tls">TLS</a> Delta Chat. Nie znalazła żadnych problemów krytycznych ani poważnych. W raporcie zwrócono uwagę na kilka słabych punktów o średniej wadze – same w sobie nie stanowią zagrożenia dla użytkowników Delta Chat, ponieważ zależą od środowiska, w którym używany jest Delta Chat. Ze względu na użyteczność i kompatybilność nie możemy złagodzić wszystkich z nich i zdecydowaliśmy się przedstawić zalecenia dotyczące bezpieczeństwa zagrożonym użytkownikom. Pełny raport można przeczytać <a href="https://delta.chat/assets/blog/2020-second-security-review.pdf">tutaj</a>.</p>
+    <p>W 2020 r. firma <a href="https://includesecurity.com">Include Security</a> przeanalizowała biblioteki Rust <a href="https://github.com/chatmail/core/">core</a>, <a href="https://github.com/async-email/async-imap">IMAP</a>, <a href="https://github.com/async-email/async-smtp">SMTP</a> i <a href="https://github.com/async-email/async-native-tls">TLS</a> Delta Chat. Nie znalazła żadnych problemów krytycznych ani poważnych. W raporcie zwrócono uwagę na kilka słabych punktów o średniej wadze – same w sobie nie stanowią zagrożenia dla użytkowników Delta Chat, ponieważ zależą od środowiska, w którym używany jest Delta Chat. Ze względu na użyteczność i kompatybilność nie możemy złagodzić wszystkich z nich i zdecydowaliśmy się przedstawić zalecenia dotyczące bezpieczeństwa zagrożonym użytkownikom. Pełny raport można przeczytać <a href="https://delta.chat/assets/blog/2020-second-security-review.pdf">tutaj</a>.</p>
   </li>
   <li>
     <p>W 2019 r. firma <a href="https://includesecurity.com">Include Security</a> przeanalizowała biblioteki <a href="https://github.com/rpgp/rpgp">PGP</a> i <a href="https://github.com/RustCrypto/RSA">RSA</a> Delta Chat. Nie znaleziono żadnych krytycznych problemów, ale dwa poważne problemy, które później naprawiliśmy. Ujawniła również jeden problem o średniej wadze i kilka mniej poważnych, ale nie było możliwości wykorzystania tych luk w implementacji Delta Chat. Niektóre z nich jednak naprawiliśmy od czasu zakończenia kontroli. Pełny raport można przeczytać <a href="https://delta.chat/assets/blog/2019-first-security-review.pdf">tutaj</a>.</p>
@@ -1250,7 +1250,7 @@ Jednak niektórzy dostawcy potrzebują specjalnych opcji, aby działać poprawni
 
 <p>Podobnie jak w przypadku innych programów pocztowych, takich jak Thunderbird, K9-Mail lub Outlook, program potrzebuje hasła, aby można było go używać do wysyłania i odbierania e-maili. Oczywiście hasło jest przechowywane tylko na Twoim urządzeniu. Hasło jest przesyłane tylko do Twojego dostawcy poczty e-mail (po zalogowaniu), który i tak ma dostęp do Twojej poczty</p>
 
-<p>Ponieważ Delta Chat jest Open Source, możesz sprawdzić <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Kod źródłowy</a>
+<p>Ponieważ Delta Chat jest Open Source, możesz sprawdzić <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Kod źródłowy</a>
 jeśli chcesz sprawdzić, czy Twoje poświadczenia są przetwarzane w bezpieczny sposób. Cieszymy się z opinii, które sprawiają, że aplikacja jest bezpieczniejsza dla wszystkich naszych użytkowników.</p>
     
       <h3 id="jakie-wiadomości-pojawiają-się-w-delta-chat">
@@ -1371,7 +1371,7 @@ jeśli chcesz sprawdzić, czy Twoje poświadczenia są przetwarzane w bezpieczny
       </h3>
 
 <ul>
-  <li>Zobacz <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Standardy używane w Delta Chat</a>.</li>
+  <li>Zobacz <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Standardy używane w Delta Chat</a>.</li>
 </ul>
     
       <h3 id="gdzie-moi-znajomi-mogą-znaleźć-delta-chat">

--- a/static/help/pt/help.html
+++ b/static/help/pt/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1240,7 +1240,7 @@ or read the <a href="https://delta.chat/assets/blog/MER-01-report.pdf">full repo
   </li>
   <li>
     <p>2020, <a href="https://includesecurity.com">Include Security</a> analyzed Delta
-Chat’s Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>,
+Chat’s Rust <a href="https://github.com/chatmail/core/">core</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a>, and
 <a href="https://github.com/async-email/async-native-tls">TLS</a> libraries.
@@ -1714,7 +1714,7 @@ blogpost</a>.</li>
 
 <p>Como acontece em qualquer outro programa de comunicação que usa email, como Thunderbird, K9-Mail ou Outlook, sua senha é necessária para poder receber e enviar emails. Obviamente, sua senha fica guardada no seu dispositivo. E ela só é transmitida para o seu provedor de email (no momento que você faz login), que é quem já tem inevitavelmente acesso aos seus emails.</p>
 
-<p>Como o Delta Chat é um programa de Código Aberto, você pode revisar seu <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Código Fonte</a> se você quiser verificar que as suas credenciais estão sendo manuseadas de forma segura. Ficaremos felizes de receber comentários que contribuam para fazer o aplicativo mais seguro para todos os nossos usuários.</p>
+<p>Como o Delta Chat é um programa de Código Aberto, você pode revisar seu <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Código Fonte</a> se você quiser verificar que as suas credenciais estão sendo manuseadas de forma segura. Ficaremos felizes de receber comentários que contribuam para fazer o aplicativo mais seguro para todos os nossos usuários.</p>
     
       <h3 id="quais-mensagens-aparecem-no-delta-chat">
         
@@ -1889,7 +1889,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>Veja <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">As normas usadas no Delta Chat</a>.</li>
+  <li>Veja <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">As normas usadas no Delta Chat</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/ru/help.html
+++ b/static/help/ru/help.html
@@ -169,7 +169,7 @@
   </li>
   <li>
     <p>Бесплатное программное обеспечение с открытым исходным кодом, как на стороне приложения, так и на стороне сервера. 
-Разработано на основе <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">стандартов электронной почты и интернета</a>, 
+Разработано на основе <a href="https://github.com/chatmail/core/blob/master/standards.md">стандартов электронной почты и интернета</a>, 
 <a href="https://xkcd.com/927/">чтобы избежать “синдрома нового стандарта (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1243,7 +1243,7 @@ Applied Cryptography в ETH Цюрихе и устранили все выявл
   </li>
   <li>
     <p>2020 год, <a href="https://includesecurity.com">Include Security</a> проанализировала Delta
-Chat Rust <a href="https://github.com/deltachat/deltachat-core-rust/">ядро</a>,
+Chat Rust <a href="https://github.com/chatmail/core/">ядро</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a> и
 Библиотеки <a href="https://github.com/async-email/async-native-tls">TLS</a>.
@@ -1721,7 +1721,7 @@ Delta Chat необходим пароль, чтобы использовать 
 провайдеру электронной почты (при входе в систему), который и так имеет доступ к вашей почте.</p>
 
 <p>Поскольку Delta Chat является программой открытым исходным кодом, вы
-можете изучить <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">исходный код</a>, если хотите убедиться, что ваши
+можете изучить <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">исходный код</a>, если хотите убедиться, что ваши
 учётные данные обрабатываются безопасно. Мы рады получить обратную связь,
 которая поможет сделать приложение более безопасным для всех наших пользователей.</p>
     
@@ -1898,7 +1898,7 @@ Chat.</li>
       </h3>
 
 <ul>
-  <li>Смотрите <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Стандарты, используемые в Delta Chat</a>.</li>
+  <li>Смотрите <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Стандарты, используемые в Delta Chat</a>.</li>
 </ul>
     
       <h3 id="где-мои-друзья-могут-найти-delta-chat">

--- a/static/help/sk/help.html
+++ b/static/help/sk/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1246,7 +1246,7 @@ or read the <a href="https://delta.chat/assets/blog/MER-01-report.pdf">full repo
   </li>
   <li>
     <p>2020, <a href="https://includesecurity.com">Include Security</a> analyzed Delta
-Chat’s Rust <a href="https://github.com/deltachat/deltachat-core-rust/">core</a>,
+Chat’s Rust <a href="https://github.com/chatmail/core/">core</a>,
 <a href="https://github.com/async-email/async-imap">IMAP</a>,
 <a href="https://github.com/async-email/async-smtp">SMTP</a>, and
 <a href="https://github.com/async-email/async-native-tls">TLS</a> libraries.
@@ -1724,7 +1724,7 @@ blogpost</a>.</li>
 program potrebuje heslo, aby ste ho mohli používať na odosielanie e-mailov. Samozrejme,
 heslo je uložené iba vo vašom zariadení. Heslo sa prenáša iba na vášho poskytovateľa e-mailu (keď sa prihlásite), ktorý má aj tak prístup k vašim e-mailom.</p>
 
-<p>Keďže Delta Chat je Open Source, môžete skontrolovať <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Zdrojový
+<p>Keďže Delta Chat je Open Source, môžete skontrolovať <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Zdrojový
 Kód</a>
 ak chcete overiť, že vaše poverenia sú spracované bezpečne. Sme radi
 o spätnej väzbe, vďaka ktorej je aplikácia bezpečnejšia pre všetkých našich používateľov.</p>
@@ -1899,7 +1899,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>Pozrite si <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Štandardy používané v Delta Chate</a>.</li>
+  <li>Pozrite si <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Štandardy používané v Delta Chate</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/sq/help.html
+++ b/static/help/sq/help.html
@@ -169,7 +169,7 @@ safe against network and server attacks.</p>
   </li>
   <li>
     <p>Free and Open Source software, both app and server side. 
-Built on <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
+Built on <a href="https://github.com/chatmail/core/blob/master/standards.md">E-mail and Web Internet Standards</a>, 
 <a href="https://xkcd.com/927/">to avoid “yet another standard syndrome (xkcd 927)”</a></p>
   </li>
 </ul>
@@ -1248,7 +1248,7 @@ Mund të lexoni më tepër rreth auditimit <a href="https://delta.chat/en/2023-0
 ose të lexoni <a href="https://delta.chat/assets/blog/MER-01-report.pdf">raportin e plotë këtu</a>.</p>
   </li>
   <li>
-    <p>Më 2020-n, <a href="https://includesecurity.com">Include Security</a> analizoi <a href="https://github.com/deltachat/deltachat-core-rust/">bazën</a>
+    <p>Më 2020-n, <a href="https://includesecurity.com">Include Security</a> analizoi <a href="https://github.com/chatmail/core/">bazën</a>
 në Rust të Delta Chat-it, si dhe bibliotekat <a href="https://github.com/async-email/async-imap">IMAP</a>, <a href="https://github.com/async-email/async-smtp">SMTP</a>
 dhe <a href="https://github.com/async-email/async-native-tls">TLS</a>.
 S’gjeti ndonjë problem kritik apo të rëndësisë së madhe.
@@ -1728,7 +1728,7 @@ Sigurisht, fjalëkalimi depozitohet vetëm në pajisjen tuaj. Fjalëkalimi i tra
 vetëm furnizuesit të email-it tuaj (kur bëni hyrjen), i cili mund të hyjë te email-et
 tuaj, sido qoftë.</p>
 
-<p>Ngaqë Delta Chat-i është Me Burim të Hapur, mund të kontrolloni <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">Kodin
+<p>Ngaqë Delta Chat-i është Me Burim të Hapur, mund të kontrolloni <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">Kodin
 Burim</a>,
 nëse doni të verifikoni se a trajtohen me siguri kredencialet tuaja. Na gëzojnë
 përshtypjet që e bëjn aplikacionin më të sigurt për krejt përdoruesit tanë.</p>
@@ -1910,7 +1910,7 @@ Otherwise you might receive undecryptable messages from those group chats.</p>
       </h3>
 
 <ul>
-  <li>Shihni <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Standarde të përdorur në Delta Chat</a>.</li>
+  <li>Shihni <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Standarde të përdorur në Delta Chat</a>.</li>
 </ul>
     
       <h3 id="where-can-my-friends-find-delta-chat">

--- a/static/help/uk/help.html
+++ b/static/help/uk/help.html
@@ -155,7 +155,7 @@
     <p><a href="#security-audits">Аудитоване наскрізне шифрування</a> захищене від мережевих та серверних атак.</p>
   </li>
   <li>
-    <p>Вільне програмне забезпечення з відкритим вихідним кодом, як для додатків, так і для сервера. Побудовано на основі <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">Стандартів електронної пошти та інтернету</a>, <a href="https://xkcd.com/927/">щоб уникнути “синдрому ще одного стандарту (xkcd 927)”</a></p>
+    <p>Вільне програмне забезпечення з відкритим вихідним кодом, як для додатків, так і для сервера. Побудовано на основі <a href="https://github.com/chatmail/core/blob/master/standards.md">Стандартів електронної пошти та інтернету</a>, <a href="https://xkcd.com/927/">щоб уникнути “синдрому ще одного стандарту (xkcd 927)”</a></p>
   </li>
 </ul>
     
@@ -898,7 +898,7 @@ Look for something like <strong>Start Autocrypt Setup Transfer</strong> in the s
     <p>Починаючи з 2023 року <a href="https://cure53.de">Cure53</a> проаналізував транспортне шифрування мережевих з’єднань Delta Chat і відтворюване налаштування поштового сервера як <a href="https://delta.chat/uk/serverguide">рекомендовано на цьому сайті</a>. Ви можете прочитати більше про аудит <a href="https://delta.chat/en/2023-03-27-third-independent-security-audit">у нашому блозі</a> або прочитайте <a href="https://delta.chat/assets/blog/MER-01-report.pdf">повний звіт тут</a>.</p>
   </li>
   <li>
-    <p>У 2020 році <a href="https://includesecurity.com">Include Security</a> проаналізувала Rust-<a href="https://github.com/deltachat/deltachat-core-rust/">ядро</a> Delta Chat і бібліотеки <a href="https://github.com/async-email/async-imap">IMAP</a>, <a href="https://github.com/async-email/async-smtp">SMTP</a> та <a href="https://github.com/async-email/async-native-tls">TLS</a>. Він не виявив критичних або серйозних проблем. У звіті виявлено кілька слабких місць середнього ступеня тяжкості – вони самі по собі не становлять загрози для користувачів Delta Chat оскільки вони залежать від середовища, у якому використовується Delta Chat. З міркувань зручності використання та сумісності ми не можемо пом’якшити їх усі тому вирішили надати рекомендації щодо безпеки користувачам, яким загрожує небезпека. Ви можете прочитати <a href="https://delta.chat/assets/blog/2020-second-security-review.pdf">повний звіт тут</a>.</p>
+    <p>У 2020 році <a href="https://includesecurity.com">Include Security</a> проаналізувала Rust-<a href="https://github.com/chatmail/core/">ядро</a> Delta Chat і бібліотеки <a href="https://github.com/async-email/async-imap">IMAP</a>, <a href="https://github.com/async-email/async-smtp">SMTP</a> та <a href="https://github.com/async-email/async-native-tls">TLS</a>. Він не виявив критичних або серйозних проблем. У звіті виявлено кілька слабких місць середнього ступеня тяжкості – вони самі по собі не становлять загрози для користувачів Delta Chat оскільки вони залежать від середовища, у якому використовується Delta Chat. З міркувань зручності використання та сумісності ми не можемо пом’якшити їх усі тому вирішили надати рекомендації щодо безпеки користувачам, яким загрожує небезпека. Ви можете прочитати <a href="https://delta.chat/assets/blog/2020-second-security-review.pdf">повний звіт тут</a>.</p>
   </li>
   <li>
     <p>У 2019 році <a href="https://includesecurity.com">Include Security</a> проаналізувала бібліотеки <a href="https://github.com/rpgp/rpgp">PGP</a> і <a href="https://github.com/RustCrypto/RSA">RSA</a> із Delta Chat. Він не виявив критичних проблем, лише дві серйозні проблеми, які ми згодом виправили. Він також виявив одну проблему середньої тяжкості та кілька менш серйозних, але не було можливості використати ці вразливості в реалізації Delta Chat. Деякі з них ми все ж усунули після завершення аудиту. Ви можете прочитати <a href="https://delta.chat/assets/blog/2019-first-security-review.pdf">повний звіт тут</a>.</p>
@@ -1272,7 +1272,7 @@ Look for something like <strong>Start Autocrypt Setup Transfer</strong> in the s
 
 <p>Як і інші поштові програми, такі як Thunderbird, K9-Mail або Outlook, програма програма потребує пароля, щоб ви могли використовувати її для надсилання листів. Звичайно, пароль пароль зберігається лише на вашому пристрої. Пароль передається лише вашому поштовому провайдеру (коли ви входите в систему), який і так має доступ до вашої пошти.</p>
 
-<p>Оскільки Delta Chat має відкритий код, ви можете ознайомитись із <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">початковим кодом</a> якщо бажаєте перевірити що ваші дані для авторизації надійно зберігаються. Ми будемо раді вашим пропозиціям, які зроблять додаток більш безпечним для всіх користувачів.</p>
+<p>Оскільки Delta Chat має відкритий код, ви можете ознайомитись із <a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">початковим кодом</a> якщо бажаєте перевірити що ваші дані для авторизації надійно зберігаються. Ми будемо раді вашим пропозиціям, які зроблять додаток більш безпечним для всіх користувачів.</p>
     
       <h3 id="які-повідомлення-відображаються-у-delta-chat">
         
@@ -1393,7 +1393,7 @@ Look for something like <strong>Start Autocrypt Setup Transfer</strong> in the s
       </h3>
 
 <ul>
-  <li>Дивіться <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Стандарти, що використовуються у Delta Chat</a>.</li>
+  <li>Дивіться <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Стандарти, що використовуються у Delta Chat</a>.</li>
 </ul>
     
       <h3 id="де-мої-друзі-можуть-знайти-delta-chat">

--- a/static/help/zh_CN/help.html
+++ b/static/help/zh_CN/help.html
@@ -169,7 +169,7 @@
   </li>
   <li>
     <p>免费开源软件，包括应用程序和服务器端。 
-基于<a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md">电子邮件和网络互联网标准</a>、 
+基于<a href="https://github.com/chatmail/core/blob/master/standards.md">电子邮件和网络互联网标准</a>、 
 <a href="https://xkcd.com/927/">避免 “又一个标准综合症（xkcd 927）”</a></p>
   </li>
 </ul>
@@ -1176,7 +1176,7 @@ releases on all appstores since December 2024.</p>
 ，或在此处阅读 <a href="https://delta.chat/assets/blog/MER-01-report.pdf">完整报告</a>。</p>
   </li>
   <li>
-    <p>2020 年，<a href="https://includesecurity.com">Include Security</a> 分析了 Delta Chat 的 Rust <a href="https://github.com/deltachat/deltachat-core-rust/">核心</a>、
+    <p>2020 年，<a href="https://includesecurity.com">Include Security</a> 分析了 Delta Chat 的 Rust <a href="https://github.com/chatmail/core/">核心</a>、
 <a href="https://github.com/async-email/async-imap">IMAP</a>、
 <a href="https://github.com/async-email/async-smtp">SMTP</a> 和
 <a href="https://github.com/async-email/async-native-tls">TLS</a> 库。
@@ -1603,7 +1603,7 @@ mailcow 和 mailadm 的组合，如 <a href="https://delta.chat/en/2023-01-27-up
 
 <p>与其他电子邮件程序（比如 Thunderbird、K9-Mail 或 Outlook）一样，本程序需要您的密码来允许您通过它发送邮件。当然，密码仅储存在您的设备上，并只会在登录时发送给您的电子邮件提供商（无论如何，您的提供商总是能够访问您的邮件）。</p>
 
-<p>由于 Delta Chat 是开源的，要验证您的凭据是否被安全地处理了，可以检查<a href="https://github.com/deltachat/deltachat-core-rust/blob/master/src/login_param.rs">源代码</a>。我们很高兴能收到使本应用对我们的所有用户更加安全的反馈。</p>
+<p>由于 Delta Chat 是开源的，要验证您的凭据是否被安全地处理了，可以检查<a href="https://github.com/chatmail/core/blob/master/src/login_param.rs">源代码</a>。我们很高兴能收到使本应用对我们的所有用户更加安全的反馈。</p>
     
       <h3 id="哪些消息会在-delta-chat-中出现">
         
@@ -1755,7 +1755,7 @@ Delta Chat 使用的 <a href="https://autocrypt.org/">Autocrypt</a> 不兼容。
       </h3>
 
 <ul>
-  <li>请参阅 <a href="https://github.com/deltachat/deltachat-core-rust/blob/master/standards.md#standards-used-in-delta-chat">Delta Chat 中使用的标准</a>。</li>
+  <li>请参阅 <a href="https://github.com/chatmail/core/blob/master/standards.md#standards-used-in-delta-chat">Delta Chat 中使用的标准</a>。</li>
 </ul>
     
       <h3 id="我的朋友在哪里可以找到-delta-chat">


### PR DESCRIPTION
https://github.com/deltachat-core-rust is now at https://github.com/chatmail/core

I left references to issues & PRs in comments to point to the old repository URL since we have the redirects in place.

#skip-changelog