### PR TITLE
tauri: refactor: remove unnecessary `Arc`s

### DIFF
--- a/packages/target-tauri/src-tauri/src/html_window/mod.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/mod.rs
@@ -95,7 +95,7 @@ pub(crate) async fn open_html_window(
                 subject: subject.to_owned(),
                 sender: sender.to_owned(),
                 receive_time: receive_time.to_owned(),
-                html_content: Arc::new(content.to_owned()),
+                html_content: content.to_owned(),
                 network_allow_state: toggle_network_initial_state,
                 blocked_by_proxy,
             },

--- a/packages/target-tauri/src-tauri/src/state/app.rs
+++ b/packages/target-tauri/src-tauri/src/state/app.rs
@@ -1,8 +1,4 @@
-use std::{
-    path::PathBuf,
-    sync::{Arc, Mutex},
-    time::SystemTime,
-};
+use std::{path::PathBuf, sync::Mutex, time::SystemTime};
 
 use anyhow::{bail, Context};
 use log::info;
@@ -20,7 +16,7 @@ pub(crate) struct InnerAppState {
 }
 
 pub(crate) struct AppState {
-    pub(crate) inner: Arc<Mutex<InnerAppState>>,
+    pub(crate) inner: Mutex<InnerAppState>,
     pub(crate) startup_timestamp: SystemTime,
     pub(crate) current_log_file_path: String,
 
@@ -47,7 +43,7 @@ impl AppState {
         let all_languages_for_menu = get_all_languages(app.handle()).await?;
 
         Ok(Self {
-            inner: Arc::new(Mutex::new(InnerAppState::default())),
+            inner: Mutex::new(InnerAppState::default()),
             startup_timestamp,
             current_log_file_path,
             all_languages_for_menu,

--- a/packages/target-tauri/src-tauri/src/state/html_email_instances.rs
+++ b/packages/target-tauri/src-tauri/src/state/html_email_instances.rs
@@ -4,7 +4,7 @@ in essence its the metadata and content,
 so it can be served from the special scheme.
 */
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use log::warn;
 use tokio::sync::RwLock;
@@ -17,18 +17,18 @@ pub(crate) struct InnerHtmlEmailInstanceData {
     pub(crate) sender: String, // this is called "from" in electron edition
     pub(crate) receive_time: String,
     pub(crate) network_allow_state: bool,
-    pub(crate) html_content: Arc<String>,
+    pub(crate) html_content: String,
     pub(crate) blocked_by_proxy: bool,
 }
 
 pub(crate) struct HtmlEmailInstancesState {
-    pub(crate) inner: Arc<RwLock<HashMap<String, InnerHtmlEmailInstanceData>>>,
+    pub(crate) inner: RwLock<HashMap<String, InnerHtmlEmailInstanceData>>,
 }
 
 impl HtmlEmailInstancesState {
     pub(crate) fn new() -> Self {
         HtmlEmailInstancesState {
-            inner: Arc::new(RwLock::new(HashMap::new())),
+            inner: RwLock::new(HashMap::new()),
         }
     }
 

--- a/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
+++ b/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use deltachat_jsonrpc::yerpc;
 use std::str::FromStr;
 use tauri::{ipc::Channel, State, WebviewWindow};
@@ -42,13 +40,13 @@ pub(crate) struct InnerMainWindowChannelsState {
 
 /// Channels to communicate with the front-end's Runtime class (see `runtime.ts`).
 pub(crate) struct MainWindowChannels {
-    inner: Arc<RwLock<Option<InnerMainWindowChannelsState>>>,
+    inner: RwLock<Option<InnerMainWindowChannelsState>>,
 }
 
 impl MainWindowChannels {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(RwLock::new(None)),
+            inner: RwLock::new(None),
         }
     }
 

--- a/packages/target-tauri/src-tauri/src/state/translations.rs
+++ b/packages/target-tauri/src-tauri/src/state/translations.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use log::error;
 
 use tauri::AppHandle;
@@ -16,7 +14,7 @@ pub struct TranslationStateInner {
 }
 
 pub(crate) struct TranslationState {
-    inner: Arc<RwLock<TranslationStateInner>>,
+    inner: RwLock<TranslationStateInner>,
 }
 
 impl TranslationState {
@@ -27,7 +25,7 @@ impl TranslationState {
             .and_then(|s| s.as_str().map(|s| s.to_owned()))
             .unwrap_or("en".to_owned());
         let locale_data = get_locale_data(&locale, app.handle().clone()).await?;
-        let locale_data = Arc::new(RwLock::new(TranslationStateInner { data: locale_data }));
+        let locale_data = RwLock::new(TranslationStateInner { data: locale_data });
 
         Ok(Self { inner: locale_data })
     }

--- a/packages/target-tauri/src-tauri/src/state/webxdc_instances.rs
+++ b/packages/target-tauri/src-tauri/src/state/webxdc_instances.rs
@@ -3,7 +3,7 @@ State that is attached to webxdc windows.
 to give the webxdc schemes and the commands the context
 */
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use deltachat::message::Message;
 use tauri::ipc::Channel;
@@ -24,13 +24,13 @@ pub(crate) struct WebxdcInstance {
 
 pub(crate) struct WebxdcInstancesState {
     // key of hashmap is window label
-    pub(crate) inner: Arc<RwLock<HashMap<String, WebxdcInstance>>>,
+    pub(crate) inner: RwLock<HashMap<String, WebxdcInstance>>,
 }
 
 impl WebxdcInstancesState {
     pub(crate) fn new() -> Self {
         WebxdcInstancesState {
-            inner: Arc::new(RwLock::new(HashMap::new())),
+            inner: RwLock::new(HashMap::new()),
         }
     }
 


### PR DESCRIPTION
Tauri's `State` manages `Arc`s itself,
we don't have to make them explicitly.
See https://tauri.app/develop/state-management/#do-you-need-arc.

#skip-changelog because it's just a refactor

For good measure, I made a build. It works fine.