### PR TITLE
Refactoring configure & instant onboarding

### DIFF
--- a/docs/UPDATE_CORE.md
+++ b/docs/UPDATE_CORE.md
@@ -66,7 +66,7 @@ If you already have a core git checkout, you can skip the first step. Set the en
 
 1. clone the core repo, right next to your desktop repo folder: `git clone git@github.com:chatmail/core.git`
 2. go into your core checkout and run `git pull` to update it to the newest version, then create a branch for your changes
-3. run `python3 deltachat-rpc-server/npm-package/scripts/make_local_dev_version.py`
+3. run `python3 deltachat-rpc-server/npm-package/scripts/make_local_dev_version.py` (needs at least python 3.12)
 4. run `npm i` and `npm run build` inside `../core/deltachat-jsonrpc/typescript/`
 5. go into your desktop repo and run `./bin/link_core/link_local.sh` [^1]
 

--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -40,28 +40,6 @@ const CertificateChecks = {
   acceptInvalidCertificates: 'acceptInvalidCertificates',
 } as const satisfies { [P in T.EnteredCertificateChecks]: P }
 
-export function defaultCredentials(credentials?: Credentials): Credentials {
-  const defaultCredentials: Credentials = {
-    addr: '',
-    imapUser: null,
-    password: '',
-    imapServer: null,
-    imapPort: null,
-    imapSecurity: null,
-    certificateChecks: null,
-    smtpUser: null,
-    smtpPassword: null,
-    smtpServer: null,
-    smtpPort: null,
-    smtpSecurity: null,
-    oauth2: null,
-    proxyEnabled: false,
-    proxyUrl: null,
-  }
-
-  return { ...defaultCredentials, ...credentials }
-}
-
 type LoginProps = React.PropsWithChildren<{
   credentials: Credentials
   setCredentials: (credentials: Credentials) => void

--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -15,17 +15,7 @@ import SettingsSwitch from './Settings/SettingsSwitch'
 
 const log = getLogger('renderer/loginForm')
 
-export type Credentials = T.EnteredLoginParam & ProxySettings
-
-type ProxySettings = {
-  proxyEnabled: boolean
-  proxyUrl: string | null
-}
-
-export enum Proxy {
-  DISABLED = '0',
-  ENABLED = '1',
-}
+import type { Credentials } from './Settings/DefaultCredentials'
 
 const Socket = {
   automatic: 'automatic',

--- a/packages/frontend/src/components/Settings/DefaultCredentials.ts
+++ b/packages/frontend/src/components/Settings/DefaultCredentials.ts
@@ -1,0 +1,35 @@
+import { T } from '@deltachat/jsonrpc-client'
+
+export type Credentials = T.EnteredLoginParam & ProxySettings
+
+export type ProxySettings = {
+  proxyEnabled: boolean
+  proxyUrl: string | null
+}
+
+export enum Proxy {
+  DISABLED = '0',
+  ENABLED = '1',
+}
+
+export function defaultCredentials(credentials?: Credentials): Credentials {
+  const defaultCredentials: Credentials = {
+    addr: '',
+    imapUser: null,
+    password: '',
+    imapServer: null,
+    imapPort: null,
+    imapSecurity: null,
+    certificateChecks: null,
+    smtpUser: null,
+    smtpPassword: null,
+    smtpServer: null,
+    smtpPort: null,
+    smtpSecurity: null,
+    oauth2: null,
+    proxyEnabled: false,
+    proxyUrl: null,
+  }
+
+  return { ...defaultCredentials, ...credentials }
+}

--- a/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
@@ -135,8 +135,12 @@ export function ConfigureProgressDialog({
               await BackendRemote.rpc.listTransports(accountId)
             if (existingTransports.length > 0) {
               const existingTransport = existingTransports[0]
-              // and multiple transports are not supported yet
-              if (existingTransport.addr !== transportConfig.addr) {
+              if (
+                // there is always a "default" transport with empty addr
+                existingTransport.addr !== '' &&
+                existingTransport.addr !== transportConfig.addr
+              ) {
+                // multiple transports are not supported yet
                 throw new Error(
                   tx(
                     'Multi transport is not supported right now. Check back in a few months!'

--- a/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
@@ -15,31 +15,13 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { getDeviceChatId, saveLastChatId } from '../../backend/chat'
 
 import type { DialogProps } from '../../contexts/DialogContext'
-import { Credentials, Proxy } from '../LoginForm'
+import {
+  defaultCredentials,
+  Credentials,
+  Proxy,
+} from '../Settings/DefaultCredentials'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 const log = getLogger('renderer/loginForm')
-
-export function defaultCredentials(credentials?: Credentials): Credentials {
-  const defaultCredentials: Credentials = {
-    addr: '',
-    imapUser: null,
-    password: '',
-    imapServer: null,
-    imapPort: null,
-    imapSecurity: null,
-    certificateChecks: null,
-    smtpUser: null,
-    smtpPassword: null,
-    smtpServer: null,
-    smtpPort: null,
-    smtpSecurity: null,
-    oauth2: null,
-    proxyEnabled: false,
-    proxyUrl: null,
-  }
-
-  return { ...defaultCredentials, ...credentials }
-}
 
 interface ConfigureProgressDialogProps {
   credentials: Credentials | null

--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useCallback } from 'react'
 
 import { BackendRemote } from '../../backend-com'
-import LoginForm, { Credentials, Proxy } from '../LoginForm'
+import LoginForm from '../LoginForm'
 import {
-  ConfigureProgressDialog,
   defaultCredentials,
-} from './ConfigureProgressDialog'
+  Credentials,
+  Proxy,
+} from '../Settings/DefaultCredentials'
+import { ConfigureProgressDialog } from './ConfigureProgressDialog'
 import Dialog, {
   DialogBody,
   DialogContent,

--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react'
 
 import { BackendRemote } from '../../backend-com'
-import LoginForm, { Credentials, defaultCredentials, Proxy } from '../LoginForm'
-import { ConfigureProgressDialog } from './ConfigureProgressDialog'
+import LoginForm, { Credentials, Proxy } from '../LoginForm'
+import {
+  ConfigureProgressDialog,
+  defaultCredentials,
+} from './ConfigureProgressDialog'
 import Dialog, {
   DialogBody,
   DialogContent,
@@ -11,7 +14,6 @@ import Dialog, {
 } from '../Dialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useDialog from '../../hooks/dialog/useDialog'
-import useConfirmationDialog from '../../hooks/dialog/useConfirmationDialog'
 
 import type { DialogProps } from '../../contexts/DialogContext'
 import AlertDialog from './AlertDialog'
@@ -41,7 +43,6 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
     useState<Credentials>(defaultCredentials())
 
   const { openDialog } = useDialog()
-  const openConfirmationDialog = useConfirmationDialog()
   const tx = useTranslationFunction()
 
   const setAccountSettings = (value: Credentials) => {
@@ -97,18 +98,11 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
     }
 
     if (initialSettings.addr !== accountSettings.addr) {
-      const confirmed = await openConfirmationDialog({
-        confirmLabel: tx('perm_continue'),
-        isConfirmDanger: true,
-        message: tx('aeap_explanation', [
-          initialSettings.addr || '',
-          accountSettings.addr || '',
-        ]),
+      openDialog(AlertDialog, {
+        message:
+          'Changing your email address is not supported right now. Check back in a few months!',
       })
-
-      if (!confirmed) {
-        return
-      }
+      return
     } else if (accountSettings.proxyEnabled) {
       if (accountSettings.proxyUrl === null) {
         openDialog(AlertDialog, {
@@ -137,14 +131,7 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
       }
     }
     update()
-  }, [
-    accountSettings,
-    initialSettings,
-    onClose,
-    openConfirmationDialog,
-    openDialog,
-    tx,
-  ])
+  }, [accountSettings, initialSettings, onClose, openDialog, tx])
 
   const onOk = useCallback(async () => {
     await onUpdate()

--- a/packages/frontend/src/components/screens/AccountSetupScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountSetupScreen.tsx
@@ -1,8 +1,11 @@
 import React, { useState, useEffect, useCallback } from 'react'
 
 import ImageBackdrop from '../ImageBackdrop'
-import LoginForm, { Credentials, defaultCredentials } from '../LoginForm'
-import { ConfigureProgressDialog } from '../dialogs/ConfigureProgressDialog'
+import LoginForm, { Credentials } from '../LoginForm'
+import {
+  ConfigureProgressDialog,
+  defaultCredentials,
+} from '../dialogs/ConfigureProgressDialog'
 import Dialog, {
   DialogBody,
   DialogContent,

--- a/packages/frontend/src/components/screens/AccountSetupScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountSetupScreen.tsx
@@ -1,11 +1,9 @@
 import React, { useState, useEffect, useCallback } from 'react'
 
 import ImageBackdrop from '../ImageBackdrop'
-import LoginForm, { Credentials } from '../LoginForm'
-import {
-  ConfigureProgressDialog,
-  defaultCredentials,
-} from '../dialogs/ConfigureProgressDialog'
+import LoginForm from '../LoginForm'
+import { ConfigureProgressDialog } from '../dialogs/ConfigureProgressDialog'
+import { defaultCredentials, Credentials } from '../Settings/DefaultCredentials'
 import Dialog, {
   DialogBody,
   DialogContent,

--- a/packages/frontend/src/components/screens/WelcomeScreen/AdditionalActionInfo.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/AdditionalActionInfo.tsx
@@ -8,6 +8,10 @@ type Props = {
   accountId: number
 }
 
+/**
+ * shows additional information about the instant onboarding process
+ * depending on the type of welcomeQr code that was scanned
+ */
 export default function AdditionalActionInfo(props: Props) {
   const tx = useTranslationFunction()
   const { welcomeQr } = useInstantOnboarding()

--- a/packages/frontend/src/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
@@ -23,6 +23,17 @@ type Props = {
   selectedAccountId: number
 }
 
+/**
+ * Sub component of WelcomeScreen to set a Displayname to create an account
+ * or open a dialog with some options to use another server
+ *
+ * This is part of the instantOnboarding flow, that means possibly
+ * the user comes here after having scanned a QR code of type
+ * DCACCOUNT
+ * DCLOGIN
+ * DC_ASK_VERIFYCONTACT
+ * DC_ASK_VERIFYGROUP
+ */
 export default function InstantOnboardingScreen({
   onCancel,
   selectedAccountId,

--- a/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
@@ -18,6 +18,11 @@ type Props = {
   hasConfiguredAccounts: boolean
 }
 
+/**
+ * Sub component of WelcomeScreen shows the choice
+ * to create a new account or to use an existing one
+ */
+
 export default function OnboardingScreen(props: Props) {
   const tx = useTranslationFunction()
   const { openDialog } = useDialog()

--- a/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
@@ -19,6 +19,11 @@ type Props = {
   onExitWelcomeScreen: () => Promise<void>
 }
 
+/**
+ * Welcomescreen is shown to users when they start the app
+ * for the first time or when they have no configured accounts
+ */
+
 export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
   const {
     resetInstantOnboarding,
@@ -44,9 +49,6 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
 
   /**
    * this function is called when the back button is clicked
-   * but also if the dialog is closed by pressing esc multiple
-   * times, which will force Chrome to close the dialog
-   * see https://issues.chromium.org/issues/346597066
    *
    * it will cancel the account creation process and call
    * onExitWelcomeScreen

--- a/packages/frontend/src/hooks/useSecureJoin.ts
+++ b/packages/frontend/src/hooks/useSecureJoin.ts
@@ -55,6 +55,9 @@ export default function useSecureJoin() {
     [openConfirmationDialog, tx]
   )
 
+  /**
+   * called after scanning a contact invite link
+   */
   const secureJoinContact = useCallback(
     async (
       accountId: number,


### PR DESCRIPTION
This PR cleans up some outdated comments and namings and moves the account creation call to ConfigureProgressDialog to avoid inconsistencies (like passing default Credentials in createInstantAccount after account creation). Also prepares to pass the proxy configuration before account creation 

 - move configurationQR to ConfigureProgressDialog
 - move defaultCredentials to ConfigureProgressDialog
 - move addTransportFromQr to ConfigureProgressDialog
 - add inline documentation
 - show new AEAP message on addr change #4989

#skip-changelog