### PR TITLE
tauri: menu for html email window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - add a way to edit messages (in development mode only) #4717
 - tauri: add support for sticker picker #4707
 - tauri: add html email view #4699
-- tauri: add titlebar menu #4755
+- tauri: add titlebar menu #4755 #4787
 
 ### Changed
 - tauri: replace `tauri-plugin-shell` with `tauri-plugin-opener` #4699

--- a/packages/target-tauri/src-tauri/src/html_window/error.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/error.rs
@@ -14,6 +14,8 @@ pub(crate) enum Error {
     DeltaChat(anyhow::Error),
     #[error("you can not load remote content when you have proxy enabled")]
     BlockedByProxy,
+    #[error("MenuCreation {0}")]
+    MenuCreation(String),
 }
 
 impl serde::Serialize for Error {

--- a/packages/target-tauri/src-tauri/src/html_window/mod.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/mod.rs
@@ -4,8 +4,8 @@ use anyhow::anyhow;
 use log::{error, info, trace, warn};
 
 use tauri::{
-    async_runtime::block_on, webview::WebviewBuilder, LogicalPosition, LogicalSize, Manager, Url,
-    Webview, WebviewUrl, Window, WindowBuilder, WindowEvent,
+    async_runtime::block_on, webview::WebviewBuilder, LogicalPosition, LogicalSize, Manager, State,
+    Url, Webview, WebviewUrl, Window, WindowBuilder, WindowEvent,
 };
 use tauri_plugin_dialog::DialogExt;
 use tauri_plugin_opener::OpenerExt;
@@ -16,13 +16,17 @@ use crate::{
         error::Error,
         punycode::{puny_code_decode_host, puny_code_encode_host},
     },
+    menus::{
+        float_on_top::set_window_float_on_top_based_on_main_window,
+        html_window_menu::create_html_window_menu,
+    },
     settings::{
-        get_content_protection, get_setting_bool_or, CONFIG_FILE,
+        apply_zoom_factor_html_window, get_content_protection, get_setting_bool_or, CONFIG_FILE,
         HTML_EMAIL_ALWAYS_ALLOW_REMOTE_CONTENT_DEFAULT, HTML_EMAIL_ALWAYS_ALLOW_REMOTE_CONTENT_KEY,
     },
     state::html_email_instances::InnerHtmlEmailInstanceData,
     temp_file::get_temp_folder_path,
-    DeltaChatAppState, HtmlEmailInstancesState,
+    DeltaChatAppState, HtmlEmailInstancesState, MenuManger,
 };
 
 const HEADER_HEIGHT: f64 = 100.;
