### PR TITLE
refactor: HTML msg viewer: replace `windowId` arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- tauri: improve security a little #4813
 
 
 <a id="1_55_0"></a>

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -140,8 +140,8 @@ export async function openMessageHTML(messageId: number) {
   const { isContactRequest, isProtectionBroken } =
     await BackendRemote.rpc.getBasicChatInfo(accountId, chatId)
   runtime.openMessageHTML(
-    `${accountId}.${messageId}`,
     accountId,
+    messageId,
     isContactRequest || isProtectionBroken,
     subject,
     displayName,

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -25,14 +25,13 @@ export interface Runtime {
   ): BaseDeltaChat<any>
   /**
    * open html message, in dedicated window or in system browser
-   * @param window_id unique id that we know if it's already open, should be accountid+"-"+msgid
    * @param subject subject of the email (or start of message, if we don't have a subject?)
    * @param sender sender display name
    * @param content content of the html mail
    */
   openMessageHTML(
-    window_id: string,
     accountId: number,
+    messageId: number,
     isContactRequest: boolean,
     subject: string,
     sender: string,

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -163,8 +163,8 @@ class BrowserRuntime implements Runtime {
     return new BrowserDeltachat(callCounterFunction)
   }
   openMessageHTML(
-    _window_id: string,
     _accountId: number,
+    _message_id: number,
     _isContactRequest: boolean,
     _subject: string,
     _sender: string,

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -148,8 +148,8 @@ class ElectronRuntime implements Runtime {
     return new ElectronDeltachat(callCounterFunction)
   }
   openMessageHTML(
-    window_id: string,
     accountId: number,
+    messageId: number,
     isContactRequest: boolean,
     subject: string,
     sender: string,
@@ -158,8 +158,8 @@ class ElectronRuntime implements Runtime {
   ): void {
     ipcBackend.invoke(
       'openMessageHTML',
-      window_id,
       accountId,
+      messageId,
       isContactRequest,
       subject,
       sender,

--- a/packages/target-electron/src/ipc.ts
+++ b/packages/target-electron/src/ipc.ts
@@ -321,8 +321,8 @@ export async function init(cwd: string, logHandler: LogHandler) {
     'openMessageHTML',
     async (
       _ev,
-      window_id: string,
       accountId: number,
+      messageId: number,
       isContactRequest: boolean,
       subject: string,
       sender: string,
@@ -330,8 +330,8 @@ export async function init(cwd: string, logHandler: LogHandler) {
       content: string
     ) => {
       openHtmlEmailWindow(
-        window_id,
         accountId,
+        messageId,
         isContactRequest,
         subject,
         sender,

--- a/packages/target-electron/src/windows/html_email.ts
+++ b/packages/target-electron/src/windows/html_email.ts
@@ -47,14 +47,15 @@ const open_windows: { [window_id: string]: BrowserWindow } = {}
  * @param htmlEmail
  */
 export function openHtmlEmailWindow(
-  window_id: string,
   account_id: number,
+  message_id: number,
   isContactRequest: boolean,
   subject: string,
   from: string,
   receiveTime: string,
   htmlEmail: string
 ) {
+  const window_id = `${account_id}.${message_id}`
   if (open_windows[window_id]) {
     // window already exists, focus it
     open_windows[window_id].focus()

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -78,8 +78,8 @@ class TauriRuntime implements Runtime {
     return new TauriDeltaChat(callCounterFunction)
   }
   openMessageHTML(
-    windowId: string,
     accountId: number,
+    messageId: number,
     isContactRequest: boolean,
     subject: string,
     sender: string,
@@ -87,8 +87,8 @@ class TauriRuntime implements Runtime {
     content: string
   ): void {
     invoke('open_html_window', {
-      windowId,
       accountId,
+      messageId,
       isContactRequest,
       subject,
       sender,

--- a/packages/target-tauri/src-tauri/src/html_window/mod.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/mod.rs
@@ -45,15 +45,15 @@ pub(crate) async fn open_html_window(
     html_instances_state: State<'_, HtmlEmailInstancesState>,
     dc: State<'_, DeltaChatAppState>,
     menu_manager: State<'_, MenuManager>,
-    window_id: &str,
     account_id: u32, // TODO needs to be used later for fetching webrequests over dc core
+    message_id: u32,
     is_contact_request: bool,
     subject: &str,
     sender: &str, // this is called "from" in electron edition
     receive_time: &str,
     content: &str,
 ) -> Result<(), Error> {
-    let window_id = format!("html-window:{window_id}").replace(".", "-");
+    let window_id = format!("html-window:{account_id}-{message_id}");
     trace!("open_html_window: {window_id}");
 
     #[cfg(not(any(target_os = "ios", target_os = "android")))]


### PR DESCRIPTION
In Tauri, window IDs are important for permission control,
and, prior to this commit, `open_html_window` used the `window_id`
parameter for making the label of the respective HTML message viewer window.
This commit limits the amount of control that the caller gets
over the window label, by replacing `window_id` string
with just two numbers.
So, e.g. now it's not possible to inject things like "main" there.

I have tested this change on both Electron and Tauri.
