### PR TITLE
Close instead back button

### DIFF
--- a/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
@@ -12,9 +12,8 @@ type Props = {
   onExitWelcomeScreen: () => Promise<void>
   onNextStep: () => void
   onUnSelectAccount: () => Promise<void>
-  onClickBackButton: () => Promise<void>
+  onClose: () => Promise<void>
   selectedAccountId: number
-  showBackButton: boolean
   hasConfiguredAccounts: boolean
 }
 
@@ -36,7 +35,7 @@ export default function OnboardingScreen(props: Props) {
   return (
     <>
       <DialogHeader
-        onClickBack={props.showBackButton ? props.onClickBackButton : undefined}
+        onClose={props.hasConfiguredAccounts ? props.onClose : undefined}
         title={
           props.hasConfiguredAccounts
             ? tx('add_account')

--- a/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
@@ -32,7 +32,6 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
   const { openDialog } = useDialog()
 
   useLayoutEffect(() => {
-    // Show back button when user has already created and configured accounts.
     // On a fresh DC start we will not have any yet.
     const checkAccounts = async () => {
       const accounts = await getConfiguredAccounts()
@@ -45,9 +44,7 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
   }, [])
 
   /**
-   * this function is called when the back button is clicked
-   *
-   * it will cancel the account creation process and call
+   * cancel the account creation process and call
    * onExitWelcomeScreen
    */
   const onClose = async () => {

--- a/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
@@ -30,7 +30,6 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
   } = useInstantOnboarding()
   const [hasConfiguredAccounts, setHasConfiguredAccounts] = useState(false)
   const { openDialog } = useDialog()
-  const showBackButton = hasConfiguredAccounts
 
   useLayoutEffect(() => {
     // Show back button when user has already created and configured accounts.
@@ -51,7 +50,7 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
    * it will cancel the account creation process and call
    * onExitWelcomeScreen
    */
-  const onClickBackButton = async () => {
+  const onClose = async () => {
     try {
       const acInfo = await BackendRemote.rpc.getAccountInfo(selectedAccountId)
       if (acInfo.kind === 'Unconfigured') {
@@ -72,19 +71,18 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
       <Dialog
         fixed
         width={400}
-        canEscapeKeyClose={false}
+        canEscapeKeyClose={hasConfiguredAccounts}
         backdropDragAreaOnTauriRuntime
         canOutsideClickClose={false}
-        onClose={onClickBackButton}
+        onClose={onClose}
         dataTestid='onboarding-dialog'
       >
         {!showInstantOnboarding ? (
           <OnboardingScreen
             onNextStep={() => startInstantOnboardingFlow()}
             selectedAccountId={selectedAccountId}
-            showBackButton={showBackButton}
             hasConfiguredAccounts={hasConfiguredAccounts}
-            onClickBackButton={onClickBackButton}
+            onClose={onClose}
             {...props}
           />
         ) : (


### PR DESCRIPTION
resolve #4700

- "Esc" to close the dialog, if user has configured accounts
- replace the "back" button with a "close" button

#skip-changelog