### PR TITLE
fix: a11y: `role='tablist'` for accounts list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- accessibility: add `role='tablist'` for accounts list
 
 <a id="1_58_0"></a>
 

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -249,6 +249,12 @@ export default function AccountItem({
         [styles.isSticky]: isSticky,
         'unconfigured-account': account?.kind !== 'Configured',
       })}
+      // TODO consider adding `role='tabpanel'` for the main area of the app.
+      // Although screen readers might start to announce
+      // the account name every time you focus something in the main area,
+      // which might be too verbose.
+      role='tab'
+      aria-selected={isSelected}
       aria-busy={!account}
       onClick={() => onSelectAccount(accountId)}
       onContextMenu={onContextMenu}

--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -148,6 +148,8 @@ export default function AccountListSidebar({
         ref={accountsListRef}
         className={styles.accountList}
         onScroll={updateHoverInfoPosition}
+        role='tablist'
+        aria-orientation='vertical'
       >
         <RovingTabindexProvider wrapperElementRef={accountsListRef}>
           {accounts.map(id => (


### PR DESCRIPTION
This should make it more clear that those are not just some
"buttons". UX-wise these are very close to "tabs",
so let's mark them as such.

This also adds `aria-selected`.

This, however, doesn't add the corresponding `role='tabpanel'`
element (see the comment).
