### PR TITLE
improvement: a11y: search: separate tabindex divs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - accessibility: add accessible labels to more items
 - accessibility: add alt text for QR invite code image
+- accessibility: improve tabbing behavior of searh results
 - accessibility: announce when a message gets edited
 
 <a id="1_57_0"></a>

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -163,7 +163,10 @@ export default function ChatList(props: {
   const { selectChat } = useChat()
 
   const rovingTabindexItemsClassName = 'roving-tabindex'
-  const tabindexWrapperElement = useRef<HTMLDivElement>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const tabindexWrapperElementChats = useRef<HTMLDivElement>(null)
+  const tabindexWrapperElementContacts = useRef<HTMLDivElement>(null)
+  const tabindexWrapperElementMessages = useRef<HTMLDivElement>(null)
 
   const addContactOnClick = async () => {
     if (!queryStrIsValidEmail || !queryStr) return
@@ -293,7 +296,7 @@ export default function ChatList(props: {
 
   useKeyBindingAction(KeybindAction.ChatList_FocusItems, () => {
     ;(
-      tabindexWrapperElement.current?.querySelector(
+      rootRef.current?.querySelector(
         // Not just the first element, but the active one, i.e.
         // if the user already interacted with the list we should not reset
         // the current selection.
@@ -361,17 +364,17 @@ export default function ChatList(props: {
 
   if (queryChatId && searchChatInfo) {
     return (
-      <div className='chat-list'>
+      <div ref={rootRef} className='chat-list'>
         <AutoSizer disableWidth>
           {({ height }) => (
-            <div ref={tabindexWrapperElement}>
+            <div ref={tabindexWrapperElementChats}>
               <div className='search-result-divider'>
                 {tx('search_in', searchChatInfo.name)}
                 {messageResultIds.length !== 0 &&
                   ': ' + translate_n('n_messages', messageResultIds.length)}
               </div>
               <RovingTabindexProvider
-                wrapperElementRef={tabindexWrapperElement}
+                wrapperElementRef={tabindexWrapperElementChats}
                 classNameOfTargetElements={rovingTabindexItemsClassName}
               >
                 <ChatListPart
@@ -398,10 +401,10 @@ export default function ChatList(props: {
   }
 
   return (
-    <div className='chat-list'>
+    <div ref={rootRef} className='chat-list'>
       <AutoSizer disableWidth>
         {({ height }) => (
-          <div ref={tabindexWrapperElement}>
+          <>
             {isSearchActive && (
               <div className='search-result-divider'>
                 {translate_n('n_chats', chatListIds.length)}
@@ -411,75 +414,91 @@ export default function ChatList(props: {
               lists, because the currently active element might get removed
               from DOM if scrolled out of view. */}
             <RovingTabindexProvider
-              wrapperElementRef={tabindexWrapperElement}
+              wrapperElementRef={tabindexWrapperElementChats}
               classNameOfTargetElements={rovingTabindexItemsClassName}
             >
-              <ChatListPart
-                isRowLoaded={isChatLoaded}
-                loadMoreRows={loadChats}
-                rowCount={chatListIds.length}
-                width={'100%'}
-                height={chatsHeight(height)}
-                setListRef={(ref: List<any> | null) =>
-                  ((listRefRef.current as any) = ref)
-                }
-                itemKey={index => 'key' + chatListIds[index]}
-                itemData={chatlistData}
-                itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-              >
-                {ChatListItemRowChat}
-              </ChatListPart>
+              <div ref={tabindexWrapperElementChats}>
+                <ChatListPart
+                  isRowLoaded={isChatLoaded}
+                  loadMoreRows={loadChats}
+                  rowCount={chatListIds.length}
+                  width={'100%'}
+                  height={chatsHeight(height)}
+                  setListRef={(ref: List<any> | null) =>
+                    ((listRefRef.current as any) = ref)
+                  }
+                  itemKey={index => 'key' + chatListIds[index]}
+                  itemData={chatlistData}
+                  itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+                >
+                  {ChatListItemRowChat}
+                </ChatListPart>
+              </div>
               {isSearchActive && (
                 <>
                   <div className='search-result-divider'>
                     {translate_n('n_contacts', contactIds.length)}
                   </div>
-                  <ChatListPart
-                    isRowLoaded={isContactLoaded}
-                    loadMoreRows={loadContact}
-                    rowCount={contactIds.length}
-                    width={'100%'}
-                    height={contactsHeight(height)}
-                    itemKey={index => 'key' + contactIds[index]}
-                    itemData={contactlistData}
-                    itemHeight={CHATLISTITEM_CONTACT_HEIGHT}
+                  <RovingTabindexProvider
+                    wrapperElementRef={tabindexWrapperElementContacts}
+                    classNameOfTargetElements={rovingTabindexItemsClassName}
                   >
-                    {ChatListItemRowContact}
-                  </ChatListPart>
-                  {contactIds.length === 0 &&
-                    chatListIds.length === 0 &&
-                    queryStrIsValidEmail && (
-                      <PseudoListItemAddContact
-                        queryStr={queryStr?.trim() || ''}
-                        queryStrIsEmail={queryStrIsValidEmail}
-                        onClick={addContactOnClick}
-                      />
-                    )}
-                  {showPseudoListItemAddContactFromInviteLink && (
-                    <PseudoListItemAddContactOrGroupFromInviteLink
-                      inviteLink={queryStr!}
-                      accountId={accountId}
-                    />
-                  )}
+                    <div ref={tabindexWrapperElementContacts}>
+                      <ChatListPart
+                        isRowLoaded={isContactLoaded}
+                        loadMoreRows={loadContact}
+                        rowCount={contactIds.length}
+                        width={'100%'}
+                        height={contactsHeight(height)}
+                        itemKey={index => 'key' + contactIds[index]}
+                        itemData={contactlistData}
+                        itemHeight={CHATLISTITEM_CONTACT_HEIGHT}
+                      >
+                        {ChatListItemRowContact}
+                      </ChatListPart>
+                      {contactIds.length === 0 &&
+                        chatListIds.length === 0 &&
+                        queryStrIsValidEmail && (
+                          <PseudoListItemAddContact
+                            queryStr={queryStr?.trim() || ''}
+                            queryStrIsEmail={queryStrIsValidEmail}
+                            onClick={addContactOnClick}
+                          />
+                        )}
+                      {showPseudoListItemAddContactFromInviteLink && (
+                        <PseudoListItemAddContactOrGroupFromInviteLink
+                          inviteLink={queryStr!}
+                          accountId={accountId}
+                        />
+                      )}
+                    </div>
+                  </RovingTabindexProvider>
                   <div className='search-result-divider'>
                     {translated_messages_label(messageResultIds.length)}
                   </div>
 
-                  <ChatListPart
-                    isRowLoaded={isMessageLoaded}
-                    loadMoreRows={loadMessages}
-                    rowCount={messageResultIds.length}
-                    width={'100%'}
-                    height={
-                      // take remaining space
-                      messagesHeight(height)
-                    }
-                    itemKey={index => 'key' + messageResultIds[index]}
-                    itemData={messagelistData}
-                    itemHeight={CHATLISTITEM_MESSAGE_HEIGHT}
+                  <RovingTabindexProvider
+                    wrapperElementRef={tabindexWrapperElementMessages}
+                    classNameOfTargetElements={rovingTabindexItemsClassName}
                   >
-                    {ChatListItemRowMessage}
-                  </ChatListPart>
+                    <div ref={tabindexWrapperElementMessages}>
+                      <ChatListPart
+                        isRowLoaded={isMessageLoaded}
+                        loadMoreRows={loadMessages}
+                        rowCount={messageResultIds.length}
+                        width={'100%'}
+                        height={
+                          // take remaining space
+                          messagesHeight(height)
+                        }
+                        itemKey={index => 'key' + messageResultIds[index]}
+                        itemData={messagelistData}
+                        itemHeight={CHATLISTITEM_MESSAGE_HEIGHT}
+                      >
+                        {ChatListItemRowMessage}
+                      </ChatListPart>
+                    </div>
+                  </RovingTabindexProvider>
                 </>
               )}
             </RovingTabindexProvider>
@@ -497,7 +516,7 @@ export default function ChatList(props: {
                 }}
               ></div>
             </button>
-          </div>
+          </>
         )}
       </AutoSizer>
     </div>

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -361,28 +361,118 @@ export default function ChatList(props: {
 
   if (queryChatId && searchChatInfo) {
     return (
-      <>
-        <div className='chat-list'>
-          <AutoSizer disableWidth>
-            {({ height }) => (
-              <div ref={tabindexWrapperElement}>
-                <div className='search-result-divider'>
-                  {tx('search_in', searchChatInfo.name)}
-                  {messageResultIds.length !== 0 &&
-                    ': ' + translate_n('n_messages', messageResultIds.length)}
-                </div>
-                <RovingTabindexProvider
-                  wrapperElementRef={tabindexWrapperElement}
-                  classNameOfTargetElements={rovingTabindexItemsClassName}
+      <div className='chat-list'>
+        <AutoSizer disableWidth>
+          {({ height }) => (
+            <div ref={tabindexWrapperElement}>
+              <div className='search-result-divider'>
+                {tx('search_in', searchChatInfo.name)}
+                {messageResultIds.length !== 0 &&
+                  ': ' + translate_n('n_messages', messageResultIds.length)}
+              </div>
+              <RovingTabindexProvider
+                wrapperElementRef={tabindexWrapperElement}
+                classNameOfTargetElements={rovingTabindexItemsClassName}
+              >
+                <ChatListPart
+                  isRowLoaded={isMessageLoaded}
+                  loadMoreRows={loadMessages}
+                  rowCount={messageResultIds.length}
+                  width={'100%'}
+                  height={
+                    /* take remaining space */
+                    height - DIVIDER_HEIGHT
+                  }
+                  itemKey={index => 'key' + messageResultIds[index]}
+                  itemData={messagelistData}
+                  itemHeight={CHATLISTITEM_MESSAGE_HEIGHT}
                 >
+                  {ChatListItemRowMessage}
+                </ChatListPart>
+              </RovingTabindexProvider>
+            </div>
+          )}
+        </AutoSizer>
+      </div>
+    )
+  }
+
+  return (
+    <div className='chat-list'>
+      <AutoSizer disableWidth>
+        {({ height }) => (
+          <div ref={tabindexWrapperElement}>
+            {isSearchActive && (
+              <div className='search-result-divider'>
+                {translate_n('n_chats', chatListIds.length)}
+              </div>
+            )}
+            {/* TODO RovingTabindex doesn't work well with virtualized
+              lists, because the currently active element might get removed
+              from DOM if scrolled out of view. */}
+            <RovingTabindexProvider
+              wrapperElementRef={tabindexWrapperElement}
+              classNameOfTargetElements={rovingTabindexItemsClassName}
+            >
+              <ChatListPart
+                isRowLoaded={isChatLoaded}
+                loadMoreRows={loadChats}
+                rowCount={chatListIds.length}
+                width={'100%'}
+                height={chatsHeight(height)}
+                setListRef={(ref: List<any> | null) =>
+                  ((listRefRef.current as any) = ref)
+                }
+                itemKey={index => 'key' + chatListIds[index]}
+                itemData={chatlistData}
+                itemHeight={CHATLISTITEM_CHAT_HEIGHT}
+              >
+                {ChatListItemRowChat}
+              </ChatListPart>
+              {isSearchActive && (
+                <>
+                  <div className='search-result-divider'>
+                    {translate_n('n_contacts', contactIds.length)}
+                  </div>
+                  <ChatListPart
+                    isRowLoaded={isContactLoaded}
+                    loadMoreRows={loadContact}
+                    rowCount={contactIds.length}
+                    width={'100%'}
+                    height={contactsHeight(height)}
+                    itemKey={index => 'key' + contactIds[index]}
+                    itemData={contactlistData}
+                    itemHeight={CHATLISTITEM_CONTACT_HEIGHT}
+                  >
+                    {ChatListItemRowContact}
+                  </ChatListPart>
+                  {contactIds.length === 0 &&
+                    chatListIds.length === 0 &&
+                    queryStrIsValidEmail && (
+                      <PseudoListItemAddContact
+                        queryStr={queryStr?.trim() || ''}
+                        queryStrIsEmail={queryStrIsValidEmail}
+                        onClick={addContactOnClick}
+                      />
+                    )}
+                  {showPseudoListItemAddContactFromInviteLink && (
+                    <PseudoListItemAddContactOrGroupFromInviteLink
+                      inviteLink={queryStr!}
+                      accountId={accountId}
+                    />
+                  )}
+                  <div className='search-result-divider'>
+                    {translated_messages_label(messageResultIds.length)}
+                  </div>
+
                   <ChatListPart
                     isRowLoaded={isMessageLoaded}
                     loadMoreRows={loadMessages}
                     rowCount={messageResultIds.length}
                     width={'100%'}
                     height={
-                      /* take remaining space */
-                      height - DIVIDER_HEIGHT
+                      // take remaining space
+                      messagesHeight(height)
                     }
                     itemKey={index => 'key' + messageResultIds[index]}
                     itemData={messagelistData}
@@ -390,121 +480,27 @@ export default function ChatList(props: {
                   >
                     {ChatListItemRowMessage}
                   </ChatListPart>
-                </RovingTabindexProvider>
-              </div>
-            )}
-          </AutoSizer>
-        </div>
-      </>
-    )
-  }
-
-  return (
-    <>
-      <div className='chat-list'>
-        <AutoSizer disableWidth>
-          {({ height }) => (
-            <div ref={tabindexWrapperElement}>
-              {isSearchActive && (
-                <div className='search-result-divider'>
-                  {translate_n('n_chats', chatListIds.length)}
-                </div>
+                </>
               )}
-              {/* TODO RovingTabindex doesn't work well with virtualized
-              lists, because the currently active element might get removed
-              from DOM if scrolled out of view. */}
-              <RovingTabindexProvider
-                wrapperElementRef={tabindexWrapperElement}
-                classNameOfTargetElements={rovingTabindexItemsClassName}
-              >
-                <ChatListPart
-                  isRowLoaded={isChatLoaded}
-                  loadMoreRows={loadChats}
-                  rowCount={chatListIds.length}
-                  width={'100%'}
-                  height={chatsHeight(height)}
-                  setListRef={(ref: List<any> | null) =>
-                    ((listRefRef.current as any) = ref)
-                  }
-                  itemKey={index => 'key' + chatListIds[index]}
-                  itemData={chatlistData}
-                  itemHeight={CHATLISTITEM_CHAT_HEIGHT}
-                >
-                  {ChatListItemRowChat}
-                </ChatListPart>
-                {isSearchActive && (
-                  <>
-                    <div className='search-result-divider'>
-                      {translate_n('n_contacts', contactIds.length)}
-                    </div>
-                    <ChatListPart
-                      isRowLoaded={isContactLoaded}
-                      loadMoreRows={loadContact}
-                      rowCount={contactIds.length}
-                      width={'100%'}
-                      height={contactsHeight(height)}
-                      itemKey={index => 'key' + contactIds[index]}
-                      itemData={contactlistData}
-                      itemHeight={CHATLISTITEM_CONTACT_HEIGHT}
-                    >
-                      {ChatListItemRowContact}
-                    </ChatListPart>
-                    {contactIds.length === 0 &&
-                      chatListIds.length === 0 &&
-                      queryStrIsValidEmail && (
-                        <PseudoListItemAddContact
-                          queryStr={queryStr?.trim() || ''}
-                          queryStrIsEmail={queryStrIsValidEmail}
-                          onClick={addContactOnClick}
-                        />
-                      )}
-                    {showPseudoListItemAddContactFromInviteLink && (
-                      <PseudoListItemAddContactOrGroupFromInviteLink
-                        inviteLink={queryStr!}
-                        accountId={accountId}
-                      />
-                    )}
-                    <div className='search-result-divider'>
-                      {translated_messages_label(messageResultIds.length)}
-                    </div>
-
-                    <ChatListPart
-                      isRowLoaded={isMessageLoaded}
-                      loadMoreRows={loadMessages}
-                      rowCount={messageResultIds.length}
-                      width={'100%'}
-                      height={
-                        // take remaining space
-                        messagesHeight(height)
-                      }
-                      itemKey={index => 'key' + messageResultIds[index]}
-                      itemData={messagelistData}
-                      itemHeight={CHATLISTITEM_MESSAGE_HEIGHT}
-                    >
-                      {ChatListItemRowMessage}
-                    </ChatListPart>
-                  </>
-                )}
-              </RovingTabindexProvider>
-              <button
-                className='floating-action-button'
-                onClick={onCreateChat}
-                id='new-chat-button'
-                aria-label={tx('menu_new_chat')}
-                aria-keyshortcuts='Control+N'
-              >
-                <div
-                  className='Icon'
-                  style={{
-                    WebkitMask: 'url(./images/icons/plus.svg) no-repeat center',
-                  }}
-                ></div>
-              </button>
-            </div>
-          )}
-        </AutoSizer>
-      </div>
-    </>
+            </RovingTabindexProvider>
+            <button
+              className='floating-action-button'
+              onClick={onCreateChat}
+              id='new-chat-button'
+              aria-label={tx('menu_new_chat')}
+              aria-keyshortcuts='Control+N'
+            >
+              <div
+                className='Icon'
+                style={{
+                  WebkitMask: 'url(./images/icons/plus.svg) no-repeat center',
+                }}
+              ></div>
+            </button>
+          </div>
+        )}
+      </AutoSizer>
+    </div>
   )
 }
 


### PR DESCRIPTION
Previously, all the search results, i.e. contacts, chats, messages,
were a part of the same "roving tabindex" widget.
This is perhaps not intuitive, because they're in different sections.
Let's fix that, and make each section separately tabbable to.

For easier review, turn off "show whitespace".

I have checked that it works.