### PR TITLE
tauri: fix: deny navigation to https://webxdc.localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - profile view redesign #4897
 
 ### Fixed
-- tauri: improve security #4826, #4936, #4937
+- tauri: improve security #4826, #4936, #4937, #4944
 - improve fatal error dialog readability by removing color from deltachat-rpc-server errors
 - prevent dragging around of webxdc icon #4740
 - tauri: clear temp folder on exit #4839

--- a/packages/target-tauri/src-tauri/src/html_window/mod.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/mod.rs
@@ -58,6 +58,8 @@ pub(crate) async fn open_html_window(
     receive_time: &str,
     content: &str,
 ) -> Result<(), Error> {
+    use crate::util::url_origin::UrlOriginExtension;
+
     let window_id = format!("html-window:{account_id}-{message_id}");
     trace!("open_html_window: {window_id}");
 
@@ -137,8 +139,6 @@ pub(crate) async fn open_html_window(
             Url::from_str("http://email.localhost/index.html").unwrap()
         }
     };
-    let initial_url_scheme = initial_url.scheme().to_owned();
-    let initial_url_host = initial_url.host_str().map(|o| o.to_owned());
 
     let mut mail_view_builder = tauri::webview::WebviewBuilder::new(
         format!("{window_id}-mail"),
@@ -159,9 +159,11 @@ pub(crate) async fn open_html_window(
         // We only really care about  navigating to `initial_url`:
         // the HTML message viewer is not supposed to be multipage,
         // so it's OK to handle such weird links as external, below.
-        let will_be_intercepted = url.scheme() == initial_url_scheme
-            && url.host_str().map(|o| o.to_owned()) == initial_url_host
-            && url.port() == initial_url.port();
+        //
+        // `initial_url.origin()` won't work, because it returns
+        // an opaque origin for `webxdc:` protocol,
+        // and no two opaque origins are equal.
+        let will_be_intercepted = url.origin_no_opaque() == initial_url.origin_no_opaque();
         if will_be_intercepted {
             return true;
         }

--- a/packages/target-tauri/src-tauri/src/util/mod.rs
+++ b/packages/target-tauri/src-tauri/src/util/mod.rs
@@ -4,5 +4,6 @@ mod truncate_text;
 
 #[cfg(desktop)]
 pub(crate) mod fs_watcher;
+pub mod url_origin;
 
 pub(crate) use truncate_text::truncate_text;

--- a/packages/target-tauri/src-tauri/src/util/url_origin.rs
+++ b/packages/target-tauri/src-tauri/src/util/url_origin.rs
@@ -1,0 +1,33 @@
+pub trait UrlOriginExtension {
+    fn origin_no_opaque(&self) -> (&str, Option<url::Host<&str>>, Option<u16>);
+}
+
+impl UrlOriginExtension for url::Url {
+    /// Similar to [`url::Url::origin`], but returns a non-opaque origin
+    /// even for custom protocols, such as `webxdc:`.
+    ///
+    /// Note that this function is also slightly different from
+    /// [`url::Url::origin`] in other ways, such as the fact that it utilizes
+    /// [`Url::port`] instead of [`Url::port_or_known_default`],
+    /// which is probably divergent from the spec,
+    /// but should me more conservative when in comes to comparing two origins.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let url_1 = Url::from_str("webxdc://dummy.host/index.html");
+    ///
+    /// let url_2 = Url::from_str("webxdc://dummy.host/other.html");
+    /// assert_eq!(url_1.origin_no_opaque(), url_2.origin_no_opaque());
+    ///
+    /// let url_3 = Url::from_str("dcblob://dummy.host/index.html");
+    /// assert_ne!(url_1.origin_no_opaque(), url_3.origin_no_opaque());
+    /// let url_4 = Url::from_str("webxdc://other-dummy.host/index.html");
+    /// assert_ne!(url_1.origin_no_opaque(), url_4.origin_no_opaque());
+    /// let url_5 = Url::from_str("https://example.com/index.html");
+    /// assert_ne!(url_1.origin_no_opaque(), url_5.origin_no_opaque());
+    /// ```
+    fn origin_no_opaque(&self) -> (&str, Option<url::Host<&str>>, Option<u16>) {
+        (self.scheme(), self.host(), self.port())
+    }
+}


### PR DESCRIPTION
The `on_navigation` didn't fully check the URL origin
on Windows and Android, so a webxdc app could navigate
to `https://webxdc.localhost`, which could potentially
produce network traffic on `localhost:443`.

Fortunately, thanks to the presence of `host-rules`
and `proxy_url`, this wouldn't happen
even if navigation were to take place,
but let's still properly deny it.

This also refactors the HTML email viewer `on_navigation` check.