### PR TITLE
test: reduce E2E test flakiness

### DIFF
--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -86,9 +86,10 @@ export async function createNewProfile(
   )
   await page.getByTestId('open-advanced-settings').click()
   await page.getByTestId('open-account-and-password').click()
-  const address = await page.locator('#addr').inputValue()
+  const addressLocator = page.locator('#addr')
+  await expect(addressLocator).toHaveValue(/.+@.+/)
+  const address = await addressLocator.inputValue()
 
-  expect(address).not.toBeNull()
   await page.getByTestId('cancel').click()
   await page.getByTestId('settings-advanced-close').click()
 
@@ -112,12 +113,14 @@ export async function createNewProfile(
 export async function getProfile(page: Page, accountId: string): Promise<User> {
   await page.getByTestId(`account-item-${accountId}`).click({ button: 'right' })
   await page.getByTestId('open-settings-menu-item').click()
-  const name = await page
-    .locator('.styles_module_profileDisplayName')
-    .textContent()
+  const nameLocator = page.locator('.styles_module_profileDisplayName')
+  await expect(nameLocator).not.toBeEmpty()
+  const name = await nameLocator.textContent()
   await page.getByTestId('open-advanced-settings').click()
   await page.getByTestId('open-account-and-password').click()
-  const address = await page.locator('#addr').inputValue()
+  const addressLocator = page.locator('#addr')
+  await expect(addressLocator).toHaveValue(/.+@.+/)
+  const address = await addressLocator.inputValue()
   await page.getByTestId('cancel').click()
   await page.getByTestId('settings-advanced-close').click()
 

--- a/packages/e2e-tests/tests/basic-functionality.spec.ts
+++ b/packages/e2e-tests/tests/basic-functionality.spec.ts
@@ -375,7 +375,6 @@ test('add app from picker to chat', async ({ page }) => {
   await expect(appDraft).toContainText(appName)
   await page.locator('button.send-button').click()
   const webxdcMessage = page.locator('.msg-body .webxdc')
-  await webxdcMessage.isVisible()
   await expect(webxdcMessage).toContainText(appName)
 })
 


### PR DESCRIPTION
Upon the initial render, the "address" input might be empty, as evident in https://github.com/deltachat/deltachat-desktop/actions/runs/14400757860/job/40385812833#step:7:593

Also remove a line that has no effect.

#skip-changelog
