### PR TITLE
tauri: fix: notification action parsing

### DIFF
--- a/packages/target-tauri/crates/user-notify/src/platform_impl/windows.rs
+++ b/packages/target-tauri/crates/user-notify/src/platform_impl/windows.rs
@@ -155,12 +155,13 @@ impl NotificationManagerWindows {
                 handler(crate::NotificationResponse {
                     notification_id: notification_id_clone.clone(),
                     action: action
-                        .map(|action| {
-                            if action.starts_with("dcnotification://default") {
-                                NotificationResponseAction::Default
-                            } else {
-                                NotificationResponseAction::Other(action)
-                            }
+                        .and_then(|action| {
+                            decode_deeplink(&action)
+                                .map(|response| response.action)
+                                .inspect_err(|err| {
+                                    log::error!("failed to extract action from {action}: {err}")
+                                })
+                                .ok()
                         })
                         .unwrap_or(NotificationResponseAction::Default),
                     user_text: None,


### PR DESCRIPTION
Notification action URL format has been changed in
0d5df734e0f47336f422c86a8bb6b246e5b416ea,
so parsing stopped working.

Additionally, this removes the dependency on the URL
having the `dcnotification:` scheme.

#skip-changelog