### PR TITLE
tauri: refactor: move capabilities to files

### DIFF
--- a/packages/target-tauri/src-tauri/capabilities/html-email-viewer-header.toml
+++ b/packages/target-tauri/src-tauri/capabilities/html-email-viewer-header.toml
@@ -1,0 +1,11 @@
+"$schema" = "../gen/schemas/desktop-schema.json"
+
+identifier = "html-email-viewer-header"
+# Allow _only_ for the header webview,
+# which has no user-controlled HTML content.
+webviews = ["html-window:*-header"]
+permissions = [
+  "allow-html-email-set-load-remote-content",
+  "allow-html-email-open-menu",
+  "allow-get-html-window-info",
+]

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -1,0 +1,59 @@
+"$schema" = "../gen/schemas/desktop-schema.json"
+
+identifier = "main-window"
+windows = ["main"]
+permissions = [
+  "log:allow-log",
+  # list of core permissions can be found under https://github.com/tauri-apps/tauri/tree/dev/crates/tauri/permissions
+  # or when running `pnpm tauri permission list`
+  "core:event:allow-emit",
+  "core:event:allow-listen",
+  "clipboard-manager:allow-read-text",
+  "clipboard-manager:allow-write-image",
+  "clipboard-manager:allow-write-text",
+  # TODO dialog permissions
+  "store:allow-get-store",
+  "store:allow-entries",
+  "store:allow-save",
+  "store:allow-set",
+  # borderless titlebar
+  "core:window:allow-toggle-maximize",
+  "core:window:allow-start-dragging",
+  # open current logfile & open links
+  # "opener:allow-open-path" is defined in src/runtime_capabilities.rs
+  "opener:allow-open-url",
+  "opener:allow-default-urls",
+  # Badge counter
+  "core:window:allow-set-badge-count",
+
+  "allow-deltachat-jsonrpc-request",
+
+  "allow-ui-ready",
+  "allow-ui-frontend-ready",
+
+  "allow-get-current-logfile",
+  "allow-copy-image-to-clipboard",
+  "allow-get-app-path",
+  "allow-get-clipboard-image-as-data-uri",
+  "allow-download-file",
+  "allow-show-open-file-dialog",
+  "allow-get-locale-data",
+  "allow-change-lang",
+  "allow-write-temp-file-from-base64",
+  "allow-write-temp-file",
+  "allow-remove-temp-file",
+  "allow-copy-blob-file-to-internal-tmp-dir",
+
+  "allow-on-webxdc-message-changed",
+  "allow-on-webxdc-message-deleted",
+  "allow-on-webxdc-status-update",
+  "allow-on-webxdc-realtime-data",
+  "allow-delete-webxdc-account-data",
+  "allow-close-all-webxdc-instances",
+
+  "allow-get-runtime-info",
+  "allow-change-desktop-settings-apply-side-effects",
+
+  "allow-open-help-window",
+  "allow-open-html-window",
+]

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -31,7 +31,7 @@
         "child-src": "blob:",
         "img-src": "'self' data: blob: dcblob: webxdc-icon:",
         "media-src": "'self' dcblob:"
-      },
+      }
       // TODO postponed to later
       // "pattern": {
       //   "use": "isolation",
@@ -39,78 +39,6 @@
       //     "dir": "../isolation"
       //   }
       // },
-      "capabilities": [
-        {
-          "identifier": "Main window",
-          "windows": ["main"],
-          "permissions": [
-            "log:allow-log",
-            // list of core permissions can be found under https://github.com/tauri-apps/tauri/tree/dev/crates/tauri/permissions
-            // or when running `pnpm tauri permission list`
-            "core:event:allow-emit",
-            "core:event:allow-listen",
-            "clipboard-manager:allow-read-text",
-            "clipboard-manager:allow-write-image",
-            "clipboard-manager:allow-write-text",
-            // TODO dialog permissions
-            "store:allow-get-store",
-            "store:allow-entries",
-            "store:allow-save",
-            "store:allow-set",
-            // borderless titlebar
-            "core:window:allow-toggle-maximize",
-            "core:window:allow-start-dragging",
-            // open current logfile & open links
-            // "opener:allow-open-path" is defined in src/runtime_capabilities.rs
-            "opener:allow-open-url",
-            "opener:allow-default-urls",
-            // Badge counter
-            "core:window:allow-set-badge-count",
-
-            "allow-deltachat-jsonrpc-request",
-
-            "allow-ui-ready",
-            "allow-ui-frontend-ready",
-
-            "allow-get-current-logfile",
-            "allow-copy-image-to-clipboard",
-            "allow-get-app-path",
-            "allow-get-clipboard-image-as-data-uri",
-            "allow-download-file",
-            "allow-show-open-file-dialog",
-            "allow-get-locale-data",
-            "allow-change-lang",
-            "allow-write-temp-file-from-base64",
-            "allow-write-temp-file",
-            "allow-remove-temp-file",
-            "allow-copy-blob-file-to-internal-tmp-dir",
-
-            "allow-on-webxdc-message-changed",
-            "allow-on-webxdc-message-deleted",
-            "allow-on-webxdc-status-update",
-            "allow-on-webxdc-realtime-data",
-            "allow-delete-webxdc-account-data",
-            "allow-close-all-webxdc-instances",
-
-            "allow-get-runtime-info",
-            "allow-change-desktop-settings-apply-side-effects",
-
-            "allow-open-help-window",
-            "allow-open-html-window"
-          ]
-        },
-        {
-          "identifier": "html-email-viewer-header",
-          // Allow _only_ for the header webview,
-          // which has no user-controlled HTML content.
-          "webviews": ["html-window:*-header"],
-          "permissions": [
-            "allow-html-email-set-load-remote-content",
-            "allow-html-email-open-menu",
-            "allow-get-html-window-info"
-          ]
-        }
-      ]
     }
   },
   "bundle": {


### PR DESCRIPTION
https://v2.tauri.app/security/capabilities/ says:
> It is good practice to use individual files
> and only reference them by identifier in the tauri.conf.json
> but it is also possible to define them directly
> in the capabilities field.

This adds support for edit-time schema validation and permissions autocompletion.

Why TOML and not JSON? Because it supports comments.

I have verified that the capabilities are still properly applied.

#skip-changelog