### PR TITLE
tauri: fix: notification click on Windows

### DIFF
--- a/packages/target-tauri/crates/user-notify/src/platform_impl/windows.rs
+++ b/packages/target-tauri/crates/user-notify/src/platform_impl/windows.rs
@@ -472,8 +472,8 @@ pub fn decode_deeplink(link: &str) -> Result<NotificationResponse, Error> {
     Ok(NotificationResponse {
         notification_id: url.host().map(|host| host.to_string()).unwrap_or_default(),
         action: match url.path().to_string().as_str() {
-            "__default__" => NotificationResponseAction::Default,
-            "__dismiss__" => NotificationResponseAction::Dismiss,
+            "/__default__" => NotificationResponseAction::Default,
+            "/__dismiss__" => NotificationResponseAction::Dismiss,
             action => NotificationResponseAction::Other(action.to_owned()),
         },
         user_text: None,

--- a/packages/target-tauri/crates/user-notify/src/platform_impl/windows.rs
+++ b/packages/target-tauri/crates/user-notify/src/platform_impl/windows.rs
@@ -353,7 +353,7 @@ impl NotificationManager for NotificationManagerWindows {
             if let Some(notification_protocol) = self.notification_protocol.as_ref() {
                 let launch_url = encode_deeplink(
                     notification_protocol,
-                    NotificationResponse {
+                    &NotificationResponse {
                         notification_id: id.clone(),
                         action: NotificationResponseAction::Default,
                         user_text: None,
@@ -425,7 +425,7 @@ impl NotificationManager for NotificationManagerWindows {
     }
 }
 
-fn encode_deeplink(scheme: &str, action: NotificationResponse) -> String {
+fn encode_deeplink(scheme: &str, action: &NotificationResponse) -> String {
     let NotificationResponse {
         notification_id,
         action,
@@ -479,4 +479,25 @@ pub fn decode_deeplink(link: &str) -> Result<NotificationResponse, Error> {
         user_text: None,
         user_info,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_decode() {
+        let input = NotificationResponse {
+            action: NotificationResponseAction::Default,
+            notification_id: "abcd123-abc12".to_string(),
+            user_info: HashMap::from([
+                ("a".to_string(), "b".to_string()),
+                ("c".to_string(), "d".to_string()),
+            ]),
+            user_text: None,
+        };
+        let encoded = encode_deeplink("dcnotification", &input);
+        let output = decode_deeplink(&encoded);
+        assert_eq!(input, output.unwrap());
+    }
 }


### PR DESCRIPTION
#skip-changelog

I have tested that notifications work now, even from the Actions Center.