### PR TITLE
fix: a11y: alt text for QR invite image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- accessibility: add alt text for QR invite code image
 
 <a id="1_58_0"></a>
 

--- a/packages/frontend/src/components/dialogs/QrCode.tsx
+++ b/packages/frontend/src/components/dialogs/QrCode.tsx
@@ -96,7 +96,7 @@ export default function QrCode({
 export function QrCodeShowQrInner({
   qrCode,
   qrCodeSVG,
-  description: _description,
+  description,
   onClose,
   onBack,
 }: {
@@ -195,6 +195,7 @@ export function QrCodeShowQrInner({
               }}
               className='show-qr-dialog-qr-image'
               src={svgUrl}
+              alt={tx('qr_code') + '\n' + description}
               onContextMenu={imageContextMenu}
               tabIndex={0}
             />


### PR DESCRIPTION
Partially addresses https://github.com/deltachat/deltachat-desktop/issues/4743.
