### PR TITLE
tauri: fix: app picker not working (base64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix some webxdc apps showing the "Close app?" prompt unintentionally #4737
 - webxdc: fix menu bar hiding when pressing Escape #4753
 - tauri: fix blobs and webxdc-icon scheme under windows #4705
+- tauri: fix app picker not working for some apps
 - tauri: fix: drag regions in navbar #4719
 - tauri: fall back to base locale if dialect/variant was not found
 - tauri: entire app hanging after clicking "Show Full Message..." or the "Help" window on Windows

--- a/packages/target-tauri/src-tauri/src/temp_file.rs
+++ b/packages/target-tauri/src-tauri/src/temp_file.rs
@@ -108,18 +108,26 @@ pub(crate) async fn clear_tmp_folder(app: &AppHandle) -> Result<(), Error> {
     Ok(())
 }
 
+const BASE64_ENGINE: base64::engine::GeneralPurpose = base64::engine::GeneralPurpose::new(
+    &base64::alphabet::STANDARD,
+    base64::engine::GeneralPurposeConfig::new()
+        .with_decode_padding_mode(base64::engine::DecodePaddingMode::Indifferent),
+);
 // Tauri Commands
 // ==============
 
 // writeTempFileFromBase64
-// just accepts the raw base64 string, not data urls
+/// just accepts the raw base64 string, not data urls
+///
+/// The base64 decoder used is padding-indifferent,
+/// i.e. different base64 strings may produce the same binary contents.
 #[tauri::command]
 pub(crate) async fn write_temp_file_from_base64(
     app: AppHandle,
     name: &str,
     content: &str,
 ) -> Result<String, Error> {
-    let base64_data = base64::prelude::BASE64_STANDARD.decode(content)?;
+    let base64_data = BASE64_ENGINE.decode(content)?;
     let (mut file_handle, file_path) = create_tmp_file(&app, name).await?;
     file_handle.write_all(&base64_data).await?;
 


### PR DESCRIPTION
Core returns the base64 string without padding (`=` at the end), but `write_temp_file_from_base64` enforced padding. This commit makes it not enforce padding.

I tested with a few apps that previously didn't work (e.g. Time Tracker), and with ones that did work (Pac-1D). All work good now.