### PR TITLE
Add migration-tests to packageignore_list

### DIFF
--- a/packages/target-electron/.gitignore
+++ b/packages/target-electron/.gitignore
@@ -1,6 +1,6 @@
 html-dist
 bundle_out
 themes
-tests/compiled
+migration-tests/compiled
 
 electron-builder.json5

--- a/packages/target-electron/build/packageignore_list
+++ b/packages/target-electron/build/packageignore_list
@@ -60,7 +60,7 @@ static/
 _locales/*.xml
 build/
 runtime-electron/
-tests/
+migration-tests/
 
 # Build artifacts
 tsc-dist/renderer/


### PR DESCRIPTION
New builds were 35mb bigger than 1.56.0 since the migration-tests were not excluded

#skip-changelog
