### PR TITLE
show explicit action on 'start backup' button

### DIFF
--- a/packages/frontend/src/components/Settings/Backup.tsx
+++ b/packages/frontend/src/components/Settings/Backup.tsx
@@ -38,7 +38,7 @@ export default function Backup() {
 
     const confirmed = await openConfirmationDialog({
       message: tx('pref_backup_export_explain'),
-      confirmLabel: tx('ok'),
+      confirmLabel: tx('pref_backup_export_start_button'),
     })
 
     if (confirmed) {


### PR DESCRIPTION
according to interface guidelines,
it is recommended to show the action on the button, where possible and reasonable wrt effort.

we do not always have the verb/action,
but in this case we do :)

the string comes from iOS,
thanks for the hint in the forum.

before / after:

![Screenshot 2025-03-28 at 12 31 32](https://github.com/user-attachments/assets/d5da9378-118d-43c2-af2a-ac7d16d64d07)
![Screenshot 2025-03-28 at 12 25 58](https://github.com/user-attachments/assets/9ee923c0-4384-481f-b12b-69dc3e899219)

