### PR TITLE
Tauri: Tray Icon and `--minimized` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - `Cmd + N` shortcut to open new chat on macOS #4901
 - tauri: add cli interface: `--help`, `--version`, and developer options (like `--dev-mode`) #4908
 - tauri: add `--watch-translations` cli flag #4925
+- tauri: add tray icon #4922
+- tauri: add `--minimized` flag #4922
 
 
 ### Changed

--- a/packages/frontend/src/components/RuntimeAdapter.tsx
+++ b/packages/frontend/src/components/RuntimeAdapter.tsx
@@ -11,6 +11,7 @@ import useDialog from '../hooks/dialog/useDialog'
 import WebxdcSaveToChatDialog from './dialogs/WebxdcSendToChat'
 import { saveLastChatId } from '../backend/chat'
 import useChat from '../hooks/chat/useChat'
+import SettingsStoreInstance from '../stores/settings'
 
 type Props = {
   accountId?: number
@@ -100,6 +101,18 @@ export default function RuntimeAdapter({
       })
     }
   }, [closeDialog, openDialog, accountId])
+
+  useEffect(() => {
+    runtime.onToggleNotifications = () => {
+      const settings = SettingsStoreInstance.getState()
+      if (settings) {
+        SettingsStoreInstance.effect.setDesktopSetting(
+          'notifications',
+          !settings.desktopSettings.notifications
+        )
+      }
+    }
+  }, [])
 
   return <>{children}</>
 }

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -163,6 +163,7 @@ export interface Runtime {
       ) => void)
     | undefined
   onResumeFromSleep: (() => void) | undefined
