### PR TITLE
tauri: fix: empty "Help" window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - webxdc: fix menu bar hiding when pressing Escape #4753
 - tauri: fix blobs and webxdc-icon scheme under windows #4705
 - tauri: fix: drag regions in navbar #4719
+- tauri: entire app hanging after clicking "Show Full Message..." or the "Help" window on Windows
 
 <a id="1_54_2"></a>
 

--- a/packages/target-tauri/src-tauri/src/help_window.rs
+++ b/packages/target-tauri/src-tauri/src/help_window.rs
@@ -29,10 +29,19 @@ pub(crate) async fn open_help_window(
         url = "help/en/help.html".to_owned();
         warn!("Did not find help file for language {locale}, falling back to english");
     }
-
+    if let Some(anchor) = anchor {
+        url.push('#');
+        url.push_str(anchor);
+    }
     let app_url = tauri::WebviewUrl::App(url.into());
 
     let help_window: WebviewWindow = if let Some(help_window) = app.get_webview_window("help") {
+        // TODO theoretically the URL here could still be
+        // about:blank if it has not loaded yet.
+        let mut url = help_window.url()?;
+        url.set_fragment(anchor);
+        help_window.navigate(url)?;
+
         help_window
     } else {
         tauri::WebviewWindowBuilder::new(&app, "help", app_url.clone()).build()?
@@ -42,10 +51,6 @@ pub(crate) async fn open_help_window(
         // on android and iOS this does not exist, there the window is opened automatically
         help_window.show()?;
     }
-
-    let mut url = help_window.url()?;
-    url.set_fragment(anchor);
-    help_window.navigate(url)?;
 
     help_window.set_title("Delta Chat Tauri - Help")?; // TODO: translate help in the title.
 

--- a/packages/target-tauri/src-tauri/src/help_window.rs
+++ b/packages/target-tauri/src-tauri/src/help_window.rs
@@ -19,7 +19,7 @@ impl serde::Serialize for Error {
 }
 
 #[tauri::command]
-pub(crate) fn open_help_window(
+pub(crate) async fn open_help_window(
     app: tauri::AppHandle,
     locale: &str,
     anchor: Option<&str>,


### PR DESCRIPTION
This MR is based on #4759.

Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/4745.

I tested it with a fresh open of the help window, and when it's already open.

#skip-changelog because previously opening the help window would just freeze the app (which is addressed in #4759)