### PR TITLE
Tauri Menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1674,8 +1674,8 @@ dependencies = [
  "sha2",
  "shadowsocks",
  "smallvec",
- "strum",
- "strum_macros",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "tagger",
  "textwrap",
  "thiserror 2.0.12",
@@ -1743,6 +1743,8 @@ dependencies = [
  "png",
  "serde",
  "serde_json",
+ "strum 0.27.0",
+ "strum_macros 0.27.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -3894,7 +3896,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "smallvec",
- "strum",
+ "strum 0.26.3",
  "stun-rs",
  "thiserror 2.0.12",
  "tokio",
@@ -7872,14 +7874,33 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
 
 [[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9688894b43459159c82bfa5a5fa0435c19cbe3c9b427fa1dd7b1ce0c279b18a7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1744,7 +1744,6 @@ dependencies = [
  "serde",
  "serde_json",
  "strum 0.27.0",
- "strum_macros 0.27.0",
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
@@ -7882,6 +7881,9 @@ name = "strum"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce1475c515a4f03a8a7129bb5228b81a781a86cb0b3fbbc19e1c556d491a401f"
+dependencies = [
+ "strum_macros 0.27.0",
+]
 
 [[package]]
 name = "strum_macros"

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -264,6 +264,16 @@ class TauriRuntime implements Runtime {
     listen<string>('locale_reloaded', event => {
       this.onChooseLanguage?.(event.payload)
     })
+
+    listen<string>('showAboutDialog', () => {
+      this.onShowDialog?.("about")
+    });
+    listen<string>('showSettingsDialog', () => {
+      this.onShowDialog?.("settings")
+    });
+    listen<string>('showKeybindingsDialog', () => {
+      this.onShowDialog?.("keybindings")
+    });
   }
   reloadWebContent(): void {
     // for now use the browser method as long as it is sufficient

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -44,6 +44,8 @@ base64 = "0.22.1"
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-opener = "2.2.5"
 unic-idna-punycode = "0.9.0"
+strum = "0.27"
+strum_macros = "0.27"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -44,8 +44,7 @@ base64 = "0.22.1"
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-opener = "2.2.5"
 unic-idna-punycode = "0.9.0"
-strum = "0.27"
-strum_macros = "0.27"
+strum = {version = "0.27", features = ["derive"]}
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -44,7 +44,7 @@ base64 = "0.22.1"
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-opener = "2.2.5"
 unic-idna-punycode = "0.9.0"
-strum = {version = "0.27", features = ["derive"]}
+strum = {version = "0.27", features = ["derive"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2"

--- a/packages/target-tauri/src-tauri/src/help_window.rs
+++ b/packages/target-tauri/src-tauri/src/help_window.rs
@@ -1,5 +1,5 @@
 use log::warn;
-use tauri::{Manager, WebviewWindow};
+use tauri::{Manager, Runtime};
 
 use crate::settings::apply_content_protection;
 
@@ -19,8 +19,8 @@ impl serde::Serialize for Error {
 }
 
 #[tauri::command]
-pub(crate) fn open_help_window(
-    app: tauri::AppHandle,
+pub(crate) fn open_help_window<A: Runtime>(
+    app: tauri::AppHandle<A>,
     locale: &str,
     anchor: Option<&str>,
 ) -> Result<(), Error> {
@@ -32,7 +32,7 @@ pub(crate) fn open_help_window(
 
     let app_url = tauri::WebviewUrl::App(url.into());
 
-    let help_window: WebviewWindow = if let Some(help_window) = app.get_webview_window("help") {
+    let mut help_window = if let Some(help_window) = app.get_webview_window("help") {
         help_window
     } else {
         tauri::WebviewWindowBuilder::new(&app, "help", app_url.clone()).build()?

--- a/packages/target-tauri/src-tauri/src/help_window.rs
+++ b/packages/target-tauri/src-tauri/src/help_window.rs
@@ -1,5 +1,5 @@
 use log::warn;
-use tauri::{Manager, Runtime};
+use tauri::{Manager};
 
 use crate::settings::apply_content_protection;
 
@@ -19,8 +19,8 @@ impl serde::Serialize for Error {
 }
 
 #[tauri::command]
-pub(crate) fn open_help_window<A: Runtime>(
-    app: tauri::AppHandle<A>,
+pub(crate) fn open_help_window(
+    app: tauri::AppHandle,
     locale: &str,
     anchor: Option<&str>,
 ) -> Result<(), Error> {
@@ -32,7 +32,7 @@ pub(crate) fn open_help_window<A: Runtime>(
 
     let app_url = tauri::WebviewUrl::App(url.into());
 
-    let mut help_window = if let Some(help_window) = app.get_webview_window("help") {
+    let help_window = if let Some(help_window) = app.get_webview_window("help") {
         help_window
     } else {
         tauri::WebviewWindowBuilder::new(&app, "help", app_url.clone()).build()?

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -1,12 +1,14 @@
 use std::time::SystemTime;
 
 use clipboard::copy_image_to_clipboard;
-use settings::load_and_apply_desktop_settings_on_startup;
-use state::{
-    app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,
-};
-use tauri::Manager;
+
+use menus::{handle_menu_event, main_menu::create_main_menu, set_zoom};
+use settings::{load_and_apply_desktop_settings_on_startup, ZOOM_FACTOR_KEY};
+use state::{app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,};
 use util::csp::add_custom_schemes_to_csp_for_window_and_android;
+use tauri::Manager;
+use tauri_plugin_store::StoreExt;
+
 mod app_path;
 mod blobs;
 mod clipboard;
@@ -14,6 +16,7 @@ mod file_dialogs;
 mod help_window;
 mod html_window;
 mod i18n;
+mod menus;
 mod runtime_info;
 mod settings;
 mod state;
@@ -202,6 +205,9 @@ pub fn run() {
                 webview.set_title_bar_style(tauri::TitleBarStyle::Overlay)?;
                 webview.set_title("")?;
             }
+
+            app.set_menu(create_main_menu(app.handle())?)?;
+            app.on_menu_event(handle_menu_event);
 
             Ok(())
         })

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -2,12 +2,13 @@ use std::time::SystemTime;
 
 use clipboard::copy_image_to_clipboard;
 
-use menus::{handle_menu_event, main_menu::create_main_menu, set_zoom};
-use settings::{load_and_apply_desktop_settings_on_startup, ZOOM_FACTOR_KEY};
-use state::{app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,};
-use util::csp::add_custom_schemes_to_csp_for_window_and_android;
+use menus::{handle_menu_event, main_menu::create_main_menu};
+use settings::load_and_apply_desktop_settings_on_startup;
+use state::{
+    app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,
+};
 use tauri::Manager;
-use tauri_plugin_store::StoreExt;
+use util::csp::add_custom_schemes_to_csp_for_window_and_android;
 
 mod app_path;
 mod blobs;

--- a/packages/target-tauri/src-tauri/src/menus/float_on_top.rs
+++ b/packages/target-tauri/src-tauri/src/menus/float_on_top.rs
@@ -1,0 +1,21 @@
+use std::sync::atomic::AtomicBool;
+
+use tauri::WebviewWindow;
+
+// TODO: there should also be an option in tauri to get current float on top state,
+// so that we don't need to track it ourselves
+// especially needed when we get other windows that can have multiple instances
+// (html window and webxdc)
+pub static MAIN_FLOATING: AtomicBool = AtomicBool::new(false);
+pub static HELP_FLOATING: AtomicBool = AtomicBool::new(false);
+
+pub fn set_float_on_top_based_on_main_window(
+    window: &WebviewWindow,
+    window_float_on_top_state: &AtomicBool,
+) {
+    // TODO: is relaxed the correct ordering
+    if MAIN_FLOATING.load(std::sync::atomic::Ordering::Relaxed) {
+        let _ = window.set_always_on_top(true);
+        window_float_on_top_state.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+}

--- a/packages/target-tauri/src-tauri/src/menus/help_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/help_menu.rs
@@ -1,10 +1,10 @@
 use super::HelpMenuAction;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
-    AppHandle, Runtime,
+    AppHandle, Wry,
 };
 
-pub(crate) fn create_help_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Result<Menu<A>> {
+pub(crate) fn create_help_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> {
     let menu = Menu::with_items(
         handle,
         &[

--- a/packages/target-tauri/src-tauri/src/menus/help_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/help_menu.rs
@@ -1,0 +1,73 @@
+use super::HelpMenuAction;
+use tauri::{
+    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
+    AppHandle, Runtime,
+};
+
+pub(crate) fn create_help_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Result<Menu<A>> {
+    let menu = Menu::with_items(
+        handle,
+        &[
+            &Submenu::with_items(
+                handle,
+                "File",
+                true,
+                &[&MenuItem::with_id(
+                    handle,
+                    HelpMenuAction::HelpQuit,
+                    "Quit",
+                    true,
+                    None::<&str>,
+                )?],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::copy(handle, Some("Copy"))?,
+                    &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "View",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::ResetZoom,
+                        "Actual Size",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::ZoomIn,
+                        "Zoom In",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::ZoomOut,
+                        "Zoom Out",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &MenuItem::with_id(
+                        handle,
+                        HelpMenuAction::HelpFloatOnTop,
+                        "Float on Top",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::fullscreen(handle, Some("Toggle Full Screen"))?,
+                ],
+            )?,
+        ],
+    )?;
+
+    Ok(menu)
+}

--- a/packages/target-tauri/src-tauri/src/menus/help_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/help_menu.rs
@@ -1,8 +1,61 @@
-use super::HelpMenuAction;
+use crate::settings::{apply_zoom_factor_help_window, CONFIG_FILE, HELP_ZOOM_FACTOR_KEY};
+
+use super::{float_on_top::HELP_FLOATING, menu_action::MenuAction};
+use anyhow::Context;
+use strum::{AsRefStr, EnumString};
 use tauri::{
-    menu::{Menu, MenuItem, PredefinedMenuItem, Submenu},
-    AppHandle, Wry,
+    menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
+    AppHandle, Manager, Wry,
 };
+use tauri_plugin_store::StoreExt;
+
+#[derive(Debug, AsRefStr, EnumString)]
+pub(crate) enum HelpMenuAction {
+    HelpQuit,
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
+    HelpFloatOnTop,
+}
+
+super::menu_action::impl_menu_conversion!(HelpMenuAction);
+
+impl MenuAction<'static> for HelpMenuAction {
+    fn execute(self, app: &AppHandle) -> anyhow::Result<()> {
+        let help_window = app
+            .get_webview_window("help")
+            .context("help window not found")?;
+        match self {
+            HelpMenuAction::HelpQuit => {
+                help_window.close()?;
+            }
+            HelpMenuAction::ZoomIn | HelpMenuAction::ZoomOut | HelpMenuAction::ResetZoom => {
+                let store = app
+                    .get_store(CONFIG_FILE)
+                    .context("config store not found")?;
+                let curr_zoom: f64 = store
+                    .get(HELP_ZOOM_FACTOR_KEY)
+                    .and_then(|f| f.as_f64())
+                    .unwrap_or(1.0);
+
+                let new_zoom = match self {
+                    HelpMenuAction::ZoomIn => curr_zoom * 1.2,
+                    HelpMenuAction::ResetZoom => 1.,
+                    HelpMenuAction::ZoomOut => curr_zoom * 0.8,
+                    _ => unreachable!(),
+                };
+
+                store.set(HELP_ZOOM_FACTOR_KEY, new_zoom);
+                apply_zoom_factor_help_window(app)?;
+            }
+            HelpMenuAction::HelpFloatOnTop => {
+                let previous = HELP_FLOATING.fetch_xor(true, std::sync::atomic::Ordering::SeqCst);
+                help_window.set_always_on_top(previous)?;
+            }
+        }
+        Ok(())
+    }
+}
 
 pub(crate) fn create_help_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> {
     let menu = Menu::with_items(
@@ -56,11 +109,12 @@ pub(crate) fn create_help_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> 
                         None::<&str>,
                     )?,
                     &PredefinedMenuItem::separator(handle)?,
-                    &MenuItem::with_id(
+                    &CheckMenuItem::with_id(
                         handle,
                         HelpMenuAction::HelpFloatOnTop,
                         "Float on Top",
                         true,
+                        HELP_FLOATING.load(std::sync::atomic::Ordering::Relaxed),
                         None::<&str>,
                     )?,
                     &PredefinedMenuItem::fullscreen(handle, Some("Toggle Full Screen"))?,

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -1,10 +1,126 @@
-use super::MainMenuAction;
-use crate::settings::ZOOM_FACTOR_KEY;
+use std::sync::atomic::Ordering;
+
+use crate::{
+    help_window::open_help_window,
+    settings::{apply_zoom_factor, CONFIG_FILE, ZOOM_FACTOR_KEY},
+    AppState,
+};
+use anyhow::Context;
+use strum::{AsRefStr, EnumString};
 use tauri::{
     menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
-    AppHandle, Wry,
+    AppHandle, Emitter, Manager, Wry,
 };
+use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::StoreExt;
+
+use super::{
+    float_on_top::MAIN_FLOATING,
+    menu_action::{impl_menu_conversion, MenuAction},
+};
+
+#[derive(Debug, AsRefStr, EnumString)]
+pub(crate) enum MainMenuAction {
+    Settings,
+    Help,
+    Quit,
+    FloatOnTop,
+    Zoom06,
+    Zoom08,
+    Zoom10,
+    Zoom12,
+    Zoom14,
+    DevTools,
+    LogFolder,
+    CurrentLogFile,
+    Keybindings,
+    Contribute,
+    Report,
+    Learn,
+    About,
+}
+
+impl_menu_conversion!(MainMenuAction);
+
+impl MenuAction<'static> for MainMenuAction {
+    fn execute(self, app: &AppHandle) -> anyhow::Result<()> {
+        let main_window = app
+            .get_webview_window("main")
+            .context("main window not found")?;
+        match self {
+            MainMenuAction::Settings => {
+                app.emit("showSettingsDialog", None::<String>)?;
+            }
+            MainMenuAction::Help => {
+                open_help_window(app.clone(), "", None)?;
+            }
+            MainMenuAction::Quit => {
+                app.exit(0);
+            }
+            MainMenuAction::FloatOnTop => {
+                let previous = MAIN_FLOATING.fetch_xor(true, std::sync::atomic::Ordering::SeqCst);
+                main_window.set_always_on_top(previous)?;
+            }
+            MainMenuAction::Zoom06
+            | MainMenuAction::Zoom08
+            | MainMenuAction::Zoom10
+            | MainMenuAction::Zoom12
+            | MainMenuAction::Zoom14 => {
+                let zoom_factor = match self {
+                    MainMenuAction::Zoom06 => 0.6,
+                    MainMenuAction::Zoom08 => 0.8,
+                    MainMenuAction::Zoom10 => 1.0,
+                    MainMenuAction::Zoom12 => 1.2,
+                    MainMenuAction::Zoom14 => 1.4,
+                    _ => unreachable!(),
+                };
+                let store = app.store(CONFIG_FILE)?;
+                store.set(ZOOM_FACTOR_KEY, zoom_factor);
+                apply_zoom_factor(app)?;
+            }
+
+            MainMenuAction::DevTools => {
+                if cfg!(feature = "inspector_in_production") {
+                    main_window.open_devtools();
+                }
+            }
+            MainMenuAction::LogFolder => {
+                if let Ok(path) = &app.path().app_log_dir() {
+                    if let Some(path) = path.to_str() {
+                        app.opener().open_path(path, None::<String>)?;
+                    }
+                }
+            }
+            MainMenuAction::CurrentLogFile => {
+                let path = app.state::<AppState>().current_log_file_path.clone();
+                app.opener().open_path(path, None::<String>)?;
+            }
+            MainMenuAction::Keybindings => {
+                app.emit("showKeybindingsDialog", None::<String>)?;
+            }
+            MainMenuAction::Contribute => {
+                app.opener().open_url(
+                    "https://github.com/deltachat/deltachat-desktop",
+                    None::<String>,
+                )?;
+            }
+            MainMenuAction::Report => {
+                app.opener().open_url(
+                    "https://github.com/deltachat/deltachat-desktop/issues",
+                    None::<String>,
+                )?;
+            }
+            MainMenuAction::Learn => {
+                app.opener()
+                    .open_url("https://delta.chat/de/", None::<String>)?;
+            }
+            MainMenuAction::About => {
+                app.emit("showAboutDialog", None::<String>)?;
+            }
+        }
+        Ok(())
+    }
+}
 
 pub(crate) fn create_main_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> {
     let zoom_factor = handle
@@ -61,7 +177,7 @@ pub(crate) fn create_main_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> 
                         MainMenuAction::FloatOnTop,
                         "Float on Top",
                         true,
-                        false,
+                        MAIN_FLOATING.load(Ordering::Relaxed),
                         None::<&str>,
                     )?,
                     &Submenu::with_items(
@@ -116,7 +232,7 @@ pub(crate) fn create_main_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> 
                         "Developer",
                         true,
                         &[
-                            #[cfg(feature = "crabnebula_extras")]
+                            #[cfg(feature = "inspector_in_production")]
                             &MenuItem::with_id(
                                 handle,
                                 MainMenuAction::DevTools,
@@ -194,5 +310,5 @@ pub(crate) fn create_main_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> 
             )?,
         ],
     )
-    .map_err(anyhow::Error::from)
+    .map_err(|err| err.into())
 }

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -2,11 +2,11 @@ use super::MainMenuAction;
 use crate::settings::ZOOM_FACTOR_KEY;
 use tauri::{
     menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
-    AppHandle, Runtime,
+    AppHandle, Wry,
 };
 use tauri_plugin_store::StoreExt;
 
-pub(crate) fn create_main_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Result<Menu<A>> {
+pub(crate) fn create_main_menu(handle: &AppHandle) -> anyhow::Result<Menu<Wry>> {
     let zoom_factor = handle
         .get_store("config.json")
         .and_then(|store| store.get(ZOOM_FACTOR_KEY))

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -1,0 +1,198 @@
+use super::MainMenuAction;
+use crate::settings::ZOOM_FACTOR_KEY;
+use tauri::{
+    menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
+    AppHandle, Runtime,
+};
+use tauri_plugin_store::StoreExt;
+
+pub(crate) fn create_main_menu<A: Runtime>(handle: &AppHandle<A>) -> anyhow::Result<Menu<A>> {
+    let zoom_factor = handle
+        .get_store("config.json")
+        .and_then(|store| store.get(ZOOM_FACTOR_KEY))
+        .and_then(|f| f.as_f64())
+        .unwrap_or(1.0);
+
+    Menu::with_items(
+        handle,
+        &[
+            &Submenu::with_items(
+                handle,
+                "File",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Quit,
+                        MainMenuAction::Quit,
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Settings,
+                        MainMenuAction::Settings,
+                        true,
+                        None::<&str>,
+                    )?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::undo(handle, Some("Undo"))?,
+                    &PredefinedMenuItem::redo(handle, Some("Redo"))?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &PredefinedMenuItem::cut(handle, Some("Cut"))?,
+                    &PredefinedMenuItem::copy(handle, Some("Copy"))?,
+                    &PredefinedMenuItem::paste(handle, Some("Paste"))?,
+                    &PredefinedMenuItem::select_all(handle, Some("Select All"))?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "View",
+                true,
+                &[
+                    &CheckMenuItem::with_id(
+                        handle,
+                        MainMenuAction::FloatOnTop,
+                        "Float on Top",
+                        true,
+                        false,
+                        None::<&str>,
+                    )?,
+                    &Submenu::with_items(
+                        handle,
+                        "Zoom",
+                        true,
+                        &[
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom06,
+                                "0.6x Extra Small",
+                                true,
+                                zoom_factor == 0.6,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom08,
+                                "0.8x Small",
+                                true,
+                                zoom_factor == 0.8,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom10,
+                                "1.0x Normal",
+                                true,
+                                zoom_factor == 1.0,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom12,
+                                "1.2x Large",
+                                true,
+                                zoom_factor == 1.2,
+                                None::<&str>,
+                            )?,
+                            &CheckMenuItem::with_id(
+                                handle,
+                                MainMenuAction::Zoom14,
+                                "1.4x Extra Large",
+                                true,
+                                zoom_factor == 1.4,
+                                None::<&str>,
+                            )?,
+                        ],
+                    )?,
+                    &Submenu::with_items(
+                        handle,
+                        "Developer",
+                        true,
+                        &[
+                            #[cfg(feature = "crabnebula_extras")]
+                            &MenuItem::with_id(
+                                handle,
+                                MainMenuAction::DevTools,
+                                "Open Developer Tools",
+                                true,
+                                None::<&str>,
+                            )?,
+                            &MenuItem::with_id(
+                                handle,
+                                MainMenuAction::LogFolder,
+                                "Open the Log Folder",
+                                true,
+                                None::<&str>,
+                            )?,
+                            &MenuItem::with_id(
+                                handle,
+                                MainMenuAction::CurrentLogFile,
+                                "Open Current Log File",
+                                true,
+                                None::<&str>,
+                            )?,
+                        ],
+                    )?,
+                ],
+            )?,
+            &Submenu::with_items(
+                handle,
+                "Help",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Help,
+                        MainMenuAction::Help,
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Keybindings,
+                        "Keybindings",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Learn,
+                        "Learn more about Delta Chat",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Contribute,
+                        "Contribute on Github",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::separator(handle)?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::Report,
+                        "Report an Issue",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        handle,
+                        MainMenuAction::About,
+                        "About Delta Chat",
+                        true,
+                        None::<&str>,
+                    )?,
+                ],
+            )?,
+        ],
+    )
+    .map_err(anyhow::Error::from)
+}

--- a/packages/target-tauri/src-tauri/src/menus/menu_action.rs
+++ b/packages/target-tauri/src-tauri/src/menus/menu_action.rs
@@ -1,0 +1,25 @@
+use tauri::{menu::MenuId, AppHandle};
+
+pub trait MenuAction<'a>: TryFrom<&'a MenuId> + Into<MenuId> {
+    fn execute(self, app: &AppHandle) -> anyhow::Result<()>;
+}
+
+macro_rules! impl_menu_conversion {
+    ($enum_name:ident) => {
+        impl TryFrom<&tauri::menu::MenuId> for $enum_name {
+            type Error = anyhow::Error;
+
+            fn try_from(item: &tauri::menu::MenuId) -> Result<Self, Self::Error> {
+                use std::str::FromStr;
+                Self::from_str(item.as_ref()).map_err(|e| e.into())
+            }
+        }
+
+        impl From<$enum_name> for tauri::menu::MenuId {
+            fn from(action: $enum_name) -> Self {
+                tauri::menu::MenuId::new(action)
+            }
+        }
+    };
+}
+pub(super) use impl_menu_conversion;

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -1,200 +1,20 @@
-use crate::settings::ZOOM_FACTOR_KEY;
-use crate::{help_window::open_help_window, AppState};
-use help_menu::create_help_menu;
-use main_menu::create_main_menu;
-use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering};
-use strum::{AsRefStr, EnumString};
-use tauri::menu::MenuId;
-use tauri::{menu::MenuEvent, AppHandle, Emitter, Manager, WebviewWindow};
-use tauri_plugin_opener::OpenerExt;
-use tauri_plugin_store::StoreExt;
-pub mod help_menu;
+use help_menu::HelpMenuAction;
+use main_menu::MainMenuAction;
+use menu_action::MenuAction;
+use tauri::{menu::MenuEvent, AppHandle};
+
+pub(crate) mod float_on_top;
+pub(crate) mod help_menu;
 pub(crate) mod main_menu;
-
-const HELP_ZOOM_FACTOR_KEY: &str = "helpZoomFactor";
-static FLOATING: AtomicBool = AtomicBool::new(false);
-
-#[derive(Debug, AsRefStr, EnumString)]
-pub(crate) enum MainMenuAction {
-    Settings,
-    Help,
-    Quit,
-    FloatOnTop,
-    Zoom06,
-    Zoom08,
-    Zoom10,
-    Zoom12,
-    Zoom14,
-    DevTools,
-    LogFolder,
-    CurrentLogFile,
-    Keybindings,
-    Contribute,
-    Report,
-    Learn,
-    About,
-}
-
-impl From<MainMenuAction> for MenuId {
-    fn from(action: MainMenuAction) -> Self {
-        MenuId::new(action)
-    }
-}
-
-impl TryFrom<&MenuId> for MainMenuAction {
-    type Error = anyhow::Error;
-
-    fn try_from(item: &MenuId) -> Result<Self, Self::Error> {
-        MainMenuAction::from_str(item.as_ref()).map_err(|e| e.into())
-    }
-}
-
-#[derive(Debug, AsRefStr, EnumString)]
-pub(crate) enum HelpMenuAction {
-    HelpQuit,
-    ZoomIn,
-    ZoomOut,
-    ResetZoom,
-    HelpFloatOnTop,
-}
-
-impl TryFrom<&MenuId> for HelpMenuAction {
-    type Error = anyhow::Error;
-
-    fn try_from(item: &MenuId) -> Result<Self, Self::Error> {
-        HelpMenuAction::from_str(item.as_ref()).map_err(|e| e.into())
-    }
-}
-
-impl From<HelpMenuAction> for MenuId {
-    fn from(action: HelpMenuAction) -> Self {
-        MenuId::new(action)
-    }
-}
+mod menu_action;
 
 pub fn handle_event(app: &AppHandle, event: MenuEvent) -> anyhow::Result<()> {
     if let Ok(action) = MainMenuAction::try_from(event.id()) {
-        match action {
-            MainMenuAction::Settings => {
-                app.emit("showSettingsDialog", None::<String>).ok();
-            }
-            MainMenuAction::Help => {
-                open_help_window(app.clone(), "", None).ok();
-
-                let window = app
-                    .get_webview_window("help")
-                    .ok_or(anyhow::anyhow!("help window not found"))?;
-                window.set_menu(create_help_menu(&app)?)?;
-            }
-            MainMenuAction::Quit => {
-                app.exit(0);
-            }
-            MainMenuAction::FloatOnTop => {
-                get_main_window(app)?.set_always_on_top(true).ok();
-            }
-            MainMenuAction::Zoom06 => {
-                set_zoom(app, 0.6, "main")?;
-            }
-            MainMenuAction::Zoom08 => {
-                set_zoom(app, 0.8, "main")?;
-            }
-            MainMenuAction::Zoom10 => {
-                set_zoom(app, 1.0, "main")?;
-            }
-            MainMenuAction::Zoom12 => {
-                set_zoom(app, 1.2, "main")?;
-            }
-            MainMenuAction::Zoom14 => {
-                set_zoom(app, 1.4, "main")?;
-            }
-            MainMenuAction::DevTools => {
-                get_main_window(&app)?.open_devtools();
-            }
-            MainMenuAction::LogFolder => {
-                if let Ok(path) = &app.path().app_log_dir() {
-                    if let Some(path) = path.to_str() {
-                        app.opener().open_path(path, None::<String>).ok();
-                    }
-                }
-            }
-            MainMenuAction::CurrentLogFile => {
-                let path = || app.state::<AppState>().current_log_file_path.clone();
-                app.opener().open_path(path(), None::<String>).ok();
-            }
-            MainMenuAction::Keybindings => {
-                app.emit("showKeybindingsDialog", None::<String>)?;
-            }
-            MainMenuAction::Contribute => {
-                app.opener().open_url(
-                    "https://github.com/deltachat/deltachat-desktop",
-                    None::<String>,
-                )?;
-            }
-            MainMenuAction::Report => {
-                app.opener().open_url(
-                    "https://github.com/deltachat/deltachat-desktop/issues",
-                    None::<String>,
-                )?;
-            }
-            MainMenuAction::Learn => {
-                app.opener()
-                    .open_url("https://delta.chat/de/", None::<String>)?;
-            }
-            MainMenuAction::About => {
-                app.emit("showAboutDialog", None::<String>)?;
-            }
-        }
+        action.execute(app)?;
     }
 
     if let Ok(action) = HelpMenuAction::try_from(event.id()) {
-        match action {
-            HelpMenuAction::HelpQuit => {
-                let window = app
-                    .get_webview_window("help")
-                    .ok_or(anyhow::anyhow!("help window not found"))?;
-                window.close().ok();
-            }
-            HelpMenuAction::ZoomIn => {
-                let store = app
-                    .get_store("config.json")
-                    .ok_or(anyhow::anyhow!("store not found"))?;
-                let curr_zoom = store
-                    .get(HELP_ZOOM_FACTOR_KEY)
-                    .and_then(|f| f.as_f64())
-                    .unwrap_or(1.0);
-                let new_zoom = curr_zoom * 1.2;
-                store.set(HELP_ZOOM_FACTOR_KEY, new_zoom);
-                if let Some(window) = app.get_webview_window("help") {
-                    window.set_zoom(new_zoom)?;
-                }
-            }
-            HelpMenuAction::ZoomOut => {
-                let store = app
-                    .get_store("config.json")
-                    .ok_or(anyhow::anyhow!("store not found"))?;
-                let curr_zoom = store
-                    .get(HELP_ZOOM_FACTOR_KEY)
-                    .and_then(|f| f.as_f64())
-                    .unwrap_or(1.0);
-                let new_zoom = curr_zoom * 0.8;
-                store.set(HELP_ZOOM_FACTOR_KEY, new_zoom);
-                if let Some(window) = app.get_webview_window("help") {
-                    window.set_zoom(new_zoom)?;
-                }
-            }
-            HelpMenuAction::ResetZoom => {
-                if let Some(window) = app.get_webview_window("help") {
-                    window.set_zoom(1.0)?;
-                }
-            }
-            HelpMenuAction::HelpFloatOnTop => {
-                if let Some(window) = app.get_webview_window("help") {
-                    let previous = FLOATING.fetch_xor(true, Ordering::SeqCst);
-                    window.set_always_on_top(previous)?;
-                }
-            }
-        }
+        action.execute(app)?;
     }
 
     Ok(())
@@ -204,25 +24,4 @@ pub(crate) fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
     if let Err(e) = handle_event(app, event) {
         log::error!("{:?}", e);
     }
-}
-
-pub(crate) fn get_main_window(app: &AppHandle) -> anyhow::Result<WebviewWindow> {
-    app.get_webview_window("main")
-        .ok_or(anyhow::anyhow!("main window not found"))
-}
-
-pub(crate) fn set_zoom(app: &AppHandle, zoom: f64, window: &str) -> anyhow::Result<()> {
-    let webview = app
-        .get_webview_window(window)
-        .ok_or(anyhow::anyhow!("webview not found"))?;
-    webview.set_zoom(zoom)?;
-
-    let store = app
-        .get_store("config.json")
-        .ok_or(anyhow::anyhow!("store not found"))?;
-    store.set(ZOOM_FACTOR_KEY, zoom);
-
-    app.set_menu(create_main_menu(app)?)?;
-
-    Ok(())
 }

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use strum_macros::{AsRefStr, EnumString};
 use tauri::menu::MenuId;
-use tauri::{menu::MenuEvent, AppHandle, Emitter, Manager, Runtime, WebviewWindow};
+use tauri::{menu::MenuEvent, AppHandle, Emitter, Manager, WebviewWindow};
 use tauri_plugin_opener::OpenerExt;
 use tauri_plugin_store::StoreExt;
 pub mod help_menu;
@@ -73,7 +73,7 @@ impl From<HelpMenuAction> for MenuId {
     }
 }
 
-pub fn handle_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) -> anyhow::Result<()> {
+pub fn handle_event(app: &AppHandle, event: MenuEvent) -> anyhow::Result<()> {
     if let Ok(action) = MainMenuAction::try_from(event.id()) {
         match action {
             MainMenuAction::Settings => {
@@ -200,22 +200,18 @@ pub fn handle_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) -> anyhow:
     Ok(())
 }
 
-pub(crate) fn handle_menu_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) {
+pub(crate) fn handle_menu_event(app: &AppHandle, event: MenuEvent) {
     if let Err(e) = handle_event(app, event) {
         log::error!("{:?}", e);
     }
 }
 
-pub(crate) fn get_main_window<A: Runtime>(app: &AppHandle<A>) -> anyhow::Result<WebviewWindow<A>> {
+pub(crate) fn get_main_window(app: &AppHandle) -> anyhow::Result<WebviewWindow> {
     app.get_webview_window("main")
         .ok_or(anyhow::anyhow!("main window not found"))
 }
 
-pub(crate) fn set_zoom<A: Runtime>(
-    app: &AppHandle<A>,
-    zoom: f64,
-    window: &str,
-) -> anyhow::Result<()> {
+pub(crate) fn set_zoom(app: &AppHandle, zoom: f64, window: &str) -> anyhow::Result<()> {
     let webview = app
         .get_webview_window(window)
         .ok_or(anyhow::anyhow!("webview not found"))?;

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -4,7 +4,7 @@ use help_menu::create_help_menu;
 use main_menu::create_main_menu;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use strum_macros::{AsRefStr, EnumString};
+use strum::{AsRefStr, EnumString};
 use tauri::menu::MenuId;
 use tauri::{menu::MenuEvent, AppHandle, Emitter, Manager, WebviewWindow};
 use tauri_plugin_opener::OpenerExt;

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -1,0 +1,232 @@
+use crate::settings::ZOOM_FACTOR_KEY;
+use crate::{help_window::open_help_window, AppState};
+use help_menu::create_help_menu;
+use main_menu::create_main_menu;
+use std::str::FromStr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use strum_macros::{AsRefStr, EnumString};
+use tauri::menu::MenuId;
+use tauri::{menu::MenuEvent, AppHandle, Emitter, Manager, Runtime, WebviewWindow};
+use tauri_plugin_opener::OpenerExt;
+use tauri_plugin_store::StoreExt;
+pub mod help_menu;
+pub(crate) mod main_menu;
+
+const HELP_ZOOM_FACTOR_KEY: &str = "helpZoomFactor";
+static FLOATING: AtomicBool = AtomicBool::new(false);
+
+#[derive(Debug, AsRefStr, EnumString)]
+pub(crate) enum MainMenuAction {
+    Settings,
+    Help,
+    Quit,
+    FloatOnTop,
+    Zoom06,
+    Zoom08,
+    Zoom10,
+    Zoom12,
+    Zoom14,
+    DevTools,
+    LogFolder,
+    CurrentLogFile,
+    Keybindings,
+    Contribute,
+    Report,
+    Learn,
+    About,
+}
+
+impl From<MainMenuAction> for MenuId {
+    fn from(action: MainMenuAction) -> Self {
+        MenuId::new(action)
+    }
+}
+
+impl TryFrom<&MenuId> for MainMenuAction {
+    type Error = anyhow::Error;
+
+    fn try_from(item: &MenuId) -> Result<Self, Self::Error> {
+        MainMenuAction::from_str(item.as_ref()).map_err(|e| e.into())
+    }
+}
+
+#[derive(Debug, AsRefStr, EnumString)]
+pub(crate) enum HelpMenuAction {
+    HelpQuit,
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
+    HelpFloatOnTop,
+}
+
+impl TryFrom<&MenuId> for HelpMenuAction {
+    type Error = anyhow::Error;
+
+    fn try_from(item: &MenuId) -> Result<Self, Self::Error> {
+        HelpMenuAction::from_str(item.as_ref()).map_err(|e| e.into())
+    }
+}
+
+impl From<HelpMenuAction> for MenuId {
+    fn from(action: HelpMenuAction) -> Self {
+        MenuId::new(action)
+    }
+}
+
+pub fn handle_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) -> anyhow::Result<()> {
+    if let Ok(action) = MainMenuAction::try_from(event.id()) {
+        match action {
+            MainMenuAction::Settings => {
+                app.emit("showSettingsDialog", None::<String>).ok();
+            }
+            MainMenuAction::Help => {
+                open_help_window(app.clone(), "", None).ok();
+
+                let window = app
+                    .get_webview_window("help")
+                    .ok_or(anyhow::anyhow!("help window not found"))?;
+                window.set_menu(create_help_menu(&app)?)?;
+            }
+            MainMenuAction::Quit => {
+                app.exit(0);
+            }
+            MainMenuAction::FloatOnTop => {
+                get_main_window(app)?.set_always_on_top(true).ok();
+            }
+            MainMenuAction::Zoom06 => {
+                set_zoom(app, 0.6, "main")?;
+            }
+            MainMenuAction::Zoom08 => {
+                set_zoom(app, 0.8, "main")?;
+            }
+            MainMenuAction::Zoom10 => {
+                set_zoom(app, 1.0, "main")?;
+            }
+            MainMenuAction::Zoom12 => {
+                set_zoom(app, 1.2, "main")?;
+            }
+            MainMenuAction::Zoom14 => {
+                set_zoom(app, 1.4, "main")?;
+            }
+            MainMenuAction::DevTools => {
+                get_main_window(&app)?.open_devtools();
+            }
+            MainMenuAction::LogFolder => {
+                if let Ok(path) = &app.path().app_log_dir() {
+                    if let Some(path) = path.to_str() {
+                        app.opener().open_path(path, None::<String>).ok();
+                    }
+                }
+            }
+            MainMenuAction::CurrentLogFile => {
+                let path = || app.state::<AppState>().current_log_file_path.clone();
+                app.opener().open_path(path(), None::<String>).ok();
+            }
+            MainMenuAction::Keybindings => {
+                app.emit("showKeybindingsDialog", None::<String>)?;
+            }
+            MainMenuAction::Contribute => {
+                app.opener().open_url(
+                    "https://github.com/deltachat/deltachat-desktop",
+                    None::<String>,
+                )?;
+            }
+            MainMenuAction::Report => {
+                app.opener().open_url(
+                    "https://github.com/deltachat/deltachat-desktop/issues",
+                    None::<String>,
+                )?;
+            }
+            MainMenuAction::Learn => {
+                app.opener()
+                    .open_url("https://delta.chat/de/", None::<String>)?;
+            }
+            MainMenuAction::About => {
+                app.emit("showAboutDialog", None::<String>)?;
+            }
+        }
+    }
+
+    if let Ok(action) = HelpMenuAction::try_from(event.id()) {
+        match action {
+            HelpMenuAction::HelpQuit => {
+                let window = app
+                    .get_webview_window("help")
+                    .ok_or(anyhow::anyhow!("help window not found"))?;
+                window.close().ok();
+            }
+            HelpMenuAction::ZoomIn => {
+                let store = app
+                    .get_store("config.json")
+                    .ok_or(anyhow::anyhow!("store not found"))?;
+                let curr_zoom = store
+                    .get(HELP_ZOOM_FACTOR_KEY)
+                    .and_then(|f| f.as_f64())
+                    .unwrap_or(1.0);
+                let new_zoom = curr_zoom * 1.2;
+                store.set(HELP_ZOOM_FACTOR_KEY, new_zoom);
+                if let Some(window) = app.get_webview_window("help") {
+                    window.set_zoom(new_zoom)?;
+                }
+            }
+            HelpMenuAction::ZoomOut => {
+                let store = app
+                    .get_store("config.json")
+                    .ok_or(anyhow::anyhow!("store not found"))?;
+                let curr_zoom = store
+                    .get(HELP_ZOOM_FACTOR_KEY)
+                    .and_then(|f| f.as_f64())
+                    .unwrap_or(1.0);
+                let new_zoom = curr_zoom * 0.8;
+                store.set(HELP_ZOOM_FACTOR_KEY, new_zoom);
+                if let Some(window) = app.get_webview_window("help") {
+                    window.set_zoom(new_zoom)?;
+                }
+            }
+            HelpMenuAction::ResetZoom => {
+                if let Some(window) = app.get_webview_window("help") {
+                    window.set_zoom(1.0)?;
+                }
+            }
+            HelpMenuAction::HelpFloatOnTop => {
+                if let Some(window) = app.get_webview_window("help") {
+                    let previous = FLOATING.fetch_xor(true, Ordering::SeqCst);
+                    window.set_always_on_top(previous)?;
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn handle_menu_event<A: Runtime>(app: &AppHandle<A>, event: MenuEvent) {
+    if let Err(e) = handle_event(app, event) {
+        log::error!("{:?}", e);
+    }
+}
+
+pub(crate) fn get_main_window<A: Runtime>(app: &AppHandle<A>) -> anyhow::Result<WebviewWindow<A>> {
+    app.get_webview_window("main")
+        .ok_or(anyhow::anyhow!("main window not found"))
+}
+
+pub(crate) fn set_zoom<A: Runtime>(
+    app: &AppHandle<A>,
+    zoom: f64,
+    window: &str,
+) -> anyhow::Result<()> {
+    let webview = app
+        .get_webview_window(window)
+        .ok_or(anyhow::anyhow!("webview not found"))?;
+    webview.set_zoom(zoom)?;
+
+    let store = app
+        .get_store("config.json")
+        .ok_or(anyhow::anyhow!("store not found"))?;
+    store.set(ZOOM_FACTOR_KEY, zoom);
+
+    app.set_menu(create_main_menu(app)?)?;
+
+    Ok(())
+}

--- a/packages/target-tauri/src-tauri/src/settings.rs
+++ b/packages/target-tauri/src-tauri/src/settings.rs
@@ -6,6 +6,7 @@ use tauri_plugin_store::StoreExt;
 pub(crate) const CONFIG_FILE: &str = "config.json";
 
 pub(crate) const ZOOM_FACTOR_KEY: &str = "zoomFactor";
+pub(crate) const HELP_ZOOM_FACTOR_KEY: &str = "helpZoomFactor";
 pub(crate) const CONTENT_PROTECTION_KEY: &str = "contentProtectionEnabled";
 pub(crate) const CONTENT_PROTECTION_DEFAULT: bool = false;
 pub(crate) const HTML_EMAIL_WARNING_KEY: &str = "HTMLEmailAskForRemoteLoadingConfirmation";
@@ -36,16 +37,27 @@ pub(crate) fn load_and_apply_desktop_settings_on_startup(app: &AppHandle) -> any
 pub(crate) fn apply_zoom_factor(app: &AppHandle) -> anyhow::Result<()> {
     let store = app.store(CONFIG_FILE)?;
     let zoom_factor: f64 = store
-        .get("ZOOM_FACTOR_KEY")
+        .get(ZOOM_FACTOR_KEY)
         .and_then(|f| f.as_f64())
         .unwrap_or(1.0);
 
     // at the moment this only affect the main window like in the electron version
-    let webview = app
-        .get_webview_window("main")
-        .context("main window not found")?;
-    webview.set_zoom(zoom_factor)?;
+    app.get_webview_window("main")
+        .context("main window not found")?
+        .set_zoom(zoom_factor)?;
 
+    Ok(())
+}
+
+pub(crate) fn apply_zoom_factor_help_window(app: &AppHandle) -> anyhow::Result<()> {
+    let store = app.store(CONFIG_FILE)?;
+    let zoom_factor: f64 = store
+        .get(HELP_ZOOM_FACTOR_KEY)
+        .and_then(|f| f.as_f64())
+        .unwrap_or(1.0);
+    app.get_webview_window("help")
+        .context("help window not found")?
+        .set_zoom(zoom_factor)?;
     Ok(())
 }
 

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -64,7 +64,7 @@
             "opener:allow-open-path",
             "opener:allow-open-url",
             // Badge counter
-            "core:window:allow-set-badge-count"
+            "core:window:allow-set-badge-count",
           ]
         }
       ]
@@ -81,7 +81,7 @@
       "icons/icon.ico"
     ],
     "resources": {
-      "../../../_locales/*.json" : "_locales"
+      "../../../_locales/*.json": "_locales"
     },
     "iOS": {
       "minimumSystemVersion": "13.0",


### PR DESCRIPTION
- **add menu (this commit contains all 18 commits of #4641 rebased to main branch)**
- **make it compile after rebase, remove unessesary generic**
- **remove explicit dependency on strum_macros**
- **refactor, fix bugs and make it work on macOS**


## Progress

- [x] menu for main window and help 
- [x] make it work on macOS
- [x] open new windows floating on top if main window floats on top 
- [ ] Proper float on top state (needs tauri pr to add `get_always_on_top`, or better state handling)
- [ ] easy way to update menu on state changes? (especially on language change, but maybe other changes like float on top could benefit if we rebuild it)
- [ ] Implement language selector (this is technically still part of making the main menu)
- [ ] document what does not work and hide those options for now on the platforms where they don't work
- [ ] figgure out better way to handle menu events, because current method is not compatible with multiple instances (webxdc, html email viewer)

successor to #4641


## What does not work

- dictate text on macOS
- on windows and linux some of the edit items (TODO clarify which ones)
