### PR TITLE
tauri: webxdc hardening: disable webrtc by overwriting the JS API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 - fix sticker folder not resolved on windows #4939
 - tauri: improve performance a little #4812
 - settings: fix: wait for setting to be applied before calling callback #4754
+- tauri: prevent webrtc from being accessed in webxdc apps #4851
 
 ### Removed
 - remove experimental option to disable IMAP IDLE #4991

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -47,13 +47,15 @@ console.log("hello from INIT_SCRIPT")
 
 // remove peer connection by overwriting api
 try {
-window.RTCPeerConnection = ()=>{};
-RTCPeerConnection = ()=>{};
-} catch (e){console.error("failed to overwrite RTCPeerConnection apis",e)}
+    window.RTCPeerConnection = () => {};
+    RTCPeerConnection = () => {};
+} catch (e) {
+    console.error("failed to overwrite RTCPeerConnection apis",e)
+}
 try {
-    window.webkitRTCPeerConnection = ()=>{};
-    webkitRTCPeerConnection = ()=>{};
-} catch (e){}
+    window.webkitRTCPeerConnection = () => {};
+    webkitRTCPeerConnection = () => {};
+} catch (e) {}
 "#;
 
 #[cfg(desktop)]

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -41,12 +41,11 @@ use crate::{
 use super::{commands::WebxdcUpdate, error::Error};
 
 const INIT_SCRIPT: &str = r#"
+// keep this log line as long as we are testing
+// to easily see that it is called from every frame
 console.log("hello from INIT_SCRIPT")
-// this is only run once, not in every iframe, we need an api that is run in every iframe
-// so documentation for this is wrong
-// atleast on macOS
 
-// attempt to remove peer connection on macOS
+// remove peer connection by overwriting api
 try {
 window.RTCPeerConnection = ()=>{};
 RTCPeerConnection = ()=>{};
@@ -309,7 +308,7 @@ pub(crate) async fn open_webxdc<'a>(
         &window_id,
         WebviewUrl::CustomProtocol(initial_url.clone()),
     )
-    .initialization_script(INIT_SCRIPT, true)
+    .initialization_script_for_all_frames(INIT_SCRIPT)
     // Use a non-working proxy to almost(!) isolate the app
     // from the internet.
     // "Almost" because there are still cases where the webview

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -309,7 +309,7 @@ pub(crate) async fn open_webxdc<'a>(
         &window_id,
         WebviewUrl::CustomProtocol(initial_url.clone()),
     )
-    .initialization_script(INIT_SCRIPT)
+    .initialization_script(INIT_SCRIPT, true)
     // Use a non-working proxy to almost(!) isolate the app
     // from the internet.
     // "Almost" because there are still cases where the webview


### PR DESCRIPTION
depends on https://github.com/tauri-apps/tauri/pull/13076

Try it on:
- [x] MacOS: works ✅ 
- [x] Linux: works ✅ 
- [x] Windows