### PR TITLE
do not SHOUT OUT time, unify with other platform

### DIFF
--- a/packages/frontend/scss/chat/_chat-list-item.scss
+++ b/packages/frontend/scss/chat/_chat-list-item.scss
@@ -89,7 +89,6 @@
         overflow-x: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
-        text-transform: uppercase;
         user-select: none;
       }
     }

--- a/packages/frontend/scss/dialogs/_audit_log.scss
+++ b/packages/frontend/scss/dialogs/_audit_log.scss
@@ -32,7 +32,6 @@
     li.time {
       padding-bottom: 11px;
       div {
-        text-transform: capitalize;
         border-bottom: 2px solid var(--globalText);
         font-size: 15px;
         font-weight: bold;

--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -38,11 +38,7 @@
     letter-spacing: 0.3px;
     color: var(--messageMetadataDate);
   }
-  & > .date {
-    text-transform: uppercase;
-  }
   & > .edited {
-    text-transform: lowercase;
     // Assumes that there is always a date after it.
     margin-inline-end: 0.5ch;
   }


### PR DESCRIPTION
changes date, time and edited flag being shown in the given case, without additional transformations.

this unifies desktop to what is done on android and iOS, and also gives a smarter LESS YELLING look.

#skip-changelog