### PR TITLE
no second device experiments

### DIFF
--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupDialog.tsx
@@ -70,8 +70,6 @@ export function ReceiveBackupDialog({ onClose }: Props & DialogProps) {
       <DialogBody>
         <p className={styles.receiveSteps}>
           {tx('multidevice_open_settings_on_other_device')}
-          <br />
-          {tx('multidevice_experimental_hint')}
         </p>
         <QrReader onScanSuccess={handleScan} onError={handleError} />
       </DialogBody>

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
@@ -228,9 +228,7 @@ function SendBackupSteps() {
   return (
     <div className={styles.sendBackupSteps}>
       <ol className={styles.sendBackupStepsList}>
-        <li>
-          {tx('multidevice_install_dc_on_other_device')}
-        </li>
+        <li>{tx('multidevice_install_dc_on_other_device')}</li>
         <li>{tx('multidevice_same_network_hint')}</li>
         <li>{tx('multidevice_tap_scan_on_other_device')}</li>
       </ol>

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
@@ -229,8 +229,7 @@ function SendBackupSteps() {
     <div className={styles.sendBackupSteps}>
       <ol className={styles.sendBackupStepsList}>
         <li>
-          {tx('multidevice_install_dc_on_other_device')}{' '}
-          {tx('multidevice_experimental_hint')}
+          {tx('multidevice_install_dc_on_other_device')}
         </li>
         <li>{tx('multidevice_same_network_hint')}</li>
         <li>{tx('multidevice_tap_scan_on_other_device')}</li>


### PR DESCRIPTION
add-second-device is arguably no longer experimental, we're pointing to that options officially and often.

#skip-changelog as rewordings usually do not make it to the changelog (not sure if that fits on desktop, someone, please adapt to real policies :)

counterpart of https://github.com/deltachat/deltachat-android/pull/3685 and https://github.com/deltachat/deltachat-ios/pull/2646