### PR TITLE
remove address from primary settings UI

### DIFF
--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -84,13 +84,13 @@ export async function createNewProfile(
   await expect(page.locator('.styles_module_profileDisplayName')).toHaveText(
     name
   )
-  const address = await page
-    .locator('.styles_module_profileAddress')
-    .textContent()
+  await page.getByTestId('open-advanced-settings').click()
+  await page.getByTestId('open-account-and-password').click()
+  const address = await page.locator('#addr').inputValue()
 
   expect(address).not.toBeNull()
-
-  await page.getByTestId('settings-close').click()
+  await page.getByTestId('cancel').click()
+  await page.getByTestId('settings-advanced-close').click()
 
   const newId = await accountList
     .last()
@@ -115,10 +115,11 @@ export async function getProfile(page: Page, accountId: string): Promise<User> {
   const name = await page
     .locator('.styles_module_profileDisplayName')
     .textContent()
-  const address = await page
-    .locator('.styles_module_profileAddress')
-    .textContent()
-  await page.getByTestId('settings-close').click()
+  await page.getByTestId('open-advanced-settings').click()
+  await page.getByTestId('open-account-and-password').click()
+  const address = await page.locator('#addr').inputValue()
+  await page.getByTestId('cancel').click()
+  await page.getByTestId('settings-advanced-close').click()
 
   return {
     id: accountId,

--- a/packages/frontend/src/components/Settings/Advanced.tsx
+++ b/packages/frontend/src/components/Settings/Advanced.tsx
@@ -49,6 +49,7 @@ export default function Advanced({ settingsStore }: Props) {
             settingsStore,
           })
         }}
+        dataTestid='open-account-and-password'
       >
         {tx('pref_password_and_account_settings')}
       </SettingsButton>

--- a/packages/frontend/src/components/Settings/Profile.tsx
+++ b/packages/frontend/src/components/Settings/Profile.tsx
@@ -33,9 +33,6 @@ export default function Profile({ settingsStore }: Props) {
         <div className={styles.profileDisplayName}>
           {settingsStore.settings.displayname}
         </div>
-        <div className={styles.profileAddress}>
-          {settingsStore.selfContact.address}
-        </div>
       </div>
     </div>
   )

--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -121,6 +121,7 @@ export default function Settings({ onClose }: DialogProps) {
             <SettingsIconButton
               icon='code-tags'
               onClick={() => setSettingsMode('advanced')}
+              dataTestid='open-advanced-settings'
             >
               {tx('menu_advanced')}
             </SettingsIconButton>
@@ -195,6 +196,7 @@ export default function Settings({ onClose }: DialogProps) {
             title={tx('menu_advanced')}
             onClickBack={() => setSettingsMode('main')}
             onClose={onClose}
+            dataTestid='settings-advanced'
           />
           <DialogBody>
             <Advanced settingsStore={settingsStore} />

--- a/packages/frontend/src/components/Settings/SettingsButton.tsx
+++ b/packages/frontend/src/components/Settings/SettingsButton.tsx
@@ -8,12 +8,14 @@ import styles from './styles.module.scss'
 type Props = PropsWithChildren<{
   onClick: () => void
   highlight?: boolean
+  dataTestid?: string
 }>
 
 export default function SettingsButton({
   children,
   onClick,
   highlight = false,
+  dataTestid,
 }: Props) {
   return (
     <button
@@ -21,6 +23,7 @@ export default function SettingsButton({
         [styles.highlight]: highlight,
       })}
       onClick={onClick}
+      data-testid={dataTestid}
     >
       {children}
     </button>

--- a/packages/frontend/src/components/Settings/SettingsIconButton.tsx
+++ b/packages/frontend/src/components/Settings/SettingsIconButton.tsx
@@ -11,6 +11,7 @@ type Props = PropsWithChildren<{
   icon: IconName
   isLink?: boolean
   onClick: () => void
+  dataTestid?: string
 }>
 
 export default function SettingsIconButton({
@@ -18,9 +19,14 @@ export default function SettingsIconButton({
   icon,
   isLink = false,
   onClick,
+  dataTestid,
 }: Props) {
   return (
-    <button className={styles.settingsIconButton} onClick={onClick}>
+    <button
+      className={styles.settingsIconButton}
+      onClick={onClick}
+      data-testid={dataTestid}
+    >
       <Icon className={styles.settingsIcon} icon={icon} />
       <span className={styles.settingsIconButtonLabel}>{children}</span>
       {isLink && <Icon className={styles.settingsIcon} icon='open_in_new' />}


### PR DESCRIPTION
showing the address here prominently results in bad UX as ppl try to pass the address around,
which will not result in e2ee and will often not work.

see https://github.com/deltachat/deltachat-ios/pull/2664 for more resoning and discussion, eg. why remove it unconditionally

cmp https://github.com/deltachat/deltachat-android/pull/3730

#skip-changelog