### PR TITLE
Expose open dialog IDs from DialogContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - prevent dragging around of webxdc icon #4740
 - tauri: clear temp folder on exit #4839
 - fix wrong punycode warnings in links #4864
+- fix esc key closing wrong dialog in settings #4865
 
 <a id="1_56_0"></a>
 

--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -28,7 +28,7 @@ type SettingsView =
   | 'advanced'
 
 export default function Settings({ onClose }: DialogProps) {
-  const { openDialog } = useDialog()
+  const { openDialog, closeDialog, openDialogs: openDialogIds } = useDialog()
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const settingsStore = useSettingsStore()[0]!
   const tx = useTranslationFunction()
@@ -42,12 +42,19 @@ export default function Settings({ onClose }: DialogProps) {
         evt.key === 'Escape'
       ) {
         evt.preventDefault()
-        setSettingsMode('main')
+        if (openDialogIds.length > 1) {
+          // if there is an open dialog on top of settings dialog
+          // (like Backup or Password & Account dialog) close that
+          closeDialog(openDialogIds[openDialogIds.length - 1].toString())
+        } else {
+          // switch back to main Settings dialog
+          setSettingsMode('main')
+        }
       }
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [settingsMode])
+  }, [settingsMode, openDialogIds, closeDialog])
 
   useEffect(() => {
     if (window.__settingsOpened) {

--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -28,7 +28,7 @@ type SettingsView =
   | 'advanced'
 
 export default function Settings({ onClose }: DialogProps) {
-  const { openDialog, closeDialog, openDialogs: openDialogIds } = useDialog()
+  const { openDialog, closeDialog, openDialogIds } = useDialog()
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const settingsStore = useSettingsStore()[0]!
   const tx = useTranslationFunction()

--- a/packages/frontend/src/contexts/DialogContext.tsx
+++ b/packages/frontend/src/contexts/DialogContext.tsx
@@ -27,6 +27,7 @@ type DialogContextValue = {
   openDialog: OpenDialog
   closeDialog: CloseDialog
   closeAllDialogs: CloseAllDialogs
+  openDialogIds: String[] // IDs of currently opened dialogs
 }
 
 const initialValues: DialogContextValue = {
@@ -34,6 +35,7 @@ const initialValues: DialogContextValue = {
   openDialog: _ => '',
   closeDialog: _ => {},
   closeAllDialogs: () => {},
+  openDialogIds: [],
 }
 
 export const DialogContext =
@@ -63,9 +65,6 @@ export const DialogContextProvider = ({ children }: PropsWithChildren<{}>) => {
             closeDialog(newDialogId)
           },
           ...additionalProps,
-          // dataTestid: additionalProps?.dataTestid
-          //   ? additionalProps?.dataTestid
-          //   : `dialog-${newDialogId}`,
         }
       )
 
@@ -85,11 +84,16 @@ export const DialogContextProvider = ({ children }: PropsWithChildren<{}>) => {
     return Object.keys(dialogs).length > 0
   }, [dialogs])
 
+  const openDialogIds = useMemo(() => {
+    return Object.keys(dialogs)
+  }, [dialogs])
+
   const value = {
     hasOpenDialogs,
     openDialog,
     closeDialog,
     closeAllDialogs,
+    openDialogIds,
   }
 
   return (

--- a/packages/frontend/src/hooks/dialog/useDialog.ts
+++ b/packages/frontend/src/hooks/dialog/useDialog.ts
@@ -3,13 +3,19 @@ import { useContext } from 'react'
 import { DialogContext } from '../../contexts/DialogContext'
 
 export default function useDialog() {
-  const { openDialog, closeDialog, hasOpenDialogs, closeAllDialogs } =
-    useContext(DialogContext)
+  const {
+    openDialog,
+    closeDialog,
+    hasOpenDialogs,
+    closeAllDialogs,
+    openDialogIds: openDialogs,
+  } = useContext(DialogContext)
 
   return {
     openDialog,
     closeDialog,
     hasOpenDialogs,
     closeAllDialogs,
+    openDialogs,
   }
 }

--- a/packages/frontend/src/hooks/dialog/useDialog.ts
+++ b/packages/frontend/src/hooks/dialog/useDialog.ts
@@ -8,7 +8,7 @@ export default function useDialog() {
     closeDialog,
     hasOpenDialogs,
     closeAllDialogs,
-    openDialogIds: openDialogs,
+    openDialogIds,
   } = useContext(DialogContext)
 
   return {
@@ -16,6 +16,6 @@ export default function useDialog() {
     closeDialog,
     hasOpenDialogs,
     closeAllDialogs,
-    openDialogs,
+    openDialogIds,
   }
 }


### PR DESCRIPTION
resolves #4865

Closing the "latest" dialog by calling closeDialog(latestDialogID) could be a generic solution to "always" close the last opened dialog. Just a consideration in case we have longer stacks of dialogs some day