### PR TITLE
Infinite loading in gallery

### DIFF
--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -441,21 +441,21 @@ function GridGallery({
 
   const isMessageLoaded: (index: number) => boolean = index =>
     !!messageLoadState[mediaMessageIds[index]]
-  const loadMessages: (
-    startIndex: number,
-    stopIndex: number
-  ) => Promise<void> = async (startIndex, stopIndex) => {
+  const loadMessages: (startIndex: number, stopIndex: number) => void = (
+    startIndex,
+    stopIndex
+  ) => {
     const ids = mediaMessageIds.slice(startIndex, stopIndex + 1)
-
     setMessageLoading(state => {
       ids.forEach(id => (state[id] = LoadStatus.FETCHING))
       return state
     })
-    const messages = await BackendRemote.rpc.getMessages(accountId, ids)
-    setMessageCache(cache => ({ ...cache, ...messages }))
-    setMessageLoading(state => {
-      ids.forEach(id => (state[id] = LoadStatus.LOADED))
-      return state
+    BackendRemote.rpc.getMessages(accountId, ids).then(messages => {
+      setMessageCache(cache => ({ ...cache, ...messages }))
+      setMessageLoading(state => {
+        ids.forEach(id => (state[id] = LoadStatus.LOADED))
+        return state
+      })
     })
   }
 
@@ -510,7 +510,7 @@ function GridGallery({
                   rowHeight={itemHeight}
                   columnCount={itemsPerRow}
                   rowCount={rowCount}
-                  overscanRowCount={10}
+                  overscanRowCount={itemsPerRow * 10}
                   ref={ref}
                   onItemsRendered={props => {
                     const { visibleColumnStartIndex, visibleRowStartIndex } =

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, Component, createRef, useRef } from 'react'
+import React, {
+  ChangeEvent,
+  Component,
+  createRef,
+  useRef,
+  useState,
+} from 'react'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import { FixedSizeGrid, FixedSizeList } from 'react-window'
 import moment from 'moment'
@@ -24,6 +30,8 @@ import {
   RovingTabindexProvider,
   useRovingTabindex,
 } from '../contexts/RovingTabindex'
+import InfiniteLoader from 'react-window-infinite-loader'
+import { T } from '@deltachat/jsonrpc-client'
 
 const log = getLogger('renderer/Gallery')
 
@@ -186,10 +194,10 @@ export default class Gallery extends Component<
     BackendRemote.rpc
       .getChatMedia(accountId, chatId, msgTypes[0], msgTypes[1], null)
       .then(async media_ids => {
-        const mediaLoadResult = await BackendRemote.rpc.getMessages(
-          accountId,
-          media_ids
-        )
+        const mediaLoadResult =
+          tab !== 'files'
+            ? []
+            : await BackendRemote.rpc.getMessages(accountId, media_ids)
         media_ids.reverse() // order newest up - if we need different ordering we need to do it in core
         this.setState({
           currentTab: tab,
@@ -267,13 +275,18 @@ export default class Gallery extends Component<
     const tx = window.static_translate // static because dynamic isn't too important here
     const emptyTabMessage = this.emptyTabMessage(currentTab)
 
-    const filteredMediaMessageIds = mediaMessageIds.filter(id => {
-      const result = mediaLoadResult[id]
-      return (
-        result.kind === 'message' &&
-        result.fileName?.toLowerCase().indexOf(queryText.toLowerCase()) !== -1
-      )
-    })
+    const filteredMediaMessageIds =
+      currentTab !== 'files'
+        ? []
+        : mediaMessageIds.filter(id => {
+            const result = mediaLoadResult[id]
+            return (
+              result.kind === 'message' &&
+              result.fileName
+                ?.toLowerCase()
+                .indexOf(queryText.toLowerCase()) !== -1
+            )
+          })
 
     const showDateHeader =
       currentTab !== 'files' && currentTab !== 'webxdc_apps'
@@ -379,88 +392,16 @@ export default class Gallery extends Component<
             )}
 
             {currentTab !== 'files' && (
-              <AutoSizer>
-                {({ width, height }) => {
-                  const widthWithoutScrollbar = width - 6
-
-                  let minWidth = 160
-
-                  if (currentTab === 'webxdc_apps') {
-                    minWidth = 265
-                  } else if (currentTab === 'audio') {
-                    minWidth = 322
-                  }
-
-                  const itemsPerRow = Math.max(
-                    Math.floor(widthWithoutScrollbar / minWidth),
-                    1
-                  )
-
-                  const itemWidth = widthWithoutScrollbar / itemsPerRow
-
-                  const rowCount = Math.ceil(
-                    mediaMessageIds.length / itemsPerRow
-                  )
-
-                  let itemHeight = itemWidth
-
-                  if (currentTab === 'webxdc_apps') {
-                    itemHeight = 61
-                  } else if (currentTab === 'audio') {
-                    itemHeight = 94
-                  }
-
-                  return (
-                    <RovingTabindexProvider
-                      wrapperElementRef={this.galleryItemsRef}
-                      // TODO improvement: perhaps we can easily write
-                      // proper grid navigation,
-                      // since grid dimensions are known.
-                      direction='both'
-                    >
-                      <FixedSizeGrid
-                        width={width}
-                        height={height}
-                        columnWidth={itemWidth}
-                        rowHeight={itemHeight}
-                        columnCount={itemsPerRow}
-                        rowCount={rowCount}
-                        overscanRowCount={10}
-                        onItemsRendered={({
-                          visibleColumnStartIndex,
-                          visibleRowStartIndex,
-                        }) => {
-                          const msgId =
-                            mediaMessageIds[
-                              visibleRowStartIndex * itemsPerRow +
-                                visibleColumnStartIndex
-                            ]
-                          const message = mediaLoadResult[msgId]
-                          if (!message) {
-                            return
-                          }
-                          this.updateFirstVisibleMessage(message)
-                        }}
-                        itemData={{
-                          Component: this.state.element,
-                          mediaMessageIds,
-                          mediaLoadResult,
-                          openFullscreenMedia:
-                            this.openFullscreenMedia.bind(this),
-                          itemsPerRow,
-                        }}
-                        itemKey={({ rowIndex, columnIndex, data }) =>
-                          data.mediaMessageIds[
-                            rowIndex * itemsPerRow + columnIndex
-                          ]
-                        }
-                      >
-                        {GalleryGridCell}
-                      </FixedSizeGrid>
-                    </RovingTabindexProvider>
-                  )
-                }}
-              </AutoSizer>
+              <GridGallery
+                currentTab={currentTab}
+                element={this.state.element}
+                openFullscreenMedia={this.openFullscreenMedia.bind(this)}
+                mediaMessageIds={mediaMessageIds}
+                galleryItemsRef={this.galleryItemsRef}
+                updateFirstVisibleMessage={this.updateFirstVisibleMessage.bind(
+                  this
+                )}
+              />
             )}
           </div>
         </div>
@@ -468,6 +409,167 @@ export default class Gallery extends Component<
     )
   }
 }
+
+const enum LoadStatus {
+  FETCHING = 1,
+  LOADED = 2,
+}
+
+function GridGallery({
+  currentTab,
+  mediaMessageIds,
+  galleryItemsRef,
+  updateFirstVisibleMessage,
+  element,
+  openFullscreenMedia,
+}: {
+  currentTab: MediaTabKey
+  mediaMessageIds: number[]
+  galleryItemsRef: React.RefObject<HTMLDivElement>
+  updateFirstVisibleMessage: (msg: T.MessageLoadResult) => void
+  element: GalleryElement
+  openFullscreenMedia: (message: Type.Message) => void
+}): React.ReactNode {
+  const accountId = selectedAccountId()
+
+  const [messageCache, setMessageCache] = useState<{
+    [id: number]: T.MessageLoadResult | undefined
+  }>({})
+  const [messageLoadState, setMessageLoading] = useState<{
+    [id: number]: undefined | LoadStatus.FETCHING | LoadStatus.LOADED
+  }>({})
+
+  const isMessageLoaded: (index: number) => boolean = index =>
+    !!messageLoadState[mediaMessageIds[index]]
+  const loadMessages: (
+    startIndex: number,
+    stopIndex: number
+  ) => Promise<void> = async (startIndex, stopIndex) => {
+    const ids = mediaMessageIds.slice(startIndex, stopIndex + 1)
+
+    setMessageLoading(state => {
+      ids.forEach(id => (state[id] = LoadStatus.FETCHING))
+      return state
+    })
+    const messages = await BackendRemote.rpc.getMessages(accountId, ids)
+    setMessageCache(cache => ({ ...cache, ...messages }))
+    setMessageLoading(state => {
+      ids.forEach(id => (state[id] = LoadStatus.LOADED))
+      return state
+    })
+  }
+
+  return (
+    <AutoSizer>
+      {({ width, height }) => {
+        const widthWithoutScrollbar = width - 6
+
+        let minWidth = 160
+
+        if (currentTab === 'webxdc_apps') {
+          minWidth = 265
+        } else if (currentTab === 'audio') {
+          minWidth = 322
+        }
+
+        const itemsPerRow = Math.max(
+          Math.floor(widthWithoutScrollbar / minWidth),
+          1
+        )
+
+        const itemWidth = widthWithoutScrollbar / itemsPerRow
+
+        const rowCount = Math.ceil(mediaMessageIds.length / itemsPerRow)
+
+        let itemHeight = itemWidth
+
+        if (currentTab === 'webxdc_apps') {
+          itemHeight = 61
+        } else if (currentTab === 'audio') {
+          itemHeight = 94
+        }
+
+        return (
+          <RovingTabindexProvider
+            wrapperElementRef={galleryItemsRef}
+            // TODO improvement: perhaps we can easily write
+            // proper grid navigation,
+            // since grid dimensions are known.
+            direction='both'
+          >
+            <InfiniteLoader
+              isItemLoaded={isMessageLoaded}
+              itemCount={mediaMessageIds.length}
+              loadMoreItems={loadMessages}
+            >
+              {({ onItemsRendered, ref }) => (
+                <FixedSizeGrid
+                  width={width}
+                  height={height}
+                  columnWidth={itemWidth}
+                  rowHeight={itemHeight}
+                  columnCount={itemsPerRow}
+                  rowCount={rowCount}
+                  overscanRowCount={10}
+                  ref={ref}
+                  onItemsRendered={props => {
+                    const { visibleColumnStartIndex, visibleRowStartIndex } =
+                      props
+                    const msgId =
+                      mediaMessageIds[
+                        visibleRowStartIndex * itemsPerRow +
+                          visibleColumnStartIndex
+                      ]
+                    const message = messageCache[msgId]
+                    if (message) {
+                      updateFirstVisibleMessage(message)
+                    }
+                    let translatedProps = {
+                      overscanStartIndex: Math.min(
+                        mediaMessageIds.length - 1,
+                        props.overscanRowStartIndex * itemsPerRow +
+                          props.overscanColumnStartIndex
+                      ),
+                      overscanStopIndex: Math.min(
+                        mediaMessageIds.length - 1,
+                        props.overscanRowStopIndex * itemsPerRow +
+                          props.overscanColumnStopIndex
+                      ),
+                      visibleStartIndex: Math.min(
+                        mediaMessageIds.length - 1,
+                        visibleRowStartIndex * itemsPerRow +
+                          visibleColumnStartIndex
+                      ),
+                      visibleStopIndex: Math.min(
+                        mediaMessageIds.length - 1,
+                        props.visibleRowStopIndex * itemsPerRow +
+                          props.visibleColumnStopIndex
+                      ),
+                    }
+                    onItemsRendered(translatedProps)
+                  }}
+                  itemData={{
+                    Component: element,
+                    mediaMessageIds,
+                    messageCache,
+                    openFullscreenMedia,
+                    itemsPerRow,
+                  }}
+                  itemKey={({ rowIndex, columnIndex, data }) =>
+                    data.mediaMessageIds[rowIndex * itemsPerRow + columnIndex]
+                  }
+                >
+                  {GalleryGridCell}
+                </FixedSizeGrid>
+              )}
+            </InfiniteLoader>
+          </RovingTabindexProvider>
+        )
+      }}
+    </AutoSizer>
+  )
+}
+
 function GalleryGridCell({
   columnIndex,
   rowIndex,
@@ -480,7 +582,7 @@ function GalleryGridCell({
   data: {
     Component: GalleryElement
     mediaMessageIds: number[]
-    mediaLoadResult: Record<number, Type.MessageLoadResult>
+    messageCache: Record<number, Type.MessageLoadResult | undefined>
     openFullscreenMedia: (message: Type.Message) => void
     itemsPerRow: number
   }
@@ -488,14 +590,15 @@ function GalleryGridCell({
   const {
     Component,
     mediaMessageIds,
-    mediaLoadResult,
+    messageCache,
     openFullscreenMedia,
     itemsPerRow,
   } = data
 
   const msgId = mediaMessageIds[rowIndex * itemsPerRow + columnIndex]
-  const message = mediaLoadResult[msgId]
+  const message = messageCache[msgId]
   if (!message) {
+    // todo skeleton item (for each mode a fitting shape: image, video, audio, webxdc)
     return null
   }
   return (


### PR DESCRIPTION
This addresses the infinite list part of #4867. I still think an optimized jsonrpc call with less db calls makes sense, but inifinite list has the biggest impact so we should focus on it first.


Currently this doesn't have the highest priotiry for me, so someone can take over this pr if they want.

## TO DO

- [ ] test if rowing tab index still works
- [ ] skeleton items for not loaded items
- [ ] handle deleted message events and message changed events
- [ ] remember scroll position when window width changes
- [ ] fix weird horizontal scrollbar

