### PR TITLE
Use worker for processing qr images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Fixed
 - fix some webxdc apps showing the "Close app?" prompt unintentionally #4737
 - improve QR scanner performance
+- avoid UI freeze when processing QR code from clipboard #4639
 - webxdc: fix menu bar hiding when pressing Escape #4753
 - tauri: fix blobs and webxdc-icon scheme under windows #4705
 - tauri: fix app picker not working for some apps

--- a/packages/frontend/src/components/CopyContentAlertDialog.tsx
+++ b/packages/frontend/src/components/CopyContentAlertDialog.tsx
@@ -41,10 +41,12 @@ export default function CopyContentAlertDialog({
       </DialogBody>
       <DialogFooter>
         <FooterActions>
-          <FooterActionButton onClick={onCopy}>
+          <FooterActionButton onClick={onCopy} styling='secondary'>
             {tx('global_menu_edit_copy_desktop')}
           </FooterActionButton>
-          <FooterActionButton onClick={onCancel}>{tx('ok')}</FooterActionButton>
+          <FooterActionButton styling='secondary' onClick={onCancel}>
+            {tx('ok')}
+          </FooterActionButton>
         </FooterActions>
       </DialogFooter>
     </Dialog>

--- a/packages/frontend/src/components/QrReader/helper.ts
+++ b/packages/frontend/src/components/QrReader/helper.ts
@@ -1,9 +1,3 @@
-import scanQrCode, { QRCode } from 'jsqr'
-import { Runtime } from '@deltachat-desktop/runtime-interface'
-import { getLogger } from '@deltachat-desktop/shared/logger'
-
-const log = getLogger('renderer/QrReader/helper')
-
 /**
  * Convert file data to base64 encoded data URL string.
  */
@@ -58,41 +52,4 @@ export async function base64ToImageData(base64: string): Promise<ImageData> {
     })
     image.src = base64
   })
-}
-
-/**
- * @throws Error (no data in clipboard)
- */
-export async function qrCodeFromClipboard(runtime: Runtime): Promise<string> {
-  // Try interpreting the clipboard data as an image
-  let base64: string | null = null
-  try {
-    base64 = await runtime.readClipboardImage()
-  } catch (error) {
-    log.warn('qrCodeFromClipboard: readClipboardImage', error)
-  }
-  if (base64) {
-    const imageData = await base64ToImageData(base64)
-    const result = scanQrCode(imageData.data, imageData.width, imageData.height)
-    if (result?.data) {
-      return result.data
-    } else {
-      throw new Error('no data in clipboard image')
-    }
-  }
-
-  // .. otherwise return non-image data from clipboard directly
-  const data = await runtime.readClipboardText()
-  if (!data) {
-    throw new Error('no data in clipboard')
-  }
-  // trim whitespaces because user might copy them by accident when sending over other messengers
-  // see https://github.com/deltachat/deltachat-desktop/issues/4161#issuecomment-2390428338
-  return data.trim()
-}
-
-export async function qrCodeFromImage(file: File): Promise<QRCode | null> {
-  const base64 = await fileToBase64(file)
-  const imageData = await base64ToImageData(base64)
-  return scanQrCode(imageData.data, imageData.width, imageData.height)
 }

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -4,6 +4,8 @@ import React, {
   useEffect,
   useRef,
   useState,
+  forwardRef,
+  useImperativeHandle,
 } from 'react'
 import classNames from 'classnames'
 
@@ -39,409 +41,449 @@ const SCAN_QR_INTERVAL_MS = 1000 / 30
 
 let worker: Worker
 
