### PR TITLE
fix: a11y: `aria-setsize="-1"` for message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - i18n: fix wrong order of substitutions for some strings #4889
 - i18n: translate some more strings
 - accessibility: don't announce "padlock" on messages
+- accessibility: don't announce the number of currently loaded messages in the current chat
 - fix double escape bypasses dialog attribute `canEscapeKeyClose={false}`
 - fix order when sending multiple files at once #4895
 - fix error messages not being shown on some errors, e.g. when QR scan action fails

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -859,14 +859,22 @@ export const MessageListInner = React.memo(
     if (!loaded) {
       return (
         <div id='message-list' ref={messageListRef} onScroll={onScroll2}>
-          <ol></ol>
+          <ol aria-setsize={-1}></ol>
         </div>
       )
     }
 
     return (
       <div id='message-list' ref={messageListRef} onScroll={onScroll2}>
-        <ol>
+        {/* aria-setsize='-1' means "undetermined size".
+        This is mostly because not all messages are loaded,
+        and otherwise screen readers just announce the number of messages
+        that are currently in the DOM, which is not helpful.
+        Theoretically we could specify the actual number of messages
+        in this chat, and figure out the order of each individual message,
+        but this is perhaps still not the information that the user
+        would want to hear every time they focus the message list. */}
+        <ol aria-setsize={-1}>
           <RovingTabindexProvider wrapperElementRef={messageListRef}>
             {messageListItems.length === 0 && <EmptyChatMessage chat={chat} />}
             {activeView.map(messageId => {


### PR DESCRIPTION
It would be nice to also apply this to our virtualized lists,
but this requires modifying the library:
https://github.com/bvaughn/react-window/issues/808.

FYI NVDA still announces the number of messages, which, I suppose, is an NVDA bug.