### PR TITLE
tauri: fix: HTML viewer and help hanging on Win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - webxdc: fix menu bar hiding when pressing Escape #4753
 - tauri: fix blobs and webxdc-icon scheme under windows #4705
 - tauri: fix: drag regions in navbar #4719
+- tauri: entire app hanging after clicking "Show Full Message..." or the "Help" window on Windows
 
 <a id="1_54_2"></a>
 

--- a/packages/target-tauri/src-tauri/src/help_window.rs
+++ b/packages/target-tauri/src-tauri/src/help_window.rs
@@ -19,7 +19,7 @@ impl serde::Serialize for Error {
 }
 
 #[tauri::command]
-pub(crate) fn open_help_window(
+pub(crate) async fn open_help_window(
     app: tauri::AppHandle,
     locale: &str,
     anchor: Option<&str>,


### PR DESCRIPTION
Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/4745.

This implements the recommendadtion stated in `WebBuilder::new()` docs:
> On Windows, this function deadlocks when used
> in a synchronous command, see
> [the Webview2 issue](https://github.com/tauri-apps/wry/issues/583).
> You should use async commands when creating windows.

The windows don't hang the app anymore, but they are empty on Windows.
Opening the HTML message viewer also opens
"http://email.localhost/index.html" in the default system browser, which doesn't seem intentional.

Tokio complained about `block_on`, so I replaced it with `await`.