### PR TITLE
chore: tweaks to fix intermittent errors seen in running e2e tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 - fix some webxdc apps showing the "Close app?" prompt unintentionally #4737
+- fixed some intermittent e2e test issues
 - improve QR scanner performance
 - webxdc: fix menu bar hiding when pressing Escape #4753
 - tauri: fix blobs and webxdc-icon scheme under windows #4705

--- a/packages/e2e-tests/tests/basic-functionality.spec.ts
+++ b/packages/e2e-tests/tests/basic-functionality.spec.ts
@@ -60,6 +60,7 @@ const getUser = (index: number) => {
  * chatmail server on first start or after
  */
 test('create profiles', async ({ page, context, browserName }) => {
+  test.setTimeout(120_000)
   if (existingProfiles.length > 0) {
     // this test should only run on a fresh start
     throw new Error(

--- a/packages/frontend/src/components/Settings/Profile.tsx
+++ b/packages/frontend/src/components/Settings/Profile.tsx
@@ -14,7 +14,7 @@ type Props = {
 
 export default function Profile({ settingsStore }: Props) {
   const initials = avatarInitial(
-    settingsStore.settings.displayname || '',
+    settingsStore.settings?.displayname || '',
     settingsStore.selfContact.address
   )
 


### PR DESCRIPTION
I was running into a number of intermittent issues running the e2e tests.

- Often the `create profiles` was simply running too long for the default 30s timeout, so increased it to 120s (on my laptop I'm often seeing ~28-44s)
- That said, I also slowed it down a bit afterward because there is a race condition in the testing where the "onboarding" dialog does not necessarily precede the "add account" button. The code was written as if only one of the two will resolve, but that isn't true (anymore?). The "add account" is always present, so it would randomly win the race. I've updated it to wait for up to 1 second for the "onboarding", and then fall back on the "add account".
- Sometimes "after" hooks would error out because `settings` was null, so added a check there