### PR TITLE
Avoid any width cropping

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -400,7 +400,7 @@
   }
 }
 
-@media (max-width: 925px) {
+@media (max-width: 980px) {
   .message {
     max-width: 100%;
 
@@ -411,12 +411,8 @@
     &.outgoing {
       margin-left: auto;
     }
-    /**
-     * on small screens the limiting factor is the
-     * width not the height (except for stickers)
-     */
     img.portrait:not(.sticker) {
-      height: 300px;
+      height: 275px;
     }
   }
 }


### PR DESCRIPTION
This should have no width cropping at all for portrait images. Just as an experiment. The payoff is, that I had to reduce the image height even more and start it earlier. (width 980px)

#skip-changelog