### PR TITLE
tauri: fix: don't use `process::exit`, return instead

### DIFF
--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -106,7 +106,7 @@ fn get_current_logfile(state: tauri::State<AppState>) -> String {
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
-pub fn run() {
+pub fn run() -> i32 {
     let startup_timestamp = SystemTime::now();
 
     #[cfg(desktop)]
@@ -479,7 +479,7 @@ pub fn run() {
     });
 
     #[allow(clippy::single_match)]
-    app.run(|app_handle, run_event| match run_event {
+    let exit_code = app.run_return(|app_handle, run_event| match run_event {
         // tauri::RunEvent::ExitRequested { code, api, .. } => {}
         #[cfg(target_os = "macos")]
         tauri::RunEvent::Reopen { .. } => {
@@ -504,6 +504,7 @@ pub fn run() {
         }
         _ => {}
     });
+    exit_code
 }
 
 async fn cleanup(app_handle: &tauri::AppHandle) {

--- a/packages/target-tauri/src-tauri/src/main.rs
+++ b/packages/target-tauri/src-tauri/src/main.rs
@@ -1,6 +1,10 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-fn main() {
-    deltachat_tauri_lib::run()
+fn main() -> std::process::ExitCode {
+    let exit_code_i32 = deltachat_tauri_lib::run();
+    let Ok(exit_code_u8) = u8::try_from(exit_code_i32) else {
+        std::process::exit(exit_code_i32);
+    };
+    std::process::ExitCode::from(exit_code_u8)
 }


### PR DESCRIPTION
This is to make sure that all the `drop()` that need to be called
do get called.

I don't know whether this has a practical effect,
but let's do it to be sure.

#skip-changelog because it's not clear whether there is a user-visible change.