### PR TITLE
tauri: fix: emoji picker styles not working (CSP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895
 - tauri: fix: sticker picker previews not working
+- tauri: fix emoji picker being super ugly
 
 <a id="1_56_0"></a>
 

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -24,7 +24,15 @@
       "csp": {
         "default-src": "none",
         "connect-src": "'self' ipc:",
-        "style-src": "'self' 'unsafe-inline'",
+        // The sha256 value is for `emoji-mart`. We can't use 'unsafe-inline',
+        // because Tauri injects nonce values,
+        // (see https://tauri.app/security/csp/), and the browser complains:
+        // > Note that 'unsafe-inline' is ignored if either a hash
+        // > or nonce value is present in the source list.
+        //
+        // TODO if you look in dev tools console, we have more warnings
+        // about CSP. Figure out what these are.
+        "style-src": "'self' 'sha256-+A14ONesVdzkn6nr37Osn+rUqNz4oFGZFDbLXrlae04='",
         "font-src": "'self'",
         "script-src": "'self' 'wasm-unsafe-eval'",
         "worker-src": "blob:",


### PR DESCRIPTION
I have verified that this works, at least on Windows.