### PR TITLE
tauri: hardening: check webview label in custom protos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - profile view redesign #4897
 
 ### Fixed
-- tauri: improve security #4826
+- tauri: improve security #4826, #4936
 - improve fatal error dialog readability by removing color from deltachat-rpc-server errors
 - prevent dragging around of webxdc icon #4740
 - tauri: clear temp folder on exit #4839

--- a/packages/target-tauri/src-tauri/src/blobs.rs
+++ b/packages/target-tauri/src-tauri/src/blobs.rs
@@ -28,13 +28,7 @@ pub(crate) fn delta_blobs_protocol<R: tauri::Runtime>(
             .clone()
     };
 
-    if ctx.webview_label().ends_with("-mail") {
-        error!(
-            "prevented html email from accessing dcblob:// scheme (webview label: {})",
-            ctx.webview_label()
-        );
-        return;
-    } else if ctx.webview_label() != "main" {
+    if ctx.webview_label() != "main" {
         error!(
             "prevented other window from accessing dcblob:// scheme (webview label: {})",
             ctx.webview_label()

--- a/packages/target-tauri/src-tauri/src/html_window/email_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/email_scheme.rs
@@ -34,6 +34,15 @@ pub(crate) fn email_protocol<R: tauri::Runtime>(
     // URI format is email://<anything>
     // (file path doesn't matter, because the html content is always returned)
 
+    let webview_label = ctx.webview_label();
+    if !webview_label.starts_with("html-window:") || !webview_label.ends_with("-mail") {
+        error!(
+            "prevented other window from accessing email:// scheme (webview label: {})",
+            webview_label
+        );
+        return;
+    }
+
     let webview_label = ctx.webview_label().to_owned().replace("-mail", "");
     let app_handle = ctx.app_handle().clone();
 

--- a/packages/target-tauri/src-tauri/src/stickers.rs
+++ b/packages/target-tauri/src-tauri/src/stickers.rs
@@ -17,6 +17,14 @@ pub(crate) fn delta_stickers_protocol<R: tauri::Runtime>(
     // - Mac, linux, iOS: dcsticker://<account folder name>/<sticker pack>/<sticker filename>
     // - windows, android: http://dcsticker.localhost/<account folder name>/<sticker pack>/<sticker filename>
 
+    if ctx.webview_label() != "main" {
+        error!(
+            "prevented other window from accessing dcsticker:// scheme (webview label: {})",
+            ctx.webview_label()
+        );
+        return;
+    }
+
     let app_state_deltachat = {
         ctx.app_handle()
             .state::<DeltaChatAppState>()

--- a/packages/target-tauri/src-tauri/src/webxdc/icon_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/icon_scheme.rs
@@ -12,6 +12,14 @@ pub(crate) fn webxdc_icon_protocol<R: tauri::Runtime>(
 ) {
     // info!("webxdc-icon {}", request.uri());
 
+    if ctx.webview_label() != "main" {
+        error!(
+            "prevented other window from accessing webxdc-icon:// scheme (webview label: {})",
+            ctx.webview_label()
+        );
+        return;
+    }
+
     let app_state_deltachat = {
         ctx.app_handle()
             .state::<DeltaChatAppState>()

--- a/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
@@ -99,6 +99,14 @@ pub(crate) fn webxdc_protocol<R: tauri::Runtime>(
     // windows/android:   webxdc://webxdc.localhost/<path>
 
     let webview_label = ctx.webview_label().to_owned();
+    if !webview_label.starts_with("webxdc:") {
+        error!(
+            "prevented other window from accessing webxdc:// scheme (webview label: {})",
+            webview_label
+        );
+        return;
+    }
+
     let app_handle = ctx.app_handle().clone();
 
     tauri::async_runtime::spawn(async move {


### PR DESCRIPTION
There is not a known explot that this fixes, but let's do it to be extra safe.