### PR TITLE
fix typo in CONFIG_MUTED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - slight gradients for avatars for a more modern look #4877
 - change usage of `nameAndAddr` to `displayName` #4882
 - remove addresses from contact list items unless they are not verified. #4880
-- migrate account mute state to new is_muted config option #4888
+- migrate account mute state to new is_muted config option #4888 #4924
 - technical: change script format and imports to esm/module #4871
 - Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.158.0`
   - Simplify e2ee decision logic, remove majority vote

--- a/packages/frontend/src/stores/accountNotifications.ts
+++ b/packages/frontend/src/stores/accountNotifications.ts
@@ -6,11 +6,11 @@ import { onReady } from '../onready'
 import { Store, useStore } from './store'
 
 /**
- * core ui config key to mute an account on desktop.
+ * core config key to mute an account on desktop.
  *
  * `"1"` means muted, anything else is interpreted as not muted
  */
-const UI_CONFIG_MUTED = 'ui.is_muted'
+const CONFIG_MUTED = 'is_muted'
 const UI_CONFIG_DESKTOP_MUTED_OLD = 'ui.desktop.muted'
 
 interface AccountNotificationState {
@@ -43,19 +43,18 @@ class AccountNotificationStore extends Store<AccountNotificationStoreState> {
         accounts.map(async accountId => {
           const config_old = await BackendRemote.rpc.batchGetConfig(accountId, [
             UI_CONFIG_DESKTOP_MUTED_OLD,
-            UI_CONFIG_MUTED,
+            CONFIG_MUTED,
           ])
           if (config_old[UI_CONFIG_DESKTOP_MUTED_OLD]) {
             await BackendRemote.rpc.batchSetConfig(accountId, {
               [UI_CONFIG_DESKTOP_MUTED_OLD]: null,
-              [UI_CONFIG_MUTED]: config_old[UI_CONFIG_DESKTOP_MUTED_OLD],
+              [CONFIG_MUTED]: config_old[UI_CONFIG_DESKTOP_MUTED_OLD],
             })
-            config_old[UI_CONFIG_MUTED] =
-              config_old[UI_CONFIG_DESKTOP_MUTED_OLD]
+            config_old[CONFIG_MUTED] = config_old[UI_CONFIG_DESKTOP_MUTED_OLD]
           }
           return {
             id: accountId,
-            muted: config_old[UI_CONFIG_MUTED] === '1',
+            muted: config_old[CONFIG_MUTED] === '1',
           }
         })
       )
@@ -70,7 +69,7 @@ class AccountNotificationStore extends Store<AccountNotificationStoreState> {
     setMuted: async (accountId: number, mute: boolean) => {
       await BackendRemote.rpc.setConfig(
         accountId,
-        UI_CONFIG_MUTED,
+        CONFIG_MUTED,
         mute ? '1' : '0'
       )
       this.effect.loadSettings()

--- a/packages/frontend/src/stores/accountNotifications.ts
+++ b/packages/frontend/src/stores/accountNotifications.ts
@@ -10,7 +10,7 @@ import { Store, useStore } from './store'
  *
  * `"1"` means muted, anything else is interpreted as not muted
  */
-const UI_CONFIG_MUTED = 'ui.id_muted'
+const UI_CONFIG_MUTED = 'ui.is_muted'
 const UI_CONFIG_DESKTOP_MUTED_OLD = 'ui.desktop.muted'
 
 interface AccountNotificationState {


### PR DESCRIPTION
I did not add extra migrations, because the change wasn't released yet.