### PR TITLE
tauri: secure CSP to only contain `.localhost` urls on windows and android where they are intercepted

### DIFF
--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
-use std::time::SystemTime;
+use std::{collections::HashMap, time::SystemTime};
 
 use clipboard::copy_image_to_clipboard;
+use log::kv::source;
 use settings::load_and_apply_desktop_settings_on_startup;
 use state::{
     app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,
 };
 use tauri::Manager;
+use util::csp::add_custom_schemes_to_csp_for_window;
 mod app_path;
 mod blobs;
 mod clipboard;
@@ -18,6 +20,7 @@ mod settings;
 mod state;
 mod stickers;
 mod temp_file;
+mod util;
 mod webxdc;
 
 // Learn more about Tauri commands at https://tauri.app/develop/calling-rust/
@@ -203,6 +206,19 @@ pub fn run() {
 
             Ok(())
         })
-        .run(tauri::generate_context!())
+        .run({
+            let mut context = tauri::generate_context!();
+
+            #[cfg(debug_assertions)]
+            {
+                let csp = context.config_mut().app.security.csp.clone();
+                if let Some(csp) = csp {
+                    context.config_mut().app.security.csp =
+                        Some(add_custom_schemes_to_csp_for_window(csp, false));
+                }
+            }
+
+            context
+        })
         .expect("error while running tauri application");
 }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -1,13 +1,12 @@
-use std::{collections::HashMap, time::SystemTime};
+use std::time::SystemTime;
 
 use clipboard::copy_image_to_clipboard;
-use log::kv::source;
 use settings::load_and_apply_desktop_settings_on_startup;
 use state::{
     app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,
 };
 use tauri::Manager;
-use util::csp::add_custom_schemes_to_csp_for_window;
+use util::csp::add_custom_schemes_to_csp_for_window_and_android;
 mod app_path;
 mod blobs;
 mod clipboard;
@@ -209,12 +208,12 @@ pub fn run() {
         .run({
             let mut context = tauri::generate_context!();
 
-            #[cfg(debug_assertions)]
+            #[cfg(any(debug_assertions, target_os = "windows", target_os = "android"))]
             {
                 let csp = context.config_mut().app.security.csp.clone();
                 if let Some(csp) = csp {
                     context.config_mut().app.security.csp =
-                        Some(add_custom_schemes_to_csp_for_window(csp, false));
+                        Some(add_custom_schemes_to_csp_for_window_and_android(csp, false));
                 }
             }
 

--- a/packages/target-tauri/src-tauri/src/util/csp.rs
+++ b/packages/target-tauri/src-tauri/src/util/csp.rs
@@ -1,0 +1,42 @@
+use std::collections::HashMap;
+
+use tauri::utils::config::Csp;
+
+/// Adds custom windows and android variant of custom schemes,
+///
+/// But only on windows and android, to prevent access to localhost on the other platforms.
+///
+/// Schemes are different on those 2 platforms `custom:` becomes `http://custom.localhost`.
+pub fn add_custom_schemes_to_csp_for_window(csp: Csp, is_https: bool) -> Csp {
+    let mut map: HashMap<_, _> = csp.into();
+    for (key, value) in map.iter_mut() {
+        let sources: Vec<String> = value.to_owned().into();
+        let mut custom_schemes = Vec::with_capacity(sources.len());
+        for source in &sources {
+            if source.ends_with(':') && source != "blob:" && source != "data:" {
+                custom_schemes.push(source.clone());
+            }
+            if source.ends_with(".localhost") {
+                panic!("invalid source found in key {key}: {source} - localhost sources for windows are added automatically and only on window");
+            }
+        }
+        // println!("custom_schemes: {key}: {custom_schemes:?}");
+        #[cfg(any(debug_assertions, target_os = "windows", target_os = "android"))]
+        {
+            let custom_sources = custom_schemes
+                .iter()
+                .map(|s| {
+                    format!(
+                        "{}://{}.localhost",
+                        if is_https { "https" } else { "http" },
+                        s.strip_suffix(':').unwrap()
+                    )
+                })
+                .collect();
+
+            value.extend(custom_sources);
+        }
+    }
+
+    map.into()
+}

--- a/packages/target-tauri/src-tauri/src/util/csp.rs
+++ b/packages/target-tauri/src-tauri/src/util/csp.rs
@@ -9,7 +9,7 @@ use tauri::utils::config::Csp;
 /// Schemes are different on those 2 platforms.
 /// E.g. `dcblob:` becomes `http://dcblob.localhost`,
 /// `ipc:` becomes `http://ipc.localhost`, etc.
-pub fn add_custom_schemes_to_csp_for_window(csp: Csp, is_https: bool) -> Csp {
+pub fn add_custom_schemes_to_csp_for_window_and_android(csp: Csp, is_https: bool) -> Csp {
     let mut map: HashMap<_, _> = csp.into();
     for (key, value) in map.iter_mut() {
         let sources: Vec<String> = value.to_owned().into();
@@ -23,7 +23,7 @@ pub fn add_custom_schemes_to_csp_for_window(csp: Csp, is_https: bool) -> Csp {
             }
         }
         // println!("custom_schemes: {key}: {custom_schemes:?}");
-        #[cfg(any(debug_assertions, target_os = "windows", target_os = "android"))]
+        #[cfg(any(target_os = "windows", target_os = "android"))]
         {
             let custom_sources = custom_schemes
                 .iter()

--- a/packages/target-tauri/src-tauri/src/util/csp.rs
+++ b/packages/target-tauri/src-tauri/src/util/csp.rs
@@ -6,7 +6,9 @@ use tauri::utils::config::Csp;
 ///
 /// But only on windows and android, to prevent access to localhost on the other platforms.
 ///
-/// Schemes are different on those 2 platforms `custom:` becomes `http://custom.localhost`.
+/// Schemes are different on those 2 platforms.
+/// E.g. `dcblob:` becomes `http://dcblob.localhost`,
+/// `ipc:` becomes `http://ipc.localhost`, etc.
 pub fn add_custom_schemes_to_csp_for_window(csp: Csp, is_https: bool) -> Csp {
     let mut map: HashMap<_, _> = csp.into();
     for (key, value) in map.iter_mut() {

--- a/packages/target-tauri/src-tauri/src/util/mod.rs
+++ b/packages/target-tauri/src-tauri/src/util/mod.rs
@@ -1,0 +1,1 @@
+pub mod csp;

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -22,14 +22,14 @@
     "security": {
       "csp": {
         "default-src": "none",
-        "connect-src": "'self' ipc: http://ipc.localhost",
+        "connect-src": "'self' ipc:",
         "style-src": "'self' 'unsafe-inline'",
         "font-src": "'self'",
         "script-src": "'self' 'wasm-unsafe-eval'",
-        "worker-src": "blob: http://blob.localhost",
-        "child-src": "blob: http://blob.localhost",
-        "img-src": "'self' data: blob: http://blob.localhost dcblob: http://dcblob.localhost webxdc-icon: http://webxdc-icon.localhost",
-        "media-src": "'self' dcblob: http://dcblob.localhost"
+        "worker-src": "blob:",
+        "child-src": "blob:",
+        "img-src": "'self' data: blob: dcblob: webxdc-icon:",
+        "media-src": "'self' dcblob:"
       },
       // TODO postponed to later
       // "pattern": {

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -20,6 +20,7 @@
       }
     ],
     "security": {
+      // The CSP will be further adjusted in `run()`, see `context.config_mut()`.
       "csp": {
         "default-src": "none",
         "connect-src": "'self' ipc:",


### PR DESCRIPTION
#skip-changelog
