### PR TITLE
tauri: refactor: simplify webxdc commands

### DIFF
--- a/packages/target-tauri/src-tauri/src/menus/webxdc_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/webxdc_menu.rs
@@ -79,7 +79,7 @@ impl From<WebxdcMenuAction> for tauri::menu::MenuId {
 impl MenuAction<'static> for WebxdcMenuAction {
     async fn execute(self, app: &AppHandle) -> anyhow::Result<()> {
         let win = app
-            .get_window(&self.window_id)
+            .get_webview_window(&self.window_id)
             .context("window not found")?;
         let menu_manager = app.state::<MenuManager>();
         match self.action {
@@ -127,7 +127,7 @@ impl MenuAction<'static> for WebxdcMenuAction {
                     let instances = app.state::<WebxdcInstancesState>();
                     let dc = app.state::<DeltaChatAppState>();
                     let tx = app.state::<TranslationState>();
-                    if let Some(instance) = instances.get(win.label()).await {
+                    if let Some(instance) = instances.get(&win).await {
                         let dc = dc.deltachat.read().await;
                         if let Some(account) = dc.get_account(instance.account_id) {
                             if let Ok(info) = instance.message.get_webxdc_info(&account).await {

--- a/packages/target-tauri/src-tauri/src/state/webxdc_instances.rs
+++ b/packages/target-tauri/src-tauri/src/state/webxdc_instances.rs
@@ -34,29 +34,47 @@ impl WebxdcInstancesState {
         }
     }
 
-    pub(crate) async fn remove(&self, window_label: &str) {
-        let _ = self.inner.write().await.remove(window_label);
+    #[allow(dead_code)]
+    pub(crate) async fn remove(&self, webxdc_window: &tauri::WebviewWindow) {
+        self.remove_by_window_label(webxdc_window.label()).await
+    }
+    pub(crate) async fn remove_by_window_label(&self, webxdc_window_label: &str) {
+        let _ = self.inner.write().await.remove(webxdc_window_label);
     }
 
-    pub(crate) async fn add(&self, window_label: &str, data: WebxdcInstance) {
+    #[allow(dead_code)]
+    pub(crate) async fn add(&self, webxdc_window: &tauri::WebviewWindow, data: WebxdcInstance) {
+        self.add_by_window_label(webxdc_window.label(), data).await
+    }
+    pub(crate) async fn add_by_window_label(
+        &self,
+        webxdc_window_label: &str,
+        data: WebxdcInstance,
+    ) {
         let _ = self
             .inner
             .write()
             .await
-            .insert(window_label.to_owned(), data);
+            .insert(webxdc_window_label.to_string(), data);
     }
 
-    pub(crate) async fn get(&self, window_label: &str) -> Option<WebxdcInstance> {
-        self.inner.read().await.get(window_label).cloned()
+    pub(crate) async fn get(&self, webxdc_window: &tauri::WebviewWindow) -> Option<WebxdcInstance> {
+        self.get_by_window_label(webxdc_window.label()).await
+    }
+    pub(crate) async fn get_by_window_label(
+        &self,
+        webxdc_window_label: &str,
+    ) -> Option<WebxdcInstance> {
+        self.inner.read().await.get(webxdc_window_label).cloned()
     }
 
     pub(crate) async fn set_channel(
         &self,
-        window_label: &str,
+        webxdc_window: &tauri::WebviewWindow,
         channel: Channel<WebxdcUpdate>,
     ) -> Result<(), String> {
         let mut writer = self.inner.write().await;
-        if let Some(m) = writer.get_mut(window_label) {
+        if let Some(m) = writer.get_mut(webxdc_window.label()) {
             m.channel = Some(channel);
             Ok(())
         } else {

--- a/packages/target-tauri/src-tauri/src/webxdc/commands.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands.rs
@@ -421,12 +421,7 @@ pub(crate) async fn send_webxdc_update<'a>(
         account_id,
         message,
         ..
-    } = webxdc_instances
-        .get(&window)
-        .await
-        .ok_or(Error::WebxdcInstanceNotFoundByLabel(
-            window.label().to_owned(),
-        ))?;
+    } = get_this_webxdc_instance(&webxdc_instances, &window).await?;
     let dc = dc.deltachat.read().await;
     let account = dc
         .get_account(account_id)
@@ -451,12 +446,7 @@ pub(crate) async fn get_webxdc_updates<'a>(
         account_id,
         message,
         ..
-    } = webxdc_instances
-        .get(&window)
-        .await
-        .ok_or(Error::WebxdcInstanceNotFoundByLabel(
-            window.label().to_owned(),
-        ))?;
+    } = get_this_webxdc_instance(&webxdc_instances, &window).await?;
     let dc = dc.deltachat.read().await;
     let account = dc
         .get_account(account_id)
@@ -478,12 +468,7 @@ pub(crate) async fn join_webxdc_realtime_channel<'a>(
         account_id,
         message,
         ..
-    } = webxdc_instances
-        .get(&window)
-        .await
-        .ok_or(Error::WebxdcInstanceNotFoundByLabel(
-            window.label().to_owned(),
-        ))?;
+    } = get_this_webxdc_instance(&webxdc_instances, &window).await?;
     let dc = dc.deltachat.read().await;
     let account = dc
         .get_account(account_id)
@@ -511,12 +496,7 @@ pub(crate) async fn leave_webxdc_realtime_channel<'a>(
         account_id,
         message,
         ..
-    } = webxdc_instances
-        .get(&window)
-        .await
-        .ok_or(Error::WebxdcInstanceNotFoundByLabel(
-            window.label().to_owned(),
-        ))?;
+    } = get_this_webxdc_instance(&webxdc_instances, &window).await?;
     let dc = dc.deltachat.read().await;
     let account = dc
         .get_account(account_id)
@@ -539,12 +519,7 @@ pub(crate) async fn send_webxdc_realtime_data<'a>(
         account_id,
         message,
         ..
-    } = webxdc_instances
-        .get(&window)
-        .await
-        .ok_or(Error::WebxdcInstanceNotFoundByLabel(
-            window.label().to_owned(),
-        ))?;
+    } = get_this_webxdc_instance(&webxdc_instances, &window).await?;
     let dc = dc.deltachat.read().await;
     let account = dc
         .get_account(account_id)
@@ -565,16 +540,24 @@ pub(crate) async fn webxdc_send_to_chat(
     options: SendToChatOptions,
 ) -> Result<(), Error> {
     let WebxdcInstance { account_id, .. } =
-        webxdc_instances
-            .get(&window)
-            .await
-            .ok_or(Error::WebxdcInstanceNotFoundByLabel(
-                window.label().to_owned(),
-            ))?;
+        get_this_webxdc_instance(&webxdc_instances, &window).await?;
 
     main_window_channels
         .send_to_chat(window.app_handle(), options, Some(account_id))
         .await
         .map_err(Error::Anyhow)?;
     Ok(())
+}
+
+/// Returns the [`WebxdcInstance`] that corresponds to the window.
+async fn get_this_webxdc_instance(
+    webxdc_instances: &State<'_, WebxdcInstancesState>,
+    window: &WebviewWindow,
+) -> Result<WebxdcInstance, Error> {
+    webxdc_instances
+        .get(window)
+        .await
+        .ok_or(Error::WebxdcInstanceNotFoundByLabel(
+            window.label().to_owned(),
+        ))
 }

--- a/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
@@ -112,7 +112,7 @@ pub(crate) fn webxdc_protocol<R: tauri::Runtime>(
                 message,
                 ..
             } = instances
-                .get(&webview_label)
+                .get_by_window_label(&webview_label)
                 .await
                 .ok_or(anyhow!("webxdc instance not found in open instances"))?;
 


### PR DESCRIPTION
- **tauri: refactor: `WebxdcInstancesState`: accept `Window`**
  This gives better type safety, now it's harder to pass
  an "arbitrary" `&str` to the methods of `WebxdcInstancesState`.
- **tauri: refactor: simplify webxdc commands**
  A little less boilerplate

#skip-changelog because it's just a refactor