### PR TITLE
tauri: fix: sticker picker previews not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - accessibility: don't announce "padlock" on messages
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895
+- tauri: fix: sticker picker previews not working
 
 <a id="1_56_0"></a>
 

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -29,7 +29,7 @@
         "script-src": "'self' 'wasm-unsafe-eval'",
         "worker-src": "blob:",
         "child-src": "blob:",
-        "img-src": "'self' data: blob: dcblob: webxdc-icon:",
+        "img-src": "'self' data: blob: dcblob: webxdc-icon: dcsticker:",
         "media-src": "'self' dcblob:"
       }
       // TODO postponed to later


### PR DESCRIPTION
Apparently this is only visible in non-dev mode.