### PR TITLE
style: fix "Copy Link" color in QR dialog

### DIFF
--- a/packages/frontend/scss/dialogs/_qr-code.scss
+++ b/packages/frontend/scss/dialogs/_qr-code.scss
@@ -48,5 +48,5 @@
   height: 20px;
   transform: rotate(135deg);
   margin-inline-end: 8px;
-  @include color-svg('./images/icons/link.svg', var(--buttonPrimaryText), 100%);
+  @include color-svg('./images/icons/link.svg', currentcolor, 100%);
 }


### PR DESCRIPTION
This is a follow-up to d4938ceffa036119b9ead78ac2cde7de9320d3be
(https://github.com/deltachat/deltachat-desktop/pull/4642).

#skip-changelog

Before / after
![image](https://github.com/user-attachments/assets/34cf943b-5956-4baf-98bf-91c18c292245) ![image](https://github.com/user-attachments/assets/03376466-1cdb-4cde-8b5b-93a7168325be)
