### PR TITLE
fix: webxdc: same `selfAddr` on different webxdcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 ### Fixed
+- webxdc apps sometimes having wrong `selfAddr`, resulting in apps treating the same user as a new one (e.g. the "Poll" app would allow you to vote twice) #5068
 - accessibility: add accessible labels and descriptions to more items #5050, #5055
 - accessibility: add `role='tablist'` for accounts list #5040
 - accessibility: add alt text for QR invite code image


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4993,
and likely https://github.com/deltachat/deltachat-desktop/issues/4401.

The issue is that we register the `webxdc:` scheme protocol handler
once per account, when you open the first webxdc, and when we do,
we incorrectly use the captured `webxdcInfo` var inside the handler,
resulting in us using `selfAddr` of the first opened webxdc app
for all the subsequently opened apps.

The fix is to get `selfAddr` from the respective webxdcInfo object
for each app instance.
This commit also does the same for other `webxdcInfo` properties,
such as `sendUpdateInterval`.

`selfAddr` used to be the email address, so this used to be fine,
but then `selfAddr` started to be different between messages
(https://github.com/deltachat/deltachat-desktop/issues/4401).

I have confirmed that this fixes the bug.