### PR TITLE
Hide send button if nothing to send

### DIFF
--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -79,7 +79,8 @@
 
     .emoji-button {
       height: 40px;
-      padding: 0px 8px 0px 3px;
+      padding: 0px 3px;
+      margin-inline-end: 5px;
       &:focus:not(:focus-visible) {
         outline: none;
       }

--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -79,7 +79,7 @@
 
     .emoji-button {
       height: 40px;
-      padding: 0px 3px;
+      padding: 0px 8px 0px 3px;
       &:focus:not(:focus-visible) {
         outline: none;
       }

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -91,7 +91,6 @@ const Composer = forwardRef<
   const chatId = selectedChat.id
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showAppPicker, setShowAppPicker] = useState(false)
-  const [showSendButton, setShowSendButton] = useState(false)
   const [currentEditText, setCurrentEditText] = useState('')
 
   const emojiAndStickerRef = useRef<HTMLDivElement>(null)
@@ -139,13 +138,7 @@ const Composer = forwardRef<
     }
   }, [selectedChat.canSend])
 
-  useEffect(() => {
-    if (currentEditText === '' && !draftState.file) {
-      setShowSendButton(false)
-    } else {
-      setShowSendButton(true)
-    }
-  }, [draftState, currentEditText])
+  const showSendButton = currentEditText !== '' || !!draftState.file
 
   useEffect(() => {
     return onDCEvent(accountId, 'SecurejoinJoinerProgress', ({ progress }) => {

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -91,7 +91,7 @@ const Composer = forwardRef<
   const chatId = selectedChat.id
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showAppPicker, setShowAppPicker] = useState(false)
-  const [canSendMessage, setCanSendMessage] = useState(false)
+  const [showSendButton, setShowSendButton] = useState(false)
 
   const emojiAndStickerRef = useRef<HTMLDivElement>(null)
   const pickerButtonRef = useRef<HTMLButtonElement>(null)
@@ -143,9 +143,9 @@ const Composer = forwardRef<
       currentComposerMessageInputRef.current?.getText() === '' &&
       !draftState.file
     ) {
-      setCanSendMessage(false)
+      setShowSendButton(false)
     } else {
-      setCanSendMessage(true)
+      setShowSendButton(true)
     }
   }, [currentComposerMessageInputRef, draftState])
 
@@ -590,7 +590,7 @@ const Composer = forwardRef<
               <span />
             </button>
           )}
-          {canSendMessage && (
+          {showSendButton && (
             <button
               // This ensures that the button loses focus as we switch between
               // the editing mode and the regular mode,

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -92,6 +92,7 @@ const Composer = forwardRef<
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showAppPicker, setShowAppPicker] = useState(false)
   const [showSendButton, setShowSendButton] = useState(false)
+  const [currentEditText, setCurrentEditText] = useState('')
 
   const emojiAndStickerRef = useRef<HTMLDivElement>(null)
   const pickerButtonRef = useRef<HTMLButtonElement>(null)
@@ -139,15 +140,12 @@ const Composer = forwardRef<
   }, [selectedChat.canSend])
 
   useEffect(() => {
-    if (
-      currentComposerMessageInputRef.current?.getText() === '' &&
-      !draftState.file
-    ) {
+    if (currentEditText === '' && !draftState.file) {
       setShowSendButton(false)
     } else {
       setShowSendButton(true)
     }
-  }, [currentComposerMessageInputRef, draftState])
+  }, [draftState, currentEditText])
 
   useEffect(() => {
     return onDCEvent(accountId, 'SecurejoinJoinerProgress', ({ progress }) => {
@@ -559,6 +557,7 @@ const Composer = forwardRef<
                 chatName={selectedChat.name}
                 updateDraftText={updateDraftText}
                 onPaste={handlePaste ?? undefined}
+                onChange={setCurrentEditText}
               />
               <ComposerMessageInput
                 isMessageEditingMode={true}
@@ -576,6 +575,7 @@ const Composer = forwardRef<
                 updateDraftText={() => {}}
                 // Message editing mode doesn't support file pasting.
                 // onPaste={handlePaste}
+                onChange={setCurrentEditText}
               />
             </>
           )}

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -91,6 +91,7 @@ const Composer = forwardRef<
   const chatId = selectedChat.id
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showAppPicker, setShowAppPicker] = useState(false)
+  const [canSendMessage, setCanSendMessage] = useState(false)
 
   const emojiAndStickerRef = useRef<HTMLDivElement>(null)
   const pickerButtonRef = useRef<HTMLButtonElement>(null)
@@ -136,6 +137,17 @@ const Composer = forwardRef<
       hasSecureJoinEnded.current = false
     }
   }, [selectedChat.canSend])
