### PR TITLE
tauri: perf: move "get RPC channel" out of loop

### DIFF
--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -219,6 +219,9 @@ pub fn run() {
                 app,
                 startup_timestamp,
             ))?);
+            app.manage(MainWindowChannels::new());
+            // Note that `DeltaChatAppState::try_new` depends on
+            // `MainWindowChannels` to be managed already.
             app.manage(tauri::async_runtime::block_on(DeltaChatAppState::try_new(
                 app,
             ))?);
@@ -228,7 +231,6 @@ pub fn run() {
                 app,
             ))?);
             app.manage(WebxdcInstancesState::new());
-            app.manage(MainWindowChannels::new());
             app.state::<AppState>()
                 .log_duration_since_startup("base setup done");
 

--- a/packages/target-tauri/src-tauri/src/state/deltachat.rs
+++ b/packages/target-tauri/src-tauri/src/state/deltachat.rs
@@ -37,6 +37,8 @@ impl DeltaChatAppState {
         let handle = app.handle().clone();
 
         let send_task: JoinHandle<anyhow::Result<()>> = tauri::async_runtime::spawn(async move {
+            let state = handle.state::<MainWindowChannels>();
+
             loop {
                 let message = match out_receiver.next().await {
                     None => break,
@@ -44,7 +46,6 @@ impl DeltaChatAppState {
                 };
                 // TODO fail will drop out of loop, do we want that here? or do we just want to log and ignore the error
 
-                let state = handle.state::<MainWindowChannels>();
                 if let Err(err) = state.send_jsonrpc_response(message).await {
                     error!("send_jsonrpc_response failed: {err}");
                 }


### PR DESCRIPTION
This is not expected to have a hige impact
because JSON-RPC messages are not super frequent,
but why not go for it if we can.

#skip-changelog because it's minor.

I have checked that it works.
