### PR TITLE
tauri: fix: webxdc: href query not working

### DIFF
--- a/packages/target-tauri/src-tauri/src/webxdc/commands.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands.rs
@@ -221,7 +221,7 @@ fn href_to_webxdc_url(href: String) -> Result<Url, Error> {
         url.set_path(url_with_href.path());
     }
     url.set_fragment(url_with_href.fragment());
-    url.set_query(url_with_href.fragment());
+    url.set_query(url_with_href.query());
     Ok(url)
 }
 


### PR DESCRIPTION
#skip-changelog because webxdc in Tauri has not been released yet.