### PR TITLE
tauri: add `--watch-translations` cli flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - tauri: experimental: make it compile for android #4871
 - `Cmd + N` shortcut to open new chat on macOS #4901
 - tauri: add cli interface: `--help`, `--version`, and developer options (like `--dev-mode`) #4908
+- tauri: add `--watch-translations` cli flag #4925
 
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,6 +1817,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
+ "notify",
  "once_cell",
  "percent-encoding",
  "png",
@@ -2657,6 +2658,15 @@ dependencies = [
 name = "format-flowed"
 version = "1.0.0"
 source = "git+https://github.com/chatmail/core?tag=v1.158.0#3efd94914c2b94b502889eaae46eb323edb02777"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -3870,6 +3880,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4359,6 +4389,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,6 +4742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -5034,6 +5085,31 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "notify"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
+dependencies = [
+ "bitflags 2.9.0",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -312,7 +312,7 @@ class TauriRuntime implements Runtime {
           account || undefined
         )
       } else if (event.event === 'localeReloaded') {
-        // event.data is only null in case of reloading via --transation-watch
+        // event.data is only null in case of reloading via --watch-translations
         this.onChooseLanguage?.(event.data || window.localeData.locale)
       } else if (event.event === 'showAboutDialog') {
         this.onShowDialog?.('about')

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -44,7 +44,7 @@ type MainWindowEvents =
     }
   | {
       event: 'localeReloaded'
-      data: string
+      data: string | null
     }
   | {
       event: 'showAboutDialog'
@@ -312,7 +312,8 @@ class TauriRuntime implements Runtime {
           account || undefined
         )
       } else if (event.event === 'localeReloaded') {
-        this.onChooseLanguage?.(event.data)
+        // event.data is only null in case of reloading via --transation-watch
+        this.onChooseLanguage?.(event.data || window.localeData.locale)
       } else if (event.event === 'showAboutDialog') {
         this.onShowDialog?.('about')
       } else if (event.event === 'showSettingsDialog') {

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ mime_guess = "2.0.5"
 once_cell = "1.21.1"
 clap = { version = "4.5.35", features = ["derive"] }
 chrono = { version = "0.4.40", default-features = false }
+notify = "8.0.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 include_dir = "0.7.4"

--- a/packages/target-tauri/src-tauri/src/cli.rs
+++ b/packages/target-tauri/src-tauri/src/cli.rs
@@ -20,7 +20,7 @@ pub struct Cli {
     /// enable auto-reload for translations.
     /// You can use it in combination with the env var `DELTACHAT_LOCALE_DIR`.
     #[arg(long)]
-    translation_watch: bool,
+    watch_translations: bool,
     /// Print version
     #[arg(short = 'V', long)]
     version: bool,
@@ -59,6 +59,6 @@ Webview: {:?}",
         log_to_console: cli.dev_mode || cli.log_to_console,
         devtools: cli.dev_mode,
         dev_mode: cli.dev_mode,
-        translation_watch: cli.dev_mode || cli.translation_watch,
+        translation_watch: cli.dev_mode || cli.watch_translations,
     }
 }

--- a/packages/target-tauri/src-tauri/src/cli.rs
+++ b/packages/target-tauri/src-tauri/src/cli.rs
@@ -17,6 +17,10 @@ pub struct Cli {
     /// Output the log to stdout / Browser dev console
     #[arg(long)]
     log_to_console: bool,
+    /// enable auto-reload for translations.
+    /// You can use it in combination with the env var `DELTACHAT_LOCALE_DIR`.
+    #[arg(long)]
+    translation_watch: bool,
     /// Print version
     #[arg(short = 'V', long)]
     version: bool,
@@ -55,5 +59,6 @@ Webview: {:?}",
         log_to_console: cli.dev_mode || cli.log_to_console,
         devtools: cli.dev_mode,
         dev_mode: cli.dev_mode,
+        translation_watch: cli.dev_mode || cli.translation_watch,
     }
 }

