### PR TITLE
style: fix app picker clear search button hidden

### DIFF
--- a/packages/frontend/src/components/AppPicker/styles.module.scss
+++ b/packages/frontend/src/components/AppPicker/styles.module.scss
@@ -75,6 +75,11 @@
   position: absolute;
   top: 2px;
   right: 0;
+
+  // For higher specificity, to ensure override.
+  &.searchInputButton {
+    color: var(--picker-text-rgb);
+  }
 }
 
 .appIcon {

--- a/packages/frontend/src/components/SearchInput/styles.module.scss
+++ b/packages/frontend/src/components/SearchInput/styles.module.scss
@@ -27,6 +27,7 @@ $closeButtonSize: 30px;
 .searchInputButton {
   align-items: center;
   background-color: transparent;
+  color: var(--navBarText);
   border-radius: $borderRadius;
   border: 0;
   display: flex;
@@ -44,5 +45,5 @@ $closeButtonSize: 30px;
 }
 
 .searchInputButtonIcon {
-  background-color: var(--navBarText);
+  background-color: currentcolor;
 }


### PR DESCRIPTION
The original navbar buttons are not affected by this, I tested.

#skip-changelog

