### PR TITLE
refactor: move webxdc proto handler to top level

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -37,6 +37,7 @@ import {
   refresh as refreshTitleMenu,
 } from '../menu.js'
 import { T } from '@deltachat/jsonrpc-client'
+import type * as Jsonrpc from '@deltachat/jsonrpc-client'
 import { setContentProtection } from '../content-protection.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -175,111 +176,9 @@ export default class DCWebxdc {
 
       if (!accounts_sessions.includes(accountId)) {
         accounts_sessions.push(accountId)
-        ses.protocol.handle('webxdc', async request => {
-          /**
-           * Make sure to only `return makeResponse()` because it sets headers
-           * that are important for security, namely `Content-Security-Policy`.
-           * Failing to set CSP might result in the app being able to create
-           * an <iframe> with no CSP, e.g. `<iframe src="/no_such_file.lol">`
-           * within which they can then do whatever
-           * through the parent frame, see
-           * "XDC-01-002 WP1: Full CSP bypass via desktop app webxdc.js"
-           * https://public.opentech.fund/documents/XDC-01-report_2_1.pdf
-           */
-          const makeResponse = (
-            body: BodyInit,
-            responseInit: Omit<ResponseInit, 'headers'>,
-            mime_type?: undefined | string
-          ) => {
-            const headers = new Headers()
-            if (!open_apps[id].internet_access) {
-              headers.append('Content-Security-Policy', CSP)
-            }
-            // Ensure that the client doesn't try to interpret a file as
-            // one with 'application/pdf' mime type and therefore open it
-            // in the PDF viewer, see
-            // "XDC-01-005 WP1: Full CSP bypass via desktop app PDF embed"
-            // https://public.opentech.fund/documents/XDC-01-report_2_1.pdf
-            headers.append('X-Content-Type-Options', 'nosniff')
-            if (mime_type) {
-              headers.append('content-type', mime_type)
-            }
-            return new Response(body, {
-              ...responseInit,
-              headers,
-            })
-          }
-
-          const url = new URL(request.url)
-          const [account, msg] = url.hostname.split('.')
-          const id = `${account}.${msg}`
-
-          if (!open_apps[id]) {
-            return makeResponse('', { status: 500 })
-          }
-
-          let filename = url.pathname
-          // remove leading / trailing "/"
-          if (filename.endsWith('/')) {
-            filename = filename.substring(0, filename.length - 1)
-          }
-          if (filename.startsWith('/')) {
-            filename = filename.substring(1)
-          }
-
-          let mimeType: string | undefined = Mime.lookup(filename) || ''
-          // Make sure that the browser doesn't open files in the PDF viewer.
-          // TODO is this the only mime type that opens the PDF viewer?
-          // TODO consider a mime type whitelist instead.
-          if (mimeType === 'application/pdf') {
-            // TODO make sure that `callback` won't internally set mime type back
-            // to 'application/pdf' (at the time of writing it's not the case).
-            // Otherwise consider explicitly setting it as a header.
-            mimeType = undefined
-          }
-
-          if (filename === WRAPPER_PATH) {
-            return makeResponse(
-              await readFile(join(htmlDistDir(), '/webxdc_wrapper.html')),
-              {},
-              mimeType
-            )
-          } else if (filename === 'webxdc.js') {
-            const displayName = Buffer.from(open_apps[id].displayName).toString(
-              'base64'
-            )
-            const selfAddr = Buffer.from(open_apps[id].selfAddr).toString(
-              'base64'
-            )
-            // initializes the preload script, the actual implementation of `window.webxdc` is found there: static/webxdc-preload.js
-            return makeResponse(
-              Buffer.from(
-                `window.parent.webxdc_internal.setup("${selfAddr}","${displayName}", ${Number(
-                  open_apps[id].sendUpdateInterval
-                )}, ${Number(open_apps[id].sendUpdateMaxSize)})
-                window.webxdc = window.parent.webxdc
-                window.webxdc_custom = window.parent.webxdc_custom`
-              ),
-              {},
-              mimeType
-            )
-          } else {
-            try {
-              const blob = Buffer.from(
-                await this.rpc.getWebxdcBlob(
-                  open_apps[id].accountId,
-                  open_apps[id].msgId,
-                  filename
-                ),
-                'base64'
-              )
-              return makeResponse(blob, {}, mimeType)
-            } catch (error) {
-              log.error('webxdc: load blob:', error)
-              return makeResponse('', { status: 404 })
-            }
-          }
-        })
+        ses.protocol.handle('webxdc', (...args) =>
+          webxdcProtocolHandler(this.rpc, ...args)
+        )
       }
 
       const app_icon = icon_blob && nativeImage?.createFromBuffer(icon_blob)
