### PR TITLE
refactor: rename and comment vars in useDraft

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -746,7 +746,16 @@ export function useDraft(
   removeFile: () => void
   clearDraft: () => void
 } {
-  const [draftState, _setDraft] = useState<DraftObject>(emptyDraft(chatId))
+  const [
+    draftState,
+    /**
+     * Set `draftState`, but don't update the value of the message textarea
+     * (because it's managed by a separate piece of state).
+     *
+     * This will not save the draft to the backend.
+     */
+    _setDraftStateButKeepTextareaValue,
+  ] = useState<DraftObject>(emptyDraft(chatId))
   /**
    * `draftRef.current` gets set to `draftState` on every render.
    * That is, when you mutate the value of this ref,
@@ -762,7 +771,7 @@ export function useDraft(
   draftRef.current = draftState
 
   const clearDraft = useCallback(() => {
-    _setDraft(_ => emptyDraft(chatId))
+    _setDraftStateButKeepTextareaValue(_ => emptyDraft(chatId))
   }, [chatId])
 
   const loadDraft = useCallback(
@@ -778,7 +787,7 @@ export function useDraft(
           clearDraft()
           inputRef.current?.setText('')
         } else {
-          _setDraft(old => ({
+          _setDraftStateButKeepTextareaValue(old => ({
             ...old,
             id: newDraft.id,
             text: newDraft.text || '',
@@ -853,7 +862,7 @@ export function useDraft(
       ? await BackendRemote.rpc.getDraft(accountId, chatId)
       : null
     if (newDraft) {
-      _setDraft(old => ({
+      _setDraftStateButKeepTextareaValue(old => ({
         ...old,
         id: newDraft.id,
         file: newDraft.file,

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -747,6 +747,17 @@ export function useDraft(
   clearDraft: () => void
 } {
   const [draftState, _setDraft] = useState<DraftObject>(emptyDraft(chatId))
+  /**
+   * `draftRef.current` gets set to `draftState` on every render.
+   * That is, when you mutate the value of this ref,
+   * `draftState` also gets mutated.
+   *
+   * Having this `ref` is just a hack to perform direct state mutations
+   * without triggering a re-render or linter's warnings about the missing
+   * `draftState` hook dependency.
+   *
+   * TODO figure out why this is needed.
+   */
   const draftRef = useRef<DraftObject>(emptyDraft(chatId))
   draftRef.current = draftState
 

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -101,7 +101,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     removeQuote,
     addFileToDraft,
     removeFile,
-    clearDraft,
+    clearDraftStateButKeepTextareaValue,
   } = useDraft(
     accountId,
     chat.id,
@@ -336,7 +336,9 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         removeQuote={removeQuote}
         addFileToDraft={addFileToDraft}
         removeFile={removeFile}
-        clearDraft={clearDraft}
+        clearDraftStateButKeepTextareaValue={
+          clearDraftStateButKeepTextareaValue
+        }
       />
     </div>
   )


### PR DESCRIPTION
- **refactor: add comment about `draftRef`**
- **refactor: rename `_setDraftButKeepTextareaValue`**
- **refactor: rename `clearDraft` var and add docs**

This does not affect behavior. This is only about renaming and comments.

#skip-changelog