### PR TITLE
Avoid stickers to be cropped in height

### DIFF
--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -31,6 +31,9 @@
     object-position: center;
     max-width: 450px;
     min-width: 200px;
+    &.sticker {
+      min-width: auto;
+    }
 
     // The padding on the bottom of the bubble produces 4 extra pixels of space at the
     //   bottom, so this doesn't match up with the padding numbers above.
@@ -208,4 +211,9 @@
       margin-top: 3px;
     }
   }
+}
+
+// no border radius for stickers
+.type-sticker .message-attachment-media {
+  border-radius: 0px;
 }

--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -209,8 +209,3 @@
     }
   }
 }
-
-// no border radius for stickers
-.type-sticker .message-attachment-media {
-  border-radius: 0px;
-}

--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -42,9 +42,6 @@
     // redundant with attachment-container, but we get cursor flashing on move otherwise
     cursor: pointer;
 
-    &.portrait {
-      max-width: 350px;
-    }
     &.video-content {
       height: 350px;
       min-width: 300px;

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -298,6 +298,8 @@
 
   .message-attachment-media {
     background-color: transparent;
+    // no border radius for stickers
+    border-radius: 0px;
     & > .attachment-content {
       // Make space for the footer, which is `position: absolute;`.
       // However, this does not account for the case
@@ -408,6 +410,13 @@
 
     &.outgoing {
       margin-left: auto;
+    }
+    /**
+     * on small screens the limiting factor is the
+     * width not the height (except for stickers)
+     */
+    img.portrait:not(.sticker) {
+      height: auto;
     }
   }
 }

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -151,7 +151,8 @@ export default function Attachment({
         <img
           className={classNames(
             'attachment-content',
-            isPortrait(message) ? 'portrait' : null
+            isPortrait(message) ? 'portrait' : null,
+            message.viewType === 'Sticker' ? 'sticker' : null
           )}
           src={runtime.transformBlobURL(message.file)}
           height={calculateHeight(message)}


### PR DESCRIPTION
 - no min-width for stickers (to avoid height crop)
 - no border radius for stickers
 - no max-width for images in portrait mode

#skip-changelog