@@ -38,8 +42,9 @@ mod punycode;
 #[tauri::command]
 pub(crate) async fn open_html_window(
     app: tauri::AppHandle,
-    html_instances_state: tauri::State<'_, HtmlEmailInstancesState>,
-    dc: tauri::State<'_, DeltaChatAppState>,
+    html_instances_state: State<'_, HtmlEmailInstancesState>,
+    dc: State<'_, DeltaChatAppState>,
+    menu_manager: State<'_, MenuManger>,
     window_id: &str,
     account_id: u32, // TODO needs to be used later for fetching webrequests over dc core
     is_contact_request: bool,
@@ -224,8 +229,7 @@ pub(crate) async fn open_html_window(
 
     let header_view_arc = Arc::new(header_view);
     let mail_view_arc = Arc::new(mail_view);
-    let window_arc = Arc::new(window);
-    let window = window_arc.clone();
+    let window_arc = Arc::new(window.clone());
 
     // resize
     window.on_window_event(move |event| {
@@ -272,6 +276,23 @@ pub(crate) async fn open_html_window(
         truncate_text(subject, 42),
         truncate_text(sender, 40)
     ))?;
+
+    if let Err(err) = apply_zoom_factor_html_window(&app) {
+        error!("failed to apply zoom factor: {err}")
+    }
+    if let Err(err) = set_window_float_on_top_based_on_main_window(&window) {
+        error!("failed to apply float on top: {err}")
+    }
+
+    let window_clone = window.clone();
+    menu_manager
+        .register_window(
+            &app,
+            &window,
+            Box::new(move |app| create_html_window_menu(app, &window_clone)),
+        )
+        .await
+        .map_err(|err| Error::MenuCreation(err.to_string()))?;
 
     Ok(())
 }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -159,6 +159,9 @@ pub fn run() {
                 .level_for("async_smtp", log::LevelFilter::Warn)
                 .level_for("rustls", log::LevelFilter::Warn)
                 .level_for("iroh_net", log::LevelFilter::Warn)
+                .level_for("iroh", log::LevelFilter::Warn)
+                .level_for("iroh_quinn", log::LevelFilter::Warn)
+                .level_for("iroh_quinn_proto", log::LevelFilter::Warn)
                 // also emitted by tauri
                 .level_for("tracing", log::LevelFilter::Warn)
                 .level_for("igd_next", log::LevelFilter::Warn)

--- a/packages/target-tauri/src-tauri/src/menus/float_on_top.rs
+++ b/packages/target-tauri/src-tauri/src/menus/float_on_top.rs
@@ -1,7 +1,18 @@
 use anyhow::Context;
-use tauri::{Manager, WebviewWindow};
+use tauri::{Manager, WebviewWindow, Window};
 
 pub fn set_float_on_top_based_on_main_window(window: &WebviewWindow) -> anyhow::Result<()> {
+    if window
+        .get_window("main")
+        .context("main window not found")?
+        .is_always_on_top()?
+    {
+        window.set_always_on_top(true)?;
+    }
+    Ok(())
+}
+
+pub fn set_window_float_on_top_based_on_main_window(window: &Window) -> anyhow::Result<()> {
     if window
         .get_window("main")
         .context("main window not found")?

--- a/packages/target-tauri/src-tauri/src/menus/html_window_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/html_window_menu.rs
@@ -1,0 +1,241 @@
+use crate::{
+    settings::{apply_zoom_factor_html_window, CONFIG_FILE, HTML_EMAIL_ZOOM_FACTOR_KEY},
+    state::menu_manager::MenuManger,
+};
+
+use super::menu_action::MenuAction;
+use anyhow::Context;
+use strum::{AsRefStr, EnumString};
+use tauri::{
+    menu::{CheckMenuItem, Menu, MenuItem, PredefinedMenuItem, Submenu},
+    AppHandle, Manager, Window, Wry,
+};
+use tauri_plugin_store::StoreExt;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct HtmlWindowMenuAction {
+    window_id: String,
+    action: HtmlWindowMenuActionVariant,
+}
+
+#[derive(Debug, AsRefStr, EnumString, PartialEq, Eq)]
+enum HtmlWindowMenuActionVariant {
+    QuitApp,
+    CloseHtmlWindow,
+    ZoomIn,
+    ZoomOut,
+    ResetZoom,
+    FloatOnTop,
+}
+
+// serialisation of event is:
+// `HtmlWindowMenuAction||<window_id>|<action variant>`
+
+impl TryFrom<&tauri::menu::MenuId> for HtmlWindowMenuAction {
+    type Error = anyhow::Error;
+
+    fn try_from(item: &tauri::menu::MenuId) -> Result<Self, Self::Error> {
+        use std::str::FromStr;
+        let mut item_name = item.as_ref().split("||");
+        if let Some(stringify!(HtmlWindowMenuAction)) = item_name.nth(0) {
+            let mut id_and_variant = item_name
+                .last()
+                .context("could not split menu item name")?
+                .split('|');
+            if let (Some(id), Some(variant)) = (id_and_variant.nth(0), id_and_variant.last()) {
+                Ok(HtmlWindowMenuAction {
+                    window_id: id.to_owned(),
+                    action: HtmlWindowMenuActionVariant::from_str(variant)?,
+                })
+            } else {
+                Err(anyhow::anyhow!("not the right format: {:?}", item.as_ref()))
+            }
+        } else {
+            Err(anyhow::anyhow!("not the right enum name"))
+        }
+    }
+}
+
+impl From<HtmlWindowMenuAction> for tauri::menu::MenuId {
+    fn from(action: HtmlWindowMenuAction) -> Self {
+        tauri::menu::MenuId::new(format!(
+            "{}||{}|{}",
+            stringify!(HtmlWindowMenuAction),
+            action.window_id,
+            action.action.as_ref()
+        ))
+    }
+}
+
+impl MenuAction<'static> for HtmlWindowMenuAction {
+    fn execute(self, app: &AppHandle) -> anyhow::Result<()> {
+        let win = app
+            .get_window(&self.window_id)
+            .context("window not found")?;
+        let menu_manager = app.state::<MenuManger>();
+        match self.action {
+            HtmlWindowMenuActionVariant::QuitApp => {
+                app.exit(0);
+            }
+            HtmlWindowMenuActionVariant::CloseHtmlWindow => {
+                win.close()?;
+            }
+            HtmlWindowMenuActionVariant::ZoomIn
+            | HtmlWindowMenuActionVariant::ZoomOut
+            | HtmlWindowMenuActionVariant::ResetZoom => {
+                let store = app
+                    .get_store(CONFIG_FILE)
+                    .context("config store not found")?;
+                let curr_zoom: f64 = store
+                    .get(HTML_EMAIL_ZOOM_FACTOR_KEY)
+                    .and_then(|f| f.as_f64())
+                    .unwrap_or(1.0);
+
+                let new_zoom = match self.action {
+                    HtmlWindowMenuActionVariant::ZoomIn => curr_zoom * 1.2,
+                    HtmlWindowMenuActionVariant::ResetZoom => 1.,
+                    HtmlWindowMenuActionVariant::ZoomOut => curr_zoom * 0.8,
+                    _ => unreachable!(),
+                };
+
+                store.set(HTML_EMAIL_ZOOM_FACTOR_KEY, new_zoom);
+                apply_zoom_factor_html_window(app)?;
+                // this is fast/effient enough, even though it updates all window
+                // if you want to implement sth else you need to take macOS behaviour into account
+                menu_manager.update_all(app);
+            }
+            HtmlWindowMenuActionVariant::FloatOnTop => {
+                win.set_always_on_top(!win.is_always_on_top()?)?;
+                // this is fast/effient enough, even though it updates all window
+                // if you want to implement sth else you need to take macOS behaviour into account
+                menu_manager.update_all(app);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) fn create_html_window_menu(
+    app: &AppHandle,
+    html_email_window: &Window,
+) -> anyhow::Result<Menu<Wry>> {
+    let window_id = html_email_window.label().to_owned();
+    let action = |action: HtmlWindowMenuActionVariant| HtmlWindowMenuAction {
+        window_id: window_id.clone(),
+        action,
+    };
+
+    let quit = MenuItem::with_id(
+        app,
+        action(HtmlWindowMenuActionVariant::QuitApp),
+        "Quit Delta Chat", // TODO translate
+        true,
+        Some("CmdOrCtrl+Q"),
+    )?;
+    let menu = Menu::with_items(
+        app,
+        &[
+            // MacOS has an app menu
+            #[cfg(target_os = "macos")]
+            &Submenu::with_items(app, "App", true, &[&quit])?,
+            &Submenu::with_items(
+                app,
+                "File",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        app,
+                        action(HtmlWindowMenuActionVariant::CloseHtmlWindow),
+                        "Close HTML Email",
+                        true,
+                        Some("CmdOrCtrl+W"),
+                    )?,
+                    // macOS has this in the app menu already
+                    #[cfg(not(target_os = "macos"))]
+                    &quit,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "Edit",
+                true,
+                &[
+                    &PredefinedMenuItem::copy(app, Some("Copy"))?,
+                    &PredefinedMenuItem::select_all(app, Some("Select All"))?,
+                ],
+            )?,
+            &Submenu::with_items(
+                app,
+                "View",
+                true,
+                &[
+                    &MenuItem::with_id(
+                        app,
+                        action(HtmlWindowMenuActionVariant::ResetZoom),
+                        "Actual Size",
+                        true,
+                        None::<&str>,
+                    )?,
+                    &MenuItem::with_id(
+                        app,
+                        action(HtmlWindowMenuActionVariant::ZoomIn),
+                        "Zoom In",
+                        true,
+                        if cfg!(target_os = "macos") {
+                            Some("Command++")
+                        } else {
+                            Some("Ctrl++")
+                        },
+                    )?,
+                    &MenuItem::with_id(
+                        app,
+                        action(HtmlWindowMenuActionVariant::ZoomOut),
+                        "Zoom Out",
+                        true,
+                        if cfg!(target_os = "macos") {
+                            Some("Command+-")
+                        } else {
+                            Some("Ctrl+-")
+                        },
+                    )?,
+                    &PredefinedMenuItem::separator(app)?,
+                    &CheckMenuItem::with_id(
+                        app,
+                        action(HtmlWindowMenuActionVariant::FloatOnTop),
+                        "Float on Top",
+                        true,
+                        html_email_window.is_always_on_top()?,
+                        None::<&str>,
+                    )?,
+                    &PredefinedMenuItem::fullscreen(app, Some("Toggle Full Screen"))?,
+                ],
+            )?,
+        ],
+    )?;
+
+    Ok(menu)
+}
+
+#[cfg(test)]
+mod tests {
+    use tauri::menu::MenuId;
+
+    use super::*;
+
+    #[test]
+    fn test_decoding_id() -> anyhow::Result<()> {
+        let r = HtmlWindowMenuAction::try_from(&MenuId::new(
+            "HtmlWindowMenuAction||html-window:1-13027|CloseHtmlWindow",
+        ))?;
+
+        assert_eq!(
+            r,
+            HtmlWindowMenuAction {
+                window_id: "html-window:1-13027".to_owned(),
+                action: HtmlWindowMenuActionVariant::CloseHtmlWindow
+            }
+        );
+        Ok(())
+    }
+}

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -1,11 +1,13 @@
 use anyhow::Context;
 use help_menu::HelpMenuAction;
+use html_window_menu::HtmlWindowMenuAction;
 use main_menu::{MainMenuAction, SET_LOCALE_MENU_ID_PREFIX};
 use menu_action::MenuAction;
 use tauri::{menu::MenuEvent, AppHandle, Emitter};
 
 pub(crate) mod float_on_top;
 pub(crate) mod help_menu;
+pub(crate) mod html_window_menu;
 pub(crate) mod main_menu;
 mod menu_action;
 
@@ -28,6 +30,10 @@ pub fn handle_event(app: &AppHandle, event: MenuEvent) -> anyhow::Result<()> {
                 .last()
                 .context("no language found in id")?,
         )?;
+    }
+
+    if let Ok(action) = HtmlWindowMenuAction::try_from(event.id()) {
+        action.execute(app)?;
     }
 
     Ok(())

--- a/packages/target-tauri/src-tauri/src/settings.rs
+++ b/packages/target-tauri/src-tauri/src/settings.rs
@@ -8,6 +8,7 @@ pub(crate) const CONFIG_FILE: &str = "config.json";
 pub(crate) const LOCALE_KEY: &str = "locale";
 pub(crate) const ZOOM_FACTOR_KEY: &str = "zoomFactor";
 pub(crate) const HELP_ZOOM_FACTOR_KEY: &str = "helpZoomFactor";
+pub(crate) const HTML_EMAIL_ZOOM_FACTOR_KEY: &str = "htmlEmailZoomFactor";
 pub(crate) const CONTENT_PROTECTION_KEY: &str = "contentProtectionEnabled";
 pub(crate) const CONTENT_PROTECTION_DEFAULT: bool = false;
 pub(crate) const HTML_EMAIL_WARNING_KEY: &str = "HTMLEmailAskForRemoteLoadingConfirmation";
@@ -59,6 +60,22 @@ pub(crate) fn apply_zoom_factor_help_window(app: &AppHandle) -> anyhow::Result<(
     app.get_webview_window("help")
         .context("help window not found")?
         .set_zoom(zoom_factor)?;
+    Ok(())
+}
+
+pub(crate) fn apply_zoom_factor_html_window(app: &AppHandle) -> anyhow::Result<()> {
+    let store = app.store(CONFIG_FILE)?;
+    let zoom_factor: f64 = store
+        .get(HTML_EMAIL_ZOOM_FACTOR_KEY)
+        .and_then(|f| f.as_f64())
+        .unwrap_or(1.0);
+    for (label, window) in app.windows().iter() {
+        if label.starts_with("html-window:") {
+            for webview in window.webviews() {
+                webview.set_zoom(zoom_factor)?;
+            }
+        }
+    }
     Ok(())
 }
 

--- a/packages/target-tauri/src-tauri/src/state/menu_manager.rs
+++ b/packages/target-tauri/src-tauri/src/state/menu_manager.rs
@@ -65,6 +65,7 @@ impl MenuManger {
         let _ = self.inner.write().await.insert(id.to_owned(), data);
     }
 
+    #[cfg(target_os = "macos")]
     pub(crate) async fn get_menu_for_window(
         &self,
         app: &AppHandle,
@@ -117,6 +118,8 @@ impl MenuManger {
                     });
                 }
             });
+            // window was just opened so change menu to it
+            app.set_menu(menu_generator_arc(app)?)?;
         }
 
         let self_clone = self.clone();


### PR DESCRIPTION
- **ignore more logs for iroh**
- **conditionaly compile `get_menu_for_window` method that it does not produce an unused warning and always set the menu on mac when creating a window**
- **html window menu**

