### PR TITLE
fix: error dialog not showing on `setConfigFromQr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - accessibility: don't announce "padlock" on messages
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895
+- show error message when QR scan action fails
 - tauri: fix: sticker picker previews not working
 - tauri: fix emoji picker being super ugly
 - tauri: use current locale in "Help" window when opening it through menu

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -59,11 +59,16 @@ export default function useProcessQR() {
       try {
         await BackendRemote.rpc.setConfigFromQr(accountId, qrContent)
       } catch (error) {
-        if (error instanceof Error) {
-          openAlertDialog({
-            message: error.message,
-          })
-        }
+        openAlertDialog({
+          message:
+            (typeof error === 'object' && error != null
+              ? 'message' in error
+                ? `${error.message}`
+                : 'toString' in error
+                  ? error.toString()
+                  : null
+              : null) ?? 'Failed to setConfigFromQr',
+        })
       }
     },
     [openAlertDialog]


### PR DESCRIPTION
`error instanceof Error` is not true
for errors returned by the backend,
so we would basically ignore all errors.

I tested it, now the error dialog gets shown when you pass an invalid text there.