### PR TITLE
Always use a fix height

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -416,7 +416,7 @@
      * width not the height (except for stickers)
      */
     img.portrait:not(.sticker) {
-      height: auto;
+      height: 300px;
     }
   }
 }


### PR DESCRIPTION
Height for images should never be "auto" since the message height might be wrong calculated. So the fix to avoid width cropped images is to reduce the height for small screens to 300px instead 450px. The cropping then only happens on screen width <= 380px which is fine I would say

#skip-changelog