### PR TITLE
tauri: hardening: invalid proxy for network isolation

### DIFF
--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -20,6 +20,8 @@ tauri-build = { version = "2", features = ["config-json5"] }
 
 [dependencies]
 tauri = { version = "2", features = [
+    # for `proxy_url()` for webxdc.
+    "macos-proxy",
     "image-png",
     "image-ico",
     # 'unstable' feature, because of multiple webviews in html email window

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -34,6 +34,7 @@ mod i18n;
 // menus are not available on mobile
 #[cfg(desktop)]
 mod menus;
+mod network_isolation_dummy_proxy;
 mod resume_from_sleep;
 mod run_config;
 mod runtime_capabilities;

--- a/packages/target-tauri/src-tauri/src/network_isolation_dummy_proxy.rs
+++ b/packages/target-tauri/src-tauri/src/network_isolation_dummy_proxy.rs
@@ -1,0 +1,93 @@
+/*!
+A dummy TCP listener that does nothing except occupy a port.
+
+This TCP listener is to be used as a proxy for certain windows of our app,
+such as webxdc windows and HTML email viewer windows,
+where we need to ensure network isolation.
+Setting an invalid proxy should make the browser unable to perform requests,
+at least to some degree.
+
+Providing just any address (e.g. `127.0.0.1:123`)
+where we don't expect a valid proxy is not good,
+because
+1. Theoretically there could actually be a proxy listening there.
+2. If something is listening on that port, even if that is not a valid proxy,
+   we still don't want to direct any traffic there.
+   This could be classified as the "confused deputy" problem
+   ([CWE-441: Unintended Proxy or Intermediary ('Confused Deputy')](https://cwe.mitre.org/data/definitions/441.html)).
+
+So we need to occupy the port.
+*/
+
+use std::{
+    net::{SocketAddr, SocketAddrV4, TcpListener},
+    str::FromStr,
+};
+
+use anyhow::{anyhow, Context};
+use log::{error, info};
+use once_cell::sync::Lazy;
+use url::Url;
+
+/// The URL is in the form of `socks5://127.0.0.1:54321`,
+/// where only port is variable.
+pub static DUMMY_LOCALHOST_PROXY_URL: Lazy<Result<Url, ()>> = Lazy::new(|| {
+    DUMMY_LOCALHOST_PROXY_AND_URL
+        .as_ref()
+        .map(|(_listener, url)| url.clone())
+        .map_err(|err| *err)
+});
+
+// Do _not_ try to simplify this to only store `Url` and not `TcpListener`,
+// because dropping `TcpListener` will automatically cause it
+// to stop listening.
+//
+// TODO but is it fine not to close the listener on program exit?
+static DUMMY_LOCALHOST_PROXY_AND_URL: Lazy<Result<(TcpListener, Url), ()>> = Lazy::new(|| {
+    listen()
+        .context("failed to make dummy blackhole proxy listener")
+        // It's a pain to try to clone Error for users of `DUMMY_PROXY_URL`,
+        // so let's just print and return `Err(())`.
+        .inspect_err(|err| error!("{err}"))
+        .map_err(|_err| ())
+});
+
+fn listen() -> anyhow::Result<(TcpListener, Url)> {
+    // Regarding SOCKS5 and UDP: apparently we don't need to also listen on UDP,
+    // because SOCKS5 clients are not supposed to be sending UDP
+    // prior to establishing the SOCKS5 connection over TCP.
+    // This is implied by the following in
+    // [the RFC](https://www.rfc-editor.org/rfc/rfc1928#section-6):
+    // > A UDP association terminates when the TCP connection that the UDP
+    // > ASSOCIATE request arrived on terminates.
+
+    // TODO do we need to handle forced close of the listener?
+    // When can it happen?
+    // We'd need to close existing windows that use the proxy,
+    // and stop creating new windows. Or just terminate the entire app.
+
+    // We're using `:0` port instead of a fixed one because binding would fail
+    // if something else is already listening on that fixed port.
+    let listener = TcpListener::bind("127.0.0.1:0").context("failed to bind TCP listener")?;
+
+    let listen_addr: SocketAddrV4 =
+        match listener.local_addr().context("failed to get local_addr")? {
+            SocketAddr::V4(addr) => addr,
+            _ => {
+                // This shouldn't happen.
+                return Err(anyhow!("expected a SocketAddrV4"));
+            }
+        };
+
+    info!("Dummy blackhole proxy listening on {listen_addr}");
+
+    Ok((
+        listener,
+        Url::from_str(&format!(
+            "socks5://{}:{}",
+            listen_addr.ip(),
+            listen_addr.port()
+        ))
+        .context("failed to convert addr to Url")?,
+    ))
+}

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -455,11 +455,6 @@ fn get_chromium_hardening_browser_args() -> String {
     // > and all requests would necessarily fail
     // > with PROXY_CONNECTION_FAILED.
     //
-    // TODO it's not clear, however, why the WebView doesn't try
-    // to connect to the proxy even when `host-rules` and
-    // `host-resolver-rules` are omitted.
-    // Maybe it has to do with Tauri intercepting requests?
-    //
     // Docs on command line args:
     // - https://peter.sh/experiments/chromium-command-line-switches/
     // - https://learn.microsoft.com/en-us/microsoft-edge/webview2/concepts/webview-features-flags#available-webview2-browser-flags
@@ -472,7 +467,7 @@ fn get_chromium_hardening_browser_args() -> String {
         // Use a non-private address and a reserved port, juuust in case
         // the browser actually tries to connect to the proxy.
         // https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.txt
-        "--proxy-url=\"socks5://example.com:1024\"",
+        "--proxy-server=\"socks5://example.com:1024\"",
     ]
     .join(" ")
 }

--- a/packages/target-tauri/src-tauri/src/webxdc/error.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/error.rs
@@ -20,6 +20,8 @@ pub(crate) enum Error {
     WebxdcInstanceNotFoundByLabel(String),
     #[error("anyhow {0:?}")]
     Anyhow(anyhow::Error),
+    #[error("failed to make a dummy blackhole proxy, webxdc network isolation might not work")]
+    BlackholeProxyUnavailable,
     #[error("channel not initialized yet")]
     ChannelNotInitializedYet,
     #[error("instance exists, but window missing")]


### PR DESCRIPTION
Making a browser use a proxy is arguably the most powerful way
(out of all feasible ways) to disable internet access
for webxdc apps.
Let's use it!

I have verified that on Windows (Chromium) the proxy still
doesn't receive any packets (because of `host-rules`).
I also tried disabling `host-rules`, in which case the packets
to the dummy proxy do get sent, but I was unable to produce
any kind of other network activity, not DNS prefetch, not WebRTC,
even if I removed the webxdc CSP.

This also fixes the wrong argument name on Windows,
`--proxy-url` -> `--proxy-server`.

#skip-changelog because Tauri webxdc has not been released yet.

TODO
- [x] test on macOS.
- [x] test on Linux.

Things to test:
- [ ] that we keep listening on this port until the app is closed (netstat) 
- [ ] Remove CSP and Check, if the webxdc test app causes any network activity, with Wireshark.