### PR TITLE
remove now superfluous broadcast-not-encrypted hint

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -1,8 +1,4 @@
 {
-  "broadcast_list_warning": {
-    "comment": "this won't be translated, as our goal is to have encrypted broadcast lists - simon & bjoern as of oct 2023",
-    "message": "Broadcast Lists are always unencrypted because they use blind copy (BCC)"
-  },
   "no_account_selected": {
     "message": "No profile selected"
   },

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -681,15 +681,6 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
         <DialogContent>
           <div className='broadcast-list-hint'>
             <p>{tx('chat_new_broadcast_hint')}</p>
-            <p
-              style={{
-                marginTop: '3px',
-                color: 'var(--colorDanger)',
-                fontWeight: 'bold',
-              }}
-            >
-              ⚠️ {tx('broadcast_list_warning')}
-            </p>
           </div>
           <br />
           <ChatSettingsSetNameAndProfileImage


### PR DESCRIPTION
broadcasts are now encrypted as other chats,
in case of chatmail, always.

this change was needed as usage was broken otherwise, see https://github.com/chatmail/core/pull/6781 for more details

#skip-changelog