### PR TITLE
style: fix "Archived Chats" title ugliness

### DIFF
--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -198,7 +198,7 @@ export default function MainScreen({ accountId }: Props) {
                   <Icon icon='arrow-left' className='backButtonIcon'></Icon>
                 </Button>
               </span>
-              <div className='archived-chats-title' data-no-drag-region>
+              <div className={styles.archivedChatsTitle} data-no-drag-region>
                 {tx('chat_archived_chats_title')}
               </div>
             </>

--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -39,7 +39,7 @@
     align-items: center;
     padding: 0px 10px;
 
-    .archived-chats-title {
+    .archivedChatsTitle {
       flex: 1 1 auto;
       overflow-x: hidden;
       white-space: nowrap;


### PR DESCRIPTION
This is a regression introduced in
66c96d7df19f591a8c8610842952cb9f7b9ed540
(https://github.com/deltachat/deltachat-desktop/pull/4672).

Before / after:

![image](https://github.com/user-attachments/assets/887241a7-ca22-4a9a-b0fc-bbf97b0e7cbe)

#skip-changelog because insignificant