### PR TITLE
slight gradients for avatars for a more modern look

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - switch to account the webxdc is from when sending to chat (tauri and electron edition) #4740
 - change the Reply button for messages to be a verb rather than a noun #4853
 - Update message-parser to v0.13.0
+- slight gradients for avatars for a more modern look #4877
 
 ### Fixed
 - tauri: improve security #4826

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -38,6 +38,24 @@
       & > .label {
         user-select: none;
         color: var(--avatarLabelColor);
+        --local-avatar-color: #bcbac9;
+        background-color: var(--local-avatar-color);
+        @supports (
+          // text-wrap was introduced in 2023 slightly after color-mix,
+          // since we can't test for color-mix support directly we use this instead.
+          text-wrap: wrap
+        ) {
+          // make avatars look slightly 3D
+          background: linear-gradient(
+            45deg,
+            var(--local-avatar-color),
+            color-mix(
+              in srgb,
+              var(--local-avatar-color) var(--avatarGradientMixFactor),
+              white
+            )
+          );
+        }
 
         top: -121px;
         left: -10px;

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -47,7 +47,7 @@
         ) {
           // make avatars look slightly 3D
           background: linear-gradient(
-            45deg,
+            var(--avatarGradientAngle),
             var(--local-avatar-color),
             color-mix(
               in srgb,
@@ -583,7 +583,7 @@
   }
 }
 
-/* This is for making links in quoted texts unclickable and 
+/* This is for making links in quoted texts unclickable and
    have an appereance like the rest of text in there */
 .quoted-text > a {
   pointer-events: none;

--- a/packages/frontend/scss/misc/_avatar.scss
+++ b/packages/frontend/scss/misc/_avatar.scss
@@ -51,12 +51,33 @@
   }
 
   div.content {
-    background-color: #505050;
+    --local-avatar-color: #505050;
+    background-color: var(--local-avatar-color);
+
     line-height: var(--local-avatar-size);
     object-fit: cover;
     color: var(--avatarLabelColor);
     text-align: center;
     font-size: var(--local-avatar-font-size);
+
+    @supports (
+      // text-wrap was introduced in 2023 slightly after color-mix,
+      // since we can't test for color-mix support directly we use this instead.
+      text-wrap: wrap
+    ) {
+      // make avatars look slightly 3D
+      background: linear-gradient(
+        45deg,
+        var(--local-avatar-color),
+        color-mix(
+          in srgb,
+          var(--local-avatar-color) var(--avatarGradientMixFactor),
+          white
+        )
+      );
+    }
+    // TODO author avatar
+    // TODO .styles_module_largeProfileImageArea
 
     .avatar-qr-code-img {
       width: 22px;

--- a/packages/frontend/scss/misc/_avatar.scss
+++ b/packages/frontend/scss/misc/_avatar.scss
@@ -77,7 +77,6 @@
       );
     }
     // TODO author avatar
-    // TODO .styles_module_largeProfileImageArea
 
     .avatar-qr-code-img {
       width: 22px;

--- a/packages/frontend/scss/misc/_avatar.scss
+++ b/packages/frontend/scss/misc/_avatar.scss
@@ -67,7 +67,7 @@
     ) {
       // make avatars look slightly 3D
       background: linear-gradient(
-        45deg,
+        var(--avatarGradientAngle),
         var(--local-avatar-color),
         color-mix(
           in srgb,

--- a/packages/frontend/scss/misc/_avatar.scss
+++ b/packages/frontend/scss/misc/_avatar.scss
@@ -76,7 +76,6 @@
         )
       );
     }
-    // TODO author avatar
 
     .avatar-qr-code-img {
       width: 22px;

--- a/packages/frontend/src/components/Avatar/index.tsx
+++ b/packages/frontend/src/components/Avatar/index.tsx
@@ -68,7 +68,7 @@ export function Avatar(props: {
   const content = avatarPath ? (
     <img className='content' src={runtime.transformBlobURL(avatarPath)} />
   ) : (
-    <div className='content' style={{ backgroundColor: color }}>
+    <div className='content' style={{ ["--local-avatar-color"]: color }}>
       {avatarInitial(displayName, addr)}
     </div>
   )

--- a/packages/frontend/src/components/Avatar/index.tsx
+++ b/packages/frontend/src/components/Avatar/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 import classNames from 'classnames'
 
 import useDialog from '../../hooks/dialog/useDialog'
@@ -32,6 +32,10 @@ export function avatarInitial(name: string, addr?: string) {
 }
 
 type htmlDivProps = React.HTMLAttributes<HTMLDivElement>
+
+interface CssWithAvatarColor extends CSSProperties {
+  '--local-avatar-color': string
+}
 
 export function Avatar(props: {
   avatarPath?: string | null
@@ -68,7 +72,10 @@ export function Avatar(props: {
   const content = avatarPath ? (
     <img className='content' src={runtime.transformBlobURL(avatarPath)} />
   ) : (
-    <div className='content' style={{ ["--local-avatar-color"]: color }}>
+    <div
+      className='content'
+      style={{ '--local-avatar-color': color } as CssWithAvatarColor}
+    >
       {avatarInitial(displayName, addr)}
     </div>
   )

--- a/packages/frontend/src/components/LargeProfileImage/index.tsx
+++ b/packages/frontend/src/components/LargeProfileImage/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { CSSProperties } from 'react'
 
 import Icon from '../Icon'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
@@ -10,6 +10,10 @@ type Props = {
   color?: string
   imageUrl?: string
   initials: string
+}
+
+interface CssWithAvatarColor extends CSSProperties {
+  '--local-avatar-color': string
 }
 
 export default function LargeProfileImage({
@@ -32,7 +36,7 @@ export default function LargeProfileImage({
       ) : (
         <span
           className={styles.largeProfileImageArea}
-          style={{ backgroundColor: color }}
+          style={{ '--local-avatar-color': color } as CssWithAvatarColor}
         >
           {initials ? (
             initials

--- a/packages/frontend/src/components/LargeProfileImage/styles.module.scss
+++ b/packages/frontend/src/components/LargeProfileImage/styles.module.scss
@@ -18,7 +18,7 @@ $imageSize: 100px;
   ) {
     // make avatars look slightly 3D
     background: linear-gradient(
-      45deg,
+      var(--avatarGradientAngle),
       var(--local-avatar-color),
       color-mix(
         in srgb,

--- a/packages/frontend/src/components/LargeProfileImage/styles.module.scss
+++ b/packages/frontend/src/components/LargeProfileImage/styles.module.scss
@@ -9,7 +9,24 @@ $imageSize: 100px;
 
 .largeProfileImageArea {
   align-items: center;
-  background-color: #bcbac9;
+  --local-avatar-color: #bcbac9;
+  background-color: var(--local-avatar-color);
+  @supports (
+    // text-wrap was introduced in 2023 slightly after color-mix,
+    // since we can't test for color-mix support directly we use this instead.
+    text-wrap: wrap
+  ) {
+    // make avatars look slightly 3D
+    background: linear-gradient(
+      45deg,
+      var(--local-avatar-color),
+      color-mix(
+        in srgb,
+        var(--local-avatar-color) var(--avatarGradientMixFactor),
+        white
+      )
+    );
+  }
   border-radius: 100%;
   color: white;
   display: flex;

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1,4 +1,5 @@
 import React, {
+  CSSProperties,
   useCallback,
   useContext,
   useEffect,
@@ -60,6 +61,10 @@ import type { JumpToMessage } from '../../hooks/chat/useMessage'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 import { useRovingTabindex } from '../../contexts/RovingTabindex'
 
+interface CssWithAvatarColor extends CSSProperties {
+  '--local-avatar-color': string
+}
+
 const Avatar = ({
   contact,
   onContactClick,
@@ -91,7 +96,10 @@ const Avatar = ({
         onClick={onClick}
         tabIndex={tabIndex}
       >
-        <div style={{ backgroundColor: color }} className='label'>
+        <div
+          style={{ '--local-avatar-color': color } as CssWithAvatarColor}
+          className='label'
+        >
           {initial}
         </div>
       </button>

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -170,7 +170,7 @@ $hover-contrast-change: 2%;
   --galleryBg: #{$bgPrimary};
   --avatarLabelColor: #ffffff; // Manual value: This will not get generated in the future
   --avatarGradientMixFactor: 80%;
-  --avatarGradientAngle: 45deg;
+  --avatarGradientAngle: -45deg;
   --brokenMediaText: #070c14;
   --brokenMediaBg: #ffffff;
   --unreadCountBg: #{$accentColor};

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -169,6 +169,7 @@ $hover-contrast-change: 2%;
   /* Misc */
   --galleryBg: #{$bgPrimary};
   --avatarLabelColor: #ffffff; // Manual value: This will not get generated in the future
+  --avatarGradientMixFactor: 80%;
   --brokenMediaText: #070c14;
   --brokenMediaBg: #ffffff;
   --unreadCountBg: #{$accentColor};

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -170,6 +170,7 @@ $hover-contrast-change: 2%;
   --galleryBg: #{$bgPrimary};
   --avatarLabelColor: #ffffff; // Manual value: This will not get generated in the future
   --avatarGradientMixFactor: 80%;
+  --avatarGradientAngle: 45deg;
   --brokenMediaText: #070c14;
   --brokenMediaBg: #ffffff;
   --unreadCountBg: #{$accentColor};


### PR DESCRIPTION
- **gradient for color avatars**
- **add gradient to largeProfileImageArea and add type for it so ts doesn't complain**
- **add gradient to avatars in message view (author avatars)**

Basically makes the colors a bit less flat or harsh. Gives a slight impression of 3D.
Telegram also does this, though they have a much stronger gradient.

| Before | After |
|----|----|
| <img width="438" alt="Bildschirmfoto 2025-03-29 um 20 44 11" src="https://github.com/user-attachments/assets/550b3a53-9c47-4435-a557-4d505c2d3302" />|<img width="438" alt="Bildschirmfoto 2025-03-29 um 20 44 39" src="https://github.com/user-attachments/assets/bcabaee1-f7d4-4eaa-bca0-b768053c3184" /> | 


Why did I do this? This is inspired by feedback from older people that complained about harsh colors. (they also asked for a different/softer nav bar color, but thats a different topic for a different pr and discussion)

## TODO:

- [x] flip the gradient.