--- a/packages/target-tauri/src-tauri/src/i18n/load.rs
+++ b/packages/target-tauri/src-tauri/src/i18n/load.rs
@@ -31,8 +31,9 @@ pub(super) async fn get_locales_dir_from_resource_dir(
     }
 
     let places = vec![
-        resource_dir.join("_locales"),      // TODO - test on windows and linux
-        PathBuf::from("../../../_locales"), // development
+        #[cfg(debug_assertions)]
+        PathBuf::from("../../_locales"), // development
+        resource_dir.join("_locales"),
     ];
 
     if let Some(place) = places

--- a/packages/target-tauri/src-tauri/src/i18n/load.rs
+++ b/packages/target-tauri/src-tauri/src/i18n/load.rs
@@ -32,7 +32,9 @@ pub(super) async fn get_locales_dir_from_resource_dir(
 
     let places = vec![
         #[cfg(debug_assertions)]
-        PathBuf::from("../../_locales"), // development
+        PathBuf::from("../../../_locales"), // development (pnpm tauri dev)
+        #[cfg(debug_assertions)]
+        PathBuf::from("../../_locales"), // development (cargo run)
         resource_dir.join("_locales"),
     ];
 

--- a/packages/target-tauri/src-tauri/src/i18n/mod.rs
+++ b/packages/target-tauri/src-tauri/src/i18n/mod.rs
@@ -68,3 +68,41 @@ pub async fn get_all_languages(app: &AppHandle) -> Result<Vec<(String, String)>,
     vec.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     Ok(vec)
 }
+
+#[cfg(desktop)]
+pub fn watch_translations(app: AppHandle) {
+    use std::time::Duration;
+    use tauri::Manager;
+
+    use crate::{
+        state::main_window_channels::MainWindowEvents, util::fs_watcher::async_watch_debounced,
+        MainWindowChannels,
+    };
+
+    let app_clone = app.clone();
+    let callback = Box::new(move || {
+        let app_clone = app_clone.clone(); // Shadows arc
+        async move {
+            if let Err(err) = app_clone
+                .state::<MainWindowChannels>()
+                .emit_event(MainWindowEvents::LocaleReloaded(None))
+                .await
+            {
+                log::error!("watch_translations: failed notify frontend: {err}:?");
+            }
+        }
+    });
+
+    tauri::async_runtime::spawn(async move {
+        if let Ok(watch_dir) = get_locales_dir(&app).await {
+            log::info!("watch_translations: watching for changes in {watch_dir:?}");
+            if let Err(err) =
+                async_watch_debounced(watch_dir, callback, Duration::from_millis(400)).await
+            {
+                log::error!("watch_translations: failed to watch locales dir: {err:?}");
+            }
+        } else {
+            log::error!("watch_translations: failed to get locales dir");
+        }
+    });
+}

