### PR TITLE
improvement: a11y: announce msg "edited" change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- accessibility: announce when a message gets edited
 
 <a id="1_57_0"></a>
 

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -175,7 +175,7 @@
   margin-right: 32px;
 
   .metadata:not(.with-image-no-caption) {
-    & > .padlock-icon {
+    .padlock-icon {
       @include color-svg(
         './images/padlock.svg',
         var(--messageMetadataIconColorIncoming),
@@ -183,7 +183,7 @@
       );
     }
 
-    & > .location-icon {
+    .location-icon {
       @include color-svg(
         './images/map-marker.svg',
         var(--messageMetadataIconColorIncoming),
@@ -191,7 +191,7 @@
       );
     }
 
-    & > .saved-message-icon {
+    .saved-message-icon {
       @include color-svg(
         './images/icons/bookmark-filled.svg',
         var(--messageMetadataIconColorIncoming),
@@ -199,8 +199,8 @@
       );
     }
 
-    & > .date,
-    & > .edited {
+    .date,
+    .edited {
       color: var(--messageMetadataIncoming);
     }
   }
@@ -223,12 +223,12 @@
   margin-right: 0;
 
   .metadata:not(.with-image-no-caption) {
-    & > .date,
-    & > .edited {
+    .date,
+    .edited {
       color: var(--messageOutgoingStatusColor);
     }
 
-    & > .padlock-icon {
+    .padlock-icon {
       @include color-svg(
         './images/padlock.svg',
         var(--messageMetadataIconColorOutgoing),
@@ -236,7 +236,7 @@
       );
     }
 
-    & > .location-icon {
+    .location-icon {
       @include color-svg(
         './images/map-marker.svg',
         var(--messageMetadataIconColorOutgoing),
@@ -244,7 +244,7 @@
       );
     }
 
-    & > .saved-message-icon {
+    .saved-message-icon {
       @include color-svg(
         './images/icons/bookmark-filled.svg',
         var(--messageMetadataIconColorOutgoing),
@@ -252,8 +252,8 @@
       );
     }
 
-    & > .status-icon.read,
-    & > .status-icon.delivered {
+    .status-icon.read,
+    .status-icon.delivered {
       background-color: var(--messageOutgoingStatusColor);
     }
   }
@@ -318,21 +318,21 @@
   }
 
   .metadata {
-    & > .date,
-    & > .edited {
+    .date,
+    .edited {
       font-size: 11px;
       color: white;
     }
 
-    & > .padlock-icon {
+    .padlock-icon {
       @include color-svg('./images/padlock.svg', white, 125%);
     }
 
-    & > .location-icon {
+    .location-icon {
       @include color-svg('./images/map-marker.svg', white, 100%);
     }
 
-    & > .saved-message-icon {
+    .saved-message-icon {
       @include color-svg('./images/icons/bookmark-filled.svg', white, 100%);
     }
   }
@@ -663,20 +663,20 @@
     .metadata {
       margin: 0;
 
-      & > .padlock-icon {
+      .padlock-icon {
         @include color-svg('./images/padlock.svg', white, 125%);
       }
 
-      & > .location-icon {
+      .location-icon {
         @include color-svg('./images/map-marker.svg', white, 100%);
       }
 
-      & > .saved-message-icon {
+      .saved-message-icon {
         @include color-svg('./images/icons/bookmark-filled.svg', white, 100%);
       }
 
-      & > .date,
-      & > .edited {
+      .date,
+      .edited {
         color: white;
       }
     }

--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -13,16 +13,16 @@
     border-radius: 4px;
     font-weight: bold;
 
-    & > .date,
-    & > .edited {
+    .date,
+    .edited {
       color: white;
     }
 
-    & > .padlock-icon {
+    .padlock-icon {
       @include color-svg('./images/padlock.svg', white, 125%);
     }
 
-    & > .saved-message-icon {
+    .saved-message-icon {
       @include color-svg('./images/icons/bookmark-filled.svg', white, 100%);
     }
 
@@ -31,29 +31,29 @@
     }
   }
 
-  & > .status-icon {
+  .status-icon {
     margin-bottom: 2px;
   }
 
-  & > .date,
-  & > .edited {
+  .date,
+  .edited {
     font-size: 11.5px;
     line-height: 16px;
     letter-spacing: 0.3px;
     color: var(--messageMetadataDate);
   }
-  & > .edited {
+  .edited {
     // Assumes that there is always a date after it.
     margin-inline-end: 0.5ch;
   }
 
-  & > .spacer {
+  .spacer {
     flex-grow: 1;
   }
 
-  & > .padlock-icon,
-  & > .location-icon,
-  & > .saved-message-icon {
+  .padlock-icon,
+  .location-icon,
+  .saved-message-icon {
     width: 12px;
     height: 12px;
     display: inline-block;
@@ -61,8 +61,8 @@
     margin-bottom: 3px;
   }
 
-  & > .location-icon,
-  & > .saved-message-icon {
+  .location-icon,
+  .saved-message-icon {
     margin-bottom: 0;
   }
 }

--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -31,6 +31,12 @@
     }
   }
 
+  .aria-live-wrapper {
+    // Basically try to behave the same as if the wrapper just wasn't there.
+    display: inline-block;
+    line-height: 0;
+  }
+
   .status-icon {
     margin-bottom: 2px;
   }

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -50,6 +50,9 @@ export default function MessageMetaData(props: Props) {
         ),
       })}
     >
+      {/* FYI the padlock doesn't need `aria-live`
+      as we don't expect it to get removed. See
+      https://github.com/deltachat/deltachat-desktop/pull/5023#discussion_r2059382983 */}
       {padlock && (
         <div
           aria-label={tx('a11y_encryption_padlock')}
@@ -63,11 +66,22 @@ export default function MessageMetaData(props: Props) {
           className={'padlock-icon'}
         />
       )}
-      {isSavedMessage && (
-        <div aria-label={tx('saved')} className={'saved-message-icon'} />
-      )}
+      <div
+        className='aria-live-wrapper'
+        aria-live='polite'
+        // Also announce removals as to notify when a message gets unsaved.
+        // AFAIK "saved" / "unsaved" changes only as a result of user action,
+        // but let's do it for confirmation, and for future-proofing.
+        aria-relevant='all'
+      >
+        {isSavedMessage && (
+          <div aria-label={tx('saved')} className={'saved-message-icon'} />
+        )}
+      </div>
       {hasLocation && <span className={'location-icon'} />}
-      {isEdited && <span className='edited'>{tx('edited')}</span>}
+      <div className='aria-live-wrapper' aria-live='polite'>
+        {isEdited && <span className='edited'>{tx('edited')}</span>}
+      </div>
       <Timestamp
         timestamp={timestamp}
         extended


### PR DESCRIPTION
This will only announce the "edited" status,
and not the new text of the message.

This also includes a refactor, see individual commits for clarity.

I have checked that the layout didn't change, at least in basic cases.