-export default function QrReader({ onError, onScanSuccess }: Props) {
-  const tx = useTranslationFunction()
-  const { openContextMenu } = useContext(ContextMenuContext)
+let workerClipBoard: Worker
 
-  const videoRef = useRef<HTMLVideoElement>(null)
-  const canvasRef = useRef<OffscreenCanvas>(new OffscreenCanvas(640, 480))
-  const inputRef = useRef<HTMLInputElement>(null)
+export type QrCodeScanRef = {
+  handlePasteFromClipboard: () => void
+}
 
-  const [ready, setReady] = useState(false)
-  const [cameraAccessError, setCameraAccessError] = useState(false)
-  const [videoDevices, setVideoDevices] = useState<MediaDeviceInfo[]>([])
-  const [deviceId, setDeviceId] = useState<string | undefined>(undefined)
-  const [processingFile, setProcessingFile] = useState(false)
+/**
+ * component to read and process QR codes either
+ * by constantly reading image data from a video stream
+ * provided by a camera or by processing image data from
+ * clipboard or an imported image file
+ *
+ * used in Qr dialog (QrCode) in second tab
+ */
+export const QrReader = forwardRef<QrCodeScanRef, Props>(
+  ({ onError, onScanSuccess }: Props, ref) => {
+    const tx = useTranslationFunction()
+    const { openContextMenu } = useContext(ContextMenuContext)
 
-  useEffect(() => {
-    worker = new QrWorker() as Worker
-    return () => {
-      worker.terminate()
-    }
-  }, [])
+    const videoRef = useRef<HTMLVideoElement>(null)
+    const canvasRef = useRef<OffscreenCanvas>(new OffscreenCanvas(640, 480))
+    const inputRef = useRef<HTMLInputElement>(null)
 
-  // Get all current video devices available to the user.
-  useEffect(() => {
-    const getAllCameras = async () => {
-      const devices = await navigator.mediaDevices.enumerateDevices()
-      setVideoDevices(
-        devices.filter(device => {
-          return device.kind === 'videoinput'
-        })
-      )
+    const [ready, setReady] = useState(false)
+    const [cameraAccessError, setCameraAccessError] = useState(false)
+    const [videoDevices, setVideoDevices] = useState<MediaDeviceInfo[]>([])
+    const [deviceId, setDeviceId] = useState<string | undefined>(undefined)
+    const [processingFile, setProcessingFile] = useState(false)
 
-      // Automatically select first available video device
-      if (devices.length > 0) {
-        setDeviceId(devices[0].deviceId)
+    useEffect(() => {
+      worker = new QrWorker() as Worker
+      workerClipBoard = new QrWorker() as Worker
+      return () => {
+        // terminate worker if component is unmounted,
+        // otherwise we might get a delayed error message
+        // if scan fails, even after closing the QR dialog
+        worker.terminate()
+        workerClipBoard.terminate()
       }
-    }
+    }, [])
 
-    getAllCameras()
-  }, [])
+    // Get all current video devices available to the user.
+    useEffect(() => {
+      const getAllCameras = async () => {
+        const devices = await navigator.mediaDevices.enumerateDevices()
+        setVideoDevices(
+          devices.filter(device => {
+            return device.kind === 'videoinput'
+          })
+        )
 
-  // General handler for errors which might occur during scanning.
-  const handleError = useCallback(
-    (error: any) => {
-      if (typeof error === 'string') {
-        onError(error)
-      } else {
-        onError(error.toString())
+        // Automatically select first available video device
+        if (devices.length > 0) {
+          setDeviceId(devices[0].deviceId)
+        }
       }
-    },
-    [onError]
-  )
 
-  const processQrCodeWithWorker = useCallback(
-    async (
-      imageData: ImageData,
-      onScanSuccess: (scanResult: string) => void,
-      handleError: (error: any) => void
-    ) => {
-      try {
-        worker.postMessage(imageData)
+      getAllCameras()
+    }, [])
 
-        const scanResultP = new Promise(r => {
-          worker.addEventListener(
-            'message',
-            event => {
-              setProcessingFile(false)
-              r(event.data)
-            },
-            { once: true }
-          )
-        })
-        const scanResult = (await scanResultP) as string
-        if (scanResult) {
-          onScanSuccess(scanResult)
+    // General handler for errors which might occur during scanning.
+    const handleError = useCallback(
+      (error: any) => {
+        if (typeof error === 'string') {
+          onError(error)
         } else {
-          throw Error(`no data in image`)
+          onError(error.toString())
         }
-      } catch (error: any) {
-        setProcessingFile(false)
-        handleError(error)
-      }
-    },
-    []
-  )
+      },
+      [onError]
+    )
 
-  const handlePasteFromClipboard = useCallback(async () => {
-    try {
-      // Try interpreting the clipboard data as an image
-      let base64: string | null = null
-      setProcessingFile(true)
+    /**
+     * pass the processing of imageData to a worker
+     * to avoid UI freeze when processing large images
+     * or with low peformance cpu
+     */
+    const processQrCodeWithWorker = useCallback(
+      async (
+        imageData: ImageData,
+        onScanSuccess: (scanResult: string) => void,
+        handleError: (error: any) => void
+      ) => {
+        try {
+          workerClipBoard.postMessage(imageData)
+          const scanResultP = new Promise(r => {
+            workerClipBoard.addEventListener(
+              'message',
+              event => {
+                setProcessingFile(false)
+                r(event.data)
+              },
+              { once: true }
+            )
+          })
+          const scanResult = (await scanResultP) as string
+          if (scanResult) {
+            onScanSuccess(scanResult)
+          } else {
+            throw Error(`no data in image`)
+          }
+        } catch (error: any) {
+          setProcessingFile(false)
+          handleError(error)
+        }
+      },
+      []
+    )
+
+    useImperativeHandle(ref, () => ({
+      handlePasteFromClipboard() {
+        handlePasteFromClipboard()
+      },
+    }))
+
+    const handlePasteFromClipboard = useCallback(async () => {
       try {
-        base64 = await runtime.readClipboardImage()
+        // Try interpreting the clipboard data as an image
+        let base64: string | null = null
+        setProcessingFile(true)
+        try {
+          base64 = await runtime.readClipboardImage()
+        } catch (error) {
+          log.warn('qrCodeFromClipboard: readClipboardImage', error)
+        }
+        if (base64) {
+          const imageData = await base64ToImageData(base64)
+          processQrCodeWithWorker(imageData, onScanSuccess, handleError)
+        } else {
+          // .. otherwise return non-image data from clipboard directly
+          const data = await runtime.readClipboardText()
+          if (!data) {
+            throw new Error('no data in clipboard')
+          }
+          // trim whitespaces because user might copy them by accident when sending over other messengers
+          // see https://github.com/deltachat/deltachat-desktop/issues/4161#issuecomment-2390428338
+          onScanSuccess(data.trim())
+        }
       } catch (error) {
-        log.warn('qrCodeFromClipboard: readClipboardImage', error)
-      }
-      if (base64) {
-        const imageData = await base64ToImageData(base64)
-        processQrCodeWithWorker(imageData, onScanSuccess, handleError)
-      } else {
-        // .. otherwise return non-image data from clipboard directly
-        const data = await runtime.readClipboardText()
-        if (!data) {
-          throw new Error('no data in clipboard')
-        }
-        // trim whitespaces because user might copy them by accident when sending over other messengers
-        // see https://github.com/deltachat/deltachat-desktop/issues/4161#issuecomment-2390428338
-        onScanSuccess(data.trim())
-      }
-    } catch (error) {
-      setProcessingFile(false)
-      handleError(error)
-    }
-  }, [processQrCodeWithWorker, onScanSuccess, handleError])
-
-  // Read data from an external image file.
-  //
-  // We first trigger an "file open" dialog by automatically "clicking"
-  // an <input> element. The actual conversion and scanning of the file data
-  // happens afterwards.
-  const handleImportImage = useCallback(async () => {
-    if (inputRef.current) {
-      inputRef.current.click()
-    }
-  }, [])
-
-  const handleFileInputChange = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (!event.target.files || event.target.files.length === 0) {
-        return
-      }
-      const file = event.target.files[0]
-      setProcessingFile(true)
-      try {
-        // Convert file to correct image data
-        const base64 = await fileToBase64(file)
-        const imageData = await base64ToImageData(base64)
-
-        processQrCodeWithWorker(imageData, onScanSuccess, handleError)
-      } catch (error: any) {
         setProcessingFile(false)
         handleError(error)
       }
+    }, [processQrCodeWithWorker, onScanSuccess, handleError])
 
-      // Reset the input element again, otherwise we wouldn't be able to trigger
-      // another `onChange` again when selecting the same image
+    // Read data from an external image file.
+    //
+    // We first trigger an "file open" dialog by automatically "clicking"
+    // an <input> element. The actual conversion and scanning of the file data
+    // happens afterwards.
+    const handleImportImage = useCallback(async () => {
       if (inputRef.current) {
-        inputRef.current.value = ''
+        inputRef.current.click()
       }
-    },
-    [handleError, onScanSuccess, setProcessingFile, processQrCodeWithWorker]
-  )
+    }, [])
 
-  // Show a context menu with different video input options to the user.
-  const handleSelectInput = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
-      // Allow user to select a different camera when more than one is given
-      const cameraItems: ContextMenuItem[] =
-        videoDevices.length > 1
-          ? videoDevices.map(device => {
-              const marker = device.deviceId === deviceId ? ' ✓' : ''
-              return {
-                label: `${device.label}${marker}`,
-                action: () => setDeviceId(device.deviceId),
-              }
-            })
-          : []
+    const handleFileInputChange = useCallback(
+      async (event: React.ChangeEvent<HTMLInputElement>) => {
+        if (!event.target.files || event.target.files.length === 0) {
+          return
+        }
+        const file = event.target.files[0]
+        setProcessingFile(true)
+        try {
+          // Convert file to correct image data
+          const base64 = await fileToBase64(file)
+          const imageData = await base64ToImageData(base64)
 
-      const items: ContextMenuItem[] = [
-        ...cameraItems,
-        {
-          label: tx('load_qr_code_as_image'),
-          action: handleImportImage,
-          dataTestid: 'load-qr-code-as-image',
-        },
-        {
-          label: tx('paste_from_clipboard'),
-          action: handlePasteFromClipboard,
-          dataTestid: 'paste-from-clipboard',
-        },
+          processQrCodeWithWorker(imageData, onScanSuccess, handleError)
+        } catch (error: any) {
+          setProcessingFile(false)
+          handleError(error)
+        }
+
+        // Reset the input element again, otherwise we wouldn't be able to trigger
+        // another `onChange` again when selecting the same image
+        if (inputRef.current) {
+          inputRef.current.value = ''
+        }
+      },
+      [handleError, onScanSuccess, processQrCodeWithWorker]
+    )
+
+    // Show a context menu with different video input options to the user.
+    const handleSelectInput = useCallback(
+      (event: React.MouseEvent<HTMLButtonElement>) => {
+        // Allow user to select a different camera when more than one is given
+        const cameraItems: ContextMenuItem[] =
+          videoDevices.length > 1
+            ? videoDevices.map(device => {
+                const marker = device.deviceId === deviceId ? ' ✓' : ''
+                return {
+                  label: `${device.label}${marker}`,
+                  action: () => setDeviceId(device.deviceId),
+                }
+              })
+            : []
+
+        const items: ContextMenuItem[] = [
+          ...cameraItems,
+          {
+            label: tx('load_qr_code_as_image'),
+            action: handleImportImage,
+            dataTestid: 'load-qr-code-as-image',
+          },
+          {
+            label: tx('paste_from_clipboard'),
+            action: handlePasteFromClipboard,
+            dataTestid: 'paste-from-clipboard',
+          },
+        ]
+
+        openContextMenu({
+          ...mouseEventToPosition(event),
+          items,
+        })
+      },
+      [
+        deviceId,
+        handleImportImage,
+        handlePasteFromClipboard,
+        openContextMenu,
+        tx,
+        videoDevices,
       ]
+    )
 
-      openContextMenu({
-        ...mouseEventToPosition(event),
-        items,
-      })
-    },
-    [
-      deviceId,
-      handleImportImage,
-      handlePasteFromClipboard,
-      openContextMenu,
-      tx,
-      videoDevices,
-    ]
-  )
+    // Whenever a camera was (automatically or manually) selected we attempt
+    // starting a video stream from it which gets rendered in a video element.
+    useEffect(() => {
+      let activeStream: MediaStream | undefined
+      let unmounted = false
 
-  // Whenever a camera was (automatically or manually) selected we attempt
-  // starting a video stream from it which gets rendered in a video element.
-  useEffect(() => {
-    let activeStream: MediaStream | undefined
-    let unmounted = false
-
-    const video = videoRef.current
-    if (!video) {
-      return
-    }
-
-    const stopStream = async (stream?: MediaStream) => {
-      if (!stream) {
+      const video = videoRef.current
+      if (!video) {
         return
       }
 
-      for (const track of stream.getTracks()) {
-        track.stop()
-      }
-    }
-
-    const startStream = async () => {
-      const videoConstraints: MediaTrackConstraints = {
-        deviceId,
-        facingMode: 'user',
-      }
-
-      try {
-        setReady(false)
-
-        // Stop all streams if some existed before we begin a new one
-        stopStream(activeStream)
-
-        const stream = await navigator.mediaDevices.getUserMedia({
-          video: videoConstraints,
-          audio: false,
-        })
-
-        if (unmounted) {
-          stopStream(stream)
+      const stopStream = async (stream?: MediaStream) => {
+        if (!stream) {
           return
         }
 
-        const videoTracks = stream.getVideoTracks()
-        if (videoTracks.length === 0) {
-          stopStream(stream)
-          throw new Error('no video tracks given')
+        for (const track of stream.getTracks()) {
+          track.stop()
+        }
+      }
+
+      const startStream = async () => {
+        const videoConstraints: MediaTrackConstraints = {
+          deviceId,
+          facingMode: 'user',
         }
 
-        video.srcObject = stream
-        activeStream = stream
+        try {
+          setReady(false)
 
-        const settings = videoTracks[0].getSettings()
-        if (settings.deviceId) {
-          setDeviceId(settings.deviceId)
+          // Stop all streams if some existed before we begin a new one
+          stopStream(activeStream)
+
+          const stream = await navigator.mediaDevices.getUserMedia({
+            video: videoConstraints,
+            audio: false,
+          })
+
+          if (unmounted) {
+            stopStream(stream)
+            return
+          }
+
+          const videoTracks = stream.getVideoTracks()
+          if (videoTracks.length === 0) {
+            stopStream(stream)
+            throw new Error('no video tracks given')
+          }
+
+          video.srcObject = stream
+          activeStream = stream
+
+          const settings = videoTracks[0].getSettings()
+          if (settings.deviceId) {
+            setDeviceId(settings.deviceId)
+          }
+
+          if (settings.width && settings.height) {
+            canvasRef.current.width = settings.width
+            canvasRef.current.height = settings.height
+          }
+
+          setReady(true)
+        } catch {
+          stopStream(activeStream)
+          setCameraAccessError(true)
+        }
+      }
+
+      startStream()
+
+      return () => {
+        unmounted = true
+
+        if (video) {
+          video.srcObject = null
         }
 
-        if (settings.width && settings.height) {
-          canvasRef.current.width = settings.width
-          canvasRef.current.height = settings.height
-        }
-
-        setReady(true)
-      } catch {
         stopStream(activeStream)
-        setCameraAccessError(true)
+
+        setReady(false)
+        setCameraAccessError(false)
       }
-    }
+    }, [deviceId])
 
-    startStream()
+    // Frequently scan image data for QR code with "jsqr" library.
+    //
+    // We achieve this by extracting the image data from the video element using
+    // an intermediary canvas context.
+    useEffect(() => {
+      const canvas = canvasRef.current
+      const video = videoRef.current
 
-    return () => {
-      unmounted = true
-
-      if (video) {
-        video.srcObject = null
-      }
-
-      stopStream(activeStream)
-
-      setReady(false)
-      setCameraAccessError(false)
-    }
-  }, [deviceId])
-
-  // Frequently scan image data for QR code with "jsqr" library.
-  //
-  // We achieve this by extracting the image data from the video element using
-  // an intermediary canvas context.
-  useEffect(() => {
-    const canvas = canvasRef.current
-    const video = videoRef.current
-
-    if (!canvas) {
-      return
-    }
-
-    const context = canvas.getContext('2d', {
-      willReadFrequently: true,
-      alpha: false,
-      desynchronized: true,
-    })
-
-    if (!context) {
-      return
-    }
-
-    let stopScanning = false
-    const scan = async () => {
-      context.drawImage(
-        video as CanvasImageSource,
-        0,
-        0,
-        canvas.width,
-        canvas.height
-      )
-
-      if (stopScanning) {
+      if (!canvas) {
         return
       }
 
-      let scanResult: any
-      const imageData = context.getImageData(0, 0, canvas.width, canvas.height)
+      const context = canvas.getContext('2d', {
+        willReadFrequently: true,
+        alpha: false,
+        desynchronized: true,
+      })
 
-      if (stopScanning) {
+      if (!context) {
         return
       }
 
-      try {
-        worker.postMessage(imageData, { transfer: [imageData.data.buffer] })
-
-        const scanResultP = new Promise(r => {
-          worker.addEventListener(
-            'message',
-            event => {
-              r(event.data)
-            },
-            { once: true }
-          )
-        })
-        scanResult = await scanResultP
+      let stopScanning = false
+      const scan = async () => {
+        context.drawImage(
+          video as CanvasImageSource,
+          0,
+          0,
+          canvas.width,
+          canvas.height
+        )
 
         if (stopScanning) {
           return
         }
-      } catch (error: any) {
-        handleError(error)
-      }
-      if (scanResult) {
-        onScanSuccess(scanResult)
-      }
-    }
 
-    ;(async () => {
-      while (!stopScanning) {
-        await scan()
-        await new Promise(r => setTimeout(r, SCAN_QR_INTERVAL_MS))
+        let scanResult: any
+        const imageData = context.getImageData(
+          0,
+          0,
+          canvas.width,
+          canvas.height
+        )
+
+        if (stopScanning) {
+          return
+        }
+
+        try {
+          worker.postMessage(imageData, { transfer: [imageData.data.buffer] })
+
+          const scanResultP = new Promise(r => {
+            worker.addEventListener(
+              'message',
+              event => {
+                r(event.data)
+              },
+              { once: true }
+            )
+          })
+          scanResult = await scanResultP
+
+          if (stopScanning) {
+            return
+          }
+        } catch (error: any) {
+          handleError(error)
+        }
+        if (scanResult) {
+          onScanSuccess(scanResult)
+        }
       }
-    })()
 
-    return () => {
-      stopScanning = true
-    }
-  }, [handleError, onScanSuccess])
+      ;(async () => {
+        while (!stopScanning) {
+          await scan()
+          await new Promise(r => setTimeout(r, SCAN_QR_INTERVAL_MS))
+        }
+      })()
 
-  return (
-    <div className={styles.qrReader}>
-      <div className={classNames(styles.qrReaderStatus, styles.info)}>
-        <Spinner />
-      </div>
-      <video
-        className={classNames(styles.qrReaderVideo, {
-          [styles.visible]: ready && !cameraAccessError && !processingFile,
-        })}
-        autoPlay
-        muted
-        disablePictureInPicture
-        playsInline
-        ref={videoRef}
-      />
-      {cameraAccessError && !processingFile && (
-        <div className={classNames(styles.qrReaderStatus, styles.error)}>
-          {tx('camera_access_failed')}
+      return () => {
+        stopScanning = true
+      }
+    }, [handleError, onScanSuccess])
+
+    return (
+      <div className={styles.qrReader}>
+        <div className={classNames(styles.qrReaderStatus, styles.info)}>
+          <Spinner />
         </div>
-      )}
-      {!processingFile && <div className={styles.qrReaderOverlay} />}
-      {ready && !cameraAccessError && !processingFile && (
-        <div className={styles.qrReaderScanLine} />
-      )}
-      {!cameraAccessError && !processingFile && (
-        <div className={styles.qrReaderHint}>{tx('qrscan_hint_desktop')}</div>
-      )}
-      <button
-        className={styles.qrReaderButton}
-        onClick={handleSelectInput}
-        aria-label={tx('menu_settings')}
-        data-testid='qr-reader-settings'
-      >
-        <Icon icon='settings' size={24} className={styles.qrReaderButtonIcon} />
-      </button>
-      <input
-        className={styles.qrReaderFileInput}
-        type='file'
-        accept='image/*'
-        ref={inputRef}
-        onChange={handleFileInputChange}
-      />
-    </div>
-  )
-}
+        <video
+          className={classNames(styles.qrReaderVideo, {
+            [styles.visible]: ready && !cameraAccessError && !processingFile,
+          })}
+          autoPlay
+          muted
+          disablePictureInPicture
+          playsInline
+          ref={videoRef}
+        />
+        {cameraAccessError && !processingFile && (
+          <div className={classNames(styles.qrReaderStatus, styles.error)}>
+            {tx('camera_access_failed')}
+          </div>
+        )}
+        {!processingFile && <div className={styles.qrReaderOverlay} />}
+        {ready && !cameraAccessError && !processingFile && (
+          <div className={styles.qrReaderScanLine} />
+        )}
+        {!cameraAccessError && !processingFile && (
+          <div className={styles.qrReaderHint}>{tx('qrscan_hint_desktop')}</div>
+        )}
+        <button
+          className={styles.qrReaderButton}
+          onClick={handleSelectInput}
+          aria-label={tx('menu_settings')}
+          data-testid='qr-reader-settings'
+        >
+          <Icon
+            icon='settings'
+            size={24}
+            className={styles.qrReaderButtonIcon}
+          />
+        </button>
+        <input
+          className={styles.qrReaderFileInput}
+          type='file'
+          accept='image/*'
+          ref={inputRef}
+          onChange={handleFileInputChange}
+        />
+      </div>
+    )
+  }
+)

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -136,9 +136,9 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
         handleError: (error: any) => void
       ) => {
         try {
-          workerClipBoard.current.postMessage(imageData)
+          workerClipBoard.current?.postMessage(imageData)
           const scanResultP = new Promise(r => {
-            workerClipBoard.current.addEventListener(
+            workerClipBoard.current?.addEventListener(
               'message',
               event => {
                 setProcessingFile(false)
@@ -438,12 +438,12 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
         }
 
         try {
-          worker.current.postMessage(imageData, {
+          worker.current?.postMessage(imageData, {
             transfer: [imageData.data.buffer],
           })
 
           const scanResultP = new Promise(r => {
-            worker.current.addEventListener(
+            worker.current?.addEventListener(
               'message',
               event => {
                 r(event.data)

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -69,8 +69,16 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
     const [deviceId, setDeviceId] = useState<string | undefined>(undefined)
     const [processingFile, setProcessingFile] = useState(false)
 
-    const worker = useRef<Worker>(new QrWorker() as Worker)
-    const workerClipBoard = useRef<Worker>(new QrWorker() as Worker)
+    const worker = useRef<Worker | null>(null)
+    const workerClipBoard = useRef<Worker | null>(null)
+
+    if (worker.current === null) {
+      worker.current = new QrWorker() as Worker
+    }
+
+    if (workerClipBoard.current === null) {
+      workerClipBoard.current = new QrWorker() as Worker
+    }
 
     useEffect(() => {
       const currentWorker = worker.current
@@ -80,8 +88,8 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
         // terminate worker if component is unmounted,
         // otherwise we might get a delayed error message
         // if scan fails, even after closing the QR dialog
-        currentWorker.terminate()
-        currentWorkerClipBoard.terminate()
+        currentWorker?.terminate()
+        currentWorkerClipBoard?.terminate()
       }
     }, [])
 

--- a/packages/frontend/src/components/dialogs/QrCode.tsx
+++ b/packages/frontend/src/components/dialogs/QrCode.tsx
@@ -15,8 +15,7 @@ import Dialog, {
   FooterActions,
 } from '../Dialog'
 import FooterActionButton from '../Dialog/FooterActionButton'
-import QrReader from '../QrReader'
-import { qrCodeFromClipboard } from '../QrReader/helper'
+import { QrReader, QrCodeScanRef } from '../QrReader'
 
 import { BackendRemote } from '../../backend-com'
 import { getLogger } from '../../../../shared/logger'
@@ -39,7 +38,9 @@ type Props = {
 }
 
 /**
- * dialog to show a qr code and scan a qr code
+ * dialog showing 2 components in two tabs:
+ * one that displays a qr code and one that
+ * provides a QR code reader
  */
 export default function QrCode({
   qrCodeSVG,
@@ -224,6 +225,7 @@ export function QrCodeScanQrInner({
   const processQr = useProcessQr()
   const processingQrCode = useRef(false)
   const openAlertDialog = useAlertDialog()
+  const qrReaderRef = useRef<QrCodeScanRef | null>(null)
 
   const onDone = useCallback(() => {
     onClose()
@@ -258,22 +260,19 @@ export function QrCodeScanQrInner({
   )
 
   const pasteClipboard = useCallback(async () => {
-    try {
-      const result = await qrCodeFromClipboard(runtime)
-      handleScan(result)
-    } catch (error: any) {
-      if (typeof error === 'string') {
-        handleError(error)
-      } else {
-        handleError(error.toString())
-      }
+    if (qrReaderRef.current) {
+      qrReaderRef.current.handlePasteFromClipboard()
     }
-  }, [handleError, handleScan])
+  }, [])
 
   return (
     <>
       <DialogBody>
-        <QrReader onScanSuccess={handleScan} onError={handleError} />
+        <QrReader
+          onScanSuccess={handleScan}
+          onError={handleError}
+          ref={qrReaderRef}
+        />
       </DialogBody>
       <DialogFooter>
         <FooterActions align='spaceBetween'>

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useCallback } from 'react'
 
 import { DialogBody, DialogFooter, FooterActions } from '../../Dialog'
 import FooterActionButton from '../../Dialog/FooterActionButton'
-import QrReader from '../../QrReader'
+import { QrReader } from '../../QrReader'
 import useProcessQr from '../../../hooks/useProcessQr'
 import { selectedAccountId } from '../../../ScreenController'
 import { DialogWithHeader } from '../../Dialog'


### PR DESCRIPTION
Resolves #4639

- show the spinner while processing imported qr code images or clipboard
- enable to cancel the processing if it takes too long
- call QrCode.handlePasteFromClipboard from parent component
- use second worker for clipBoard processing to avoid race conditions