### PR TITLE
tauri: perf: don't re-serialize JSON-RPC events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - tauri: improve security a little
+- tauri: improve performance a little #4810
 
 <a id="1_55_0"></a>
 

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -36,8 +36,8 @@ class TauriTransport extends yerpc.BaseTransport {
   constructor(private callCounterFunction: (label: string) => void) {
     super()
 
-    listen<string>('dc-jsonrpc-message', event => {
-      const message: yerpc.Message = JSON.parse(event.payload)
+    listen<yerpc.Message>('dc-jsonrpc-message', event => {
+      const message: yerpc.Message = event.payload
       if (logJsonrpcConnection) {
         /* ignore-console-log */
         console.debug('%c▼ %c[JSONRPC]', 'color: red', 'color:grey', message)

--- a/packages/target-tauri/src-tauri/src/state/deltachat.rs
+++ b/packages/target-tauri/src-tauri/src/state/deltachat.rs
@@ -38,10 +38,10 @@ impl DeltaChatAppState {
             loop {
                 let message = match out_receiver.next().await {
                     None => break,
-                    Some(message) => serde_json::to_string(&message)?,
+                    Some(message) => message,
                 };
                 // TODO fail will drop out of loop, do we want that here? or do we just want to log and ignore the error
-                handle.emit_to(EventTarget::labeled("main"), "dc-jsonrpc-message", message)?;
+                handle.emit_to(EventTarget::labeled("main"), "dc-jsonrpc-message", &message)?;
             }
             Ok(())
         });


### PR DESCRIPTION
Tauri itself can serialize and deserialzie IPC messages.
From https://v2.tauri.app/concept/inter-process-communication/ :
> Because this mechanism uses a JSON-RPC like protocol
> under the hood to serialize requests and responses,
> all arguments and return data must be serializable to JSON.

I did not measure the performance difference, however.
