### PR TITLE
Transport api followup

### DIFF
--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -38,7 +38,7 @@ type ProxySettings = {
   proxyUrl: string | null
 }
 
-enum Proxy {
+export enum Proxy {
   DISABLED = '0',
   ENABLED = '1',
 }

--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -1,32 +1,16 @@
 /* eslint-disable camelcase */
 
-import { C, T, DcEventType } from '@deltachat/jsonrpc-client'
-import React, { useEffect, useRef, useState } from 'react'
+import { C, T } from '@deltachat/jsonrpc-client'
+import React, { useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce/lib'
 
-import {
-  DeltaInput,
-  DeltaPasswordInput,
-  DeltaSelect,
-  DeltaProgressBar,
-} from './Login-Styles'
+import { DeltaInput, DeltaPasswordInput, DeltaSelect } from './Login-Styles'
 import { ClickableLink } from './helpers/ClickableLink'
 import { getLogger } from '../../../shared/logger'
 import { BackendRemote, Type } from '../backend-com'
-import { selectedAccountId } from '../ScreenController'
-import Dialog, {
-  DialogBody,
-  DialogContent,
-  DialogFooter,
-  FooterActionButton,
-  FooterActions,
-} from './Dialog'
 import Collapse from './Collapse'
 import { I18nContext } from '../contexts/I18nContext'
-import useTranslationFunction from '../hooks/useTranslationFunction'
-import { getDeviceChatId, saveLastChatId } from '../backend/chat'
 
-import type { DialogProps } from '../contexts/DialogContext'
 import SettingsSwitch from './Settings/SettingsSwitch'
 
 const log = getLogger('renderer/loginForm')
@@ -357,140 +341,5 @@ export default function LoginForm({ credentials, setCredentials }: LoginProps) {
         </div>
       )}
     </I18nContext.Consumer>
-  )
-}
-
-interface ConfigureProgressDialogProps {
-  credentials: Credentials
-  onSuccess?: () => void
-  onUserCancellation?: () => void
-  onFail: (error: string) => void
-  proxyUpdated: boolean
-}
-
-export function ConfigureProgressDialog({
-  credentials,
-  onSuccess,
-  onUserCancellation,
-  onFail,
-  proxyUpdated,
-  ...dialogProps
-}: ConfigureProgressDialogProps & DialogProps) {
-  const { onClose } = dialogProps
-  const [progress, setProgress] = useState(0)
-  const [progressComment, setProgressComment] = useState('')
-  const accountId = selectedAccountId()
-  const tx = useTranslationFunction()
-
-  const onConfigureProgress = ({
-    progress,
-    comment,
-  }: DcEventType<'ConfigureProgress'>) => {
-    progress !== 0 && setProgress(progress)
-    setProgressComment(comment || '')
-  }
-
-  const wasCanceled = useRef(false)
-
-  const onCancel = async (_event: any) => {
-    try {
-      if (window.__selectedAccountId === undefined) {
-        throw new Error('no selected account')
-      }
-      wasCanceled.current = true
-      await BackendRemote.rpc.stopOngoingProcess(window.__selectedAccountId)
-    } catch (error: any) {
-      log.error('failed to stopOngoingProcess', error)
-      onFail('failed to stopOngoingProcess' + error.message || error.toString())
-      // If it fails to cancel but is still successful, it should behave like normal.
-      wasCanceled.current = false
-    }
-    onClose()
-  }
-
-  useEffect(
-    () => {
-      ;(async () => {
-        try {
-          let isFirstOnboarding = true
-          const configuration: Credentials = {
-            ...credentials,
-          }
-          const { proxyEnabled, proxyUrl, ...transportConfig } = configuration
-          // Set proxy settings only if neccessary!
-          if (proxyUpdated) {
-            await BackendRemote.rpc.batchSetConfig(accountId, {
-              proxy_enabled:
-                proxyEnabled === true ? Proxy.ENABLED : Proxy.DISABLED,
-              proxy_url: proxyUrl,
-            })
-          }
-          if (
-            transportConfig.addr !== undefined &&
-            transportConfig.addr.length > 0
-          ) {
-            // On first time onboarding addr is empty here
-            isFirstOnboarding = false
-            // If the address already exists the transport config is updated
-            // otherwise a new transport is added (not supported yet)
-            await BackendRemote.rpc.addTransport(accountId, transportConfig)
-          }
-
-          if (wasCanceled.current) {
-            onClose()
-            onUserCancellation?.()
-            return
-          }
-
-          if (isFirstOnboarding) {
-            // Select 'Device Messages' chat as the initial one. This will serve
-            // as a first introduction to the app after they've entered
-            const deviceChatId = await getDeviceChatId(accountId)
-            if (deviceChatId) {
-              await saveLastChatId(accountId, deviceChatId)
-              // SettingsStoreInstance is reloaded the first time the main screen is shown
-            }
-          }
-
-          onClose()
-          onSuccess && onSuccess()
-        } catch (err: any) {
-          log.error('configure error', err)
-          onClose()
-          onFail(err.message || err.toString())
-        }
-      })()
-    },
-    [wasCanceled] // eslint-disable-line react-hooks/exhaustive-deps
-  )
-
-  useEffect(() => {
-    const emitter = BackendRemote.getContextEvents(accountId)
-    emitter.on('ConfigureProgress', onConfigureProgress)
-    return () => {
-      emitter.off('ConfigureProgress', onConfigureProgress)
-    }
-  }, [accountId])
-
-  return (
-    <Dialog
-      onClose={onClose}
-      canEscapeKeyClose={false}
-      canOutsideClickClose={false}
-    >
-      <DialogBody>
-        <DialogContent paddingTop>
-          <DeltaProgressBar progress={progress} />
-          <p>{progressComment}</p>
-        </DialogContent>
-      </DialogBody>
-      <DialogFooter>
-        <FooterActions>
-          <FooterActionButton styling='danger' onClick={onCancel}>
-            {tx('cancel')}
-          </FooterActionButton>
-        </FooterActions>
-      </DialogFooter>
-    </Dialog>
   )
 }

