### PR TITLE
tauri: fix: use current locale in help window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - fix order when sending multiple files at once #4895
 - tauri: fix: sticker picker previews not working
 - tauri: fix emoji picker being super ugly
+- tauri: use current locale in "Help" window when opening it through menu
 - tauri: fix launching a second instance of Delta Chat not focusing the main window if it's closed
 
 <a id="1_56_0"></a>

--- a/packages/target-tauri/src-tauri/src/menus/main_menu.rs
+++ b/packages/target-tauri/src-tauri/src/menus/main_menu.rs
@@ -64,7 +64,7 @@ impl MenuAction<'static> for MainMenuAction {
                 spawn(async move {
                     let menu_manager = app_clone.state::<MenuManager>();
                     if let Err(err) =
-                        open_help_window(app_clone.clone(), menu_manager, "", None).await
+                        open_help_window(app_clone.clone(), menu_manager, None, None).await
                     {
                         error!("failed to open help window: {err}");
                     }


### PR DESCRIPTION
Prior to this, opening the help window from the menu
would always open the English version.

I tested that it works.