+
+  useEffect(() => {
+    if (
+      currentComposerMessageInputRef.current?.getText() === '' &&
+      !draftState.file
+    ) {
+      setCanSendMessage(false)
+    } else {
+      setCanSendMessage(true)
+    }
+  }, [currentComposerMessageInputRef, draftState])
 
   useEffect(() => {
     return onDCEvent(accountId, 'SecurejoinJoinerProgress', ({ progress }) => {
@@ -578,27 +590,29 @@ const Composer = forwardRef<
               <span />
             </button>
           )}
-          <button
-            // This ensures that the button loses focus as we switch between
-            // the editing mode and the regular mode,
-            // so that it's harder to accidentally send a normal message
-            // right after sending the draft by using the keyboard.
-            // Conceptually those are two different buttons.
-            key={messageEditing.isEditingModeActive.toString()}
-            className='send-button'
-            // TODO apply `disabled` if the textarea is empty
-            // or includes only whitespace.
-            // See `doSendEditRequest`.
-            onClick={
-              !messageEditing.isEditingModeActive
-                ? composerSendMessage!
-                : messageEditing.doSendEditRequest
-            }
-            aria-label={tx('menu_send')}
-            aria-keyshortcuts={ariaSendShortcut}
-          >
-            <div className='paper-plane'></div>
-          </button>
+          {canSendMessage && (
+            <button
+              // This ensures that the button loses focus as we switch between
+              // the editing mode and the regular mode,
+              // so that it's harder to accidentally send a normal message
+              // right after sending the draft by using the keyboard.
+              // Conceptually those are two different buttons.
+              key={messageEditing.isEditingModeActive.toString()}
+              className='send-button'
+              // TODO apply `disabled` if the textarea is empty
+              // or includes only whitespace.
+              // See `doSendEditRequest`.
+              onClick={
+                !messageEditing.isEditingModeActive
+                  ? composerSendMessage!
+                  : messageEditing.doSendEditRequest
+              }
+              aria-label={tx('menu_send')}
+              aria-keyshortcuts={ariaSendShortcut}
+            >
+              <div className='paper-plane'></div>
+            </button>
+          )}
         </div>
         {/* We don't want to show the app picker when
         `messageEditing.isEditingModeActive` because picking an app

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -19,6 +19,7 @@ type ComposerMessageInputProps = {
   enterKeySends: boolean
   onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
   updateDraftText: (text: string, InputChatId: number) => void
+  // used to show/hide send button
   onChange: (text: string) => void
 }
 
@@ -99,6 +100,7 @@ export default class ComposerMessageInput extends React.Component<
   setText(text: string | null) {
     this.setState({ text: text || '', loadingDraft: false })
     this.throttledSaveDraft.cancel()
+    this.props.onChange(text || '')
   }
 
   setComposerSize(size: number) {

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -191,6 +191,7 @@ export default class ComposerMessageInput extends React.Component<
 
     if (action === 'SEND') {
       this.props.sendMessageOrEditRequest()
+      this.props.onChange('')
       e.preventDefault()
       e.stopPropagation()
     }

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -193,7 +193,6 @@ export default class ComposerMessageInput extends React.Component<
 
     if (action === 'SEND') {
       this.props.sendMessageOrEditRequest()
-      this.props.onChange('')
       e.preventDefault()
       e.stopPropagation()
     }

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -19,6 +19,7 @@ type ComposerMessageInputProps = {
   enterKeySends: boolean
   onPaste?: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
   updateDraftText: (text: string, InputChatId: number) => void
+  onChange: (text: string) => void
 }
 
 type ComposerMessageInputState = {
@@ -168,6 +169,7 @@ export default class ComposerMessageInput extends React.Component<
 
   onChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
     const text = e.target.value
+    this.props.onChange(text)
     this.setState({ text /*error: false*/ })
     this.throttledSaveDraft(text, this.state.chatId)
   }
@@ -245,6 +247,7 @@ export default class ComposerMessageInput extends React.Component<
     this.setCursorPosition = textareaElem.selectionStart + str.length
 
     this.setState({ text: updatedText })
+    this.props.onChange(updatedText)
     this.throttledSaveDraft(updatedText, this.state.chatId)
   }
 


### PR DESCRIPTION
This change provides a solution for #4763  with only minimal code changes by just hiding the send button if there is nothing to send.
~~Only downside so far: it does not work when a message is edited, but we have a warning there if the send button is clicked without a message text~~

~~Maybe it would be possible to adapt the editMessageInput to provide a function to detect if the textarea of an edited message is empty?~~

#skip-changelog