### PR TITLE
tauri: hardening: webxdc: disable all web permissions

### DIFF
--- a/bin/webxdc-check-permissions-policy-count.js
+++ b/bin/webxdc-check-permissions-policy-count.js
@@ -1,0 +1,51 @@
+import fs from 'fs/promises'
+import path from 'path'
+
+// See `PERMISSIONS_POLICY_DENY_ALL` in `src-tauri/src/webxdc/webxdc_scheme.rs`.
+
+const url =
+  'https://raw.githubusercontent.com/w3c/webappsec-permissions-policy/refs/heads/main/features.md'
+
+async function getRequiredCount(url) {
+  const res = await fetch(url)
+  const count = ((await res.text()).match(/^\| `/gm) ?? []).length
+
+  if (count === 0) {
+    throw new Error('Failed to parse count')
+  }
+
+  return count
+}
+
+async function getActualCount(filePath) {
+  const fileContent = await fs.readFile(filePath, { encoding: 'utf8' })
+  const count = (fileContent.match(/^    (\/\/ )?".*?=\(\)(, )?",$/gm) ?? [])
+    .length
+
+  if (count === 0) {
+    throw new Error('Failed to parse count')
+  }
+
+  return count
+}
+
+const targetFile = path.join(
+  '.',
+  'src-tauri',
+  'src',
+  'webxdc',
+  'webxdc_scheme.rs'
+)
+
+const requiredCount = await getRequiredCount(url)
+const actualCount = await getActualCount(targetFile)
+
+if (actualCount !== requiredCount) {
+  throw new Error(
+    'PERMISSIONS_POLICY_DENY_ALL variable needs to be updated to include all the possible permissions'
+  )
+} else {
+  console.log(
+    `PERMISSIONS_POLICY_DENY_ALL value is good, permission counts are ${actualCount} == ${requiredCount}`
+  )
+}

--- a/packages/target-tauri/package.json
+++ b/packages/target-tauri/package.json
@@ -8,7 +8,7 @@
     "check:types": "tsc --noEmit -p runtime-tauri",
     "start": "tauri dev",
     "build4production": "NODE_ENV=production pnpm build",
-    "build": "pnpm build:locales && pnpm --filter=@deltachat-desktop/frontend build && pnpm build:compose-frontend && pnpm build:html-email-view && pnpm build:webxdc-js",
+    "build": "node ../../bin/webxdc-check-permissions-policy-count.js && pnpm build:locales && pnpm --filter=@deltachat-desktop/frontend build && pnpm build:compose-frontend && pnpm build:html-email-view && pnpm build:webxdc-js",
     "build:locales": "pnpm -w translations:convert",
     "build:runtime-impl": "pnpm esbuild --bundle --minify --keep-names --sourcemap --outdir=./html-dist runtime-tauri/runtime.ts",
     "build:html-email-view": "pnpm esbuild --bundle --minify --keep-names --sourcemap --outdir=./html-dist/tauri_html_email_view tauri-html-email-view/html_email_view.ts",

--- a/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
@@ -253,7 +253,7 @@ pub(crate) fn webxdc_protocol<R: tauri::Runtime>(
 // https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md.
 //
 // We make sure that this list is up to date using the
-// `/bin/webxdc-check-permissions-policy-count.sh` script.
+// `/bin/webxdc-check-permissions-policy-count.js` script.
 const PERMISSIONS_POLICY_DENY_ALL: &'static str = concat!(
     "accelerometer=(), ",
     "ambient-light-sensor=(), ",


### PR DESCRIPTION
#skip-changelog because Tauri webxdc has not been released yet.

I verified that putting `navigator.getUserMedia({ video: true }, console.log, console.error)` in the console no longer causes a permission prompt on Windows.

- [x] I just realized that the new build script might not be able to run on Windows, because it's a .sh script.
  OK, it runs in CI, but still I guess I need to rewrite it.