### PR TITLE
Improve reactions display

### DIFF
--- a/packages/frontend/src/components/Reactions/index.tsx
+++ b/packages/frontend/src/components/Reactions/index.tsx
@@ -33,12 +33,7 @@ export default function Reactions(props: Props) {
   useEffect(() => {
     let emojiSpaces = 0
     if (messageWidth <= 234) {
-      if (reactions.length <= 2) {
-        emojiSpaces = 2
-      } else {
-        // we need space for the bubble showing +n
-        emojiSpaces = 1
-      }
+      emojiSpaces = 1
     } else {
       emojiSpaces = Math.round((messageWidth - 200) / 34)
     }
@@ -49,8 +44,12 @@ export default function Reactions(props: Props) {
     const visibleReactionsCount = reactions
       .slice(0, emojiSpaces)
       .reduce((sum, item) => sum + item.count, 0)
-
-    setHiddenReactionsCount(totalReactionsCount - visibleReactionsCount)
+    if (reactions.length - emojiSpaces <= 1) {
+      emojiSpaces++
+      setHiddenReactionsCount(0)
+    } else {
+      setHiddenReactionsCount(totalReactionsCount - visibleReactionsCount)
+    }
     setVisibleEmojis(emojiSpaces)
   }, [messageWidth, reactions])
 

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -613,7 +613,7 @@ export default function Message(props: {
     return () => {
       window.removeEventListener('resize', resizeHandler)
     }
-  }, [])
+  }, [message.fileMime])
 
   // Info Message
   if (message.isInfo) {

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -25,7 +25,7 @@ import {
   enterEditMessageMode,
 } from './messageFunctions'
 import Attachment from '../attachment/messageAttachment'
-import { isGenericAttachment } from '../attachment/Attachment'
+import { isGenericAttachment, isImage } from '../attachment/Attachment'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { AvatarFromContact } from '../Avatar'
 import { ConversationType } from './MessageList'
@@ -589,9 +589,22 @@ export default function Message(props: {
   useEffect(() => {
     const resizeHandler = () => {
       if (messageContainerRef.current) {
+        let messageWidth = 0
         // set message width which is used by reaction component
         // to adapt the number of visible reactions
-        setMessageWidth(messageContainerRef.current.clientWidth)
+        if (
+          (message.fileMime && isImage(message.fileMime)) ||
+          window.innerWidth < 900
+        ) {
+          // image messages have a defined width
+          messageWidth = messageContainerRef.current.clientWidth
+        } else {
+          // text messages might be smaller than min width but
+          // they can be extended to at least max image width
+          // so we pass that value to the reaction calculation
+          messageWidth = 450
+        }
+        setMessageWidth(messageWidth)
       }
     }
     window.addEventListener('resize', resizeHandler)


### PR DESCRIPTION
follow up:

- allow more visible reactions on non image messages: since text messages can be very small the detected width would only allow 1 visible emoji although the width would grow with more emojis. That is fixed now
- avoid a +1 pill wich takes the same space as one emoji


https://github.com/user-attachments/assets/b0b14490-31d0-402a-9f70-4db959615bf6




#skip-changelog