### PR TITLE
fix: some untranslated strings, add tx type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - fix member list is not refreshed if it changes while you look at the group profile #4894
 - remove unexpected horizontal scroll in gallery #4891
 - i18n: fix wrong order of substitutions for some strings #4889
+- i18n: translate some more strings
 - accessibility: don't announce "padlock" on messages
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -73,5 +73,11 @@
   },
   "pref_autostart_not_supported": {
     "message": "Autostart is not supported on this system"
+  },
+  "need_to_be_logged_in": {
+    "message": "Please log in first"
+  },
+  "need_to_be_logged_out": {
+    "message": "Please log out first"
   }
 }

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -280,7 +280,7 @@ export function AppPicker({ onAppSelected }: Props) {
   const categoryTitle = (selectedCategory: AppCategoryEnum) => {
     return selectedCategory === AppCategoryEnum.home
       ? tx('home')
-      : tx(selectedCategory + 's')
+      : tx(`${selectedCategory}s`)
   }
 
   return (

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -508,7 +508,10 @@ export default function ChatList(props: {
   )
 }
 
-function translate_n(key: string, quantity: number) {
+function translate_n(
+  key: Parameters<typeof window.static_translate>[0],
+  quantity: number
+) {
   return window
     .static_translate(key, String(quantity), { quantity })
     .toUpperCase()

--- a/packages/frontend/src/components/message/Link.tsx
+++ b/packages/frontend/src/components/message/Link.tsx
@@ -144,7 +144,7 @@ function LabeledLinkConfirmationDialog(
                 .then(() => props.onClose())
             }}
           >
-            {tx('copy')}
+            {tx('menu_copy_link_to_clipboard')}
           </FooterActionButton>
           <FooterActionButton onClick={props.onClose}>
             {tx('cancel')}

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -78,7 +78,20 @@ export default function MessageMetaData(props: Props) {
       {direction === 'outgoing' && (
         <button
           className={classNames('status-icon', status)}
-          aria-label={tx(`a11y_delivery_status_${status}`)}
+          aria-label={tx(
+            `a11y_delivery_status_${
+              status as Exclude<
+                typeof status,
+                // '' is not supposed to happen.
+                // The others are not supposed to happen
+                // as long as direction is outgoing.
+                | ''
+                | (typeof direction extends 'outgoing'
+                    ? 'in_fresh' | 'in_seen' | 'in_noticed'
+                    : never)
+              >
+            }`
+          )}
           disabled={status !== 'error'}
           tabIndex={status === 'error' ? tabindexForInteractiveContents : -1}
           onClick={status === 'error' ? onClickError : undefined}

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -172,7 +172,7 @@ export default function useProcessQR() {
         !isLoggedIn
       ) {
         await openAlertDialog({
-          message: tx('Please login first'),
+          message: tx('need_to_be_logged_in'),
         })
         return callback?.()
       }
@@ -293,7 +293,7 @@ export default function useProcessQR() {
       if (qr.kind === 'backup2') {
         if (isLoggedIn) {
           await openAlertDialog({
-            message: tx('Please logout first'),
+            message: tx('need_to_be_logged_out'),
           })
           callback?.()
         } else {

--- a/packages/frontend/src/types-app.d.ts
+++ b/packages/frontend/src/types-app.d.ts
@@ -7,7 +7,6 @@ export type msgStatus =
   | 'draft'
   | 'delivered'
   | 'read'
-  | 'sent'
   | 'in_fresh'
   | 'in_seen'
   | 'in_noticed'

--- a/packages/shared/localize.ts
+++ b/packages/shared/localize.ts
@@ -13,18 +13,12 @@ export interface LocaleData {
   }
 }
 
-// Solution to typescript thinking our variants can be just combined into the type string
-// adapted from https://github.com/sindresorhus/type-fest/blob/cabce984e5c19558f2f0061c3cd9488a945f60e6/source/literal-union.d.ts
-export type LiteralUnion<LiteralType> =
-  | LiteralType
-  | (string & Record<never, never>)
-
 // 'other' should exists for all languages (source?)
 // https://www.unicode.org/cldr/charts/43/supplemental/language_plural_rules.html
 type getMessageOptions = { quantity?: 'other' | number }
 
 export type getMessageFunction = (
-  key: LiteralUnion<TranslationKey>,
+  key: TranslationKey,
   substitutions?: string | string[],
   raw_opts?: 'other' | getMessageOptions
 ) => string
@@ -51,7 +45,7 @@ export function translate(
   }
 
   function getMessage(
-    key: LiteralUnion<TranslationKey>,
+    key: TranslationKey,
     substitutions?: string | string[],
     raw_opts?: 'other' | getMessageOptions
   ) {


### PR DESCRIPTION
This is a follow-up to https://github.com/deltachat/deltachat-desktop/commit/1c989ce0866b590e7e83b095c567ae652b4a64f1
(https://github.com/deltachat/deltachat-desktop/pull/4287).

Now it's not only about auto-completion, but also enforcing
that the key is present.
We have `./bin/test_for_missing_translations.sh`,
but we don't run it on every build, so sometimes we end up
specifying a wrong key.

One still can pass an arbitrary string to `tx` as such
`tx(myStr as any)`.