### PR TITLE
`Cmd + N` shortcut to open new chat on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - create chat: add support for invite links to search bar #4893
 - add separators to the context menu #4883
 - add button to share contact from profile view dialog #4886
+- `Cmd + N` shortcut to open new chat on macOS
 
 ### Changed
 - switch to account the webxdc is from when sending to chat (tauri and electron edition) #4740

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - create chat: add support for invite links to search bar #4893
 - add separators to the context menu #4883
 - add button to share contact from profile view dialog #4886
-- `Cmd + N` shortcut to open new chat on macOS
+- `Cmd + N` shortcut to open new chat on macOS #4901
 
 ### Changed
 - switch to account the webxdc is from when sending to chat (tauri and electron edition) #4740

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -228,7 +228,7 @@ export function getKeybindings(
       },
       {
         title: tx('menu_new_chat'),
-        keyBindings: [['Control', 'N']],
+        keyBindings: [[isMac ? 'Meta' : 'Control', 'N']],
       },
       {
         title: tx('focus_message_input'),

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -102,7 +102,10 @@ export function keyDownEvent2Action(
         return KeybindAction.ChatList_SearchInChat
       }
       return KeybindAction.ChatList_FocusSearchInput
-    } else if (ev.ctrlKey && (ev.key === 'n' || ev.code === 'KeyN')) {
+    } else if (
+      (ev.metaKey || ev.ctrlKey) &&
+      (ev.key === 'n' || ev.code === 'KeyN')
+    ) {
       return KeybindAction.NewChat_Open
     } else if (ev.ctrlKey && (ev.key === 'm' || ev.code === 'KeyM')) {
       return KeybindAction.Composer_Focus


### PR DESCRIPTION
`Ctrl + N` exists already, but `Cmd + N` was missing.