### PR TITLE
fix: error message not being shown on RPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 - accessibility: don't announce "padlock" on messages
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895
-- show error message when QR scan action fails
+- fix error messages not being shown on some errors, e.g. when QR scan action fails
 - tauri: fix: sticker picker previews not working
 - tauri: fix emoji picker being super ugly
 - tauri: use current locale in "Help" window when opening it through menu

--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -21,6 +21,7 @@ import type { DialogProps } from '../../contexts/DialogContext'
 import AlertDialog from './AlertDialog'
 import { selectedAccountId } from '../../ScreenController'
 import { T } from '@deltachat/jsonrpc-client'
+import { unknownErrorToString } from '../helpers/unknownErrorToString'
 
 /**
  * uses a prefilled LoginForm with existing credentials
@@ -124,10 +125,8 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
           return
         }
       } catch (error) {
-        const errorStr =
-          error instanceof Error ? error.message : JSON.stringify(error)
         openDialog(AlertDialog, {
-          message: tx('proxy_invalid') + '\n' + errorStr,
+          message: tx('proxy_invalid') + '\n' + unknownErrorToString(error),
         })
         return
       }

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupProgressDialog.tsx
@@ -17,6 +17,7 @@ import useTranslationFunction from '../../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../../contexts/DialogContext'
 import { runtime } from '@deltachat-desktop/runtime-interface'
+import { unknownErrorToString } from '../../helpers/unknownErrorToString'
 
 const log = getLogger('renderer/receive_backup')
 
@@ -52,9 +53,7 @@ export function ReceiveBackupProgressDialog({
         log.debug(`Starting remote backup import of ${QrWithToken}`)
         await BackendRemote.rpc.getBackup(accountId, QrWithToken)
       } catch (err) {
-        if (err instanceof Error) {
-          setError(err.message)
-        }
+        setError(unknownErrorToString(err))
         return
       }
       onClose()

--- a/packages/frontend/src/components/helpers/unknownErrorToString.ts
+++ b/packages/frontend/src/components/helpers/unknownErrorToString.ts
@@ -1,0 +1,17 @@
+/**
+ * Useful for catching RPC errors, which are not `instanceof Error`.
+ *
+ * FYI we also have `CrashScreen.errorToText`.
+ */
+export function unknownErrorToString(error: unknown): string {
+  if (typeof error !== 'object' || error == null) {
+    return `Error: ${error}`
+  }
+  if ('message' in error) {
+    return `${error.message}`
+  }
+  if ('toString' in error && typeof error.toString === 'function') {
+    return error.toString()
+  }
+  return `Error: ${error}`
+}

--- a/packages/frontend/src/components/screens/CrashScreen.tsx
+++ b/packages/frontend/src/components/screens/CrashScreen.tsx
@@ -28,6 +28,7 @@ export class CrashScreen extends React.Component<
     })
   }
 
+  // FYI we also have `unknownErrorToString`.
   errorToText(error: object | Error) {
     if (error instanceof Error) {
       // TODO parse the stack and map the sourcemap to provide a useful stacktrace

--- a/packages/frontend/src/components/screens/RecoverableCrashScreen.tsx
+++ b/packages/frontend/src/components/screens/RecoverableCrashScreen.tsx
@@ -31,6 +31,7 @@ export class RecoverableCrashScreen extends React.Component<
     })
   }
 
+  // FYI we also have `unknownErrorToString`.
   errorToText(error: any) {
     if (error instanceof Error) {
       // TODO parse the stack and map the sourcemap to provide a useful stacktrace

--- a/packages/frontend/src/components/screens/WelcomeScreen/ImportBackupProgressDialog.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/ImportBackupProgressDialog.tsx
@@ -16,6 +16,7 @@ import { selectedAccountId } from '../../../ScreenController'
 
 import type { DcEventType } from '@deltachat/jsonrpc-client'
 import type { DialogProps } from '../../../contexts/DialogContext'
+import { unknownErrorToString } from '../../helpers/unknownErrorToString'
 
 type Props = {
   backupFile: string
@@ -51,9 +52,7 @@ export default function ImportBackupProgressDialog({
           '1'
         )
       } catch (err) {
-        if (err instanceof Error) {
-          setError(err.message)
-        }
+        setError(unknownErrorToString(err))
         return
       }
       onClose()

--- a/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
@@ -9,9 +9,7 @@ import { getConfiguredAccounts } from '../../../backend/account'
 import { BackendRemote, EffectfulBackendActions } from '../../../backend-com'
 import useDialog from '../../../hooks/dialog/useDialog'
 import AlertDialog from '../../dialogs/AlertDialog'
-import { getLogger } from '@deltachat-desktop/shared/logger'
-
-const log = getLogger('renderer/components/screens/WelcomScreen')
+import { unknownErrorToString } from '../../helpers/unknownErrorToString'
 
 type Props = {
   selectedAccountId: number
@@ -62,15 +60,10 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
       }
       props.onExitWelcomeScreen()
     } catch (error) {
-      if (error instanceof Error) {
-        openDialog(AlertDialog, {
-          message: error?.message,
-          cb: () => {},
-        })
-      } else {
-        log.error('unexpected error type', error)
-        throw error
-      }
+      openDialog(AlertDialog, {
+        message: unknownErrorToString(error),
+        cb: () => {},
+      })
     }
   }
 

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -18,6 +18,7 @@ import type { T } from '@deltachat/jsonrpc-client'
 import type { QrWithUrl } from '../backend/qr'
 import type { WelcomeQrWithUrl } from '../contexts/InstantOnboardingContext'
 import useChat from './chat/useChat'
+import { unknownErrorToString } from '../components/helpers/unknownErrorToString'
 
 const ALLOWED_QR_CODES_ON_WELCOME_SCREEN: T.Qr['kind'][] = [
   'account',
@@ -64,14 +65,7 @@ export default function useProcessQR() {
         await BackendRemote.rpc.setConfigFromQr(accountId, qrContent)
       } catch (error) {
         openAlertDialog({
-          message:
-            (typeof error === 'object' && error != null
-              ? 'message' in error
-                ? `${error.message}`
-                : 'toString' in error
-                  ? error.toString()
-                  : null
-              : null) ?? 'Failed to setConfigFromQr',
+          message: unknownErrorToString(error),
         })
       }
     },


### PR DESCRIPTION
The error thrown by `await BackendRemote.rpc...()` is not
`instanceof Error`, so we handled it incorrectly often times.

FYI there are a lot more `catch`es in our code base,
and I didn't re-check all of them.
This only fixes those that used `instanceof Error`.

Follow-up to https://github.com/deltachat/deltachat-desktop/pull/4981.

Related: https://github.com/deltachat/deltachat-desktop/issues/3883.
