### PR TITLE
style: fix dialogs not having margin, small screen

### DIFF
--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -7,8 +7,8 @@ $paddingVertical: 20px;
 .dialog {
   padding: 0;
   @media (width < $default-dialog-width) {
-    max-width: 100vw !important;
-    min-width: calc(100vw - 1rem) !important;
+    max-width: calc(100vw - 1rem) !important;
+    min-width: 0 !important;
   }
 
   &.unstyled {


### PR DESCRIPTION
#skip-changelog because it's a very minor change

Follow-up to https://github.com/deltachat/deltachat-desktop/pull/4806.

Before / After:
![image](https://github.com/user-attachments/assets/4bd9189c-2fa5-4264-a0bd-6a70d28d1923) ![image](https://github.com/user-attachments/assets/ea98c012-f669-4b8b-b98d-99ed959b89bb)
