### PR TITLE
Change Reply in message menu to notify_reply_button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - switch to account the webxdc is from when sending to chat (tauri and electron edition) #4740
+- change the Reply button for messages to be a verb rather than a noun #4853
 
 ### Fixed
 - tauri: improve security #4826

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -292,7 +292,7 @@ function buildContextMenu(
   return [
     // Reply
     showReply && {
-      label: tx('reply_noun'),
+      label: tx('notify_reply_button'),
       action: setQuoteInDraft.bind(null, message.id),
     },
     // Reply privately


### PR DESCRIPTION
This makes the label a verb rather than a noun, consistently with the [Android version][1].

[1]: https://github.com/deltachat/deltachat-android/blob/2f432bfd3b31865487ca0bf36f0289af5e6c6b6c/src/main/res/menu/conversation_context.xml#L42