### PR TITLE
improvement: a11y: don't announce "Chat" tab label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - accessibility: add alt text for QR invite code image
 - accessibility: improve tabbing behavior of searh results
 - accessibility: announce when a message gets edited and outgoing message delivery status changes (`aria-live`)
+- accessibility: don't redundantly announce "Chat property page" when the focus enters the chat
 - reduce voice messages to a lower bitrate #4977
 - tauri: improve security #4959
 

--- a/packages/frontend/src/components/NoChatSelected.tsx
+++ b/packages/frontend/src/components/NoChatSelected.tsx
@@ -15,7 +15,9 @@ export default function NoChatSelected() {
   return (
     <div
       role='tabpanel'
-      aria-labelledby='tab-message-list-view'
+      // See MessageListAndComposer as to why this is commented out.
+      // aria-labelledby='tab-message-list-view'
+
       // The main MessageListAndComposer also has this ID and class.
       id='message-list-and-composer'
       className='message-list-and-composer'

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -303,7 +303,15 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
   return (
     <div
       role='tabpanel'
-      aria-labelledby='tab-message-list-view'
+      // Techically we must apply `aria-labelledby` to `tabpanel`,
+      // but it's a little annoying that screen readers (NVDA)
+      // announce "'Chat' property page" every time
+      // the focus enters this tabpanel, because it's the "default" one,
+      // it's not often that another tab (Gallery) is selected.
+      // So, let's comment this out for now, until we resolve
+      // https://github.com/deltachat/deltachat-desktop/issues/5074.
+      // aria-labelledby='tab-message-list-view'
+
       // NoChatSelected also has this ID and class.
       id='message-list-and-composer'
       className='message-list-and-composer'


### PR DESCRIPTION
It's redundant most of the time.

Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/5074.

Partially reverts
00c7e6939675156e842f45ca9948dfa9b4cce507
(https://github.com/deltachat/deltachat-desktop/pull/4675).
