### PR TITLE
Avoid react warning and speed up rendering

### DIFF
--- a/packages/frontend/src/components/RadioGroup.tsx
+++ b/packages/frontend/src/components/RadioGroup.tsx
@@ -26,6 +26,7 @@ export default function RadioGroup({
               selected={props.value === selectedValue}
               onSelect={() => onChange && onChange(props.value)}
               name={name}
+              key={props.value}
             />
           )
         })}


### PR DESCRIPTION
Avoid RadioGroup.tsx:21 Warning: Each child in a list should have a unique "key" prop.

#skip-changelog