### PR TITLE
fix: unwanted "Close app?" dialog in Editor app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - new button styles #4741
 
 ### Fixed
+- fix some webxdc apps showing the "Close app?" prompt unintentionally #4737
 - webxdc: fix menu bar hiding when pressing Escape #4753
 - tauri: fix blobs and webxdc-icon scheme under windows #4705
 - tauri: fix: drag regions in navbar #4719

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -452,6 +452,22 @@ export default class DCWebxdc {
       // The code is taken from
       // https://www.electronjs.org/docs/latest/api/web-contents#event-will-prevent-unload
       webxdcWindow.webContents.on('will-prevent-unload', ev => {
+        // Note that this will block this (main!) thread
+        // until the user has closed the dialog.
+        // The main app will be unresponsive until then,
+        // which is probably not nice in case e.g. the user pressed "close"
+        // on the webxdc app, but then left their PC
+        // without interacting with the dialog.
+        // However, this is pretty much in line with what regular browsers do,
+        // except they also don't let you interact
+        // with the rest of the browser until you close the dialog.
+        //
+        // We could use the async version (`showMessageBox()`),
+        // but this would let the app execute its code.
+        // If the app is actually malicious, it could try to do nasty stuff,
+        // e.g. something like preventing the user from interacting
+        // with the dialog, by entering fullscreen or something.
+        // So, let's probably just stay in line with regular browsers.
         const choice = dialog.showMessageBoxSync(webxdcWindow, {
           type: 'question',
           // Chromium shows "Close" and "Cancel",


### PR DESCRIPTION
The bug was introduced in e7221753d0b03064db5e3b2abacf10cf3fa22acb
(https://github.com/deltachat/deltachat-desktop/pull/4728).

[The Editor app](https://codeberg.org/webxdc/editor),
when getting closed, would always cause the "Close app?"
dialog to get shown to the user, but it's not intentional,
because the app would close regardless of what the user picks.

See the code comments for more info.

This also adds a comment about main process blocking.

I tested it with the Editor app, and with the previously unclosable Emacs app. Appears to work fine.