--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -38,7 +38,7 @@ type ProxySettings = {
   proxyUrl: string | null
 }
 
-export enum Proxy {
+enum Proxy {
   DISABLED = '0',
   ENABLED = '1',
 }

--- a/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
@@ -109,11 +109,6 @@ export function ConfigureProgressDialog({
               await saveLastChatId(accountId, deviceChatId)
               // SettingsStoreInstance is reloaded the first time the main screen is shown
             }
-            await BackendRemote.rpc.setConfig(
-              accountId,
-              'verified_one_on_one_chats',
-              '1'
-            )
           }
 
           onClose()

--- a/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
@@ -1,0 +1,160 @@
+import { DcEventType } from '@deltachat/jsonrpc-client'
+import React, { useEffect, useRef, useState } from 'react'
+
+import { DeltaProgressBar } from '../Login-Styles'
+import { BackendRemote } from '../../backend-com'
+import { selectedAccountId } from '../../ScreenController'
+import Dialog, {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  FooterActionButton,
+  FooterActions,
+} from '../Dialog'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
+import { getDeviceChatId, saveLastChatId } from '../../backend/chat'
+
+import type { DialogProps } from '../../contexts/DialogContext'
+import { Credentials, defaultCredentials, Proxy } from '../LoginForm'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+const log = getLogger('renderer/loginForm')
+
+interface ConfigureProgressDialogProps {
+  credentials?: Credentials
+  onSuccess?: () => void
+  onUserCancellation?: () => void
+  onFail: (error: string) => void
+  proxyUpdated: boolean
+}
+
+export function ConfigureProgressDialog({
+  credentials = defaultCredentials(),
+  onSuccess,
+  onUserCancellation,
+  onFail,
+  proxyUpdated,
+  ...dialogProps
+}: ConfigureProgressDialogProps & DialogProps) {
+  const { onClose } = dialogProps
+  const [progress, setProgress] = useState(0)
+  const [progressComment, setProgressComment] = useState('')
+  const accountId = selectedAccountId()
+  const tx = useTranslationFunction()
+
+  const onConfigureProgress = ({
+    progress,
+    comment,
+  }: DcEventType<'ConfigureProgress'>) => {
+    progress !== 0 && setProgress(progress)
+    setProgressComment(comment || '')
+  }
+
+  const wasCanceled = useRef(false)
+
+  const onCancel = async (_event: any) => {
+    try {
+      if (window.__selectedAccountId === undefined) {
+        throw new Error('no selected account')
+      }
+      wasCanceled.current = true
+      await BackendRemote.rpc.stopOngoingProcess(window.__selectedAccountId)
+    } catch (error: any) {
+      log.error('failed to stopOngoingProcess', error)
+      onFail('failed to stopOngoingProcess' + error.message || error.toString())
+      // If it fails to cancel but is still successful, it should behave like normal.
+      wasCanceled.current = false
+    }
+    onClose()
+  }
+
+  useEffect(
+    () => {
+      ;(async () => {
+        try {
+          let isFirstOnboarding = true
+          const configuration: Credentials = {
+            ...credentials,
+          }
+          const { proxyEnabled, proxyUrl, ...transportConfig } = configuration
+          // Set proxy settings only if neccessary!
+          if (proxyUpdated) {
+            await BackendRemote.rpc.batchSetConfig(accountId, {
+              proxy_enabled:
+                proxyEnabled === true ? Proxy.ENABLED : Proxy.DISABLED,
+              proxy_url: proxyUrl,
+            })
+          }
+          if (
+            transportConfig.addr !== undefined &&
+            transportConfig.addr.length > 0
+          ) {
+            // On first time onboarding addr is empty here, since the new transport is created later
+            isFirstOnboarding = false
+            // If the address already exists the transport config is updated
+            // otherwise a new transport is added (not supported yet)
+            await BackendRemote.rpc.addTransport(accountId, transportConfig)
+          }
+
+          if (wasCanceled.current) {
+            onClose()
+            onUserCancellation?.()
+            return
+          }
+
+          if (isFirstOnboarding) {
+            // Select 'Device Messages' chat as the initial one. This will serve
+            // as a first introduction to the app after they've entered
+            const deviceChatId = await getDeviceChatId(accountId)
+            if (deviceChatId) {
+              await saveLastChatId(accountId, deviceChatId)
+              // SettingsStoreInstance is reloaded the first time the main screen is shown
+            }
+            await BackendRemote.rpc.setConfig(
+              accountId,
+              'verified_one_on_one_chats',
+              '1'
+            )
+          }
+
+          onClose()
+          onSuccess && onSuccess()
+        } catch (err: any) {
+          log.error('configure error', err)
+          onClose()
+          onFail(err.message || err.toString())
+        }
+      })()
+    },
+    [wasCanceled] // eslint-disable-line react-hooks/exhaustive-deps
+  )
+
+  useEffect(() => {
+    const emitter = BackendRemote.getContextEvents(accountId)
+    emitter.on('ConfigureProgress', onConfigureProgress)
+    return () => {
+      emitter.off('ConfigureProgress', onConfigureProgress)
+    }
+  }, [accountId])
+
+  return (
+    <Dialog
+      onClose={onClose}
+      canEscapeKeyClose={false}
+      canOutsideClickClose={false}
+    >
+      <DialogBody>
+        <DialogContent paddingTop>
+          <DeltaProgressBar progress={progress} />
+          <p>{progressComment}</p>
+        </DialogContent>
+      </DialogBody>
+      <DialogFooter>
+        <FooterActions>
+          <FooterActionButton styling='danger' onClick={onCancel}>
+            {tx('cancel')}
+          </FooterActionButton>
+        </FooterActions>
+      </DialogFooter>
+    </Dialog>
+  )
+}

--- a/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
@@ -15,12 +15,12 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { getDeviceChatId, saveLastChatId } from '../../backend/chat'
 
 import type { DialogProps } from '../../contexts/DialogContext'
-import { Credentials, defaultCredentials, Proxy } from '../LoginForm'
+import { Credentials, Proxy } from '../LoginForm'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 const log = getLogger('renderer/loginForm')
 
 interface ConfigureProgressDialogProps {
-  credentials?: Credentials
+  credentials: Credentials
   onSuccess?: () => void
   onUserCancellation?: () => void
   onFail: (error: string) => void
@@ -28,7 +28,7 @@ interface ConfigureProgressDialogProps {
 }
 
 export function ConfigureProgressDialog({
-  credentials = defaultCredentials(),
+  credentials,
   onSuccess,
   onUserCancellation,
   onFail,
@@ -88,7 +88,7 @@ export function ConfigureProgressDialog({
             transportConfig.addr !== undefined &&
             transportConfig.addr.length > 0
           ) {
-            // On first time onboarding addr is empty here, since the new transport is created later
+            // On first time onboarding addr is empty here
             isFirstOnboarding = false
             // If the address already exists the transport config is updated
             // otherwise a new transport is added (not supported yet)

--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -1,12 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react'
 
 import { BackendRemote } from '../../backend-com'
-import LoginForm, {
-  Credentials,
-  ConfigureProgressDialog,
-  defaultCredentials,
-  Proxy,
-} from '../LoginForm'
+import LoginForm, { Credentials, defaultCredentials, Proxy } from '../LoginForm'
+import { ConfigureProgressDialog } from './ConfigureProgressDialog'
 import Dialog, {
   DialogBody,
   DialogContent,

--- a/packages/frontend/src/components/screens/AccountSetupScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountSetupScreen.tsx
@@ -1,11 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react'
 
 import ImageBackdrop from '../ImageBackdrop'
-import LoginForm, {
-  Credentials,
-  defaultCredentials,
-  ConfigureProgressDialog,
-} from '../LoginForm'
+import LoginForm, { Credentials, defaultCredentials } from '../LoginForm'
+import { ConfigureProgressDialog } from '../dialogs/ConfigureProgressDialog'
 import Dialog, {
   DialogBody,
   DialogContent,

--- a/packages/frontend/src/hooks/useInstantOnboarding.ts
+++ b/packages/frontend/src/hooks/useInstantOnboarding.ts
@@ -16,6 +16,7 @@ import type {
   VerifyGroupQr,
 } from '../backend/qr'
 import AlertDialog from '../components/dialogs/AlertDialog'
+import { defaultCredentials } from '../components/LoginForm'
 
 type InstantOnboarding = {
   createInstantAccount: (accountId: number) => Promise<T.FullChat['id'] | null>

--- a/packages/frontend/src/hooks/useInstantOnboarding.ts
+++ b/packages/frontend/src/hooks/useInstantOnboarding.ts
@@ -3,10 +3,7 @@ import { useCallback, useContext } from 'react'
 import useDialog from './dialog/useDialog'
 import useSecureJoin from './useSecureJoin'
 import { BackendRemote } from '../backend-com'
-import {
-  ConfigureProgressDialog,
-  defaultCredentials,
-} from '../components/LoginForm'
+import { ConfigureProgressDialog } from '../components/dialogs/ConfigureProgressDialog'
 import { DEFAULT_CHATMAIL_QR_URL } from '../components/screens/WelcomeScreen/chatmailInstances'
 import { InstantOnboardingContext } from '../contexts/InstantOnboardingContext'
 

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -54,7 +54,11 @@ export default function useProcessQR() {
 
   const { selectChat } = useChat()
 
-  const setConfigFromQrCatchingErrorInAlert = useCallback(
+  /**
+   * Processes various QR codes
+   * catched errors will be shown in an alert dialog
+   */
+  const processQrCode = useCallback(
     async (accountId: number, qrContent: string) => {
       try {
         await BackendRemote.rpc.setConfigFromQr(accountId, qrContent)
@@ -297,7 +301,7 @@ export default function useProcessQR() {
         })
 
         if (userConfirmed) {
-          await setConfigFromQrCatchingErrorInAlert(accountId, url)
+          await processQrCode(accountId, url)
         }
 
         callback?.()
@@ -314,7 +318,7 @@ export default function useProcessQR() {
         })
 
         if (userConfirmed) {
-          await setConfigFromQrCatchingErrorInAlert(accountId, url)
+          await processQrCode(accountId, url)
         }
 
         callback?.()
@@ -331,7 +335,7 @@ export default function useProcessQR() {
         })
 
         if (userConfirmed) {
-          await setConfigFromQrCatchingErrorInAlert(accountId, url)
+          await processQrCode(accountId, url)
         }
 
         callback?.()
@@ -348,7 +352,7 @@ export default function useProcessQR() {
         })
 
         if (userConfirmed) {
-          await setConfigFromQrCatchingErrorInAlert(accountId, url)
+          await processQrCode(accountId, url)
         }
 
         callback?.()
@@ -373,7 +377,7 @@ export default function useProcessQR() {
       openMailtoLink,
       secureJoinContact,
       secureJoinGroup,
-      setConfigFromQrCatchingErrorInAlert,
+      processQrCode,
       startInstantOnboarding,
       addAndSelectAccount,
       selectChat,


### PR DESCRIPTION
This PR contains only a reorganization of code and moves the ConfigureProgressDialog from LoginForm to a separate file

It is based on PR #4945 but separated to make the review of the other PR easier

#skip-changelog