### PR TITLE
tauri: hardening: disable WebRTC & DNS prefetch on Win

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
-- tauri: support for webxdc #4740
+- tauri: support for webxdc #4740, #4852
 
 ### Changed
 - switch to account the webxdc is from when sending to chat (tauri and electron edition) #4740


### PR DESCRIPTION
This is about https://delta.chat/en/2023-05-22-webxdc-security.

Using the "Test Webxdc" and "Cure 53 Test App - DNS checker" apps
I was unable to get any packets to get sent with this patch.
Not to the proxy URL, not to the STUN server, not to the DNS server,
even when I disabled CSP for the webxdc.

Edit:
Also this appears to prevent the PDF CSP bypass exploit
(XDC-01-005 WP1: Full CSP bypass via desktop app PDF embed).
The iframe gets created, and does bypass CSP,
but it can't actually load, even by IP.

Yes, with this approach, the `RTCPeerConnection` objects
can still be created.

Related:
- https://github.com/deltachat/deltachat-desktop/pull/3179
- https://github.com/deltachat/deltachat-desktop/pull/4351
- https://github.com/deltachat/deltachat-android/pull/2539
- https://github.com/deltachat/deltachat-android/pull/2540
