### PR TITLE
allow unused in add_custom_schemes_to_csp_for_window_and_android

### DIFF
--- a/packages/target-tauri/src-tauri/src/html_window/mod.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn open_html_window(
                 .get_config_bool(deltachat::config::Config::ProxyEnabled)
                 .await
         })
-        .map_err(|err| Error::DeltaChat(err))?;
+        .map_err(Error::DeltaChat)?;
 
     let store = app.store(CONFIG_FILE)?;
     let always_load_remote_content = get_setting_bool_or(

--- a/packages/target-tauri/src-tauri/src/util/csp.rs
+++ b/packages/target-tauri/src-tauri/src/util/csp.rs
@@ -9,6 +9,7 @@ use tauri::utils::config::Csp;
 /// Schemes are different on those 2 platforms.
 /// E.g. `dcblob:` becomes `http://dcblob.localhost`,
 /// `ipc:` becomes `http://ipc.localhost`, etc.
+#[allow(unused_variables)]
 pub fn add_custom_schemes_to_csp_for_window_and_android(csp: Csp, is_https: bool) -> Csp {
     let mut map: HashMap<_, _> = csp.into();
     for (key, value) in map.iter_mut() {


### PR DESCRIPTION
lint says it is unused, it is mostly unused outside of windows and android, but it is used there.

#skip-changelog