### PR TITLE
improvement: a11y: `aria-live` for message status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - accessibility: add accessible labels to more items
 - accessibility: add alt text for QR invite code image
 - accessibility: improve tabbing behavior of searh results
-- accessibility: announce when a message gets edited
+- accessibility: announce when a message gets edited and outgoing message delivery status changes (`aria-live`)
 
 <a id="1_57_0"></a>
 

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -92,6 +92,21 @@ export default function MessageMetaData(props: Props) {
       {direction === 'outgoing' && (
         <button
           className={classNames('status-icon', status)}
+          // The main point of `aria-live` here is to let the user know
+          // that their message has been sent or delievered
+          // right after they they send it.
+          // We want at least some indication of something happening
+          // after they press "Enter".
+          // But this is also useful to announce when the message has been read.
+          //
+          // Note that this this applies to _all_ loaded messages
+          // and not just the last one.
+          //
+          // TODO fix: NVDA announces the change twice for some reason,
+          // even when you modify just `aria-label` through the dev tools.
+          // We probably ought to keep `aria-label` fixed to "Delivery status",
+          // and only update the content, i.e. "Delivered", "Read".
+          aria-live='polite'
           aria-label={tx(
             `a11y_delivery_status_${
               status as Exclude<


### PR DESCRIPTION
This should somewhat address this point in https://github.com/deltachat/deltachat-desktop/issues/4743

> Screenreader does not announce that it is successfully sent