@@ -909,6 +808,113 @@ export default class DCWebxdc {
   _closeAll() {
     for (const open_app of Object.keys(open_apps)) {
       open_apps[open_app].win.close()
+    }
+  }
+}
+
+async function webxdcProtocolHandler(
+  rpc: Jsonrpc.RawClient,
+  request: GlobalRequest
+): Promise<GlobalResponse> {
+  /**
+   * Make sure to only `return makeResponse()` because it sets headers
+   * that are important for security, namely `Content-Security-Policy`.
+   * Failing to set CSP might result in the app being able to create
+   * an <iframe> with no CSP, e.g. `<iframe src="/no_such_file.lol">`
+   * within which they can then do whatever
+   * through the parent frame, see
+   * "XDC-01-002 WP1: Full CSP bypass via desktop app webxdc.js"
+   * https://public.opentech.fund/documents/XDC-01-report_2_1.pdf
+   */
+  const makeResponse = (
+    body: BodyInit,
+    responseInit: Omit<ResponseInit, 'headers'>,
+    mime_type?: undefined | string
+  ) => {
+    const headers = new Headers()
+    if (!open_apps[id].internet_access) {
+      headers.append('Content-Security-Policy', CSP)
+    }
+    // Ensure that the client doesn't try to interpret a file as
+    // one with 'application/pdf' mime type and therefore open it
+    // in the PDF viewer, see
+    // "XDC-01-005 WP1: Full CSP bypass via desktop app PDF embed"
+    // https://public.opentech.fund/documents/XDC-01-report_2_1.pdf
+    headers.append('X-Content-Type-Options', 'nosniff')
+    if (mime_type) {
+      headers.append('content-type', mime_type)
+    }
+    return new Response(body, {
+      ...responseInit,
+      headers,
+    })
+  }
+
+  const url = new URL(request.url)
+  const [account, msg] = url.hostname.split('.')
+  const id = `${account}.${msg}`
+
+  if (!open_apps[id]) {
+    return makeResponse('', { status: 500 })
+  }
+
+  let filename = url.pathname
+  // remove leading / trailing "/"
+  if (filename.endsWith('/')) {
+    filename = filename.substring(0, filename.length - 1)
+  }
+  if (filename.startsWith('/')) {
+    filename = filename.substring(1)
+  }
+
+  let mimeType: string | undefined = Mime.lookup(filename) || ''
+  // Make sure that the browser doesn't open files in the PDF viewer.
+  // TODO is this the only mime type that opens the PDF viewer?
+  // TODO consider a mime type whitelist instead.
+  if (mimeType === 'application/pdf') {
+    // TODO make sure that `callback` won't internally set mime type back
+    // to 'application/pdf' (at the time of writing it's not the case).
+    // Otherwise consider explicitly setting it as a header.
+    mimeType = undefined
+  }
+
+  if (filename === WRAPPER_PATH) {
+    return makeResponse(
+      await readFile(join(htmlDistDir(), '/webxdc_wrapper.html')),
+      {},
+      mimeType
+    )
+  } else if (filename === 'webxdc.js') {
+    const displayName = Buffer.from(open_apps[id].displayName).toString(
+      'base64'
+    )
+    const selfAddr = Buffer.from(open_apps[id].selfAddr).toString('base64')
+    // initializes the preload script, the actual implementation of `window.webxdc` is found there: static/webxdc-preload.js
+    return makeResponse(
+      Buffer.from(
+        `window.parent.webxdc_internal.setup("${selfAddr}","${displayName}", ${Number(
+          open_apps[id].sendUpdateInterval
+        )}, ${Number(open_apps[id].sendUpdateMaxSize)})
+        window.webxdc = window.parent.webxdc
+        window.webxdc_custom = window.parent.webxdc_custom`
+      ),
+      {},
+      mimeType
+    )
+  } else {
+    try {
+      const blob = Buffer.from(
+        await rpc.getWebxdcBlob(
+          open_apps[id].accountId,
+          open_apps[id].msgId,
+          filename
+        ),
+        'base64'
+      )
+      return makeResponse(blob, {}, mimeType)
+    } catch (error) {
+      log.error('webxdc: load blob:', error)
+      return makeResponse('', { status: 404 })
     }
   }
 }

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -170,11 +170,11 @@ export default class DCWebxdc {
         await this.rpc.getWebxdcBlob(accountId, msg_id, icon),
         'base64'
       )
-      const ses = sessionFromAccountId(accountId)
 
       // TODO intercept / deny network access - CSP should probably be disabled for testing
 
       if (!accounts_sessions.includes(accountId)) {
+        const ses = sessionFromAccountId(accountId)
         accounts_sessions.push(accountId)
         ses.protocol.handle('webxdc', (...args) =>
           webxdcProtocolHandler(this.rpc, ...args)


### PR DESCRIPTION
Instead of defining it inside of `openWebxdc`.
This is so that it doesn't capture the variables inside of
`openWebxdc`, so that it's harder to introduce bugs like
https://github.com/deltachat/deltachat-desktop/issues/4993.

And also move `ses` declaration to inner scope, because it's only used in that scope.

FYI this does not modify its body, besides the `rpc` access. You can see it in git, showing code moves.

I have tested this, and it works.

TODO:
- [x] Merge https://github.com/deltachat/deltachat-desktop/pull/5068