--- a/packages/target-tauri/src-tauri/src/i18n/mod.rs
+++ b/packages/target-tauri/src-tauri/src/i18n/mod.rs
@@ -81,7 +81,7 @@ pub fn watch_translations(app: AppHandle) {
 
     let app_clone = app.clone();
     let callback = Box::new(move || {
-        let app_clone = app_clone.clone(); // Shadows arc
+        let app_clone = app_clone.clone();
         async move {
             if let Err(err) = app_clone
                 .state::<MainWindowChannels>()

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -321,6 +321,13 @@ pub fn run() {
 
             runtime_capabilities::add_runtime_capabilies(app.handle())?;
 
+            #[cfg(desktop)]
+            {
+                if run_config.translation_watch {
+                    i18n::watch_translations(app.handle().clone());
+                }
+            }
+
             app.state::<AppState>()
                 .log_duration_since_startup("setup done");
 

--- a/packages/target-tauri/src-tauri/src/menus/mod.rs
+++ b/packages/target-tauri/src-tauri/src/menus/mod.rs
@@ -31,7 +31,9 @@ pub async fn handle_event(app: &AppHandle, event: MenuEvent) -> anyhow::Result<(
             .context("no language found in id")?;
 
         mwc.emit_event(
-            crate::state::main_window_channels::MainWindowEvents::LocaleReloaded(id.to_owned()),
+            crate::state::main_window_channels::MainWindowEvents::LocaleReloaded(Some(
+                id.to_owned(),
+            )),
         )
         .await?;
     } else if let Ok(action) = HtmlWindowMenuAction::try_from(event.id()) {

--- a/packages/target-tauri/src-tauri/src/run_config.rs
+++ b/packages/target-tauri/src-tauri/src/run_config.rs
@@ -10,6 +10,8 @@ pub struct RunConfig {
     pub devtools: bool,
     /// enables additional developer apis
     pub dev_mode: bool,
+    /// watch locales dir and reload on changes
+    pub translation_watch: bool,
 }
 
 // Information about cli args that are also relevant for frontend

--- a/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
+++ b/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
@@ -27,7 +27,7 @@ pub enum MainWindowEvents {
         options: SendToChatOptions,
         account: Option<u32>,
     },
-    LocaleReloaded(String),
+    LocaleReloaded(Option<String>),
     ShowAboutDialog,
     ShowSettingsDialog,
     ShowKeybindingsDialog,

--- a/packages/target-tauri/src-tauri/src/util/fs_watcher.rs
+++ b/packages/target-tauri/src-tauri/src/util/fs_watcher.rs
@@ -1,0 +1,66 @@
+use std::{
+    future::Future,
+    path::Path,
+    time::{Duration, SystemTime},
+};
+
+use notify::{Config, Event, RecommendedWatcher, RecursiveMode, Watcher};
+use tauri::async_runtime::{block_on, channel, Receiver};
+
+fn async_watcher() -> notify::Result<(RecommendedWatcher, Receiver<notify::Result<Event>>)> {
+    let (tx, rx) = channel(1);
+
+    let watcher = RecommendedWatcher::new(
+        move |res| {
+            block_on(async {
+                tx.send(res).await.unwrap();
+            })
+        },
+        Config::default(),
+    )?;
+
+    Ok((watcher, rx))
+}
+
+pub async fn async_watch_debounced<P, F>(
+    path: P,
+    callback: Box<dyn Fn() -> F + Sync + Send>,
+    delay: Duration,
+) -> notify::Result<()>
+where
+    P: AsRef<Path>,
+    F: Future<Output = ()>,
+{
+    let (mut watcher, mut rx) = async_watcher()?;
+
+    // Add a path to be watched. All files and directories at that path and
+    // below will be monitored for changes.
+    watcher.watch(path.as_ref(), RecursiveMode::Recursive)?;
+
+    let mut last_action = SystemTime::now();
+
+    while let Some(res) = rx.recv().await {
+        match res {
+            Ok(event) => {
+                log::trace!("changed: {:?}", event);
+                if event.kind.is_create() || event.kind.is_modify() || event.kind.is_remove() {
+                    let now = SystemTime::now();
+                    if let Ok(elapsed) = now.duration_since(last_action) {
+                        if elapsed < delay {
+                            continue;
+                        }
+                        log::trace!("callback triggered");
+                        callback().await;
+                        last_action = now;
+                    } else {
+                        log::error!("debounce: system time error: duration_since");
+                        return Ok(());
+                    }
+                }
+            }
+            Err(e) => log::error!("watch error: {:?}", e),
+        }
+    }
+
+    Ok(())
+}

--- a/packages/target-tauri/src-tauri/src/util/mod.rs
+++ b/packages/target-tauri/src-tauri/src/util/mod.rs
@@ -2,4 +2,7 @@ pub mod csp;
 pub mod sanitization;
 mod truncate_text;
 
+#[cfg(desktop)]
+pub(crate) mod fs_watcher;
+
 pub(crate) use truncate_text::truncate_text;


### PR DESCRIPTION
- **tauri: add `--translation-watch` also load from the right folder during development**
- **rename option to --watch-translations**

enabled by default in development. So that you can edit translations and they are automatically reloaded like in the electron edition.
I renamed the option, because I thought the old name was confusing:

<img width="472" alt="Bildschirmfoto 2025-04-04 um 01 56 22" src="https://github.com/user-attachments/assets/d9ebfe76-bf1e-40e8-8d39-a6de9a0c0ab6" />

---

> [!TIP]
>
>  Idea: Together with the env var `DELTACHAT_LOCALE_DIR` you could make a visual editor for translations that could be used by translators without a dev setup, possibly even with direct integration into transifex (or weblate or whatever we eill be using then). 
