### PR TITLE
reorder attach menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - show signature/bio in settings #4984
 - change to new transport API #4849
 - update `sass` from `1.77.8` to `1.86.3` #4940
+- improve attachment menu ordering #5000
 
 ### Fixed
 - tauri: improve security #4826, #4936, #4937, #4944

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -178,15 +178,21 @@ export default function MenuAttachment({
 
   // item array used to populate menu
   const menu: (ContextMenuItem | false)[] = [
+    {
+      icon: 'person',
+      label: tx('contact'),
+      action: selectContact.bind(null),
+    },
     !!settings?.settings.webrtc_instance && {
       icon: 'phone',
       label: tx('videochat'),
       action: onVideoChat,
     },
     {
-      icon: 'image',
-      label: tx('image'),
-      action: addFilenameMedia.bind(null),
+      icon: 'apps',
+      label: tx('webxdc_app'),
+      action: selectAppPicker.bind(null),
+      dataTestid: 'open-app-picker',
     },
     {
       icon: 'upload-file',
@@ -194,15 +200,9 @@ export default function MenuAttachment({
       action: addFilenameFile.bind(null),
     },
     {
-      icon: 'person',
-      label: tx('contact'),
-      action: selectContact.bind(null),
-    },
-    {
-      icon: 'apps',
-      label: tx('webxdc_app'),
-      action: selectAppPicker.bind(null),
-      dataTestid: 'open-app-picker',
+      icon: 'image',
+      label: tx('image'),
+      action: addFilenameMedia.bind(null),
     },
   ]
 

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -199,6 +199,7 @@ export default function MenuAttachment({
       label: tx('file'),
       action: addFilenameFile.bind(null),
     },
+    { type: 'separator' },
     {
       icon: 'image',
       label: tx('image'),


### PR DESCRIPTION
the existing order was grown and appears a bit random, and also not consistent with android/ios,
where "image and related stuff" are the items most in view, and at least loosely separated (new line on android, separator on iOS)

as also on desktop, sending an image is the thing done most often, this PR reorders the menu to image/file/app/videochat/contact (from bottom to top, as focus is down, one reads from bottom, also shorter ways)

this is pretty much the same as iOS,
and still more similar to android
(which, by having horizontal layout, has different focus points)

desktop before / after:

<img width= 140 src=https://github.com/user-attachments/assets/1b665f98-e656-4920-829d-3dd9c3d8da9a> &nbsp; &nbsp; &nbsp; <img width=140 src=https://github.com/user-attachments/assets/f8e3b88c-391c-4888-a686-8ef910435d84>


ios:

<img width=170 src=https://github.com/user-attachments/assets/d9f3cbbf-b87e-496d-b19e-56dfeae17030>
