### PR TITLE
tauri: perf: `Arc::clone` instead of `window.clone()`

### DIFF
--- a/packages/target-tauri/src-tauri/src/help_window.rs
+++ b/packages/target-tauri/src-tauri/src/help_window.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use log::{error, warn};
 use tauri::{Manager, State, WebviewWindow};
 
@@ -93,11 +95,12 @@ pub(crate) async fn open_help_window(
     {
         let _ = set_float_on_top_based_on_main_window(&help_window);
 
-        let help_window_clone = help_window.clone();
+        let help_window_arc = Arc::new(help_window);
+        let help_window_clone = Arc::clone(&help_window_arc);
         menu_manager
             .register_window(
                 &app,
-                &help_window,
+                &help_window_arc,
                 Box::new(move |app| create_help_menu(app, &help_window_clone)),
             )
             .await

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use std::time::SystemTime;
+use std::{sync::Arc, time::SystemTime};
 
 use anyhow::Context;
 use clipboard::copy_image_to_clipboard;
@@ -283,10 +283,11 @@ pub fn run() {
             #[cfg(desktop)]
             {
                 let menu_manager = app.state::<MenuManager>();
-                let main_window_clone = main_window.clone();
+                let main_window_arc = Arc::new(main_window);
+                let main_window_clone = Arc::clone(&main_window_arc);
                 tauri::async_runtime::block_on(menu_manager.register_window(
                     app.handle(),
-                    &main_window,
+                    &main_window_arc,
                     Box::new(move |app| create_main_menu(app, &main_window_clone)),
                 ))?;
 

--- a/packages/target-tauri/src-tauri/src/state/menu_manager.rs
+++ b/packages/target-tauri/src-tauri/src/state/menu_manager.rs
@@ -50,6 +50,34 @@ impl<R: Runtime> WindowAbstraction<R> for Window<R> {
     }
 }
 
+impl<R: Runtime> WindowAbstraction<R> for Arc<WebviewWindow<R>> {
+    fn label(&self) -> &str {
+        (**self).label()
+    }
+
+    fn set_menu(&self, menu: Menu<R>) -> tauri::Result<Option<Menu<R>>> {
+        (**self).set_menu(menu)
+    }
+
+    fn on_window_event<F: Fn(&WindowEvent) + Send + 'static>(&self, f: F) {
+        (**self).on_window_event(f);
+    }
+}
+
+impl<R: Runtime> WindowAbstraction<R> for Arc<Window<R>> {
+    fn label(&self) -> &str {
+        (**self).label()
+    }
+
+    fn set_menu(&self, menu: Menu<R>) -> tauri::Result<Option<Menu<R>>> {
+        (**self).set_menu(menu)
+    }
+
+    fn on_window_event<F: Fn(&WindowEvent) + Send + 'static>(&self, f: F) {
+        (**self).on_window_event(f);
+    }
+}
+
 #[derive(Clone)]
 pub struct MenuManager {
     #[cfg(desktop)]

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -325,10 +325,9 @@ pub(crate) async fn open_webxdc<'a>(
 
     window_builder = set_data_store(&app, window_builder, account_id, message_id).await?;
 
-    let window = window_builder.build()?;
+    let window = Arc::new(window_builder.build()?);
 
-    let window_arc = Arc::new(window.clone());
-
+    let window_clone = Arc::clone(&window);
     let messge_id_to_leave = webxdc_message.get_id();
     window.on_window_event(move |event| {
         if let WindowEvent::Destroyed = event {
@@ -336,12 +335,12 @@ pub(crate) async fn open_webxdc<'a>(
             warn!("webxdc window destroyed {account_id} {message_id}");
 
             // remove from "running instances"-state
-            let webxdc_instances = window_arc.state::<WebxdcInstancesState>();
+            let webxdc_instances = window_clone.state::<WebxdcInstancesState>();
             block_on(webxdc_instances.remove_by_window_label(&window_id));
 
             // leave realtime channel
             // IDEA: track in WebxdcInstancesState whether webxdc joined and only call this method if it did
-            let dc = window_arc.state::<DeltaChatAppState>();
+            let dc = window_clone.state::<DeltaChatAppState>();
             if let Err(err) = block_on(async move {
                 // workaround for not yet available try_blocks feature
                 // https://doc.rust-lang.org/beta/unstable-book/language-features/try-blocks.html
@@ -391,7 +390,7 @@ pub(crate) async fn open_webxdc<'a>(
 
     #[cfg(desktop)]
     {
-        let window_clone = window.clone();
+        let window_clone = Arc::clone(&window);
         menu_manager
             .register_window(
                 &app,


### PR DESCRIPTION
I did not measure the performance impact,
but it should be a tiny bit better.

#skip-changelog because this is minor.

This is mostly just me practicing / learning Rust, so feel free to close if you don't want to bother.