+  onToggleNotifications: (() => void) | undefined
 }
 
 export const runtime: Runtime = (window as any).r

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -137,6 +137,7 @@ class BrowserRuntime implements Runtime {
   // not used in browser - other reasons
   onResumeFromSleep: (() => void) | undefined
   onOpenQrUrl: ((url: string) => void) | undefined
+  onToggleNotifications: (() => void) | undefined
 
   // #endregion
 

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -137,6 +137,7 @@ class ElectronRuntime implements Runtime {
   }
   onThemeUpdate: (() => void) | undefined
   onChooseLanguage: ((locale: string) => Promise<void>) | undefined
+  onToggleNotifications: (() => void) | undefined
   emitUIFullyReady(): void {
     ipcBackend.send('frontendReady')
   }

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -211,16 +211,17 @@ class TauriRuntime implements Runtime {
       log_to_console: boolean
       devtools: boolean
       dev_mode: boolean
+      forced_tray_icon: boolean
     }>('get_frontend_run_config')
     const rc_config: RC_Config = {
       'log-debug': config.log_debug,
       'log-to-console': config.log_to_console,
       devmode: config.dev_mode,
+      minimized: config.forced_tray_icon,
 
       theme: undefined,
       'theme-watch': false,
       'translation-watch': false,
-      minimized: false,
 
       // does not exist in delta tauri
       'allow-unsafe-core-replacement': false,

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -502,6 +502,7 @@ class TauriRuntime implements Runtime {
   }
   setBadgeCounter(value: number): void {
     getCurrentWindow().setBadgeCount(value === 0 ? undefined : value)
+    invoke('update_tray_icon_badge', { counter: value })
   }
   showNotification(_data: DcNotification): void {
     throw new Error('Method not implemented.37')

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -55,6 +55,9 @@ type MainWindowEvents =
   | {
       event: 'showKeybindingsDialog'
     }
+  | {
+      event: 'toggleNotifications'
+    }
 
 const events = new Channel<MainWindowEvents>()
 const jsonrpc = new Channel<yerpc.Message>()
@@ -299,6 +302,7 @@ class TauriRuntime implements Runtime {
     this.currentLogFileLocation = await invoke('get_current_logfile')
 
     events.onmessage = event => {
+      // this.log.info({ event })
       if (event.event === 'sendToChat') {
         const { options, account } = event.data
         this.onWebxdcSendToChat?.(
@@ -320,6 +324,8 @@ class TauriRuntime implements Runtime {
         this.onShowDialog?.('settings')
       } else if (event.event === 'showKeybindingsDialog') {
         this.onShowDialog?.('keybindings')
+      } else if (event.event === 'toggleNotifications') {
+        this.onToggleNotifications?.()
       }
     }
   }
@@ -579,6 +585,7 @@ class TauriRuntime implements Runtime {
       ) => void)
     | undefined
   onResumeFromSleep: (() => void) | undefined
+  onToggleNotifications: (() => void) | undefined
 }
 
 ;(window as any).r = new TauriRuntime()

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -303,7 +303,6 @@ class TauriRuntime implements Runtime {
     this.currentLogFileLocation = await invoke('get_current_logfile')
 
     events.onmessage = event => {
-      // this.log.info({ event })
       if (event.event === 'sendToChat') {
         const { options, account } = event.data
         this.onWebxdcSendToChat?.(

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-build = { version = "2", features = ["config-json5"] }
 
 [dependencies]
 # 'unstable' feature, because of multiple webviews in html email window
-tauri = { version = "2", features = ["image-png", "unstable"] }
+tauri = { version = "2", features = ["image-png", "unstable", "tray-icon"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = "1.38.1"

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -19,8 +19,13 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = ["config-json5"] }
 
 [dependencies]
-# 'unstable' feature, because of multiple webviews in html email window
-tauri = { version = "2", features = ["image-png", "unstable", "tray-icon"] }
+tauri = { version = "2", features = [
+    "image-png",
+    "image-ico",
+    # 'unstable' feature, because of multiple webviews in html email window
+    "unstable",
+    "tray-icon",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = "1.38.1"

--- a/packages/target-tauri/src-tauri/build.rs
+++ b/packages/target-tauri/src-tauri/build.rs
@@ -70,6 +70,7 @@ fn main() {
             "get_html_window_info",
             "html_email_open_menu",
             "html_email_set_load_remote_content",
+            "update_tray_icon_badge",
         ]),
     ))
     .expect("failed to run tauri-build");

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -63,4 +63,6 @@ permissions = [
 
     "allow-open-help-window",
     "allow-open-html-window",
+
+    "allow-update-tray-icon-badge",
 ]

--- a/packages/target-tauri/src-tauri/src/cli.rs
+++ b/packages/target-tauri/src-tauri/src/cli.rs
@@ -8,6 +8,15 @@ use crate::run_config::RunConfig;
 #[derive(Parser)]
 #[command(about, long_about = None)]
 pub struct Cli {
+    #[cfg(target_os = "macos")]
+    /// Start deltachat in minimized mode
+    #[arg(short, long)]
+    minimized: bool,
+    #[cfg(not(target_os = "macos"))]
+    /// Start deltachat in minimized mode with tray icon
+    /// (tray icon will be activated for this session regardless whether it's disabled)
+    #[arg(short, long)]
+    minimized: bool,
     /// opens devtools and activates --log-debug & --log-to-console
     #[arg(long)]
     dev_mode: bool,
@@ -60,5 +69,9 @@ Webview: {:?}",
         devtools: cli.dev_mode,
         dev_mode: cli.dev_mode,
         translation_watch: cli.dev_mode || cli.watch_translations,
+        minimized_window: cli.minimized,
+        // Tray icon is not forced on macOS because the app icon is still in the Dock,
+        // even when Delta Chat has no visible window
+        forced_tray_icon: cli.minimized && !cfg!(target_os = "macos"),
     }
 }

--- a/packages/target-tauri/src-tauri/src/html_window/mod.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/mod.rs
@@ -67,6 +67,7 @@ pub(crate) async fn open_html_window(
             // window already exists focus it - android and iOS don't have have the function
             // and those platforms also don't have multiple windows
             window.show()?;
+            window.set_focus()?;
             return Ok(());
         }
     }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -419,8 +419,9 @@ pub fn run() {
         tauri::RunEvent::Reopen { .. } => {
             // handle clicks on dock on macOS (because on macOS main window never really closes)
             let main_window = app_handle.get_webview_window("main").unwrap();
-            main_window.show().unwrap();
-            main_window.set_focus().unwrap();
+            if let Err(err) = main_window.show().and_then(|_| main_window.set_focus()) {
+                log::error!("failed to focus and show main_window {err:?}");
+            }
         }
         tauri::RunEvent::Exit => {
             log::info!("Exiting: starting cleanup...");

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -358,8 +358,6 @@ pub fn run() {
                 }
             }
 
-            init_tray_icon(&app.handle())?;
-
             app.state::<AppState>()
                 .log_duration_since_startup("setup done");
 

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -187,6 +187,9 @@ pub fn run() {
             // not yet available on mobile
             #[cfg(desktop)]
             html_window::commands::html_email_set_load_remote_content,
+            // not available on mobile
+            #[cfg(desktop)]
+            state::tray_manager::update_tray_icon_badge,
         ])
         .register_asynchronous_uri_scheme_protocol(
             "webxdc-icon",

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -418,8 +418,16 @@ pub fn run() {
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
             // handle clicks on dock on macOS (because on macOS main window never really closes)
-            let main_window = app_handle.get_webview_window("main").unwrap();
-            if let Err(err) = main_window.show().and_then(|_| main_window.set_focus()) {
+            if let Err(err) = app_handle
+                .get_webview_window("main")
+                .context("main window not found")
+                .and_then(|main_window| {
+                    main_window
+                        .show()
+                        .and_then(|_| main_window.set_focus())
+                        .context("failed to call show or set_focus")
+                })
+            {
                 log::error!("failed to focus and show main_window {err:?}");
             }
         }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -417,6 +417,7 @@ pub fn run() {
     #[allow(clippy::single_match)]
     app.run(|app_handle, run_event| match run_event {
         // tauri::RunEvent::ExitRequested { code, api, .. } => {}
+        #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
             // handle clicks on dock on macOS (because on macOS main window never really closes)
             app_handle

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -203,6 +203,8 @@ pub fn run() {
         )
         .register_asynchronous_uri_scheme_protocol("webxdc", webxdc::webxdc_scheme::webxdc_protocol)
         .setup(move |app| {
+            app.manage(run_config.clone());
+
             // Create missing directories for iOS (quick fix, better fix this upstream in tauri)
             #[cfg(target_os = "ios")]
             {
@@ -308,8 +310,6 @@ pub fn run() {
                 app.get_webview_window("main").unwrap().open_devtools();
             }
 
-            app.manage(run_config);
-
             let main_window = app.get_webview_window("main").unwrap();
             #[cfg(target_os = "macos")]
             {
@@ -362,6 +362,10 @@ pub fn run() {
 
             app.state::<AppState>()
                 .log_duration_since_startup("setup done");
+
+            if run_config.minimized_window {
+                let _ = main_window.hide();
+            }
 
             Ok(())
         })

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -13,12 +13,13 @@ use settings::{
 use state::{
     app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,
     main_window_channels::MainWindowChannels, menu_manager::MenuManager,
-    translations::TranslationState, webxdc_instances::WebxdcInstancesState,
+    translations::TranslationState, tray_manager::TrayManager,
+    webxdc_instances::WebxdcInstancesState,
 };
-use tauri::Manager;
+use tauri::{async_runtime::block_on, Manager};
 use tauri_plugin_log::{Target, TargetKind};
 
-use tray::{init_tray_icon, is_tray_icon_active};
+use tray::is_tray_icon_active;
 
 mod app_path;
 mod blobs;
@@ -289,10 +290,11 @@ pub fn run() {
                 app,
             ))?);
             app.manage(WebxdcInstancesState::new());
+            app.manage(TrayManager::new());
             app.state::<AppState>()
                 .log_duration_since_startup("base setup done");
 
-            load_and_apply_desktop_settings_on_startup(app.handle())?;
+            block_on(load_and_apply_desktop_settings_on_startup(app.handle()))?;
 
             // we can only do this in debug mode, macOS doesn't not allow this in the appstore, because it uses private apis
             // we should think about wether we want it on other production builds (except store),
@@ -352,7 +354,7 @@ pub fn run() {
                     i18n::watch_translations(app.handle().clone());
                 }
             }
-            
+
             init_tray_icon(&app.handle())?;
 
             app.state::<AppState>()

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -418,11 +418,9 @@ pub fn run() {
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
             // handle clicks on dock on macOS (because on macOS main window never really closes)
-            app_handle
-                .get_webview_window("main")
-                .unwrap()
-                .show()
-                .unwrap();
+            let main_window = app_handle.get_webview_window("main").unwrap();
+            main_window.show().unwrap();
+            main_window.set_focus().unwrap();
         }
         tauri::RunEvent::Exit => {
             log::info!("Exiting: starting cleanup...");

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -26,6 +26,7 @@ pub(crate) enum MainMenuAction {
     Settings,
     Help,
     Quit,
+    CloseWindow,
     FloatOnTop,
     Zoom06,
     Zoom08,
@@ -71,6 +72,9 @@ impl MenuAction<'static> for MainMenuAction {
             }
             MainMenuAction::Quit => {
                 app.exit(0);
+            }
+            MainMenuAction::CloseWindow => {
+                main_window.close()?;
             }
             MainMenuAction::FloatOnTop => {
                 main_window.set_always_on_top(!main_window.is_always_on_top()?)?;
@@ -172,6 +176,13 @@ pub(crate) fn create_main_menu(
         true,
         Some("CmdOrCtrl+Q"),
     )?;
+    let close_window = MenuItem::with_id(
+        app,
+        MainMenuAction::CloseWindow,
+        tx.sync_translate("close_window"),
+        true,
+        Some("CmdOrCtrl+W"),
+    )?;
     let settings = MenuItem::with_id(
         app,
         MainMenuAction::Settings,
@@ -271,11 +282,26 @@ pub(crate) fn create_main_menu(
     Menu::with_items(
         app,
         &[
+            #[cfg(target_os = "macos")]
             &Submenu::with_items(
                 app,
                 tx.sync_translate("global_menu_file_desktop"),
                 true,
                 &[&settings, &quit],
+            )?,
+            &Submenu::with_items(
+                app,
+                tx.sync_translate("global_menu_file_desktop"),
+                true,
+                &[
+                    // macOS has this in the app menu already
+                    #[cfg(not(target_os = "macos"))]
+                    &settings,
+                    &close_window,
+                    // macOS has this in the app menu already
+                    #[cfg(not(target_os = "macos"))]
+                    &quit,
+                ],
             )?,
             &Submenu::with_items(
                 app,

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -4,6 +4,7 @@ use html_window_menu::HtmlWindowMenuAction;
 use main_menu::{MainMenuAction, SET_LOCALE_MENU_ID_PREFIX};
 use menu_action::MenuAction;
 use tauri::{async_runtime::spawn, menu::MenuEvent, AppHandle, Manager};
+use tray_menu::TrayMenuAction;
 use webxdc_menu::WebxdcMenuAction;
 
 use crate::MainWindowChannels;
@@ -13,6 +14,7 @@ pub(crate) mod help_menu;
 pub(crate) mod html_window_menu;
 pub(crate) mod main_menu;
 mod menu_action;
+pub(crate) mod tray_menu;
 pub(crate) mod webxdc_menu;
 
 pub async fn handle_event(app: &AppHandle, event: MenuEvent) -> anyhow::Result<()> {
@@ -39,6 +41,8 @@ pub async fn handle_event(app: &AppHandle, event: MenuEvent) -> anyhow::Result<(
     } else if let Ok(action) = HtmlWindowMenuAction::try_from(event.id()) {
         action.execute(app).await?;
     } else if let Ok(action) = WebxdcMenuAction::try_from(event.id()) {
+        action.execute(app).await?;
+    } else if let Ok(action) = TrayMenuAction::try_from(event.id()) {
         action.execute(app).await?;
     }
 

--- a/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
@@ -1,11 +1,17 @@
 use anyhow::Context;
 use strum::{AsRefStr, EnumString};
 use tauri::{
-    menu::{Menu, MenuItem},
+    menu::{CheckMenuItem, Menu, MenuItem},
     AppHandle, Manager, Wry,
 };
+use tauri_plugin_store::StoreExt;
 
-use crate::TranslationState;
+use crate::{
+    get_setting_bool_or,
+    settings::{NOTIFICATIONS, NOTIFICATIONS_DEFAULT},
+    state::main_window_channels::MainWindowEvents,
+    MainWindowChannels, TranslationState, TrayManager, CONFIG_FILE,
+};
 
 use super::menu_action::{impl_menu_conversion, MenuAction};
 
@@ -13,6 +19,7 @@ use super::menu_action::{impl_menu_conversion, MenuAction};
 pub(crate) enum TrayMenuAction {
     Quit,
     Show,
+    MuteNotifications,
 }
 impl_menu_conversion!(TrayMenuAction);
 
@@ -25,6 +32,14 @@ impl MenuAction<'static> for TrayMenuAction {
                 app.exit(0);
             }
             TrayMenuAction::Show => main_window.show()?,
+            TrayMenuAction::MuteNotifications => {
+                // set check to real state in case it didn't change
+                app.state::<TrayManager>().update_menu(app).await?;
+                // tell frontend to change it
+                app.state::<MainWindowChannels>()
+                    .emit_event(MainWindowEvents::ToggleNotifications)
+                    .await?
+            }
         }
         Ok(())
     }
@@ -32,6 +47,11 @@ impl MenuAction<'static> for TrayMenuAction {
 
 pub(crate) fn create_tray_menu(app: &AppHandle) -> anyhow::Result<Menu<Wry>> {
     let tx = app.state::<TranslationState>();
+    let notifications_enabled = get_setting_bool_or(
+        app.store(CONFIG_FILE)?.get(NOTIFICATIONS),
+        NOTIFICATIONS_DEFAULT,
+    );
+
     let quit = MenuItem::with_id(
         app,
         TrayMenuAction::Quit,
@@ -46,5 +66,14 @@ pub(crate) fn create_tray_menu(app: &AppHandle) -> anyhow::Result<Menu<Wry>> {
         true,
         None::<&str>,
     )?;
-    Ok(Menu::with_items(app, &[&show, &quit])?)
+
+    let mute_notifications = CheckMenuItem::with_id(
+        app,
+        TrayMenuAction::MuteNotifications,
+        tx.sync_translate("menu_mute"),
+        true,
+        !notifications_enabled,
+        None::<&str>,
+    )?;
+    Ok(Menu::with_items(app, &[&show, &mute_notifications, &quit])?)
 }

--- a/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
@@ -13,7 +13,6 @@ use super::menu_action::{impl_menu_conversion, MenuAction};
 pub(crate) enum TrayMenuAction {
     Quit,
     Show,
-    Hide,
 }
 impl_menu_conversion!(TrayMenuAction);
 
@@ -26,7 +25,6 @@ impl MenuAction<'static> for TrayMenuAction {
                 app.exit(0);
             }
             TrayMenuAction::Show => main_window.show()?,
-            TrayMenuAction::Hide => main_window.hide()?,
         }
         Ok(())
     }
@@ -34,8 +32,6 @@ impl MenuAction<'static> for TrayMenuAction {
 
 pub(crate) fn create_tray_menu(app: &AppHandle) -> anyhow::Result<Menu<Wry>> {
     let tx = app.state::<TranslationState>();
-    let main_window = app.get_window("main").context("main window not found")?;
-    let main_window_visible = main_window.is_visible()?;
     let quit = MenuItem::with_id(
         app,
         TrayMenuAction::Quit,
@@ -50,15 +46,5 @@ pub(crate) fn create_tray_menu(app: &AppHandle) -> anyhow::Result<Menu<Wry>> {
         true,
         None::<&str>,
     )?;
-    let hide = MenuItem::with_id(
-        app,
-        TrayMenuAction::Hide,
-        tx.sync_translate("hide"),
-        true,
-        None::<&str>,
-    )?;
-    Ok(Menu::with_items(
-        app,
-        &[if main_window_visible { &hide } else { &show }, &quit],
-    )?)
+    Ok(Menu::with_items(app, &[&show, &quit])?)
 }

--- a/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
@@ -1,0 +1,64 @@
+use anyhow::Context;
+use strum::{AsRefStr, EnumString};
+use tauri::{
+    menu::{Menu, MenuItem},
+    AppHandle, Manager, Wry,
+};
+
+use crate::TranslationState;
+
+use super::menu_action::{impl_menu_conversion, MenuAction};
+
+#[derive(Debug, AsRefStr, EnumString)]
+pub(crate) enum TrayMenuAction {
+    Quit,
+    Show,
+    Hide,
+}
+impl_menu_conversion!(TrayMenuAction);
+
+impl MenuAction<'static> for TrayMenuAction {
+    async fn execute(self, app: &AppHandle) -> anyhow::Result<()> {
+        let main_window = app.get_window("main").context("main window not found")?;
+
+        match self {
+            TrayMenuAction::Quit => {
+                app.exit(0);
+            }
+            TrayMenuAction::Show => main_window.show()?,
+            TrayMenuAction::Hide => main_window.hide()?,
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn create_tray_menu(app: &AppHandle) -> anyhow::Result<Menu<Wry>> {
+    let tx = app.state::<TranslationState>();
+    let main_window = app.get_window("main").context("main window not found")?;
+    let main_window_visible = main_window.is_visible()?;
+    let quit = MenuItem::with_id(
+        app,
+        TrayMenuAction::Quit,
+        tx.sync_translate("global_menu_file_quit_desktop"),
+        true,
+        None::<&str>,
+    )?;
+    let show = MenuItem::with_id(
+        app,
+        TrayMenuAction::Show,
+        tx.sync_translate("show_window"),
+        true,
+        None::<&str>,
+    )?;
+    let hide = MenuItem::with_id(
+        app,
+        TrayMenuAction::Hide,
+        tx.sync_translate("hide"),
+        true,
+        None::<&str>,
+    )?;
+    Ok(Menu::with_items(
+        app,
+        &[if main_window_visible { &hide } else { &show }, &quit],
+    )?)
+}

--- a/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
@@ -34,7 +34,7 @@ impl MenuAction<'static> for TrayMenuAction {
             TrayMenuAction::Show => {
                 main_window.show()?;
                 main_window.set_focus()?;
-            },
+            }
             TrayMenuAction::MuteNotifications => {
                 // set checkmark to real state in case it didn't change
                 app.state::<TrayManager>().update_menu(app).await?;

--- a/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/tray_menu.rs
@@ -31,9 +31,12 @@ impl MenuAction<'static> for TrayMenuAction {
             TrayMenuAction::Quit => {
                 app.exit(0);
             }
-            TrayMenuAction::Show => main_window.show()?,
+            TrayMenuAction::Show => {
+                main_window.show()?;
+                main_window.set_focus()?;
+            },
             TrayMenuAction::MuteNotifications => {
-                // set check to real state in case it didn't change
+                // set checkmark to real state in case it didn't change
                 app.state::<TrayManager>().update_menu(app).await?;
                 // tell frontend to change it
                 app.state::<MainWindowChannels>()

--- a/packages/target-tauri/src-tauri/src/menus/webxdc_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/webxdc_menu.rs
@@ -235,7 +235,7 @@ pub(crate) fn create_webxdc_window_menu(
                     &MenuItem::with_id(
                         app,
                         action(WebxdcMenuActionVariant::CloseWindow),
-                        "Close HTML Email",
+                        tx.sync_translate("close_window"),
                         true,
                         Some("CmdOrCtrl+W"),
                     )?,

--- a/packages/target-tauri/src-tauri/src/run_config.rs
+++ b/packages/target-tauri/src-tauri/src/run_config.rs
@@ -12,6 +12,10 @@ pub struct RunConfig {
     pub dev_mode: bool,
     /// watch locales dir and reload on changes
     pub translation_watch: bool,
+    /// Start deltachat in minimized mode without visible window
+    pub minimized_window: bool,
+    /// Force tray icon active, because started in minimized mode without visible window
+    pub forced_tray_icon: bool,
 }
 
 // Information about cli args that are also relevant for frontend

--- a/packages/target-tauri/src-tauri/src/settings.rs
+++ b/packages/target-tauri/src-tauri/src/settings.rs
@@ -19,6 +19,8 @@ pub(crate) const HTML_EMAIL_WARNING_DEFAULT: bool = true;
 pub(crate) const HTML_EMAIL_ALWAYS_ALLOW_REMOTE_CONTENT_KEY: &str =
     "HTMLEmailAlwaysLoadRemoteContent";
 pub(crate) const HTML_EMAIL_ALWAYS_ALLOW_REMOTE_CONTENT_DEFAULT: bool = false;
+pub(crate) const MINIMIZE_TO_TRAY: &str = "minimizeToTray";
+pub(crate) const MINIMIZE_TO_TRAY_DEFAULT: bool = true;
 
 // runtime calls this when desktop settings change
 #[tauri::command]

--- a/packages/target-tauri/src-tauri/src/settings.rs
+++ b/packages/target-tauri/src-tauri/src/settings.rs
@@ -21,6 +21,8 @@ pub(crate) const HTML_EMAIL_ALWAYS_ALLOW_REMOTE_CONTENT_KEY: &str =
 pub(crate) const HTML_EMAIL_ALWAYS_ALLOW_REMOTE_CONTENT_DEFAULT: bool = false;
 pub(crate) const MINIMIZE_TO_TRAY: &str = "minimizeToTray";
 pub(crate) const MINIMIZE_TO_TRAY_DEFAULT: bool = true;
+pub(crate) const NOTIFICATIONS: &str = "notifications";
+pub(crate) const NOTIFICATIONS_DEFAULT: bool = true;
 
 // runtime calls this when desktop settings change
 #[tauri::command]
@@ -37,6 +39,8 @@ pub async fn change_desktop_settings_apply_side_effects(
                 .apply_wanted_active_state(&app)
                 .await
         }
+        // update "mute notification" menu item with new state
+        NOTIFICATIONS => app.state::<TrayManager>().update_menu(&app).await,
         _ => Ok(()),
     }
     .map_err(|err| format!("{err:#}"))

--- a/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
+++ b/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
@@ -31,6 +31,7 @@ pub enum MainWindowEvents {
     ShowAboutDialog,
     ShowSettingsDialog,
     ShowKeybindingsDialog,
+    ToggleNotifications,
 }
 
 pub(crate) struct InnerMainWindowChannelsState {

--- a/packages/target-tauri/src-tauri/src/state/menu_manager.rs
+++ b/packages/target-tauri/src-tauri/src/state/menu_manager.rs
@@ -9,6 +9,8 @@ use tokio::sync::RwLock;
 #[cfg(desktop)]
 use tauri::menu::Menu;
 
+use crate::TrayManager;
+
 #[cfg(desktop)]
 type GenerateMenuFn = Box<dyn Fn(&AppHandle) -> anyhow::Result<Menu<Wry>> + Send + Sync>;
 
@@ -154,6 +156,9 @@ impl MenuManager {
         spawn(async move {
             if let Err(err) = cloned_self.inner_update_all(&app).await {
                 error!("error while updating all menus: {err:?}");
+            }
+            if let Err(err) = app.state::<TrayManager>().update_menu(&app).await {
+                error!("error while updating tray menu: {err:?}");
             }
         });
     }

--- a/packages/target-tauri/src-tauri/src/state/mod.rs
+++ b/packages/target-tauri/src-tauri/src/state/mod.rs
@@ -4,4 +4,6 @@ pub(crate) mod html_email_instances;
 pub(crate) mod main_window_channels;
 pub(crate) mod menu_manager;
 pub(crate) mod translations;
+#[cfg(desktop)]
+pub(crate) mod tray_manager;
 pub(crate) mod webxdc_instances;

--- a/packages/target-tauri/src-tauri/src/state/tray_manager.rs
+++ b/packages/target-tauri/src-tauri/src/state/tray_manager.rs
@@ -86,13 +86,18 @@ impl TrayManager {
             return Ok(());
         }
 
+        #[cfg(target_os = "windows")]
+        let ending = "ico";
+        #[cfg(not(target_os = "windows"))]
+        let ending = "png";
+
         let lock = self.tray.read().await;
         if let Some(tray) = lock.as_ref() {
-            let asset = match counter {
-                0 => "images/tray/deltachat.png",
-                _ => "images/tray/deltachat-unread.png",
-            }
-            .to_string();
+            let image_name = match counter {
+                0 => "deltachat",
+                _ => "deltachat-unread",
+            };
+            let asset = format!("images/tray/{image_name}.{ending}");
 
             if let Some(icon) = app.asset_resolver().get(asset.clone()) {
                 tray.set_icon(Some(Image::from_bytes(&icon.bytes)?))?;

--- a/packages/target-tauri/src-tauri/src/state/tray_manager.rs
+++ b/packages/target-tauri/src-tauri/src/state/tray_manager.rs
@@ -1,7 +1,7 @@
+use deltachat::config::Config;
+use tauri::AppHandle;
 use tauri::{image::Image, tray::TrayIcon, Manager, State};
 use tokio::sync::RwLock;
-
-use tauri::AppHandle;
 
 use crate::{
     menus::tray_menu::create_tray_menu,
@@ -63,7 +63,7 @@ impl TrayManager {
             let mut counter = 0;
             for account_id in accounts.get_all() {
                 if let Some(account) = accounts.get_account(account_id) {
-                    if let Ok(mute_state) = account.get_ui_config("ui.is_muted").await {
+                    if let Ok(mute_state) = account.get_config(Config::IsMuted).await {
                         if mute_state != Some("1".to_owned()) {
                             // account not muted
                             counter += account.get_fresh_msgs().await?.len();

--- a/packages/target-tauri/src-tauri/src/state/tray_manager.rs
+++ b/packages/target-tauri/src-tauri/src/state/tray_manager.rs
@@ -1,0 +1,57 @@
+use tauri::tray::TrayIcon;
+use tokio::sync::RwLock;
+
+use anyhow::{Context, Ok};
+use tauri::AppHandle;
+
+use crate::{
+    menus::tray_menu::create_tray_menu,
+    tray::{build_tray_icon, is_tray_icon_active},
+};
+
+pub(crate) struct TrayManager {
+    pub(crate) tray: RwLock<Option<TrayIcon>>,
+}
+
+impl TrayManager {
+    pub fn new() -> Self {
+        Self {
+            tray: RwLock::new(None),
+        }
+    }
+
+    /// apply whether to show or hide the tray icon
+    pub async fn apply_wanted_active_state(&self, app: &AppHandle) -> anyhow::Result<()> {
+        let wanted_state = is_tray_icon_active(app)?;
+        let currently_active = { self.tray.read().await.is_some() };
+
+        if currently_active != wanted_state {
+            if wanted_state {
+                let tray = build_tray_icon(app)?;
+                let previous = self.tray.write().await.replace(tray);
+                assert!(previous.is_none())
+            } else {
+                let previous = self.tray.write().await.take();
+                if let Some(tray) = previous {
+                    tray.set_visible(false)?;
+                    let tray_option = app.remove_tray_by_id(tray.id());
+                    drop(tray_option);
+                } else {
+                    unreachable!()
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(crate) async fn update_menu(&self, app: &AppHandle) -> anyhow::Result<()> {
+        let lock = self.tray.read().await;
+        if let Some(tray) = lock.as_ref() {
+            let new_menu = create_tray_menu(app)?;
+            tray.set_menu(Some(new_menu))?;
+        }
+
+        Ok(())
+    }
+}

--- a/packages/target-tauri/src-tauri/src/tray.rs
+++ b/packages/target-tauri/src-tauri/src/tray.rs
@@ -6,19 +6,20 @@ use tauri::{
 use tauri_plugin_store::StoreExt;
 
 use crate::{
-    get_setting_bool_or, menus::tray_menu::create_tray_menu, CONFIG_FILE, MINIMIZE_TO_TRAY,
-    MINIMIZE_TO_TRAY_DEFAULT,
+    get_setting_bool_or, menus::tray_menu::create_tray_menu, run_config::RunConfig, CONFIG_FILE,
+    MINIMIZE_TO_TRAY, MINIMIZE_TO_TRAY_DEFAULT,
 };
 
 pub fn is_tray_icon_active(app: &AppHandle) -> anyhow::Result<bool> {
-    // TODO test for --minimized flag or --autostart flag
+    let rc = app.state::<RunConfig>();
     let minimize_to_tray = get_setting_bool_or(
         app.get_store(CONFIG_FILE)
             .context("failed to load config")?
             .get(MINIMIZE_TO_TRAY),
         MINIMIZE_TO_TRAY_DEFAULT,
     );
-    Ok(minimize_to_tray)
+
+    Ok(rc.forced_tray_icon || minimize_to_tray)
 }
 
 pub(crate) fn build_tray_icon(app: &AppHandle) -> anyhow::Result<TrayIcon> {

--- a/packages/target-tauri/src-tauri/src/tray.rs
+++ b/packages/target-tauri/src-tauri/src/tray.rs
@@ -28,6 +28,21 @@ pub(crate) fn build_tray_icon(app: &AppHandle) -> anyhow::Result<TrayIcon> {
         .menu(&menu)
         .icon(app.default_window_icon().unwrap().clone());
 
+    // // special style icon for macOS
+    // // (TODO, for now we use the tauri icon until dc tauri is really the default release?)
+    // #[cfg(target_os = "macos")]
+    // if let Some(icon) = app
+    //     .asset_resolver()
+    //     .get("images/tray/tray-icon-mac@2x.png".to_string())
+    // {
+    //     // TODO fix image scale
+    //     tray_builder = tray_builder
+    //         .icon(Image::from_bytes(&icon.bytes)?)
+    //         .icon_as_template(true);
+    // } else {
+    //     log::error!("tray icon asset not found!")
+    // }
+
     if !cfg!(target_os = "macos") {
         // outside of mac open app when clicking on tray icon
         tray_builder = tray_builder
@@ -51,5 +66,3 @@ pub(crate) fn build_tray_icon(app: &AppHandle) -> anyhow::Result<TrayIcon> {
 
     Ok(tray)
 }
-
-// TODO tray icon state.

--- a/packages/target-tauri/src-tauri/src/tray.rs
+++ b/packages/target-tauri/src-tauri/src/tray.rs
@@ -58,6 +58,9 @@ pub(crate) fn build_tray_icon(app: &AppHandle) -> anyhow::Result<TrayIcon> {
                         if let Err(err) = main_window.show() {
                             log::error!("failed to restore window after click on tray icon: {err}")
                         }
+                        if let Err(err) = main_window.set_focus() {
+                            log::error!("failed to focus window after click on tray icon: {err}")
+                        }
                     }
                 }
             });

--- a/packages/target-tauri/src-tauri/src/tray.rs
+++ b/packages/target-tauri/src-tauri/src/tray.rs
@@ -1,0 +1,65 @@
+use anyhow::Context;
+use tauri::{
+    tray::{MouseButton, TrayIcon, TrayIconBuilder},
+    AppHandle, Manager,
+};
+use tauri_plugin_store::StoreExt;
+
+use crate::{
+    get_setting_bool_or, menus::tray_menu::create_tray_menu, CONFIG_FILE, MINIMIZE_TO_TRAY,
+    MINIMIZE_TO_TRAY_DEFAULT,
+};
+
+pub fn is_tray_icon_active(app: &AppHandle) -> anyhow::Result<bool> {
+    // TODO test for --minimized flag or --autostart flag
+    let minimize_to_tray = get_setting_bool_or(
+        app.get_store(CONFIG_FILE)
+            .context("failed to load config")?
+            .get(MINIMIZE_TO_TRAY),
+        MINIMIZE_TO_TRAY_DEFAULT,
+    );
+    Ok(minimize_to_tray)
+}
+
+pub fn init_tray_icon(app: &AppHandle) -> anyhow::Result<()> {
+    if is_tray_icon_active(app)? {
+        let tray = build_tray_icon(app)?;
+
+        // TODO tray.set_icon(icon) - to update for badge on non macOS
+        // todo register it that we can later unregister it
+    }
+    Ok(())
+}
+
+fn build_tray_icon(app: &AppHandle) -> anyhow::Result<TrayIcon> {
+    let menu = create_tray_menu(app)?;
+
+    let mut tray_builder = TrayIconBuilder::new()
+        .menu(&menu)
+        .icon(app.default_window_icon().unwrap().clone());
+
+    if !cfg!(target_os = "macos") {
+        // outside of mac open app when clicking on tray icon
+        tray_builder = tray_builder
+            .show_menu_on_left_click(false)
+            .on_tray_icon_event(|tray, event| {
+                if let tauri::tray::TrayIconEvent::Click {
+                    button: MouseButton::Left,
+                    ..
+                } = event
+                {
+                    if let Some(main_window) = tray.app_handle().get_window("main") {
+                        if let Err(err) = main_window.show() {
+                            log::error!("failed to restore window after click on tray icon: {err}")
+                        }
+                    }
+                }
+            });
+    }
+
+    let tray = tray_builder.build(app)?;
+
+    Ok(tray)
+}
+
+// TODO tray icon state.

--- a/packages/target-tauri/src-tauri/src/tray.rs
+++ b/packages/target-tauri/src-tauri/src/tray.rs
@@ -21,17 +21,7 @@ pub fn is_tray_icon_active(app: &AppHandle) -> anyhow::Result<bool> {
     Ok(minimize_to_tray)
 }
 
-pub fn init_tray_icon(app: &AppHandle) -> anyhow::Result<()> {
-    if is_tray_icon_active(app)? {
-        let tray = build_tray_icon(app)?;
-
-        // TODO tray.set_icon(icon) - to update for badge on non macOS
-        // todo register it that we can later unregister it
-    }
-    Ok(())
-}
-
-fn build_tray_icon(app: &AppHandle) -> anyhow::Result<TrayIcon> {
+pub(crate) fn build_tray_icon(app: &AppHandle) -> anyhow::Result<TrayIcon> {
     let menu = create_tray_menu(app)?;
 
     let mut tray_builder = TrayIconBuilder::new()

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -238,6 +238,7 @@ pub(crate) async fn open_webxdc<'a>(
                 // window already exists focus it - android and iOS don't have have the function
                 // and those platforms also don't have multiple windows
                 window.show()?;
+                window.set_focus()?;
 
                 if !href.is_empty() {
                     window


### PR DESCRIPTION
- macOS keep in dock when closing
- translate `close_window` on webxdc window menu
- main window menu: app menu for macOS and add close window option to main window menu
- show/hide tray icon based on setting and update menu when language changes
- remove hide action from tray icon menu.
- tray icon: add option to mute notifications (bonus feature)
- implement tray icon badge
- add `--minimized` cli flag

<img width="159" alt="Bildschirmfoto 2025-04-03 um 20 56 03" src="https://github.com/user-attachments/assets/67de9d7b-8c2a-4f53-bd80-2f2127a04d93" />
