### PR TITLE
tauri: resume from sleep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - tauri: experimental: make it compile for android #4871
 - `Cmd + N` shortcut to open new chat on macOS #4901
 - tauri: add cli interface: `--help`, `--version`, and developer options (like `--dev-mode`) #4908
-- tauri: resume from sleep #4926
+- tauri: handle resume from sleep #4926
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - tauri: experimental: make it compile for android #4871
 - `Cmd + N` shortcut to open new chat on macOS #4901
 - tauri: add cli interface: `--help`, `--version`, and developer options (like `--dev-mode`) #4908
+- tauri: resume from sleep #4926
 
 
 ### Changed

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -55,6 +55,9 @@ type MainWindowEvents =
   | {
       event: 'showKeybindingsDialog'
     }
+  | {
+      event: 'resumeFromSleep'
+    }
 
 const events = new Channel<MainWindowEvents>()
 const jsonrpc = new Channel<yerpc.Message>()
@@ -319,6 +322,8 @@ class TauriRuntime implements Runtime {
         this.onShowDialog?.('settings')
       } else if (event.event === 'showKeybindingsDialog') {
         this.onShowDialog?.('keybindings')
+      } else if (event.event === 'resumeFromSleep') {
+        this.onResumeFromSleep?.()
       }
     }
   }

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ use clipboard::copy_image_to_clipboard;
 #[cfg(desktop)]
 use menus::{handle_menu_event, main_menu::create_main_menu};
 
+use resume_from_sleep::start_resume_after_sleep_detector;
 use settings::load_and_apply_desktop_settings_on_startup;
 use state::{
     app::AppState, deltachat::DeltaChatAppState, html_email_instances::HtmlEmailInstancesState,
@@ -27,6 +28,7 @@ mod i18n;
 // menus are not available on mobile
 #[cfg(desktop)]
 mod menus;
+mod resume_from_sleep;
 mod run_config;
 mod runtime_capabilities;
 mod runtime_info;
@@ -320,6 +322,8 @@ pub fn run() {
             }
 
             runtime_capabilities::add_runtime_capabilies(app.handle())?;
+
+            start_resume_after_sleep_detector(app.handle());
 
             app.state::<AppState>()
                 .log_duration_since_startup("setup done");

--- a/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
+++ b/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
@@ -27,11 +27,11 @@ pub(crate) fn start_resume_after_sleep_detector(app: &AppHandle) {
         loop {
             sleep(PROBE_INTERVAL).await;
             let now = SystemTime::now();
-            log::debug!(
-                "{:?}",
-                now.duration_since(last_time)
-                    .unwrap_or(Duration::from_secs(1))
-            );
+            // log::debug!(
+            //     "{:?}",
+            //     now.duration_since(last_time)
+            //         .unwrap_or(Duration::from_secs(1))
+            // );
             if now
                 .duration_since(last_time)
                 .unwrap_or(Duration::from_secs(1))

--- a/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
+++ b/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
@@ -1,12 +1,12 @@
-// Detector to find out whether computer resumed from sleep
-//
-// Why?
-// internet connection and imap connection gets broken by sleep
-// and needs to be reconnected
-//
-// How?
-// While we could have looked into talking with system apis (like https://github.com/pewsheen/psp),
-// For now we choose a much simpler solution: check for jumps in system time
+//! Detector to find out whether computer resumed from sleep
+//!
+//! Why?
+//! internet connection and imap connection gets broken by sleep
+//! and needs to be reconnected
+//!
+//! How?
+//! While we could have looked into talking with system apis (like https://github.com/pewsheen/psp),
+//! For now we choose a much simpler solution: check for jumps in system time
 
 use std::time::{Duration, SystemTime};
 
@@ -43,10 +43,10 @@ pub(crate) fn start_resume_after_sleep_detector(app: &AppHandle) {
                     .emit_event(MainWindowEvents::ResumeFromSleep)
                     .await
                 {
-                    log::error!("failed to call inform frontend about resume from sleep: {err:?}");
+                    log::error!("failed to inform frontend about resume from sleep: {err:?}");
                 }
             }
-            last_time = now;
+            last_time = SystemTime::now();
         }
     });
 }

