### PR TITLE
fix: a11y: dont disable composer while sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,13 @@
 
 ## [Unreleased][unreleased]
 
-<<<<<<< HEAD
-### Fixed
-- fix "Recent 3 apps" in the chat header showing apps from another chat sometimes #5265
-- don't close context menues on window resize #5418
-
-=======
 ### Added
 - support multiple selection (multiselect) in the list of chats, activated with Ctrl + Click, Shift + Click #5297
->>>>>>> b9d383489 (docs: add CHANGELOG entry)
+
+### Fixed
+- fix "Recent 3 apps" in the chat header showing apps from another chat sometimes #5265
+- accessibility: don't re-announce message input (composer) after sending every message #5049
+- don't close context menues on window resize #5418
 
 <a id="2_11_1"></a>
 

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -76,6 +76,8 @@ const Composer = forwardRef<
     ) => Promise<void>
     removeFile: () => void
     clearDraftStateButKeepTextareaValue: () => void
+    clearDraftStateAndUpdateTextareaValue: () => void
+    setDraftStateAndUpdateTextareaValue: (newValue: DraftObject) => void
   }
 >((props, ref) => {
   const {
@@ -210,49 +212,68 @@ const Composer = forwardRef<
         if (textareaRef) {
           if (textareaRef.disabled) {
             throw new Error(
-              'text area is disabled, this means it is either already sending or loading the draft'
+              'text area is disabled, this means it is loading the draft'
             )
           }
-          textareaRef.disabled = true
         }
+        const message = regularMessageInputRef.current?.getText() || ''
+        if (!regularMessageInputRef.current?.hasText() && !draftState.file) {
+          log.debug(`Empty message: don't send it...`)
+          return
+        }
+
+        const preSendDraftState = draftState
+        const sendMessagePromise = sendMessage(accountId, chatId, {
+          text: replaceColonsSafe(message),
+          file: draftState.file || undefined,
+          filename: draftState.fileName || undefined,
+          quotedMessageId:
+            draftState.quote?.kind === 'WithMessage'
+              ? draftState.quote.messageId
+              : null,
+          viewtype: draftState.viewType,
+        })
+        // _Immediately_ clear the draft from React state.
+        // This does _not_ remove the draft from the back-end yet.
+        // This is primarily to make sure that you can't accidentally
+        // doube-send the same message.
+        //
+        // We could instead disable the textarea
+        // and disable sending the next message
+        // until the previous one has been sent,
+        // but it's unnecessary to block the user in such a way,
+        // because it's not often that `sendMessage` fails.
+        // And also disabling an input makes it lose focus,
+        // so we'd have to re-focus it, which would make screen readers
+        // re-announce it, which is disorienting.
+        // See https://github.com/deltachat/deltachat-desktop/issues/4590#issuecomment-2821985528.
+        props.clearDraftStateAndUpdateTextareaValue()
+
+        let sentSuccessfully: boolean
         try {
-          const message = regularMessageInputRef.current?.getText() || ''
-          if (!regularMessageInputRef.current?.hasText() && !draftState.file) {
-            log.debug(`Empty message: don't send it...`)
-            return
-          }
-
-          const sendMessagePromise = sendMessage(accountId, chatId, {
-            text: replaceColonsSafe(message),
-            file: draftState.file || undefined,
-            filename: draftState.fileName || undefined,
-            quotedMessageId:
-              draftState.quote?.kind === 'WithMessage'
-                ? draftState.quote.messageId
-                : null,
-            viewtype: draftState.viewType,
-          })
-
           await sendMessagePromise
-
-          // Ensure that the draft is cleared
-          // and the state is reflected in the UI.
-          //
-          // At this point we know that sending has succeeded,
-          // so we do not accidentally remove the draft
-          // if the core fails to send.
-          await BackendRemote.rpc.removeDraft(selectedAccountId(), chatId)
-          window.__reloadDraft && window.__reloadDraft()
-        } catch (error) {
+          sentSuccessfully = true
+        } catch (err) {
+          sentSuccessfully = false
           openDialog(AlertDialog, {
-            message: unknownErrorToString(error),
+            message:
+              tx('systemmsg_failed_sending_to', selectedChat.name) +
+              '\n' +
+              tx('error_x', unknownErrorToString(err)),
           })
-          log.error(error)
-        } finally {
-          if (textareaRef) {
-            textareaRef.disabled = false
-          }
-          regularMessageInputRef.current?.focus()
+          // Restore the draft, since we failed to send.
+          // Note that this will not save the draft to the backend.
+          //
+          // TODO fix: hypothetically by this point the user
+          // could have started typing a new message already,
+          // and so this would override it on the frontend.
+          props.setDraftStateAndUpdateTextareaValue(preSendDraftState)
+        }
+        if (sentSuccessfully) {
+          // TODO fix: hypothetically by this point the user
+          // could have started typing (and even have sent!)
+          // a new message already, so this would override it on the backend.
+          await BackendRemote.rpc.removeDraft(accountId, chatId)
         }
       }
 
@@ -723,6 +744,8 @@ export function useDraft(
   ) => Promise<void>
   removeFile: () => void
   clearDraftStateButKeepTextareaValue: () => void
+  clearDraftStateAndUpdateTextareaValue: () => void
+  setDraftStateAndUpdateTextareaValue: (newValue: DraftObject) => void
 } {
   const [
     draftState,
@@ -749,6 +772,17 @@ export function useDraft(
   draftRef.current = draftState
 
   /**
+   * @see {@link _setDraftStateButKeepTextareaValue}.
+   */
+  const setDraftStateAndUpdateTextareaValue = useCallback(
+    (newValue: DraftObject) => {
+      _setDraftStateButKeepTextareaValue(newValue)
+      inputRef.current?.setText(newValue.text)
+    },
+    [inputRef]
+  )
+
+  /**
    * Reset `draftState` to "empty draft" value,
    * but don't save it to backend and don't change the value
    * of the textarea.
@@ -756,6 +790,12 @@ export function useDraft(
   const clearDraftStateButKeepTextareaValue = useCallback(() => {
     _setDraftStateButKeepTextareaValue(_ => emptyDraft(chatId))
   }, [chatId])
+  /**
+   * @see {@link clearDraftStateButKeepTextareaValue}
+   */
+  const clearDraftStateAndUpdateTextareaValue = useCallback(() => {
+    setDraftStateAndUpdateTextareaValue(emptyDraft(chatId))
+  }, [chatId, setDraftStateAndUpdateTextareaValue])
 
   const loadDraft = useCallback(
     (chatId: number) => {
@@ -805,11 +845,6 @@ export function useDraft(
 
   const saveDraft = useCallback(async () => {
     if (chatId === null || !canSend) {
-      return
-    }
-    if (inputRef.current?.textareaRef.current?.disabled) {
-      // Guard against strange races
-      log.warn('Do not save draft while sending')
       return
     }
     const accountId = selectedAccountId()
@@ -993,6 +1028,8 @@ export function useDraft(
     addFileToDraft,
     removeFile,
     clearDraftStateButKeepTextareaValue,
+    clearDraftStateAndUpdateTextareaValue,
+    setDraftStateAndUpdateTextareaValue,
   }
 }
 

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -108,6 +108,8 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     addFileToDraft,
     removeFile,
     clearDraftStateButKeepTextareaValue,
+    clearDraftStateAndUpdateTextareaValue,
+    setDraftStateAndUpdateTextareaValue,
   } = useDraft(
     accountId,
     chat.id,
@@ -326,6 +328,12 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         removeFile={removeFile}
         clearDraftStateButKeepTextareaValue={
           clearDraftStateButKeepTextareaValue
+        }
+        clearDraftStateAndUpdateTextareaValue={
+          clearDraftStateAndUpdateTextareaValue
+        }
+        setDraftStateAndUpdateTextareaValue={
+          setDraftStateAndUpdateTextareaValue
         }
       />
     </div>


### PR DESCRIPTION
The primary point of this change is to remove
`textarea.focus()`, which makes screen readers re-announce
the composer, which is disorienting and pointless.

Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/4590#issuecomment-2821985528.

This change has side-effects:
- Now if the user starts typing right after sending a message,
  we will not ignore it, as we would if the composer was disabled,
  which is good.
- However, as a consequence, now it's possible to type
  while a message is being sent,
  which might have unexpected consequences itself,
  i.e. race conditions, i.e. bugs.

This also ~~adds an~~ improves the alert dialog that pops up if sending fails.

"hide whitespace" should make this easier to review.

I have tested this for a bit, and it appears to work OK. I have tried causing some race conditions, but I haven't seen any that seem too important.

TODO:
- [x] Merge https://github.com/deltachat/deltachat-desktop/pull/5048, which this MR is based on.