### PR TITLE
tauri: fix: broken SVG preview in composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - tauri: fix: drag regions in navbar #4719
 - tauri: fall back to base locale if dialect/variant was not found
 - tauri: entire app hanging after clicking "Show Full Message..." or the "Help" window on Windows
+- tauri: fix SVG images not being displayed in composer draft
 
 <a id="1_54_2"></a>
 


### PR DESCRIPTION
FYI we also have the stickers, email, and the webxdc icon custom protocols, but we do not utilize
the `Content-Type` header explicitly there.

![image](https://github.com/user-attachments/assets/ed86cf01-dfbe-4ead-ba9a-5507e830103d)

Test image from https://github.com/webrtc-for-the-curious/webrtc-for-the-curious/blob/master/content/docs/images/05-frame-types.svg