### PR TITLE
Add electron to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,7 @@
           cargo
           cargo-tauri
           nodejs
+          electron
         ];
 
         buildInputs = with pkgs; [
@@ -74,7 +75,7 @@
           # Required by rust-analyzer
           RUST_SRC_PATH = "${pkgs.rustToolchain}/lib/rustlib/src/rust/library";
           LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}:$LD_LIBRARY_PATH";
-          XDG_DATA_DIRS="${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS";
+          XDG_DATA_DIRS = "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS";
           WEBKIT_DISABLE_COMPOSITING_MODE = 1;
         };
       };

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,10 @@
           XDG_DATA_DIRS = "${pkgs.gsettings-desktop-schemas}/share/gsettings-schemas/${pkgs.gsettings-desktop-schemas.name}:${pkgs.gtk3}/share/gsettings-schemas/${pkgs.gtk3.name}:$XDG_DATA_DIRS";
           WEBKIT_DISABLE_COMPOSITING_MODE = 1;
         };
+        shellHook = ''
+          # On nixos, you can not run npm electron, so we remove it here and have it in packages.
+          rm ./packages/target-electron/node_modules/.bin/electron
+        '';
       };
     });
   };


### PR DESCRIPTION
Add electron to flake, this is needed because the npm electron package can not be run natively on nixos.
To make this work, electron bin has to be deleted `rm ./packages/target-electron/node_modules/.bin/electron`