### PR TITLE
tauri: hardening: remove unnecessary `webxdc:` src

### DIFF
--- a/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
@@ -20,7 +20,7 @@ static CSP: Lazy<String> = Lazy::new(|| {
     let mut m: HashMap<String, _> = HashMap::new();
     m.insert(
         "default-src".to_owned(),
-        CspDirectiveSources::List(vec!["'self'".to_owned(), "webxdc:".to_owned()]),
+        CspDirectiveSources::List(vec!["'self'".to_owned()]),
     );
     m.insert(
         "style-src".to_string(),


### PR DESCRIPTION
It's not clear why it's there, maybe a residual
from testing iframes.
Iframes work without this source still, so let's remove it.

#skip-changelog because Tauri webxdc has not been released yet.