### PR TITLE
Fix setting profile picture

### DIFF
--- a/packages/frontend/src/components/ImageCropper/index.tsx
+++ b/packages/frontend/src/components/ImageCropper/index.tsx
@@ -17,9 +17,8 @@ import Icon from '../Icon'
 
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
-
 import styles from './styles.module.scss'
-import { BackendRemote } from '../../backend-com'
+import { copyToBlobDir } from '../../utils/copyToBlobDir'
 
 // Implementation notes:
 // * CSS-transforms for picking, canvas API to actually cut the result
@@ -31,7 +30,7 @@ import { BackendRemote } from '../../backend-com'
 //   cursor (0, 0) is always at the top-left corner of non-rotated image
 //
 // * on export we just cut the bounding box (targetWidth, targetHeight) around cursor position and rotate/flip it
-export default async function ImageCropper({
+export default function ImageCropper({
   filepath,
   shape,
   onResult,
@@ -53,15 +52,7 @@ export default async function ImageCropper({
     LastUsedSlot.ProfileImage
   )
 
-
-  const acc = await BackendRemote.rpc.getSelectedAccountId()
-  if (acc === null) {
-    console.error('No account selected')
-    return
-  }
-  const blob_path = await BackendRemote.rpc.copyToBlobDir(acc, filepath)
-  const transformed = runtime.transformBlobURL(blob_path)
-
+  const transformed = runtime.transformBlobURL(filepath)
   // cut pattern from the full image
   const cutImage = useRef<HTMLImageElement>(null)
   // full image in background
@@ -145,7 +136,7 @@ export default async function ImageCropper({
     rememberLastUsedPathPromise.then(({ setLastPath }) =>
       setLastPath(dirname(filepath))
     )
-    const blob_path = await BackendRemote.rpc.copyToBlobDir(acc, tempfilepath)
+    const blob_path = await copyToBlobDir(tempfilepath)
     onResult(blob_path)
     onClose()
   }

--- a/packages/frontend/src/components/ImageCropper/index.tsx
+++ b/packages/frontend/src/components/ImageCropper/index.tsx
@@ -182,7 +182,7 @@ export default function ImageCropper({
       targetHeight.current,
       targetWidth.current,
     ]
-      ;[flipDirX.current, flipDirY.current] = [flipDirY.current, flipDirX.current]
+    ;[flipDirX.current, flipDirY.current] = [flipDirY.current, flipDirX.current]
 
     moveImages(posX.current, posY.current)
   }
@@ -280,9 +280,11 @@ export default function ImageCropper({
     // now we compensate for origin with -nX, -nY, rotate and scale
     const imgX = container.current.clientWidth / 2 - nX
     const imgY = container.current.clientHeight / 2 - nY
-    const transformValue = `translate(${imgX}px, ${imgY}px) rotate(${rotation.current
-      }deg) scale(${zoom.current * flipDirX.current}, ${zoom.current * flipDirY.current
-      })`
+    const transformValue = `translate(${imgX}px, ${imgY}px) rotate(${
+      rotation.current
+    }deg) scale(${zoom.current * flipDirX.current}, ${
+      zoom.current * flipDirY.current
+    })`
 
     cutImage.current.style.transform = transformValue
     fullImage.current.style.transform = transformValue
@@ -312,13 +314,13 @@ export default function ImageCropper({
       ev.preventDefault()
 
       dragging.current = true
-        ;[startX.current, startY.current] = rotate(
-          ev.clientX,
-          ev.clientY,
-          -(rotation.current * Math.PI) / 180,
-          window.innerWidth / 2,
-          window.innerHeight / 2
-        )
+      ;[startX.current, startY.current] = rotate(
+        ev.clientX,
+        ev.clientY,
+        -(rotation.current * Math.PI) / 180,
+        window.innerWidth / 2,
+        window.innerHeight / 2
+      )
     }
 
     const handleMouseCoords = (ev: MouseEvent) => {
@@ -341,11 +343,11 @@ export default function ImageCropper({
       const [dx, dy] = handleMouseCoords(ev)
       const scaleFactor = zoom.current * containerScale.current
 
-        // we update position only when mouse movement stops
-        ;[posX.current, posY.current] = moveImages(
-          posX.current - (dx * flipDirX.current) / scaleFactor,
-          posY.current - (dy * flipDirY.current) / scaleFactor
-        )
+      // we update position only when mouse movement stops
+      ;[posX.current, posY.current] = moveImages(
+        posX.current - (dx * flipDirX.current) / scaleFactor,
+        posY.current - (dy * flipDirY.current) / scaleFactor
+      )
     }
 
     const onMouseMove = (ev: MouseEvent) => {

--- a/packages/frontend/src/components/ImageCropper/index.tsx
+++ b/packages/frontend/src/components/ImageCropper/index.tsx
@@ -182,7 +182,7 @@ export default function ImageCropper({
       targetHeight.current,
       targetWidth.current,
     ]
-    ;[flipDirX.current, flipDirY.current] = [flipDirY.current, flipDirX.current]
+      ;[flipDirX.current, flipDirY.current] = [flipDirY.current, flipDirX.current]
 
     moveImages(posX.current, posY.current)
   }
@@ -280,11 +280,9 @@ export default function ImageCropper({
     // now we compensate for origin with -nX, -nY, rotate and scale
     const imgX = container.current.clientWidth / 2 - nX
     const imgY = container.current.clientHeight / 2 - nY
-    const transformValue = `translate(${imgX}px, ${imgY}px) rotate(${
-      rotation.current
-    }deg) scale(${zoom.current * flipDirX.current}, ${
-      zoom.current * flipDirY.current
-    })`
+    const transformValue = `translate(${imgX}px, ${imgY}px) rotate(${rotation.current
+      }deg) scale(${zoom.current * flipDirX.current}, ${zoom.current * flipDirY.current
+      })`
 
     cutImage.current.style.transform = transformValue
     fullImage.current.style.transform = transformValue
@@ -314,13 +312,13 @@ export default function ImageCropper({
       ev.preventDefault()
 
       dragging.current = true
-      ;[startX.current, startY.current] = rotate(
-        ev.clientX,
-        ev.clientY,
-        -(rotation.current * Math.PI) / 180,
-        window.innerWidth / 2,
-        window.innerHeight / 2
-      )
+        ;[startX.current, startY.current] = rotate(
+          ev.clientX,
+          ev.clientY,
+          -(rotation.current * Math.PI) / 180,
+          window.innerWidth / 2,
+          window.innerHeight / 2
+        )
     }
 
     const handleMouseCoords = (ev: MouseEvent) => {
@@ -343,11 +341,11 @@ export default function ImageCropper({
       const [dx, dy] = handleMouseCoords(ev)
       const scaleFactor = zoom.current * containerScale.current
 
-      // we update position only when mouse movement stops
-      ;[posX.current, posY.current] = moveImages(
-        posX.current - (dx * flipDirX.current) / scaleFactor,
-        posY.current - (dy * flipDirY.current) / scaleFactor
-      )
+        // we update position only when mouse movement stops
+        ;[posX.current, posY.current] = moveImages(
+          posX.current - (dx * flipDirX.current) / scaleFactor,
+          posY.current - (dy * flipDirY.current) / scaleFactor
+        )
     }
 
     const onMouseMove = (ev: MouseEvent) => {
@@ -391,7 +389,7 @@ export default function ImageCropper({
   return (
     <Dialog canEscapeKeyClose onClose={onClose} canOutsideClickClose={false}>
       <DialogHeader title={tx('ImageEditorHud_crop')} />
-      <DialogBody className={styles.imageCropperDialogBody}>
+      <DialogBody>
         <DialogContent className={styles.imageCropperDialogContent}>
           <div ref={container} className={styles.imageCropperContainer}>
             <div ref={shade} className={styles.imageCropperShade}></div>
@@ -400,11 +398,13 @@ export default function ImageCropper({
               className={styles.imageCropperCutImage}
               src={filepath}
               onLoad={setupImages}
+              crossOrigin='anonymous'
             />
             <img
               ref={fullImage}
               className={styles.imageCropperFullImage}
               src={filepath}
+              crossOrigin='anonymous'
             />
           </div>
           <div className={styles.imageCropperControls}>

--- a/packages/frontend/src/components/ImageSelector/index.tsx
+++ b/packages/frontend/src/components/ImageSelector/index.tsx
@@ -31,7 +31,7 @@ export default function ImageSelector({
   titleLabel,
 }: Props) {
   const tx = useTranslationFunction()
-  const imageUrl = filePath ? `file://${filePath}` : undefined
+  const imageUrl = filePath ? runtime.transformBlobURL(filePath) : undefined
 
   const handleSelect = async () => {
     const { defaultPath, setLastPath } =

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -59,6 +59,7 @@ import ImageCropper from '../../ImageCropper'
 import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 import ViewProfile from '../ViewProfile'
 import { isInviteLink } from '@deltachat-desktop/shared/util'
+import { copyToBlobDir } from '../../../utils/copyToBlobDir'
 
 type ViewMode = 'main' | 'createGroup' | 'createBroadcastList'
 
@@ -900,7 +901,7 @@ export function useGroupImage(image: string | null) {
     })
     if (file) {
       openDialog(ImageCropper, {
-        filepath: file,
+        filepath: await copyToBlobDir(file),
         shape: 'circle',
         onResult: (croppedImage => {
           setGroupImage(croppedImage)

--- a/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -6,6 +6,7 @@ import ImageCropper from '../../ImageCropper'
 import { LastUsedSlot } from '../../../utils/lastUsedPaths'
 import { avatarInitial } from '../../Avatar'
 import useDialog from '../../../hooks/dialog/useDialog'
+import { copyToBlobDir } from '../../../utils/copyToBlobDir'
 
 type Props = {
   addr?: string
@@ -33,12 +34,12 @@ export default function ProfileImageSelector({
       filePath={profilePicture}
       initials={initials}
       lastUsedSlot={LastUsedSlot.ProfileImage}
-      onChange={filepath => {
+      onChange={async filepath => {
         if (!filepath) {
           setProfilePicture(null)
         } else {
           openDialog(ImageCropper, {
-            filepath,
+            filepath: await copyToBlobDir(filepath),
             shape: 'circle',
             onResult: setProfilePicture,
             onCancel: () => {},

--- a/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -45,14 +45,14 @@ export default function ProfileImageSelector({
             return
           }
           const blob_path = await BackendRemote.rpc.copyToBlobDir(acc, filepath)
-          const transformed = runtime.transformBlobURL(blob_path);
+          const transformed = runtime.transformBlobURL(blob_path)
 
           openDialog(ImageCropper, {
             filepath: transformed,
             shape: 'circle',
             onCancel: () => {},
-            onResult: async (path) => {
-              let blob_path = await BackendRemote.rpc.copyToBlobDir(acc, path)
+            onResult: async path => {
+              const blob_path = await BackendRemote.rpc.copyToBlobDir(acc, path)
               setProfilePicture(blob_path)
             },
             desiredWidth: 256,

--- a/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -39,22 +39,11 @@ export default function ProfileImageSelector({
         if (!filepath) {
           setProfilePicture(null)
         } else {
-          const acc = await BackendRemote.rpc.getSelectedAccountId()
-          if (acc === null) {
-            console.error('No account selected')
-            return
-          }
-          const blob_path = await BackendRemote.rpc.copyToBlobDir(acc, filepath)
-          const transformed = runtime.transformBlobURL(blob_path)
-
           openDialog(ImageCropper, {
-            filepath: transformed,
+            filepath,
             shape: 'circle',
             onCancel: () => {},
-            onResult: async path => {
-              const blob_path = await BackendRemote.rpc.copyToBlobDir(acc, path)
-              setProfilePicture(blob_path)
-            },
+            onResult: setProfilePicture,
             desiredWidth: 256,
             desiredHeight: 256,
           })

--- a/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
+++ b/packages/frontend/src/components/dialogs/EditProfileDialog/ProfileImageSelector.tsx
@@ -6,8 +6,6 @@ import ImageCropper from '../../ImageCropper'
 import { LastUsedSlot } from '../../../utils/lastUsedPaths'
 import { avatarInitial } from '../../Avatar'
 import useDialog from '../../../hooks/dialog/useDialog'
-import { BackendRemote } from '../../../backend-com'
-import { runtime } from '@deltachat-desktop/runtime-interface'
 
 type Props = {
   addr?: string
@@ -35,15 +33,15 @@ export default function ProfileImageSelector({
       filePath={profilePicture}
       initials={initials}
       lastUsedSlot={LastUsedSlot.ProfileImage}
-      onChange={async filepath => {
+      onChange={filepath => {
         if (!filepath) {
           setProfilePicture(null)
         } else {
           openDialog(ImageCropper, {
             filepath,
             shape: 'circle',
-            onCancel: () => {},
             onResult: setProfilePicture,
+            onCancel: () => {},
             desiredWidth: 256,
             desiredHeight: 256,
           })

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -36,6 +36,7 @@ import ImageCropper from '../ImageCropper'
 import { AddMemberDialog } from './AddMember/AddMemberDialog'
 import { RovingTabindexProvider } from '../../contexts/RovingTabindex'
 import { ChatListItemRowChat } from '../chat/ChatListItemRow'
+import { copyToBlobDir } from '../../utils/copyToBlobDir'
 
 export default function ViewGroup(
   props: {
@@ -509,12 +510,12 @@ export function GroupImageSelector(props: {
       filePath={props.groupImage}
       initials={initials}
       lastUsedSlot={LastUsedSlot.GroupImage}
-      onChange={filepath => {
+      onChange={async filepath => {
         if (!filepath) {
           props.setGroupImage(null)
         } else {
           openDialog(ImageCropper, {
-            filepath,
+            filepath: await copyToBlobDir(filepath),
             shape: 'circle',
             onResult: props.setGroupImage,
             onCancel: () => {},

--- a/packages/frontend/src/utils/copyToBlobDir.ts
+++ b/packages/frontend/src/utils/copyToBlobDir.ts
@@ -1,0 +1,10 @@
+import { BackendRemote } from '../backend-com'
+
+// Copy a file to the blob directory
+export async function copyToBlobDir(filepath: string): Promise<string> {
+  const acc = await BackendRemote.rpc.getSelectedAccountId()
+  if (acc === null) {
+    throw Error('No account selected')
+  }
+  return await BackendRemote.rpc.copyToBlobDir(acc, filepath)
+}

--- a/packages/target-tauri/src-tauri/src/blobs.rs
+++ b/packages/target-tauri/src-tauri/src/blobs.rs
@@ -101,6 +101,7 @@ pub(crate) fn delta_blobs_protocol<R: tauri::Runtime>(
                                     MimeType::OctetStream,
                                 ),
                             )
+                            .header(http::header::ACCESS_CONTROL_ALLOW_ORIGIN, "*")
                             .body(blob)?;
                         responder.respond(res);
                     }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -321,11 +321,11 @@ pub fn run() {
                 app.get_webview_window("main").unwrap().open_devtools();
             }
 
+            let main_window = app.get_webview_window("main").unwrap();
             #[cfg(target_os = "macos")]
             {
-                let webview = app.get_webview_window("main").unwrap();
-                webview.set_title_bar_style(tauri::TitleBarStyle::Overlay)?;
-                webview.set_title("")?;
+                main_window.set_title_bar_style(tauri::TitleBarStyle::Overlay)?;
+                main_window.set_title("")?;
             }
 
             let main_window_clone = main_window.clone();

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -321,11 +321,11 @@ pub fn run() {
                 app.get_webview_window("main").unwrap().open_devtools();
             }
 
-            let main_window = app.get_webview_window("main").unwrap();
             #[cfg(target_os = "macos")]
             {
-                main_window.set_title_bar_style(tauri::TitleBarStyle::Overlay)?;
-                main_window.set_title("")?;
+                let webview = app.get_webview_window("main").unwrap();
+                webview.set_title_bar_style(tauri::TitleBarStyle::Overlay)?;
+                webview.set_title("")?;
             }
 
             let main_window_clone = main_window.clone();


### PR DESCRIPTION
This PR adds image support by copying the selected profile picture to the blobfolder and using the dcblob asset scheme to display the images. `crossOrigin=anonymous` is needed because otherwise the canvas would get tainted.

#skip-changelog