### PR TITLE
chore: fix wrong changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - accessibility: improve tabbing behavior of searh results
 - accessibility: announce when a message gets edited and outgoing message delivery status changes (`aria-live`)
 - reduce voice messages to a lower bitrate #4977
+- tauri: improve security #4959
 
 <a id="1_57_0"></a>
 
@@ -67,7 +68,7 @@
 - improve attachment menu ordering #5000
 
 ### Fixed
-- tauri: improve security #4826, #4936, #4937, #4944, #4959
+- tauri: improve security #4826, #4936, #4937, #4944
 - improve fatal error dialog readability by removing color from deltachat-rpc-server errors
 - prevent dragging around of webxdc icon #4740
 - tauri: clear temp folder on exit #4839


### PR DESCRIPTION
This actually has not been merged before 1.57.0.
https://github.com/deltachat/deltachat-desktop/pull/4959.
