### PR TITLE
fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - fix wrong punycode warnings in links #4864
 - scroll to top when search query changes
 - fix esc key closing wrong dialog in settings #4865
+- fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 
 <a id="1_56_0"></a>
 

--- a/packages/frontend/src/components/Dialog/Dialog.tsx
+++ b/packages/frontend/src/components/Dialog/Dialog.tsx
@@ -73,6 +73,11 @@ const Dialog = React.memo<Props>(
         ev.preventDefault()
       }
     }
+    const onKeyDown = (ev: React.KeyboardEvent) => {
+      if (ev.code === 'Escape') {
+        onCancel(ev)
+      }
+    }
 
     useEffect(() => {
       // calling showModal is "only" the way to have ::backdrop
@@ -93,6 +98,7 @@ const Dialog = React.memo<Props>(
         onClick={onClick}
         onClose={onClose}
         onCancel={onCancel}
+        onKeyDown={onKeyDown}
         ref={dialog}
         data-no-drag-region
         data-tauri-drag-region={


### PR DESCRIPTION
closes #4397