--- a/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
+++ b/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
@@ -1,0 +1,52 @@
+// Detector to find out whether computer resumed from sleep
+//
+// Why?
+// internet connection and imap connection gets broken by sleep
+// and needs to be reconnected
+//
+// How?
+// While we could have looked into talking with system apis (like https://github.com/pewsheen/psp),
+// For now we choose a much simpler solution: check for jumps in system time
+
+use std::time::{Duration, SystemTime};
+
+use tauri::{async_runtime::spawn, AppHandle, Manager};
+use tokio::time::sleep;
+
+use crate::{state::main_window_channels::MainWindowEvents, MainWindowChannels};
+
+const PROBE_INTERVAL: Duration = Duration::from_secs(60);
+// smallest sleep duration we can detect with this
+const JUMP_DETECTION_THRESHOLD: Duration = Duration::from_secs(3);
+
+pub(crate) fn start_resume_after_sleep_detector(app: &AppHandle) {
+    let cloned_app = app.clone();
+    let _ = spawn(async move {
+        let threshold = PROBE_INTERVAL + JUMP_DETECTION_THRESHOLD;
+        let mut last_time = SystemTime::now();
+        loop {
+            sleep(PROBE_INTERVAL).await;
+            let now = SystemTime::now();
+            log::debug!(
+                "{:?}",
+                now.duration_since(last_time)
+                    .unwrap_or(Duration::from_secs(1))
+            );
+            if now
+                .duration_since(last_time)
+                .unwrap_or(Duration::from_secs(1))
+                > threshold
+            {
+                log::info!("Potential resume after sleep detected");
+                if let Err(err) = cloned_app
+                    .state::<MainWindowChannels>()
+                    .emit_event(MainWindowEvents::ResumeFromSleep)
+                    .await
+                {
+                    log::error!("failed to call inform frontend about resume from sleep: {err:?}");
+                }
+            }
+            last_time = now;
+        }
+    });
+}

--- a/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
+++ b/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
@@ -21,7 +21,7 @@ const JUMP_DETECTION_THRESHOLD: Duration = Duration::from_secs(3);
 
 pub(crate) fn start_resume_after_sleep_detector(app: &AppHandle) {
     let cloned_app = app.clone();
-    let _ = spawn(async move {
+    spawn(async move {
         let threshold = PROBE_INTERVAL + JUMP_DETECTION_THRESHOLD;
         let mut last_time = SystemTime::now();
         loop {

--- a/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
+++ b/packages/target-tauri/src-tauri/src/resume_from_sleep.rs
@@ -23,6 +23,8 @@ pub(crate) fn start_resume_after_sleep_detector(app: &AppHandle) {
     let cloned_app = app.clone();
     spawn(async move {
         let threshold = PROBE_INTERVAL + JUMP_DETECTION_THRESHOLD;
+        // Using `SystemTime` instead of `Instant` because instant pauses on sleep in my tests,
+        // it is also documented in `Instant` that it doesn't measure time linearly.
         let mut last_time = SystemTime::now();
         loop {
             sleep(PROBE_INTERVAL).await;

--- a/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
+++ b/packages/target-tauri/src-tauri/src/state/main_window_channels.rs
@@ -31,6 +31,7 @@ pub enum MainWindowEvents {
     ShowAboutDialog,
     ShowSettingsDialog,
     ShowKeybindingsDialog,
+    ResumeFromSleep,
 }
 
 pub(crate) struct InnerMainWindowChannelsState {


### PR DESCRIPTION
choose elapsed time method over native apis, because native apis are too much work for now, and not clear whether it would be worth the extra complexity. (a tiny amount of less cpu usage for a ton of more complexity to maintain)