### PR TITLE
Autostart on Tauri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - tauri: add taskbar icon "unread" badge on Windows
 - tauri: add `--minimized` flag #4922
 - tauri: add theming #4940
+- tauri: add autostart
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 - fix chatlist items sometimes not updating #4975
 - fix sticker folder not resolved on windows #4939
 - tauri: improve performance a little #4812
+- settings: fix: wait for setting to be applied before calling callback
 
 <a id="1_56_0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - tauri: add taskbar icon "unread" badge on Windows
 - tauri: add `--minimized` flag #4922
 - tauri: add theming #4940
-- tauri: add autostart
+- tauri: add autostart #4754
 
 
 ### Changed
@@ -63,6 +63,7 @@
 - accessibility: don't announce "padlock" on messages
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895
+<<<<<<< HEAD
 - show error message when QR scan action fails
 - tauri: fix: sticker picker previews not working
 - tauri: fix emoji picker being super ugly
@@ -72,6 +73,9 @@
 - fix sticker folder not resolved on windows #4939
 - tauri: improve performance a little #4812
 - settings: fix: wait for setting to be applied before calling callback
+=======
+- settings: fix: wait for setting to be applied before calling callback #4754
+>>>>>>> f6fbcef49 (add pr number to changelog entry)
 
 <a id="1_56_0"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,6 @@
 - accessibility: don't announce "padlock" on messages
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895
-<<<<<<< HEAD
 - show error message when QR scan action fails
 - tauri: fix: sticker picker previews not working
 - tauri: fix emoji picker being super ugly
@@ -72,10 +71,7 @@
 - fix chatlist items sometimes not updating #4975
 - fix sticker folder not resolved on windows #4939
 - tauri: improve performance a little #4812
-- settings: fix: wait for setting to be applied before calling callback
-=======
 - settings: fix: wait for setting to be applied before calling callback #4754
->>>>>>> f6fbcef49 (add pr number to changelog entry)
 
 <a id="1_56_0"></a>
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,6 +603,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,6 +1820,7 @@ dependencies = [
  "strum 0.27.1",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-devtools",
  "tauri-plugin-dialog",
@@ -2021,11 +2033,31 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -2036,7 +2068,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.0",
  "windows-sys 0.59.0",
 ]
 
