### PR TITLE
tauri: fix: some styles not loading (CSP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@
 - fix error messages not being shown on some errors, e.g. when QR scan action fails
 - tauri: fix: sticker picker previews not working
 - tauri: fix emoji picker being super ugly
+- tauri: fix color picker appearing during initial page load
+- tauri: fix fullscreen media pan acting a little weird
 - tauri: use current locale in "Help" window when opening it through menu
 - tauri: fix launching a second instance of Delta Chat not focusing the main window if it's closed
 - fix chatlist items sometimes not updating #4975

--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -27,6 +27,15 @@ body {
   }
 }
 
+#color-input-wrapper {
+  position: absolute;
+  touch-action: none;
+  z-index: 0;
+  user-select: none;
+  pointer-events: none;
+  opacity: 0;
+}
+
 ol,
 ul {
   list-style: none;

--- a/packages/frontend/static/main.html
+++ b/packages/frontend/static/main.html
@@ -40,17 +40,7 @@
     <script type="text/javascript" src="./fix-missing-vars.js"></script>
     <script src="./runtime.js" type="module"></script>
     <script src="./bundle.js" type="module"></script>
-    <div
-      aria-hidden="true"
-      style="
-        position: absolute;
-        touch-action: none;
-        z-index: 0;
-        user-select: none;
-        pointer-events: none;
-        opacity: 0;
-      "
-    >
+    <div id="color-input-wrapper" aria-hidden="true">
       <input id="color-input" tabindex="-1" type="color" />
     </div>
   </body>

--- a/packages/target-browser/static/test.html
+++ b/packages/target-browser/static/test.html
@@ -19,7 +19,7 @@
     <script type="text/javascript" src="./fix-missing-vars.js"></script>
     <script src="./runtime.js" type="module"></script>
     <script src="./bundle.js" type="module"></script>
-    <div aria-hidden="true" style="position: absolute; touch-action: none; z-index: 0; user-select: none; pointer-events: none; opacity: 0;">
+    <div id="color-input-wrapper" aria-hidden="true">
       <input id="color-input" tabindex="-1" type="color" />
     </div>
   </body>

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -24,15 +24,15 @@
       "csp": {
         "default-src": "none",
         "connect-src": "'self' ipc:",
-        // The sha256 value is for `emoji-mart`. We can't use 'unsafe-inline',
+        // The sha-256 values are for
+        // - `emoji-mart`.
+        // - `react-zoom-pan-pinch`'s TransformComponent (2nd and 3rd entries).
+        // We can't use 'unsafe-inline',
         // because Tauri injects nonce values,
         // (see https://tauri.app/security/csp/), and the browser complains:
         // > Note that 'unsafe-inline' is ignored if either a hash
         // > or nonce value is present in the source list.
-        //
-        // TODO if you look in dev tools console, we have more warnings
-        // about CSP. Figure out what these are.
-        "style-src": "'self' 'sha256-+A14ONesVdzkn6nr37Osn+rUqNz4oFGZFDbLXrlae04='",
+        "style-src": "'self' 'sha256-+A14ONesVdzkn6nr37Osn+rUqNz4oFGZFDbLXrlae04=' 'sha256-HV3Dam0GcDz1w0B+b1RFgSxPeS9mwy/UvkSnZ/Bh/Cc=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
         "font-src": "'self'",
         "script-src": "'self' 'wasm-unsafe-eval'",
         "worker-src": "blob:",

--- a/packages/target-tauri/static/tauri_main.html
+++ b/packages/target-tauri/static/tauri_main.html
@@ -41,17 +41,7 @@
     <script type="text/javascript" src="./fix-missing-vars.js"></script>
     <script src="./runtime.js" type="module"></script>
     <script src="./bundle.js" type="module"></script>
-    <div
-      aria-hidden="true"
-      style="
-        position: absolute;
-        touch-action: none;
-        z-index: 0;
-        user-select: none;
-        pointer-events: none;
-        opacity: 0;
-      "
-    >
+    <div id="color-input-wrapper" aria-hidden="true">
       <input id="color-input" tabindex="-1" type="color" />
     </div>
   </body>


### PR DESCRIPTION
- Fullscreen media's `TransformComponent`
- color picker hiding styles

This commit concludes fixing all the CSP issues of the main window,
at least the ones that appear on initial page load.
