### PR TITLE
improve toast after copying link to clipboard

### DIFF
--- a/packages/frontend/src/components/dialogs/QrCode.tsx
+++ b/packages/frontend/src/components/dialogs/QrCode.tsx
@@ -118,7 +118,7 @@ export function QrCodeShowQrInner({
       copyCb: () => {
         userFeedback({
           type: 'success',
-          text: tx('copy_qr_data_success'),
+          text: tx('copied_to_clipboard'),
         })
         onClose()
       },


### PR DESCRIPTION
the dialog for copying invite link does not say anything about a "QR code", and the old text saying "Copied QR url to clipboard" opens additional questions - what is a "QR url"?

this is esp. bad as the toast disappears while thinking about it :)

so, better just use the default text "Copied to clipboard" - the toast is anyway more a visual feedback that sth. has happend, not so much sth. to read.

came over that as translators have issues with the existing "QR url" text.

cmp https://github.com/deltachat/deltachat-android/pull/3697