@@ -6714,6 +6746,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
@@ -8178,7 +8221,7 @@ source = "git+https://github.com/tauri-apps/tauri?rev=51bcafe3232344cc8e4e413576
 dependencies = [
  "anyhow",
  "bytes",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "futures-util",
@@ -8229,7 +8272,7 @@ source = "git+https://github.com/tauri-apps/tauri?rev=51bcafe3232344cc8e4e413576
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -8297,6 +8340,20 @@ dependencies = [
  "tauri-utils 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c13f843e5e5df3eed270fc42b02923cc1a6b5c7e56b0f3ac1d858ab2c8b5fb"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -9163,7 +9220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d433764348e7084bad2c5ea22c96c71b61b17afe3a11645710f533bd72b6a2b5"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda",
  "objc2 0.6.0",
@@ -10372,6 +10429,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -61,5 +61,17 @@
   },
   "stop_recording": {
     "message": "Finish recording"
+  },
+  "pref_autostart": {
+    "message": "Autostart"
+  },
+  "pref_autostart_registered": {
+    "message": "Deltachat is currently registered to startup with the system"
+  },
+  "pref_autostart_not_registered": {
+    "message": "Deltachat is not registered to startup with the system"
+  },
+  "pref_autostart_not_supported": {
+    "message": "Autostart is not supported on this system"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -66,10 +66,10 @@
     "message": "Autostart"
   },
   "pref_autostart_registered": {
-    "message": "Deltachat is currently registered to startup with the system"
+    "message": "Delta Chat is currently registered to startup with the system"
   },
   "pref_autostart_not_registered": {
-    "message": "Deltachat is not registered to startup with the system"
+    "message": "Delta Chat is not registered to startup with the system"
   },
   "pref_autostart_not_supported": {
     "message": "Autostart is not supported on this system"

--- a/packages/frontend/src/components/Settings/Advanced.tsx
+++ b/packages/frontend/src/components/Settings/Advanced.tsx
@@ -85,22 +85,22 @@ function SettingsAutoStart() {
   return (
     <>
       <DesktopSettingsSwitch
+        key={String(!autostartState) /* force react to rerender element, so that the switch does not animate */}
         settingsKey='autostart'
         label={tx('pref_autostart')}
         description={
           autostartState
-            ? autostartState.isRegistered
+            ? autostartState.isSupported?
+            autostartState.isRegistered
               ? tx('pref_autostart_registered')
-              : tx('pref_autostart_not_registered')
+              : tx('pref_autostart_not_registered'):
+              tx('pref_autostart_not_supported')
             : undefined // don't show description while it is loading
         }
         disabled={!autostartState?.isSupported}
         disabledValue={false}
         callback={update}
       />
-      {autostartState && !autostartState.isSupported && (
-        <Callout>{tx('pref_autostart_not_supported')}</Callout>
-      )}
     </>
   )
 }

--- a/packages/frontend/src/components/Settings/Advanced.tsx
+++ b/packages/frontend/src/components/Settings/Advanced.tsx
@@ -14,7 +14,6 @@ import { runtime } from '@deltachat-desktop/runtime-interface'
 import CoreSettingsSwitch from './CoreSettingsSwitch'
 import DesktopSettingsSwitch from './DesktopSettingsSwitch'
 import { AutostartState } from '@deltachat-desktop/shared/shared-types'
-import Callout from '../Callout'
 
 type Props = {
   settingsStore: SettingsStoreState
@@ -85,16 +84,17 @@ function SettingsAutoStart() {
   return (
     <>
       <DesktopSettingsSwitch
-        key={String(!autostartState) /* force react to rerender element, so that the switch does not animate */}
+        // force react to rerender element, so that the switch does not animate
+        key={String(!autostartState)}
         settingsKey='autostart'
         label={tx('pref_autostart')}
         description={
           autostartState
-            ? autostartState.isSupported?
-            autostartState.isRegistered
-              ? tx('pref_autostart_registered')
-              : tx('pref_autostart_not_registered'):
-              tx('pref_autostart_not_supported')
+            ? autostartState.isSupported
+              ? autostartState.isRegistered
+                ? tx('pref_autostart_registered')
+                : tx('pref_autostart_not_registered')
+              : tx('pref_autostart_not_supported')
             : undefined // don't show description while it is loading
         }
         disabled={!autostartState?.isSupported}

--- a/packages/frontend/src/components/Settings/DesktopSettingsSwitch.tsx
+++ b/packages/frontend/src/components/Settings/DesktopSettingsSwitch.tsx
@@ -36,8 +36,8 @@ export default function DesktopSettingsSwitch({
       label={label}
       description={description}
       value={value}
-      onChange={() => {
-        SettingsStoreInstance.effect.setDesktopSetting(
+      onChange={async () => {
+        await SettingsStoreInstance.effect.setDesktopSetting(
           settingsKey,
           !settingsStore.desktopSettings[settingsKey]
         )

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -1,4 +1,5 @@
 import {
+  AutostartState,
   DcNotification,
   DcOpenWebxdcParameters,
   DesktopSettingsType,
@@ -146,6 +147,7 @@ export interface Runtime {
    */
   isDroppedFileFromOutside(file: File): boolean
 
+  getAutostartState(): Promise<AutostartState>
   // callbacks to set
   onChooseLanguage: ((locale: string) => Promise<void>) | undefined
   /** backend notifies ui to reload theme,

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -54,6 +54,8 @@ export interface DesktopSettingsType {
    * also called screen_security
    */
   contentProtectionEnabled: boolean
+  /** whether to start with system on supported platforms */
+  autostart: boolean
 }
 
 export interface RC_Config {
@@ -154,4 +156,11 @@ export interface RuntimeOpenDialogOptions {
   )[]
   defaultPath?: string
   buttonLabel?: string
+}
+
+export interface AutostartState {
+  isSupported: boolean
+  // This is not the same as enabled in the desktop settings,
+  // this is the actual state not the desktop setting
+  isRegistered: boolean
 }

--- a/packages/shared/state.ts
+++ b/packages/shared/state.ts
@@ -33,5 +33,6 @@ export function getDefaultState(): DesktopSettingsType {
     useSystemUIFont: false,
     contentProtectionEnabled: false,
     isMentionsEnabled: true,
+    autostart: true,
   }
 }

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -1,6 +1,7 @@
 // This needs to be injected / imported before the frontend script
 
 import {
+  AutostartState,
   DcNotification,
   DcOpenWebxdcParameters,
   DesktopSettingsType,
@@ -754,6 +755,12 @@ class BrowserRuntime implements Runtime {
   getConfigPath(): string {
     this.log.warn('getConfigPath method does not exist in browser.')
     return ''
+  }
+  getAutostartState(): Promise<AutostartState> {
+    return Promise.resolve({
+      isSupported: false,
+      isRegistered: false,
+    })
   }
 }
 

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -1,6 +1,7 @@
 // This needs to be injected / imported before the frontend script
 
 import {
+  AutostartState,
   DcNotification,
   DcOpenWebxdcParameters,
   DesktopSettingsType,
@@ -446,6 +447,13 @@ class ElectronRuntime implements Runtime {
   }
   getConfigPath(): string {
     return ipcBackend.sendSync('get-config-path')
+  }
+  getAutostartState(): Promise<AutostartState> {
+    // TODO - see https://github.com/deltachat/deltachat-desktop/issues/2518
+    return Promise.resolve({
+      isSupported: false,
+      isRegistered: false,
+    })
   }
 }
 

--- a/packages/target-tauri/Development.md
+++ b/packages/target-tauri/Development.md
@@ -35,3 +35,8 @@ run `cargo update` in `packages/target-tauri/src-tauri`.
 ## Quirks
 
 - When you edit runtime or frontend code you need to restart the "tauri dev" command, otherwise the changes might not be picked up.
+
+
+## Differences between devmode and release mode
+
+- in devmode autostart is disabled by default, because the result would be unexpected for developers. In release mode this option is enabled by default.

--- a/packages/target-tauri/Development.md
+++ b/packages/target-tauri/Development.md
@@ -36,7 +36,6 @@ run `cargo update` in `packages/target-tauri/src-tauri`.
 
 - When you edit runtime or frontend code you need to restart the "tauri dev" command, otherwise the changes might not be picked up.
 
-
 ## Differences between devmode and release mode
 
 - in devmode autostart is disabled by default, because the result would be unexpected for developers. In release mode this option is enabled by default.

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -9,7 +9,8 @@ import type { Store } from '@tauri-apps/plugin-store'
 import { openPath, openUrl } from '@tauri-apps/plugin-opener'
 import { writeText, readText } from '@tauri-apps/plugin-clipboard-manager'
 
-import {
+import type {
+  AutostartState,
   DcNotification,
   DcOpenWebxdcParameters,
   DesktopSettingsType,
@@ -20,7 +21,10 @@ import {
 } from '@deltachat-desktop/shared/shared-types.js'
 import '@deltachat-desktop/shared/global.d.ts'
 
-import { Runtime, RuntimeAppPath } from '@deltachat-desktop/runtime-interface'
+import type {
+  Runtime,
+  RuntimeAppPath,
+} from '@deltachat-desktop/runtime-interface'
 import { BaseDeltaChat, yerpc } from '@deltachat/jsonrpc-client'
 import type { LocaleData } from '@deltachat-desktop/shared/localize.js'
 import type {
@@ -160,6 +164,7 @@ class TauriRuntime implements Runtime {
       locale: null, // if this is null, the system chooses the system language that electron reports
       notifications: true,
       syncAllAccounts: true,
+      autostart: true,
     } satisfies Partial<DesktopSettingsType>
 
     const frontendOnly = {
@@ -615,6 +620,9 @@ class TauriRuntime implements Runtime {
   // exp.runtime.debug_get_datastore_ids()
   async debug_get_datastore_ids() {
     return await invoke('debug_get_datastore_ids')
+  }
+  getAutostartState(): Promise<AutostartState> {
+    return invoke('get_autostart_state')
   }
   onChooseLanguage: ((locale: string) => Promise<void>) | undefined
   onThemeUpdate: (() => void) | undefined

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -63,6 +63,7 @@ regex = "1.11.1"
 include_dir = "0.7.4"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+tauri-plugin-autostart = "2"
 tauri-plugin-single-instance = "2"
 tauri-plugin-window-state = "2"
 

--- a/packages/target-tauri/src-tauri/build.rs
+++ b/packages/target-tauri/src-tauri/build.rs
@@ -38,6 +38,7 @@ fn main() {
             "ui_frontend_ready",
             "get_current_logfile",
             "copy_image_to_clipboard",
+            "get_autostart_state",
             "get_app_path",
             "get_clipboard_image_as_data_uri",
             "download_file",

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -27,12 +27,12 @@ permissions = [
     # "opener:allow-open-path" is defined in src/runtime_capabilities.rs
     "opener:allow-open-url",
     "opener:allow-default-urls",
-    
+
     # Badge counter
     "core:window:allow-set-badge-count",
     # This is only needed for Windows.
     "core:window:allow-set-overlay-icon",
-    
+
     "allow-set-main-window-channels",
     "allow-get-frontend-run-config",
     "allow-deltachat-jsonrpc-request",

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -42,6 +42,7 @@ permissions = [
 
     "allow-get-current-logfile",
     "allow-copy-image-to-clipboard",
+    "allow-get-autostart-state",
     "allow-get-app-path",
     "allow-get-clipboard-image-as-data-uri",
     "allow-download-file",

--- a/packages/target-tauri/src-tauri/src/autostart.rs
+++ b/packages/target-tauri/src-tauri/src/autostart.rs
@@ -1,0 +1,42 @@
+use serde::Serialize;
+use tauri::AppHandle;
+
+// TODO command to get autostart state : {isSupported, isRegistered}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AutostartState {
+    is_supported: bool,
+    // This is not the same as enabled in the desktop settings,
+    // this is the actual state not the desktop setting
+    is_registered: bool,
+}
+
+#[cfg(not(desktop))]
+#[tauri::command]
+pub(crate) fn get_autostart_state(app: AppHandle) -> Result<AutostartState, String> {
+    Ok(AutostartState {
+        is_supported: false,
+        is_registered: false,
+    })
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(crate) fn get_autostart_state(app: AppHandle) -> Result<AutostartState, String> {
+    use tauri_plugin_autostart::ManagerExt;
+    let autostart_manager = app.autolaunch();
+    let is_registered = autostart_manager
+        .is_enabled()
+        .map_err(|err| format!("{err}"))?;
+    // IDEA: maybe this needs more complex logic for when there is a portable package for example
+    let is_supported = !cfg!(debug_assertions); // for now - only in release builds
+    Ok(AutostartState {
+        is_supported,
+        is_registered,
+    })
+}
+
+// Enabling / disabling is managed in settings.rs
+
+// Launch arguments are specified in lib.rs in `.setup(` closure

--- a/packages/target-tauri/src-tauri/src/autostart.rs
+++ b/packages/target-tauri/src-tauri/src/autostart.rs
@@ -30,7 +30,7 @@ pub(crate) fn get_autostart_state(app: AppHandle) -> Result<AutostartState, Stri
         .is_enabled()
         .map_err(|err| format!("{err}"))?;
     // IDEA: maybe this needs more complex logic for when there is a portable package for example
-    let is_supported = !cfg!(debug_assertions); // for now - only in release builds
+    let is_supported = true;
     Ok(AutostartState {
         is_supported,
         is_registered,

--- a/packages/target-tauri/src-tauri/src/autostart.rs
+++ b/packages/target-tauri/src-tauri/src/autostart.rs
@@ -1,8 +1,6 @@
 use serde::Serialize;
 use tauri::AppHandle;
 
-// TODO command to get autostart state : {isSupported, isRegistered}
-
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AutostartState {

--- a/packages/target-tauri/src-tauri/src/cli.rs
+++ b/packages/target-tauri/src-tauri/src/cli.rs
@@ -36,6 +36,8 @@ pub struct Cli {
     /// You can use it in combination with the env var `DELTACHAT_LOCALE_DIR`.
     #[arg(long)]
     watch_translations: bool,
+    #[arg(long)]
+    autostart: bool, // TODO: implement after merging tray icon
     /// Print version
     #[arg(short = 'V', long)]
     version: bool,

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -308,8 +308,7 @@ pub fn run() {
 
                 app.handle().plugin(tauri_plugin_autostart::init(
                     MacosLauncher::LaunchAgent,
-                    Some(vec!["--minimized", "--autostart"]),
-                    // TODO: note that cli arguments are not implemented yet
+                    Some(vec!["--autostart"]),
                     // TODO: `--autostart` should show a different message why the tray option is disabled
                 ))?;
             }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ use tauri_plugin_log::{Target, TargetKind};
 use tray::is_tray_icon_active;
 
 mod app_path;
+mod autostart;
 mod blobs;
 #[cfg(desktop)]
 mod cli;
@@ -155,6 +156,7 @@ pub fn run() {
             ui_frontend_ready,
             get_current_logfile,
             copy_image_to_clipboard,
+            autostart::get_autostart_state,
             app_path::get_app_path,
             clipboard::get_clipboard_image_as_data_uri,
             file_dialogs::download_file,
@@ -299,6 +301,18 @@ pub fn run() {
                 let _ = tauri_plugin_log::attach_logger(max_level, logger);
             }
             app.handle().plugin(tauri_plugin_log)?;
+
+            #[cfg(desktop)]
+            {
+                use tauri_plugin_autostart::MacosLauncher;
+
+                app.handle().plugin(tauri_plugin_autostart::init(
+                    MacosLauncher::LaunchAgent,
+                    Some(vec!["--minimized", "--autostart"]),
+                    // TODO: note that cli arguments are not implemented yet
+                    // TODO: `--autostart` should show a different message why the tray option is disabled
+                ))?;
+            }
 
             app.manage(tauri::async_runtime::block_on(AppState::try_new(
                 app,

--- a/packages/target-tauri/src-tauri/src/settings.rs
+++ b/packages/target-tauri/src-tauri/src/settings.rs
@@ -198,7 +198,7 @@ pub(crate) fn apply_autostart(app: &AppHandle) -> anyhow::Result<()> {
     if store.get(AUTOSTART_KEY).is_none() {
         store.set(AUTOSTART_KEY, AUTOSTART_DEFAULT);
     }
-    let enable = get_setting_bool_or(store.get(AUTOSTART_KEY), AUTOSTART_DEFAULT);
+    let enable = store.get_bool_or(AUTOSTART_KEY, AUTOSTART_DEFAULT);
 
     let autostart_manager = app.autolaunch();
 


### PR DESCRIPTION
- **fix: wait for setting to be applied before calling callback**
- **tauri: add autostart**

related to https://github.com/deltachat/deltachat-desktop/issues/2518, now spearheading on tauri, because tauri already has a plugin.
The option is hidden for now on electron and browser, because a disabled autostart option would only create confusion as long as tauri is not the default.

Also the option on tauri is for now only shown in release builds.

<img width="427" alt="Bildschirmfoto 2025-03-08 um 20 05 26" src="https://github.com/user-attachments/assets/9f4ceecb-74f5-470d-b441-f62456982dbb" />

<img width="427" alt="Bildschirmfoto 2025-03-08 um 20 05 32" src="https://github.com/user-attachments/assets/d4695ec6-c398-4163-98f6-eb650f066dc2" />

<img width="427" alt="Bildschirmfoto 2025-03-08 um 20 29 43" src="https://github.com/user-attachments/assets/5d1a6e71-aeeb-4df6-b9a2-2979efcddedf" />

### Progress:

- [x] Test it and disable the option for packaging options that don't work
    - [x] Linux package
    - [x] Linux appimage
    - ~~Linux flatpak~~ postponed
    - [x] Windows
    - [x] MacOS