### PR TITLE
tauri: fix: `main_window.show()` on second instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - fix order when sending multiple files at once #4895
 - tauri: fix: sticker picker previews not working
 - tauri: fix emoji picker being super ugly
+- tauri: fix launching a second instance of Delta Chat not focusing the main window if it's closed
 
 <a id="1_56_0"></a>
 

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -119,11 +119,19 @@ pub fn run() {
                     .build(),
             )
             .plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+                log::info!("second instance launched, focusing the original instance instead");
                 // TODO: handle open url case
-                let _ = app
-                    .get_webview_window("main")
-                    .expect("no main window")
-                    .set_focus();
+                let window = app.get_webview_window("main").expect("no main window");
+                window
+                    .show()
+                    .context("failed to show window after second instance launch attempt")
+                    .inspect_err(|err| log::error!("{err}"))
+                    .ok();
+                window
+                    .set_focus()
+                    .context("failed to focus window after second instance launch attempt")
+                    .inspect_err(|err| log::error!("{err}"))
+                    .ok();
             }));
     }
 


### PR DESCRIPTION
If the window is closed and not just minimized,
launching a second instance would do nothing.
