### PR TITLE
tauri: feat: custom chat background image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - tauri: add `--minimized` flag #4922
 - tauri: add theming #4940
 - tauri: add autostart #4754
+- tauri: add chat background image customization support
 - testing: add more e2e tests for onboardings etc. #5001
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,6 +1814,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "png",
+ "rand 0.9.0",
  "regex",
  "serde",
  "serde_json",

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -40,14 +40,20 @@ export function getBackgroundImageStyle(
     }
     if (bgImg.startsWith('img: ')) {
       const filePath = bgImg.slice(5)
-      style.backgroundImage =
-        runtime.getRuntimeInfo().target === 'browser'
-          ? `url("/${join('background/', filePath)}")`
-          : `url("file://${join(
-              runtime.getConfigPath(),
-              'background/',
-              filePath
-            )}")`
+      switch (runtime.getRuntimeInfo().target) {
+        case 'electron': {
+          style.backgroundImage = `url("file://${join(
+            runtime.getConfigPath(),
+            'background/',
+            filePath
+          )}")`
+          break
+        }
+        case 'browser': {
+          style.backgroundImage = `url("/${join('background/', filePath)}")`
+          break
+        }
+      }
     } else if (bgImg.startsWith('color: ')) {
       style.backgroundColor = bgImg.slice(7)
       style.backgroundImage = 'none'

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -40,7 +40,8 @@ export function getBackgroundImageStyle(
     }
     if (bgImg.startsWith('img: ')) {
       const filePath = bgImg.slice(5)
-      switch (runtime.getRuntimeInfo().target) {
+      const target = runtime.getRuntimeInfo().target
+      switch (target) {
         case 'electron': {
           style.backgroundImage = `url("file://${join(
             runtime.getConfigPath(),
@@ -49,9 +50,18 @@ export function getBackgroundImageStyle(
           )}")`
           break
         }
+        case 'tauri': {
+          const base =
+            runtime.getRuntimeInfo()?.tauriSpecific?.scheme.chatBackgroundImage
+          style.backgroundImage = `url("${base}${filePath}")`
+          break
+        }
         case 'browser': {
           style.backgroundImage = `url("/${join('background/', filePath)}")`
           break
+        }
+        default: {
+          const _: never = target
         }
       }
     } else if (bgImg.startsWith('color: ')) {

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -107,6 +107,7 @@ export type RuntimeInfo = {
   tauriSpecific?: {
     scheme: {
       blobs: string
+      chatBackgroundImage: string
       webxdcIcon: string
       stickers: string
     }

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -605,10 +605,10 @@ class TauriRuntime implements Runtime {
     }
   }
   saveBackgroundImage(
-    _file: string,
-    _isDefaultPicture: boolean
+    srcPath: string,
+    isDefaultPicture: boolean
   ): Promise<string> {
-    throw new Error('Method not implemented.49')
+    return invoke('copy_background_image_file', { srcPath, isDefaultPicture })
   }
   onDragFileOut(_file: string): void {
     throw new Error('Method not implemented.50')

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ percent-encoding = "2"
 thiserror = "2.0.11"
 png = "0.*"
 base64 = "0.22.1"
+rand = { version = "0.9.0", features = ["small_rng"] }
 uuid = { version = "1", features = ["v4"] }
 tauri-plugin-opener = "2.2.6"
 unic-idna-punycode = "0.9.0"

--- a/packages/target-tauri/src-tauri/build.rs
+++ b/packages/target-tauri/src-tauri/build.rs
@@ -49,6 +49,7 @@ fn main() {
             "write_temp_file",
             "remove_temp_file",
             "copy_blob_file_to_internal_tmp_dir",
+            "copy_background_image_file",
             "on_webxdc_message_changed",
             "on_webxdc_message_deleted",
             "on_webxdc_status_update",

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -53,6 +53,7 @@ permissions = [
     "allow-write-temp-file",
     "allow-remove-temp-file",
     "allow-copy-blob-file-to-internal-tmp-dir",
+    "allow-copy-background-image-file",
 
     "allow-on-webxdc-message-changed",
     "allow-on-webxdc-message-deleted",

--- a/packages/target-tauri/src-tauri/src/chat_background_image.rs
+++ b/packages/target-tauri/src-tauri/src/chat_background_image.rs
@@ -1,0 +1,212 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+use rand::distr::SampleString;
+use tauri::{utils::mime_type::MimeType, Manager, UriSchemeContext, UriSchemeResponder};
+use tokio::fs;
+
+pub(crate) fn delta_chat_background_image_protocol<R: tauri::Runtime>(
+    ctx: UriSchemeContext<'_, R>,
+    request: http::Request<Vec<u8>>,
+    responder: UriSchemeResponder,
+) {
+    // info!("dcchatbgimage {}", request.uri());
+
+    // URI format is
+    // - Mac, linux, iOS: dcchatbgimage://dummy.host/<file_name>
+    // - windows, android: http://dcchatbgimage.localhost/<file_name>
+
+    if ctx.webview_label() != "main" {
+        log::error!(
+            "prevented other window from accessing dcchatbgimage:// scheme (webview label: {})",
+            ctx.webview_label()
+        );
+        return;
+    }
+
+    let bg_images_dir = get_background_images_dir(ctx.app_handle());
+
+    let try_respond = async move || -> anyhow::Result<()> {
+        let uri_path = request.uri().path();
+
+        let file_name = uri_path.strip_prefix('/').unwrap_or(uri_path);
+        let file_name = percent_encoding::percent_decode_str(file_name).decode_utf8()?;
+        let file_name = Path::new(file_name.as_ref())
+            .file_name()
+            .with_context(|| format!("invalid file name {file_name}"))?;
+
+        let file_path = bg_images_dir?.join(file_name);
+        let mut components_rev = file_path.components().rev();
+        assert_eq!(components_rev.next().unwrap().as_os_str(), file_name);
+        assert_eq!(components_rev.next().unwrap().as_os_str(), "background");
+        assert!(!file_path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir)));
+
+        let blob = fs::read(&file_path).await?;
+
+        let res = http::Response::builder()
+            .status(http::StatusCode::OK)
+            .header(
+                http::header::CONTENT_TYPE,
+                MimeType::parse_with_fallback(
+                    &blob,
+                    file_name.to_str().context(format!(
+                        "failed to convert blob file name {file_name:?} to str"
+                    ))?,
+                    MimeType::OctetStream,
+                ),
+            )
+            .body(blob)?;
+        responder.respond(res);
+        Ok(())
+    };
+    tauri::async_runtime::spawn(async move {
+        try_respond()
+            .await
+            .inspect_err(|err| {
+                log::error!("Failed to build reply for dcchatbgimage protocol: {err:#}")
+            })
+            .ok();
+    });
+}
+
+/// Takes an arbitrary file path, copies it to "background" directory,
+/// deletes the old chat background file from the "background" directory
+/// and returns a string containing the new file name, in the format
+/// "img: background_{random_alphanumeric_str}.{src_file_ext}".
+///
+/// When `is_default_picture == true`, `src_path` can be just a file name,
+/// referring to an asset file in `images/backgrounds`.
+#[tauri::command]
+pub(crate) async fn copy_background_image_file<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    src_path: &Path,
+    is_default_picture: bool,
+) -> Result<String, String> {
+    copy_background_image_file_(app, src_path, is_default_picture)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+async fn copy_background_image_file_<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    src_path: &Path,
+    is_default_picture: bool,
+) -> anyhow::Result<String> {
+    let bg_images_dir = get_background_images_dir(&app)
+        .context("failed to get the chat background images directory")?;
+
+    log::info!("Copying the new chat background image {src_path:?} to the backgroud images directory {bg_images_dir:?}...");
+
+    if let Err(err) = fs::create_dir(&bg_images_dir).await {
+        if err.kind() == std::io::ErrorKind::AlreadyExists {
+            log::debug!("chat background images directory already exists");
+        } else {
+            anyhow::bail!(
+                "failed to create chat background images directory at {bg_images_dir:?}: {err}"
+            );
+        }
+    };
+
+    let file_stem_start = "background_";
+
+    // Remove the old file.
+    // We expect only one file to be there, but we'll handle the case
+    // when there are other files for some reason.
+    assert_eq!(
+        bg_images_dir.components().last().unwrap().as_os_str(),
+        "background"
+    );
+    let mut read_dir = fs::read_dir(&bg_images_dir).await?;
+    let mut iters_left: usize = 100;
+    while let Some(entry) = read_dir.next_entry().await? {
+        if iters_left == 0 {
+            // Sanity check. We don't expect this many files in the directory.
+            log::error!("can't remove the old file: too many files in the background directory");
+            break;
+        }
+        iters_left -= 1;
+
+        let old_file_path = entry.path();
+
+        let old_file_has_expected_name = old_file_path
+            .file_stem()
+            .map(|stem| stem.to_string_lossy().starts_with(file_stem_start))
+            .unwrap_or(false);
+
+        if !old_file_has_expected_name {
+            // Let's not delete file and just proceed.
+            // Maybe it's just some random file that somehow ended up here.
+            log::warn!("wanted to remove the old chat background image file, but found an unexpected file in the directory ({old_file_path:?}). Proceeding without removing the file.");
+            continue;
+        }
+
+        fs::remove_file(&old_file_path)
+            .await
+            .context("failed to delete the old chat background image file")
+            .inspect_err(|err| log::error!("{err}"))
+            .inspect(|_| log::info!("deleted old chat bacgrkound file {old_file_path:?}"))
+            .ok();
+        // After removing one file, don't try to remove any more.
+        break;
+    }
+
+    let dst_file_name = {
+        // Add some random chars to make the file name unique
+        // to make sure the browser doesn't use a cached version.
+        let rand_chars = rand::distr::Alphanumeric.sample_string(&mut rand::rng(), 8);
+
+        let mut name = PathBuf::new();
+        name.set_file_name(format!("{file_stem_start}{rand_chars}"));
+        if let Some(ext) = src_path.extension() {
+            name.set_extension(ext);
+        }
+
+        assert_eq!(name.components().count(), 1);
+        name
+    };
+    let dst_path = {
+        let path = bg_images_dir.join(&dst_file_name);
+        let mut components_rev = path.components().rev();
+
+        assert_eq!(components_rev.next().unwrap().as_os_str(), dst_file_name);
+        assert_eq!(components_rev.next().unwrap().as_os_str(), "background");
+        assert!(!path
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir)));
+        path
+    };
+
+    if is_default_picture {
+        let src_file_name = src_path
+            .file_name()
+            .with_context(|| format!("invalid src_path {src_path:?}: no file name"))?
+            .to_str()
+            .with_context(|| format!("invalid unicode file name {src_path:?}"))?;
+        let asset = app
+            .asset_resolver()
+            .get(format!("images/backgrounds/{src_file_name}"))
+            .with_context(|| format!("no such default chat background image {src_file_name:?}"))?;
+
+        fs::write(&dst_path, asset.bytes()).await
+    } else {
+        fs::copy(&src_path, &dst_path).await.map(|_| ())
+    }
+    .context("failed to copy chat background file")?;
+
+    log::info!("Copied the new chat background image {src_path:?} to {dst_path:?}");
+
+    Ok(format!(
+        "img: {}",
+        dst_file_name
+            .to_str()
+            .context("failed to convert back to str")?
+    ))
+}
+
+fn get_background_images_dir<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> tauri::Result<PathBuf> {
+    Ok(app.path().app_data_dir()?.join("background"))
+}

--- a/packages/target-tauri/src-tauri/src/chat_background_image.rs
+++ b/packages/target-tauri/src-tauri/src/chat_background_image.rs
@@ -146,7 +146,7 @@ async fn copy_background_image_file_<R: tauri::Runtime>(
             .await
             .context("failed to delete the old chat background image file")
             .inspect_err(|err| log::error!("{err}"))
-            .inspect(|_| log::info!("deleted old chat bacgrkound file {old_file_path:?}"))
+            .inspect(|_| log::info!("deleted old chat background file {old_file_path:?}"))
             .ok();
         // After removing one file, don't try to remove any more.
         break;

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ mod help_window;
 mod html_window;
 mod i18n;
 // menus are not available on mobile
+mod chat_background_image;
 #[cfg(desktop)]
 mod menus;
 mod network_isolation_dummy_proxy;
@@ -167,6 +168,7 @@ pub fn run() {
             temp_file::write_temp_file,
             temp_file::remove_temp_file,
             temp_file::copy_blob_file_to_internal_tmp_dir,
+            chat_background_image::copy_background_image_file,
             // not yet available on mobile
             #[cfg(desktop)]
             webxdc::commands_main_window::on_webxdc_message_changed,
@@ -220,6 +222,10 @@ pub fn run() {
         )
         .register_asynchronous_uri_scheme_protocol("dcblob", blobs::delta_blobs_protocol)
         .register_asynchronous_uri_scheme_protocol("dcsticker", stickers::delta_stickers_protocol)
+        .register_asynchronous_uri_scheme_protocol(
+            "dcchatbgimage",
+            chat_background_image::delta_chat_background_image_protocol,
+        )
         .register_asynchronous_uri_scheme_protocol(
             "email",
             html_window::email_scheme::email_protocol,

--- a/packages/target-tauri/src-tauri/src/runtime_info.rs
+++ b/packages/target-tauri/src-tauri/src/runtime_info.rs
@@ -26,6 +26,7 @@ struct BuildInfo {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TauriSpecificScheme {
     blobs: &'static str,
+    chat_background_image: &'static str,
     webxdc_icon: &'static str,
     stickers: &'static str,
 }
@@ -62,12 +63,14 @@ pub fn get_runtime_info() -> RuntimeInfo {
         #[cfg(not(any(target_os = "windows", target_os = "android")))]
         scheme: TauriSpecificScheme {
             blobs: "dcblob://",
+            chat_background_image: "dcchatbgimage://",
             webxdc_icon: "webxdc-icon://",
             stickers: "dcsticker://",
         },
         #[cfg(any(target_os = "windows", target_os = "android"))]
         scheme: TauriSpecificScheme {
             blobs: "http://dcblob.localhost/",
+            chat_background_image: "http://dcchatbgimage.localhost/",
             webxdc_icon: "http://webxdc-icon.localhost/",
             stickers: "http://dcsticker.localhost/",
         },

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -37,7 +37,7 @@
         "script-src": "'self' 'wasm-unsafe-eval'",
         "worker-src": "blob:",
         "child-src": "blob:",
-        "img-src": "'self' data: blob: dcblob: webxdc-icon: dcsticker:",
+        "img-src": "'self' data: blob: dcblob: webxdc-icon: dcsticker: dcchatbgimage:",
         "media-src": "'self' dcblob:"
       }
       // TODO postponed to later


### PR DESCRIPTION
The new Tauri `saveBackgroundImage` is pretty much a Rust re-implemetation of the Node version of the function, except it doesn't remove the entire directory (which is arguably a bit over-engineered, but I just didn't want to `rm` more than needed).

This introduces a custom protocol scheme to get the image.

- [x] Please test this on macOS or Linux.