### PR TITLE
improvement: `Cmd + F` to focus search on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - add separators to the context menu #4883
 - add button to share contact from profile view dialog #4886
 - tauri: experimental: make it compile for android #4871
-- `Cmd + N` shortcut to open new chat on macOS #4901
+- `Cmd + N` shortcut to open new chat and `Cmd + F` / `Cmd + Shift + F` to focus search on macOS #4901, #5013
 - tauri: add cli interface: `--help`, `--version`, and developer options (like `--dev-mode`) #4908
 - enable support for recording audio messages
 - tauri: handle resume from sleep #4926

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -220,11 +220,11 @@ export function getKeybindings(
       },
       {
         title: tx('focus_search_input'),
-        keyBindings: [['Control', 'F']],
+        keyBindings: [[isMac ? 'Meta' : 'Control', 'F']],
       },
       {
         title: tx('search_in_chat'),
-        keyBindings: [['Control', 'Shift', 'F']],
+        keyBindings: [[isMac ? 'Meta' : 'Control', 'Shift', 'F']],
       },
       {
         title: tx('menu_new_chat'),

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -95,8 +95,11 @@ export function keyDownEvent2Action(
       // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
       //   return KeybindAction.ChatList_ScrollToSelectedChat
       // }
+    } else if (
+      (ev.metaKey || ev.ctrlKey) &&
       // fallback to KeyF code for keyboard layouts without f key
-    } else if (ev.ctrlKey && (ev.key === 'f' || ev.code === 'KeyF')) {
+      (ev.key === 'f' || ev.code === 'KeyF')
+    ) {
       // https://github.com/deltachat/deltachat-desktop/issues/4579
       if (ev.shiftKey) {
         return KeybindAction.ChatList_SearchInChat


### PR DESCRIPTION
Follow-up to 19523b07bcc6d21d212332a4b2daa55a861bb77b
(https://github.com/deltachat/deltachat-desktop/pull/4901).
