### PR TITLE
Tauri Drag and Drop 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Changed
 
 ### Fixed
-
+- show error when sendMsg fails #5092
 
 <a id="1_58_1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - tauri: added notifications
 
 ### Changed
+- Update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.159.4`
+  - Better avatar quality
+  - Update iroh from 0.33.0 to 0.35.0
 
 ### Fixed
 - show error when sendMsg fails #5092

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,6 +1915,7 @@ dependencies = [
  "clap",
  "deltachat",
  "deltachat-jsonrpc",
+ "drag",
  "futures-lite",
  "http 1.3.1",
  "include_dir",
@@ -2281,6 +2282,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f25c0e292a7ca6d6498557ff1df68f32c99850012b6ea401cf8daf771f22ff53"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "drag"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fd9ae1736d6ebb2e472740fbee86fb2178b8d56feb98a6751411d4c95b7e72"
+dependencies = [
+ "cocoa",
+ "core-graphics",
+ "dunce",
+ "gdk",
+ "gdkx11",
+ "gtk",
+ "log",
+ "objc",
+ "raw-window-handle",
+ "thiserror 1.0.69",
+ "windows 0.52.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -10255,6 +10276,18 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-implement 0.52.0",
+ "windows-interface 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
@@ -10315,6 +10348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10391,6 +10433,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
@@ -10416,6 +10469,17 @@ name = "windows-implement"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,7 +231,7 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -362,6 +362,19 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compat"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bab94bde396a3f7b4962e396fdad640e241ed797d4d8d77fc8c237d14c58fc0"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "once_cell",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -571,6 +584,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
 name = "async_zip"
 version = "0.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,16 +735,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "backoff"
-version = "0.4.0"
+name = "backon"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
 dependencies = [
- "futures-core",
- "getrandom 0.2.15",
- "instant",
- "pin-project-lite",
- "rand 0.8.5",
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -743,6 +765,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base64"
@@ -818,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -931,7 +959,18 @@ checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 4.0.2",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9991eea70ea4f293524138648e41ee89b0b2b12ddef3b255effa43c8056e0e0d"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 5.0.0",
 ]
 
 [[package]]
@@ -939,6 +978,16 @@ name = "brotli-decompressor"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1222,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1359,7 +1408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1513,6 +1562,12 @@ checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -1736,8 +1791,8 @@ dependencies = [
 
 [[package]]
 name = "deltachat"
-version = "1.159.3"
-source = "git+https://github.com/chatmail/core?tag=v1.159.3#83bc497f0d9cfa61072d7c74db1d0611e927b4e1"
+version = "1.159.4"
+source = "git+https://github.com/chatmail/core?tag=v1.159.4#259ffef0bbbb41b915b2e810f50fbffb39332ce5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1748,7 +1803,7 @@ dependencies = [
  "async_zip",
  "base64 0.22.1",
  "blake3",
- "brotli",
+ "brotli 8.0.1",
  "bytes",
  "chrono",
  "data-encoding",
@@ -1820,7 +1875,7 @@ dependencies = [
 [[package]]
 name = "deltachat-contact-tools"
 version = "0.0.0"
-source = "git+https://github.com/chatmail/core?tag=v1.159.3#83bc497f0d9cfa61072d7c74db1d0611e927b4e1"
+source = "git+https://github.com/chatmail/core?tag=v1.159.4#259ffef0bbbb41b915b2e810f50fbffb39332ce5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1830,8 +1885,8 @@ dependencies = [
 
 [[package]]
 name = "deltachat-jsonrpc"
-version = "1.159.3"
-source = "git+https://github.com/chatmail/core?tag=v1.159.3#83bc497f0d9cfa61072d7c74db1d0611e927b4e1"
+version = "1.159.4"
+source = "git+https://github.com/chatmail/core?tag=v1.159.4#259ffef0bbbb41b915b2e810f50fbffb39332ce5"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -1898,12 +1953,12 @@ dependencies = [
 [[package]]
 name = "deltachat-time"
 version = "1.0.0"
-source = "git+https://github.com/chatmail/core?tag=v1.159.3#83bc497f0d9cfa61072d7c74db1d0611e927b4e1"
+source = "git+https://github.com/chatmail/core?tag=v1.159.4#259ffef0bbbb41b915b2e810f50fbffb39332ce5"
 
 [[package]]
 name = "deltachat_derive"
 version = "2.0.0"
-source = "git+https://github.com/chatmail/core?tag=v1.159.3#83bc497f0d9cfa61072d7c74db1d0611e927b4e1"
+source = "git+https://github.com/chatmail/core?tag=v1.159.4#259ffef0bbbb41b915b2e810f50fbffb39332ce5"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2489,15 +2544,6 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c138974f9d5e7fe373eb04df7cae98833802ae4b11c24ac7039a21d5af4b26c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "erased-serde"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
@@ -2507,19 +2553,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "erased_set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a02a5d186d7bf1cb21f1f95e1a9cfa5c1f2dcd803a47aad454423ceec13525c5"
-
-[[package]]
 name = "errno"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2619,7 +2659,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2701,18 +2741,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "format-flowed"
 version = "1.0.0"
-source = "git+https://github.com/chatmail/core?tag=v1.159.3#83bc497f0d9cfa61072d7c74db1d0611e927b4e1"
+source = "git+https://github.com/chatmail/core?tag=v1.159.4#259ffef0bbbb41b915b2e810f50fbffb39332ce5"
 
 [[package]]
 name = "fsevent-sys"
@@ -3227,6 +3255,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,11 +3458,10 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-proto"
-version = "0.25.0-alpha.5"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d00147af6310f4392a31680db52a3ed45a2e0f68eb18e8c3fe5537ecc96d9e2"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
 dependencies = [
- "async-recursion",
  "async-trait",
  "cfg-if",
  "data-encoding",
@@ -3434,6 +3473,7 @@ dependencies = [
  "ipnet",
  "once_cell",
  "rand 0.9.0",
+ "ring",
  "thiserror 2.0.12",
  "tinyvec",
  "tokio",
@@ -3443,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.25.0-alpha.5"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5762f69ebdbd4ddb2e975cd24690bf21fe6b2604039189c26acddbc427f12887"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3717,7 +3757,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.61.0",
 ]
 
 [[package]]
@@ -3895,9 +3935,9 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.15.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
+checksum = "d06464e726471718db9ad3fefc020529fabcde03313a0fc3967510e2db5add12"
 dependencies = [
  "async-trait",
  "attohttpc",
@@ -3908,7 +3948,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "log",
- "rand 0.8.5",
+ "rand 0.9.0",
  "tokio",
  "url",
  "xmltree",
@@ -4084,14 +4124,14 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iroh"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ffd6af2e000f04972068c0318e0d8fa90ee9cfcb2bc6124db38591500e0278"
+checksum = "6ca758f4ce39ae3f07de922be6c73de6a48a07f39554e78b5745585652ce38f5"
 dependencies = [
  "aead",
  "anyhow",
  "atomic-waker",
- "backoff",
+ "backon",
  "bytes",
  "cfg_aliases",
  "concurrent-queue",
@@ -4100,14 +4140,15 @@ dependencies = [
  "der",
  "derive_more 1.0.0",
  "ed25519-dalek",
+ "futures-buffered",
  "futures-util",
+ "getrandom 0.3.2",
  "hickory-resolver",
  "http 1.3.1",
  "igd-next",
  "instant",
  "iroh-base",
  "iroh-metrics",
- "iroh-net-report",
  "iroh-quinn",
  "iroh-quinn-proto",
  "iroh-quinn-udp",
@@ -4126,8 +4167,10 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "serde",
  "smallvec",
+ "spki",
  "strum 0.26.3",
  "stun-rs",
+ "surge-ping",
  "thiserror 2.0.12",
  "time",
  "tokio",
@@ -4143,15 +4186,14 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "011d271a95b41218d22bdaf3352f29ef1dd7d6be644ca8543941655bec5f3d35"
+checksum = "f91ac4aaab68153d726c4e6b39c30f9f9253743f0e25664e52f4caeb46f48d11"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "derive_more 1.0.0",
  "ed25519-dalek",
- "getrandom 0.2.15",
  "rand_core 0.6.4",
  "serde",
  "thiserror 2.0.12",
@@ -4173,9 +4215,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-gossip"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d4c7e330bf3d29576d443003e31a2d30d97b29ee13521af2634926d831c01d"
+checksum = "3ca43045ceb44b913369f417d56323fb1628ebf482ab4c1e9360e81f1b58cbc2"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4204,44 +4246,27 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "0.31.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571d177e20f0848a643a2c0f662be0e08968f8743b0776941f83a2152b87a180"
+checksum = "f70466f14caff7420a14373676947e25e2917af6a5b1bec45825beb2bf1eb6a7"
 dependencies = [
- "erased_set",
+ "iroh-metrics-derive",
+ "itoa 1.0.15",
  "serde",
- "struct_iterable",
- "thiserror 2.0.12",
+ "snafu",
  "tracing",
 ]
 
 [[package]]
-name = "iroh-net-report"
-version = "0.33.0"
+name = "iroh-metrics-derive"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2652f42eadc63458e36c0a422569f338639dc0b5bb469db0eb4a382b4e295c"
+checksum = "8d12f5c45c4ed2436302a4e03cad9a0ad34b2962ad0c5791e1019c0ee30eeb09"
 dependencies = [
- "anyhow",
- "bytes",
- "cfg_aliases",
- "derive_more 1.0.0",
- "hickory-resolver",
- "iroh-base",
- "iroh-metrics",
- "iroh-quinn",
- "iroh-relay",
- "n0-future",
- "netwatch",
- "portmapper",
- "rand 0.8.5",
- "reqwest",
- "rustls",
- "surge-ping",
- "thiserror 2.0.12",
- "tokio",
- "tokio-util",
- "tracing",
- "url",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -4277,7 +4302,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
  "slab",
  "thiserror 2.0.12",
  "tinyvec",
@@ -4296,20 +4320,21 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "iroh-relay"
-version = "0.33.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c930ccc4dfd0196b531344e3d0f83a0f82c45b170406e04a2491cba571faec5b"
+checksum = "c63f122cdfaa4b4e0e7d6d3921d2b878f42a0c6d3ee5a29456dc3f5ab5ec931f"
 dependencies = [
  "anyhow",
  "bytes",
  "cfg_aliases",
  "data-encoding",
  "derive_more 1.0.0",
+ "getrandom 0.3.2",
  "hickory-resolver",
  "http 1.3.1",
  "http-body-util",
@@ -4319,7 +4344,7 @@ dependencies = [
  "iroh-metrics",
  "iroh-quinn",
  "iroh-quinn-proto",
- "lru",
+ "lru 0.12.5",
  "n0-future",
  "num_enum",
  "pin-project",
@@ -4330,16 +4355,18 @@ dependencies = [
  "rustls",
  "rustls-webpki 0.102.8",
  "serde",
+ "sha1",
  "strum 0.26.3",
  "stun-rs",
  "thiserror 2.0.12",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite-wasm",
  "tokio-util",
+ "tokio-websockets",
  "tracing",
  "url",
  "webpki-roots",
+ "ws_stream_wasm",
  "z32",
 ]
 
@@ -4780,6 +4807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+
+[[package]]
 name = "lru_time_cache"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4997,9 +5030,9 @@ checksum = "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b"
 
 [[package]]
 name = "n0-future"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399e11dc3b0e8d9d65b27170d22f5d779d52d9bed888db70d7e0c2c7ce3dfc52"
+checksum = "7bb0e5d99e681ab3c938842b96fcb41bf8a7bb4bfdb11ccbd653a7e83e06c794"
 dependencies = [
  "cfg_aliases",
  "derive_more 1.0.0",
@@ -5017,15 +5050,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.15",
-]
-
-[[package]]
 name = "native-tls"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5037,7 +5061,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework 2.11.1",
+ "security-framework",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5098,6 +5122,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nested_enum_utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fa9161ed44d30e9702fe42bd78693bceac0fed02f647da749f36109023d3a3"
+dependencies = [
+ "proc-macro-crate 3.3.0",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "netdev"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5141,11 +5177,12 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.19.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c171cd77b4ee8c7708da746ce392440cb7bcf618d122ec9ecc607b12938bf4"
+checksum = "0800eae8638a299eaa67476e1c6b6692922273e0f7939fd188fc861c837b9cd2"
 dependencies = [
  "anyhow",
+ "bitflags 2.9.0",
  "byteorder",
  "libc",
  "log",
@@ -5194,34 +5231,34 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64da82edf903649e6cb6a77b5a6f7fe01387d8865065d411d139018510880302"
+checksum = "67eeaa5f7505c93c5a9b35ba84fd21fb8aa3f24678c76acfe8716af7862fb07a"
 dependencies = [
- "anyhow",
  "atomic-waker",
  "bytes",
+ "cfg_aliases",
  "derive_more 1.0.0",
- "futures-lite",
- "futures-sink",
- "futures-util",
  "iroh-quinn-udp",
+ "js-sys",
  "libc",
+ "n0-future",
+ "nested_enum_utils",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.19.0",
+ "netlink-packet-route 0.23.0",
+ "netlink-proto",
  "netlink-sys",
- "once_cell",
- "rtnetlink 0.13.1",
- "rtnetlink 0.14.1",
  "serde",
+ "snafu",
  "socket2",
- "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-util",
  "tracing",
- "windows 0.58.0",
+ "web-sys",
+ "windows 0.59.0",
+ "windows-result 0.3.2",
  "wmi",
 ]
 
@@ -5230,28 +5267,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
-]
-
-[[package]]
-name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.9.0",
- "cfg-if",
- "libc",
-]
 
 [[package]]
 name = "nix"
@@ -5334,6 +5349,21 @@ name = "notify-types"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
+
+[[package]]
+name = "ntimestamp"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c50f94c405726d3e0095e89e72f75ce7f6587b94a8bd8dc8054b73f65c0fd68c"
+dependencies = [
+ "base32",
+ "document-features",
+ "getrandom 0.2.15",
+ "httpdate",
+ "js-sys",
+ "once_cell",
+ "serde",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -5741,6 +5771,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -6108,6 +6142,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
+]
+
+[[package]]
 name = "phf"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6286,26 +6330,33 @@ dependencies = [
 
 [[package]]
 name = "pkarr"
-version = "2.3.1"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92eff194c72f00f3076855b413ad2d940e3a6e307fa697e5c7733e738341aed4"
+checksum = "e32222ae3d617bf92414db29085f8a959a4515effce916e038e9399a335a0d6d"
 dependencies = [
+ "async-compat",
+ "base32",
  "bytes",
+ "cfg_aliases",
  "document-features",
+ "dyn-clone",
  "ed25519-dalek",
- "flume",
- "futures",
- "js-sys",
- "lru",
+ "futures-buffered",
+ "futures-lite",
+ "getrandom 0.2.15",
+ "log",
+ "lru 0.13.0",
+ "ntimestamp",
+ "reqwest",
  "self_cell",
+ "serde",
+ "sha1_smol",
  "simple-dns",
  "thiserror 2.0.12",
+ "tokio",
  "tracing",
- "ureq",
- "wasm-bindgen",
+ "url",
  "wasm-bindgen-futures",
- "web-sys",
- "z32",
 ]
 
 [[package]]
@@ -6458,29 +6509,31 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5469b29e6ce2a27bfc9382720b5f0768993afec9e53b133d8248c8b09406156a"
+checksum = "7d6db66007eac4a0ec8331d0d20c734bd64f6445d64bbaf0d0a27fea7a054e36"
 dependencies = [
- "anyhow",
  "base64 0.22.1",
  "bytes",
  "derive_more 1.0.0",
  "futures-lite",
  "futures-util",
+ "hyper-util",
  "igd-next",
  "iroh-metrics",
  "libc",
+ "nested_enum_utils",
  "netwatch",
  "num_enum",
  "rand 0.8.5",
  "serde",
  "smallvec",
+ "snafu",
  "socket2",
- "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-util",
+ "tower-layer",
  "tracing",
  "url",
 ]
@@ -6823,7 +6876,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6977,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "ratelimit"
 version = "1.0.0"
-source = "git+https://github.com/chatmail/core?tag=v1.159.3#83bc497f0d9cfa61072d7c74db1d0611e927b4e1"
+source = "git+https://github.com/chatmail/core?tag=v1.159.4#259ffef0bbbb41b915b2e810f50fbffb39332ce5"
 
 [[package]]
 name = "rav1e"
@@ -7376,42 +7429,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtnetlink"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route 0.17.1",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.26.4",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "rtnetlink"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b684475344d8df1859ddb2d395dd3dac4f8f3422a1aa0725993cb375fc5caba5"
-dependencies = [
- "futures",
- "log",
- "netlink-packet-core",
- "netlink-packet-route 0.19.0",
- "netlink-packet-utils",
- "netlink-proto",
- "netlink-sys",
- "nix 0.27.1",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7487,7 +7504,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7500,7 +7517,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7516,18 +7533,6 @@ dependencies = [
  "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
-dependencies = [
- "openssl-probe",
- "rustls-pki-types",
- "schannel",
- "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -7547,33 +7552,6 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
 ]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
-dependencies = [
- "core-foundation 0.10.0",
- "core-foundation-sys",
- "jni",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki 0.103.1",
- "security-framework 3.2.0",
- "security-framework-sys",
- "webpki-root-certs",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier-android"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -7719,19 +7697,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
-dependencies = [
- "bitflags 2.9.0",
- "core-foundation 0.10.0",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
 name = "security-framework-sys"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7816,7 +7781,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
 dependencies = [
- "erased-serde 0.4.6",
+ "erased-serde",
  "serde",
  "typeid",
 ]
@@ -7993,6 +7958,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8166,6 +8137,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "snafu"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8296,35 +8288,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "struct_iterable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "849a064c6470a650b72e41fa6c057879b68f804d113af92900f27574828e7712"
-dependencies = [
- "struct_iterable_derive",
- "struct_iterable_internal",
-]
-
-[[package]]
-name = "struct_iterable_derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb939ce88a43ea4e9d012f2f6b4cc789deb2db9d47bad697952a85d6978662c"
-dependencies = [
- "erased-serde 0.3.31",
- "proc-macro2",
- "quote",
- "struct_iterable_internal",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "struct_iterable_internal"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9426b2a0c03e6cc2ea8dbc0168dbbf943f88755e409fb91bcb8f6a268305f4a"
 
 [[package]]
 name = "strum"
@@ -8662,7 +8625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93f035551bf7b11b3f51ad9bc231ebbe5e085565527991c16cf326aa38cdf47"
 dependencies = [
  "base64 0.22.1",
- "brotli",
+ "brotli 7.0.0",
  "ico",
  "json-patch",
  "plist",
@@ -8956,7 +8919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2900399c239a471bcff7f15c4399eb1a8c4fe511ba2853e07c996d771a5e0a4"
 dependencies = [
  "anyhow",
- "brotli",
+ "brotli 7.0.0",
  "cargo_metadata",
  "ctor",
  "dunce",
@@ -9020,7 +8983,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.5",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9266,36 +9229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
-name = "tokio-tungstenite-wasm"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21a5c399399c3db9f08d8297ac12b500e86bca82e930253fdc62eaf9c0de6ae"
-dependencies = [
- "futures-channel",
- "futures-util",
- "http 1.3.1",
- "httparse",
- "js-sys",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9309,6 +9242,28 @@ dependencies = [
  "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fcaf159b4e7a376b05b5bfd77bfd38f3324f5fce751b4213bfc7eaa47affb4e"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.3.2",
+ "http 1.3.1",
+ "httparse",
+ "rand 0.9.0",
+ "ring",
+ "rustls-pki-types",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
 ]
 
 [[package]]
@@ -9607,24 +9562,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http 1.3.1",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
 name = "twofish"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9802,21 +9739,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "url",
- "webpki-roots",
-]
 
 [[package]]
 name = "url"
@@ -10229,15 +10151,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-root-certs"
-version = "0.26.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10316,7 +10229,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11049,6 +10962,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ws_stream_wasm"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7999f5f4217fe3818726b66257a4475f71e74ffd190776ad053fa159e50737f5"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror 1.0.69",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11252,7 +11184,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.29.0",
+ "nix",
  "ordered-stream",
  "serde",
  "serde_repr",

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -87,15 +87,17 @@
    git push origin main --tags
    ```
 10. Now create a GitHub release for your tag:
-   - Copy the relevant part of the `CHANGELOG.md` file into the description field
-     - for fresh releases this includes the changelog of the test releases
-     - for patch releases the full changelog is not needed, the part that changed from the last release is enough
-   - Add a header `# Downloads` with a link to the download page.
-     If it's an official release, add a link to the release progress issue.
-   - for testing releases add a link to the testing forum topic:
-     ```md
-     > This release candidate is currently in the testing phase, to learn more read https://support.delta.chat/t/<rest of link>
-     ```
+
+- Copy the relevant part of the `CHANGELOG.md` file into the description field
+  - for fresh releases this includes the changelog of the test releases
+  - for patch releases the full changelog is not needed, the part that changed from the last release is enough
+- Add a header `# Downloads` with a link to the download page.
+  If it's an official release, add a link to the release progress issue.
+- for testing releases add a link to the testing forum topic:
+  ```md
+  > This release candidate is currently in the testing phase, to learn more read https://support.delta.chat/t/<rest of link>
+  ```
+
 11. As soon as the new tag is detected by our build machine, it will start
     building releases for various platforms (MacOS, Windows, Linux) and upload
     them to: `https://download.delta.chat/desktop/[version_code]`. This process

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -53,6 +53,7 @@ import {
   AudioRecorderError,
 } from '../AudioRecorder/AudioRecorder'
 import AlertDialog from '../dialogs/AlertDialog'
+import { unknownErrorToString } from '../helpers/unknownErrorToString'
 
 const log = getLogger('renderer/composer')
 
@@ -246,6 +247,9 @@ const Composer = forwardRef<
           await BackendRemote.rpc.removeDraft(selectedAccountId(), chatId)
           window.__reloadDraft && window.__reloadDraft()
         } catch (error) {
+          openDialog(AlertDialog, {
+            message: unknownErrorToString(error),
+          })
           log.error(error)
         } finally {
           if (textareaRef) {

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -111,19 +111,26 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     regularMessageInputRef
   )
 
-  const onDrop = async (e: React.DragEvent<any>) => {
+  runtime.setDragListener((e) => {
+    if (e.payload.type == "drop") {
+      handleDrop(e.payload.paths)
+    }
+  });
+
+  const onDrop = (e: React.DragEvent<any> ) => {
+    e.preventDefault()
+    e.stopPropagation()
+    handleDrop(e.dataTransfer.files)
+  }
+  const handleDrop = async (fileList: FileList) => {
     if (chat === null) {
       log.warn('dropped something, but no chat is selected')
       return
     }
 
-    e.preventDefault()
-    e.stopPropagation()
 
     const sanitizedFileList: File[] = []
     {
-      const fileList: FileList =
-        /* (e.target as any).files */ e.dataTransfer.files
       for (let i = 0; i < fileList.length; i++) {
         const file = fileList[i]
         if (runtime.isDroppedFileFromOutside(file)) {

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -318,7 +318,8 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     ? getBackgroundImageStyle(settingsStore.desktopSettings)
     : {}
 
-  const isElectron = typeof navigator === 'object' && navigator.userAgent.includes('Electron');
+  const isElectron =
+    typeof navigator === 'object' && navigator.userAgent.includes('Electron')
   return (
     <div
       role='tabpanel'

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -122,7 +122,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
   )
 
   useEffect(() => {
-    let unset = runtime.setDragListener(async e => {
+    const unset = runtime.setDragListener(async e => {
       if (e.payload.type != 'drop') {
         return
       }
@@ -185,8 +185,8 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
       }
     })
     return () => {
-      unset.then((u) => {
-        log.info("dragListenerUnset")
+      unset.then(u => {
+        log.info('dragListenerUnset')
         u()
       })
     }

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -88,9 +88,11 @@ export function getBackgroundImageStyle(
 }
 
 
+// Invariant: The called function handles windows specifically.
 function fullPath(file: ParsedPath) {
   return file.dir + '/' + file.name + file.ext
 }
+
 function isImage(file: ParsedPath) {
   const imageExtensions = ['.jpg', '.jpeg', '.png']
   return imageExtensions.includes(file.ext)

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -123,6 +123,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   // Tauri listener
   useEffect(() => {
+    console.log("drag: register")
     const unset = runtime.setDragListener(async e => {
       if (e.payload.type != 'drop') {
         return
@@ -134,7 +135,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     })
     return () => {
       unset.then(u => {
-        log.info('dragListenerUnset')
+        log.info('drag: unregister')
         u()
       })
     }
@@ -142,7 +143,10 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   // Electron and webview listener
   const onDrop = async (e: React.DragEvent<any>) => {
+    console.log("drag: electron drop")
     e.preventDefault()
+    e.stopPropagation()
+
     function writeTempFileFromFile(file: File): Promise<string> {
       if (file.size > 1e8 /* 100mb */) {
         log.warn(
@@ -173,7 +177,6 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         reader.readAsDataURL(file)
       })
     }
-    e.stopPropagation()
 
     const paths = []
     for (const path of e.dataTransfer.files) {
@@ -181,7 +184,9 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     }
     handleDrop(paths)
   }
+
   const handleDrop = async (paths: string[]) => {
+    console.log("drag: handling drop: ", paths)
     if (chat === null) {
       log.warn('dropped something, but no chat is selected')
       return

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -92,7 +92,7 @@ function fullPath(file: ParsedPath) {
   return file.dir + '/' + file.name + file.ext
 }
 function isImage(file: ParsedPath) {
-  const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif']
+  const imageExtensions = ['.jpg', '.jpeg', '.png']
   return imageExtensions.includes(file.ext)
 }
 

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -131,8 +131,6 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
       if (e.payload.type != 'drop') {
         return
       }
-
-      // sanitize files
       const paths = e.payload.paths
       handleDrop(paths)
     })

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -19,6 +19,11 @@ import { Viewtype } from '@deltachat/jsonrpc-client/dist/generated/types'
 
 const log = getLogger('renderer/MessageListAndComposer')
 
+type Props = {
+  chat: T.FullChat
+  accountId: number
+}
+
 export function getBackgroundImageStyle(
   settings: DesktopSettingsType
 ): React.CSSProperties {
@@ -82,10 +87,6 @@ export function getBackgroundImageStyle(
   return style
 }
 
-type Props = {
-  chat: T.FullChat
-  accountId: number
-}
 
 function fullPath(file: ParsedPath) {
   return file.dir + '/' + file.name + file.ext

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -85,7 +85,9 @@ type Props = {
   accountId: number
 }
 
-function fullPath(file: ParsedPath) { return file.dir + "/" + file.name + file.ext }
+function fullPath(file: ParsedPath) {
+  return file.dir + '/' + file.name + file.ext
+}
 function isImage(file: ParsedPath) {
   const imageExtensions = ['.jpg', '.jpeg', '.png', '.gif']
   return imageExtensions.includes(file.ext)
@@ -117,8 +119,8 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     regularMessageInputRef
   )
 
-  runtime.setDragListener(async (e) => {
-    if (e.payload.type != "drop") {
+  runtime.setDragListener(async e => {
+    if (e.payload.type != 'drop') {
       return
     }
     if (chat === null) {
@@ -129,13 +131,18 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     // sanitize files
     const paths = e.payload.paths
     const forbiddenPathRegEx = /DeltaChat\/.+?\.sqlite-blobs\//gi
-    const sanitized = paths.filter((path) => {
-      let val = !forbiddenPathRegEx.test(path.replace('\\', '/'))
-      if (!val) {
-        log.warn('Prevented a file from being send again while dragging it out', path)
-      }
-      return val
-    }).map((path) => parse(path))
+    const sanitized = paths
+      .filter(path => {
+        const val = !forbiddenPathRegEx.test(path.replace('\\', '/'))
+        if (!val) {
+          log.warn(
+            'Prevented a file from being send again while dragging it out',
+            path
+          )
+        }
+        return val
+      })
+      .map(path => parse(path))
 
     // get account
     const acc = await BackendRemote.rpc.getSelectedAccountId()
@@ -144,20 +151,18 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
       return
     }
 
-
     // send single file
     if (sanitized.length == 1) {
       const file = sanitized[0]
       const msgViewType: Viewtype = isImage(file) ? 'Image' : 'File'
-      await addFileToDraft(fullPath(file), file.name,
-        msgViewType)
+      await addFileToDraft(fullPath(file), file.name, msgViewType)
     }
     // send multiple files
     else if (sanitized.length > 1) {
       openDialog(ConfirmSendingFiles, {
-        sanitizedFileList: sanitized.map((path => ({
-          name: path.name
-        }))),
+        sanitizedFileList: sanitized.map(path => ({
+          name: path.name,
+        })),
         chatName: chat.name,
         onClick: async (isConfirmed: boolean) => {
           if (!isConfirmed) {
@@ -175,7 +180,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         },
       })
     }
-  });
+  })
 
   const onDrop = (e: React.DragEvent<any>) => {
     e.preventDefault()

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -191,10 +191,9 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
       log.warn('dropped something, but no chat is selected')
       return
     }
-    const forbiddenPathRegEx = /DeltaChat\/.+?\.sqlite-blobs\//gi
     const sanitized = paths
       .filter(path => {
-        const val = !forbiddenPathRegEx.test(path.replace('\\', '/'))
+        const val = runtime.isDroppedFileFromOutside(path)
         if (!val) {
           log.warn(
             'Prevented a file from being sent again while dragging it out',

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -318,6 +318,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     ? getBackgroundImageStyle(settingsStore.desktopSettings)
     : {}
 
+  const isElectron = typeof navigator === 'object' && navigator.userAgent.includes('Electron');
   return (
     <div
       role='tabpanel'
@@ -335,7 +336,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
       className='message-list-and-composer'
       style={style}
       ref={conversationRef}
-      onDrop={onDrop.bind({ props: { chat } })}
+      onDrop={isElectron ? onDrop.bind({ props: { chat } }) : undefined}
       onDragOver={onDragOver}
     >
       <div className='message-list-and-composer__message-list'>

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -124,25 +124,19 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   // Tauri listener
   useEffect(() => {
-    console.log('drag: register')
-    const unset = runtime.setDragListener(async e => {
-      if (e.payload.type != 'drop') {
-        return
-      }
-      const paths = e.payload.paths
+    log.debug('drag: register')
+    runtime.setDropListener(paths => {
       handleDrop(paths)
     })
     return () => {
-      unset.then(u => {
-        log.info('drag: unregister')
-        u()
-      })
+      log.debug('drag: unregister')
+      runtime.setDropListener(null)
     }
   })
 
   // Electron and webview listener
   const onDrop = async (e: React.DragEvent<any>) => {
-    console.log('drag: electron drop')
+    log.debug('drag: browser/electron drop')
     e.preventDefault()
     e.stopPropagation()
 

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useEffect, useCallback } from 'react'
-import { basename, join, parse, ParsedPath } from 'path'
+import { join, parse, ParsedPath } from 'path'
 import { T } from '@deltachat/jsonrpc-client'
 
 import Composer, { useDraft } from '../composer/Composer'
@@ -14,7 +14,6 @@ import ConfirmSendingFiles from '../dialogs/ConfirmSendingFiles'
 import { ReactionsBarProvider } from '../ReactionsBar'
 import useDialog from '../../hooks/dialog/useDialog'
 import useMessage from '../../hooks/chat/useMessage'
-import { BackendRemote } from '../../backend-com'
 import { Viewtype } from '@deltachat/jsonrpc-client/dist/generated/types'
 
 const log = getLogger('renderer/MessageListAndComposer')
@@ -87,7 +86,6 @@ export function getBackgroundImageStyle(
   return style
 }
 
-
 // Invariant: The called function handles windows specifically.
 function fullPath(file: ParsedPath) {
   return file.dir + '/' + file.name + file.ext
@@ -126,7 +124,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   // Tauri listener
   useEffect(() => {
-    console.log("drag: register")
+    console.log('drag: register')
     const unset = runtime.setDragListener(async e => {
       if (e.payload.type != 'drop') {
         return
@@ -144,7 +142,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   // Electron and webview listener
   const onDrop = async (e: React.DragEvent<any>) => {
-    console.log("drag: electron drop")
+    console.log('drag: electron drop')
     e.preventDefault()
     e.stopPropagation()
 
@@ -187,7 +185,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
   }
 
   const handleDrop = async (paths: string[]) => {
-    console.log("drag: handling drop: ", paths)
+    console.log('drag: handling drop: ', paths)
     if (chat === null) {
       log.warn('dropped something, but no chat is selected')
       return

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -212,7 +212,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
       await addFileToDraft(fullPath(file), file.name + file.ext, msgViewType)
     }
     // send multiple files
-    else if (sanitized.length > 1) {
+    else if (sanitized.length > 1 && !hasOpenDialogs) {
       openDialog(ConfirmSendingFiles, {
         sanitizedFileList: sanitized.map(path => ({
           name: path.name,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "@deltachat-desktop/shared": "link:../shared",
-    "@deltachat/jsonrpc-client": "catalog:"
+    "@deltachat/jsonrpc-client": "catalog:",
+    "@tauri-apps/api": "^2.2.0"
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@deltachat-desktop/shared": "link:../shared",
-    "@deltachat/jsonrpc-client": "catalog:",
-    "@tauri-apps/api": "^2.2.0"
+    "@deltachat/jsonrpc-client": "catalog:"
   }
 }

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -10,8 +10,8 @@ import {
 } from '@deltachat-desktop/shared/shared-types.js'
 import { LocaleData } from '@deltachat-desktop/shared/localize.js'
 import { BaseDeltaChat } from '@deltachat/jsonrpc-client'
-import { DragDropEvent } from '@tauri-apps/api/webview'
-import { Event, UnlistenFn } from '@tauri-apps/api/event'
+import type { DragDropEvent } from '@tauri-apps/api/webview'
+import type { Event, UnlistenFn } from '@tauri-apps/api/event'
 
 import type { getLogger as getLoggerFunction } from '@deltachat-desktop/shared/logger.js'
 import type { setLogHandler as setLogHandlerFunction } from '@deltachat-desktop/shared/logger.js'

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -10,6 +10,8 @@ import {
 } from '@deltachat-desktop/shared/shared-types.js'
 import { LocaleData } from '@deltachat-desktop/shared/localize.js'
 import { BaseDeltaChat } from '@deltachat/jsonrpc-client'
+import { DragDropEvent, getCurrentWebview } from '@tauri-apps/api/webview'
+import { Event, UnlistenFn } from '@tauri-apps/api/event'
 
 import type { getLogger as getLoggerFunction } from '@deltachat-desktop/shared/logger.js'
 import type { setLogHandler as setLogHandlerFunction } from '@deltachat-desktop/shared/logger.js'
@@ -153,6 +155,7 @@ export interface Runtime {
   /** guard function that checks if it is a file from `onDragFileOut`, if so it denies the drop.
    * It checks by checking if file path contains references to the deltachat bob dir,
    */
+  setDragListener(fn: (event: Event<DragDropEvent>) => void): Promise<UnlistenFn>
   isDroppedFileFromOutside(file: File): boolean
 
   getAutostartState(): Promise<AutostartState>

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -152,12 +152,13 @@ export interface Runtime {
 
   /** only support this if you have a real implementation for `isDroppedFileFromOutside`  */
   onDragFileOut(file: string): void
-  /** guard function that checks if it is a file from `onDragFileOut`, if so it denies the drop.
-   * It checks by checking if file path contains references to the deltachat bob dir,
-   */
+  /** Set (tauri) drag listener to handle drag and drop events */
   setDragListener(
     fn: (event: Event<DragDropEvent>) => void
   ): Promise<UnlistenFn>
+  /** guard function that checks if it is a file from `onDragFileOut`, if so it denies the drop.
+   * It checks by checking if file path contains references to the deltachat bob dir,
+   */
   isDroppedFileFromOutside(file: File): boolean
 
   getAutostartState(): Promise<AutostartState>

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -159,7 +159,7 @@ export interface Runtime {
   /** guard function that checks if it is a file from `onDragFileOut`, if so it denies the drop.
    * It checks by checking if file path contains references to the deltachat bob dir,
    */
-  isDroppedFileFromOutside(file: File): boolean
+  isDroppedFileFromOutside(file: string): boolean
 
   getAutostartState(): Promise<AutostartState>
   // callbacks to set

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -10,7 +10,7 @@ import {
 } from '@deltachat-desktop/shared/shared-types.js'
 import { LocaleData } from '@deltachat-desktop/shared/localize.js'
 import { BaseDeltaChat } from '@deltachat/jsonrpc-client'
-import { DragDropEvent, getCurrentWebview } from '@tauri-apps/api/webview'
+import { DragDropEvent } from '@tauri-apps/api/webview'
 import { Event, UnlistenFn } from '@tauri-apps/api/event'
 
 import type { getLogger as getLoggerFunction } from '@deltachat-desktop/shared/logger.js'
@@ -155,7 +155,9 @@ export interface Runtime {
   /** guard function that checks if it is a file from `onDragFileOut`, if so it denies the drop.
    * It checks by checking if file path contains references to the deltachat bob dir,
    */
-  setDragListener(fn: (event: Event<DragDropEvent>) => void): Promise<UnlistenFn>
+  setDragListener(
+    fn: (event: Event<DragDropEvent>) => void
+  ): Promise<UnlistenFn>
   isDroppedFileFromOutside(file: File): boolean
 
   getAutostartState(): Promise<AutostartState>

--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -10,8 +10,6 @@ import {
 } from '@deltachat-desktop/shared/shared-types.js'
 import { LocaleData } from '@deltachat-desktop/shared/localize.js'
 import { BaseDeltaChat } from '@deltachat/jsonrpc-client'
-import type { DragDropEvent } from '@tauri-apps/api/webview'
-import type { Event, UnlistenFn } from '@tauri-apps/api/event'
 
 import type { getLogger as getLoggerFunction } from '@deltachat-desktop/shared/logger.js'
 import type { setLogHandler as setLogHandlerFunction } from '@deltachat-desktop/shared/logger.js'
@@ -153,9 +151,7 @@ export interface Runtime {
   /** only support this if you have a real implementation for `isDroppedFileFromOutside`  */
   onDragFileOut(file: string): void
   /** Set (tauri) drag listener to handle drag and drop events */
-  setDragListener(
-    fn: (event: Event<DragDropEvent>) => void
-  ): Promise<UnlistenFn>
+  setDropListener(onDrop: ((paths: string[]) => void) | null): void
   /** guard function that checks if it is a file from `onDragFileOut`, if so it denies the drop.
    * It checks by checking if file path contains references to the deltachat bob dir,
    */

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -104,6 +104,9 @@ class BrowserRuntime implements Runtime {
       console.error('WebSocket error:', event)
     })
   }
+    setDragListener(_fn: (event: any) => void): Promise<any> {
+      return Promise.resolve()
+    }
 
   sendToBackendOverWS(message: MessageToBackend.AllTypes) {
     if (this.socket.readyState != this.socket.OPEN) {

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -104,9 +104,9 @@ class BrowserRuntime implements Runtime {
       console.error('WebSocket error:', event)
     })
   }
-    setDragListener(_fn: (event: any) => void): Promise<any> {
-      return Promise.resolve()
-    }
+  setDragListener(_fn: (event: any) => void): Promise<any> {
+    return Promise.resolve()
+  }
 
   sendToBackendOverWS(message: MessageToBackend.AllTypes) {
     if (this.socket.readyState != this.socket.OPEN) {

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -104,7 +104,7 @@ class BrowserRuntime implements Runtime {
       console.error('WebSocket error:', event)
     })
   }
-  setDragListener(_fn: (event: any) => void): Promise<any> {
+  setDropListener(_onDrop: ((paths: string[]) => void) | null) {
     return Promise.resolve()
   }
 

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -160,7 +160,7 @@ class BrowserRuntime implements Runtime {
     // Browser can not implement this
     return
   }
-  isDroppedFileFromOutside(_file: File): boolean {
+  isDroppedFileFromOutside(_file: string): boolean {
     return true // Browser does not support dragging files out, so can only be from outside
   }
   emitUIReady(): void {

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -19,20 +19,17 @@ import {
 } from '@deltachat-desktop/runtime-interface'
 import { BaseDeltaChat, yerpc } from '@deltachat/jsonrpc-client'
 
-import type { dialog, app, IpcRenderer, webUtils } from 'electron'
+import type { dialog, app, IpcRenderer } from 'electron'
 import type { LocaleData } from '@deltachat-desktop/shared/localize.js'
 import type { getLogger as getLoggerFunction } from '@deltachat-desktop/shared/logger.js'
 import type { setLogHandler as setLogHandlerFunction } from '@deltachat-desktop/shared/logger.js'
 
-const {
-  app_getPath,
-  ipcRenderer: ipcBackend,
-  getPathForFile,
-} = (window as any).get_electron_functions() as {
+const { app_getPath, ipcRenderer: ipcBackend } = (
+  window as any
+).get_electron_functions() as {
   // see static/preload.js
   ipcRenderer: IpcRenderer
   app_getPath: typeof app.getPath
-  getPathForFile: typeof webUtils.getPathForFile
 }
 
 const { BaseTransport } = yerpc
@@ -120,7 +117,7 @@ class ElectronDeltachat extends BaseDeltaChat<ElectronTransport> {
 }
 
 class ElectronRuntime implements Runtime {
-  setDragListener(_fn: (event: any) => void): Promise<any> {
+  setDropListener(_onDrop: ((paths: string[]) => void) | null) {
     return Promise.resolve()
   }
   onResumeFromSleep: (() => void) | undefined

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -138,9 +138,9 @@ class ElectronRuntime implements Runtime {
   onDragFileOut(file: string): void {
     ipcBackend.send('ondragstart', file)
   }
-  isDroppedFileFromOutside(path: string): boolean {
+  isDroppedFileFromOutside(file: string): boolean {
     const forbiddenPathRegEx = /DeltaChat\/.+?\.sqlite-blobs\//gi
-    return !forbiddenPathRegEx.test(path.replace('\\', '/'))
+    return !forbiddenPathRegEx.test(file.replace('\\', '/'))
   }
   onThemeUpdate: (() => void) | undefined
   onChooseLanguage: ((locale: string) => Promise<void>) | undefined

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -120,6 +120,9 @@ class ElectronDeltachat extends BaseDeltaChat<ElectronTransport> {
 }
 
 class ElectronRuntime implements Runtime {
+  setDragListener(_fn: (event: any) => void): Promise<any> {
+    return Promise.resolve()
+  }
   onResumeFromSleep: (() => void) | undefined
   onWebxdcSendToChat:
     | ((

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -138,8 +138,7 @@ class ElectronRuntime implements Runtime {
   onDragFileOut(file: string): void {
     ipcBackend.send('ondragstart', file)
   }
-  isDroppedFileFromOutside(file: File): boolean {
-    const path = getPathForFile(file)
+  isDroppedFileFromOutside(path: string): boolean {
     const forbiddenPathRegEx = /DeltaChat\/.+?\.sqlite-blobs\//gi
     return !forbiddenPathRegEx.test(path.replace('\\', '/'))
   }

--- a/packages/target-electron/static/preload.js
+++ b/packages/target-electron/static/preload.js
@@ -24,7 +24,6 @@
     return {
       ipcRenderer: electron.ipcRenderer,
       app_getPath: p => electron.ipcRenderer.sendSync('app-get-path', p),
-      getPathForFile: electron.webUtils.getPathForFile,
     }
   }
 

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -664,8 +664,9 @@ class TauriRuntime implements Runtime {
   onDragFileOut(_file: string): void {
     throw new Error('Method not implemented.50')
   }
-  isDroppedFileFromOutside(_file: string): boolean {
-    throw new Error('Method not implemented.51')
+  isDroppedFileFromOutside(file: string): boolean {
+    const forbiddenPathRegEx = /DeltaChat\/.+?\.sqlite-blobs\//gi
+    return !forbiddenPathRegEx.test(file.replace('\\', '/'))
   }
   // only works on macOS and iOS
   // exp.runtime.debug_get_datastore_ids()

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -36,40 +36,40 @@ import type {
 } from '@deltachat-desktop/shared/logger.js'
 import type { setLogHandler as setLogHandlerFunction } from '@deltachat-desktop/shared/logger.js'
 import { DragDropEvent, getCurrentWebview } from '@tauri-apps/api/webview'
-import { Event, UnlistenFn } from '@tauri-apps/api/event'
+import { Event } from '@tauri-apps/api/event'
 
 let logJsonrpcConnection = false
 
 type MainWindowEvents =
   | {
-    event: 'sendToChat'
-    data: {
-      options: {
-        text: string | null | undefined
-        file: { fileName: string; fileContent: string } | null
+      event: 'sendToChat'
+      data: {
+        options: {
+          text: string | null | undefined
+          file: { fileName: string; fileContent: string } | null
+        }
+        account: number | null
       }
-      account: number | null
     }
-  }
   | {
-    event: 'localeReloaded'
-    data: string | null
-  }
+      event: 'localeReloaded'
+      data: string | null
+    }
   | {
-    event: 'showAboutDialog'
-  }
+      event: 'showAboutDialog'
+    }
   | {
-    event: 'showSettingsDialog'
-  }
+      event: 'showSettingsDialog'
+    }
   | {
-    event: 'showKeybindingsDialog'
-  }
+      event: 'showKeybindingsDialog'
+    }
   | {
-    event: 'resumeFromSleep'
-  }
+      event: 'resumeFromSleep'
+    }
   | {
-    event: 'toggleNotifications'
-  }
+      event: 'toggleNotifications'
+    }
   | {
       event: 'onThemeUpdate'
     }
@@ -127,9 +127,7 @@ class TauriRuntime implements Runtime {
   emitUIFullyReady(): void {
     invoke('ui_frontend_ready')
   }
-  async setDragListener(
-    eventHandler: (event: Event<DragDropEvent>) => void
-  ) {
+  async setDragListener(eventHandler: (event: Event<DragDropEvent>) => void) {
     return getCurrentWebview().onDragDropEvent(event => {
       eventHandler(event)
     })
@@ -207,7 +205,7 @@ class TauriRuntime implements Runtime {
 
     const savedEntries = (await this.store.entries()).reduce(
       (acc, [key, value]) => {
-        ; (acc as any)[key] = value
+        ;(acc as any)[key] = value
         return acc
       },
       {} as Partial<DesktopSettingsType>
@@ -346,9 +344,9 @@ class TauriRuntime implements Runtime {
         this.onWebxdcSendToChat?.(
           options.file
             ? {
-              file_name: options.file.fileName,
-              file_content: options.file.fileContent,
-            }
+                file_name: options.file.fileName,
+                file_content: options.file.fileContent,
+              }
             : null,
           options.text || null,
           account || undefined
@@ -685,10 +683,10 @@ class TauriRuntime implements Runtime {
   onOpenQrUrl: ((url: string) => void) | undefined
   onWebxdcSendToChat:
     | ((
-      file: { file_name: string; file_content: string } | null,
-      text: string | null,
-      account_id?: number
-    ) => void)
+        file: { file_name: string; file_content: string } | null,
+        text: string | null,
+        account_id?: number
+      ) => void)
     | undefined
   onResumeFromSleep: (() => void) | undefined
   onToggleNotifications: (() => void) | undefined
@@ -700,4 +698,4 @@ class TauriRuntime implements Runtime {
   }
 }
 
-; (window as any).r = new TauriRuntime()
+;(window as any).r = new TauriRuntime()

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -126,10 +126,6 @@ class TauriRuntime implements Runtime {
   emitUIFullyReady(): void {
     invoke('ui_frontend_ready')
   }
-  onDrop: ((paths: string[]) => void) | null = null
-  setDropListener(onDrop: ((paths: string[]) => void) | null) {
-    this.onDrop = onDrop
-  }
   emitUIReady(): void {
     invoke('ui_ready')
   }
@@ -666,8 +662,12 @@ class TauriRuntime implements Runtime {
   ): Promise<string> {
     return invoke('copy_background_image_file', { srcPath, isDefaultPicture })
   }
-  onDragFileOut(_file: string): void {
-    throw new Error('Method not implemented.50')
+  onDrop: ((paths: string[]) => void) | null = null
+  setDropListener(onDrop: ((paths: string[]) => void) | null) {
+    this.onDrop = onDrop
+  }
+  onDragFileOut(fileName: string): void {
+    invoke('drag_file_out', { fileName })
   }
   isDroppedFileFromOutside(file: string): boolean {
     const forbiddenPathRegEx = /DeltaChat\/.+?\.sqlite-blobs\//gi

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -35,6 +35,9 @@ import type {
   LogLevelString,
 } from '@deltachat-desktop/shared/logger.js'
 import type { setLogHandler as setLogHandlerFunction } from '@deltachat-desktop/shared/logger.js'
+import { Z_VERSION_ERROR } from 'zlib'
+import { DragDropEvent, getCurrentWebview } from '@tauri-apps/api/webview'
+import { Event, UnlistenFn } from '@tauri-apps/api/event'
 
 let logJsonrpcConnection = false
 
@@ -124,6 +127,11 @@ class TauriRuntime implements Runtime {
   }
   emitUIFullyReady(): void {
     invoke('ui_frontend_ready')
+  }
+  async setDragListener(fn: (event: Event<DragDropEvent>) => void): Promise<UnlistenFn> {
+    return await getCurrentWebview().onDragDropEvent((event) => {
+      fn(event)
+    });
   }
   emitUIReady(): void {
     invoke('ui_ready')

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -35,7 +35,6 @@ import type {
   LogLevelString,
 } from '@deltachat-desktop/shared/logger.js'
 import type { setLogHandler as setLogHandlerFunction } from '@deltachat-desktop/shared/logger.js'
-import { Z_VERSION_ERROR } from 'zlib'
 import { DragDropEvent, getCurrentWebview } from '@tauri-apps/api/webview'
 import { Event, UnlistenFn } from '@tauri-apps/api/event'
 
@@ -128,10 +127,12 @@ class TauriRuntime implements Runtime {
   emitUIFullyReady(): void {
     invoke('ui_frontend_ready')
   }
-  async setDragListener(fn: (event: Event<DragDropEvent>) => void): Promise<UnlistenFn> {
-    return await getCurrentWebview().onDragDropEvent((event) => {
+  async setDragListener(
+    fn: (event: Event<DragDropEvent>) => void
+  ): Promise<UnlistenFn> {
+    return await getCurrentWebview().onDragDropEvent(event => {
       fn(event)
-    });
+    })
   }
   emitUIReady(): void {
     invoke('ui_ready')

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -42,34 +42,34 @@ let logJsonrpcConnection = false
 
 type MainWindowEvents =
   | {
-      event: 'sendToChat'
-      data: {
-        options: {
-          text: string | null | undefined
-          file: { fileName: string; fileContent: string } | null
-        }
-        account: number | null
+    event: 'sendToChat'
+    data: {
+      options: {
+        text: string | null | undefined
+        file: { fileName: string; fileContent: string } | null
       }
+      account: number | null
     }
+  }
   | {
-      event: 'localeReloaded'
-      data: string | null
-    }
+    event: 'localeReloaded'
+    data: string | null
+  }
   | {
-      event: 'showAboutDialog'
-    }
+    event: 'showAboutDialog'
+  }
   | {
-      event: 'showSettingsDialog'
-    }
+    event: 'showSettingsDialog'
+  }
   | {
-      event: 'showKeybindingsDialog'
-    }
+    event: 'showKeybindingsDialog'
+  }
   | {
-      event: 'resumeFromSleep'
-    }
+    event: 'resumeFromSleep'
+  }
   | {
-      event: 'toggleNotifications'
-    }
+    event: 'toggleNotifications'
+  }
   | {
       event: 'onThemeUpdate'
     }
@@ -128,10 +128,10 @@ class TauriRuntime implements Runtime {
     invoke('ui_frontend_ready')
   }
   async setDragListener(
-    fn: (event: Event<DragDropEvent>) => void
-  ): Promise<UnlistenFn> {
-    return await getCurrentWebview().onDragDropEvent(event => {
-      fn(event)
+    eventHandler: (event: Event<DragDropEvent>) => void
+  ) {
+    return getCurrentWebview().onDragDropEvent(event => {
+      eventHandler(event)
     })
   }
   emitUIReady(): void {
@@ -207,7 +207,7 @@ class TauriRuntime implements Runtime {
 
     const savedEntries = (await this.store.entries()).reduce(
       (acc, [key, value]) => {
-        ;(acc as any)[key] = value
+        ; (acc as any)[key] = value
         return acc
       },
       {} as Partial<DesktopSettingsType>
@@ -346,9 +346,9 @@ class TauriRuntime implements Runtime {
         this.onWebxdcSendToChat?.(
           options.file
             ? {
-                file_name: options.file.fileName,
-                file_content: options.file.fileContent,
-              }
+              file_name: options.file.fileName,
+              file_content: options.file.fileContent,
+            }
             : null,
           options.text || null,
           account || undefined
@@ -685,10 +685,10 @@ class TauriRuntime implements Runtime {
   onOpenQrUrl: ((url: string) => void) | undefined
   onWebxdcSendToChat:
     | ((
-        file: { file_name: string; file_content: string } | null,
-        text: string | null,
-        account_id?: number
-      ) => void)
+      file: { file_name: string; file_content: string } | null,
+      text: string | null,
+      account_id?: number
+    ) => void)
     | undefined
   onResumeFromSleep: (() => void) | undefined
   onToggleNotifications: (() => void) | undefined
@@ -700,4 +700,4 @@ class TauriRuntime implements Runtime {
   }
 }
 
-;(window as any).r = new TauriRuntime()
+; (window as any).r = new TauriRuntime()

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -664,7 +664,7 @@ class TauriRuntime implements Runtime {
   onDragFileOut(_file: string): void {
     throw new Error('Method not implemented.50')
   }
-  isDroppedFileFromOutside(_file: File): boolean {
+  isDroppedFileFromOutside(_file: string): boolean {
     throw new Error('Method not implemented.51')
   }
   // only works on macOS and iOS

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -31,8 +31,8 @@ tauri = { version = "2", features = [
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = "1.43.1"
-deltachat = { git = "https://github.com/chatmail/core", tag = "v1.159.3", version = "1.159.3" }
-deltachat-jsonrpc = { git = "https://github.com/chatmail/core", tag = "v1.159.3", version = "1.159.3" }
+deltachat = { git = "https://github.com/chatmail/core", tag = "v1.159.4", version = "1.159.4" }
+deltachat-jsonrpc = { git = "https://github.com/chatmail/core", tag = "v1.159.4", version = "1.159.4" }
 tauri-plugin-dialog = "2"
 tauri-plugin-clipboard-manager = "2.0.2"
 log = "0.4.22"
@@ -56,7 +56,7 @@ url = "*"
 mime_guess = "2.0.5"
 once_cell = "1.21.1"
 clap = { version = "4.5.35", features = ["derive"] }
-chrono = { version = "0.4.40", default-features = false }
+chrono = { version = "0.4.41", default-features = false }
 notify = "8.0.0"
 regex = "1.11.1"
 register-default-handler = { version = "0.1.0", path = "../crates/register-default-handler" }

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -62,6 +62,7 @@ regex = "1.11.1"
 register-default-handler = { version = "0.1.0", path = "../crates/register-default-handler" }
 # ashpd = { version = "0.11.0", optional = true }
 ashpd = "0.11.0"
+drag = "2.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 include_dir = "0.7.4"

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -60,9 +60,10 @@ chrono = { version = "0.4.41", default-features = false }
 notify = "8.0.0"
 regex = "1.11.1"
 register-default-handler = { version = "0.1.0", path = "../crates/register-default-handler" }
-# ashpd = { version = "0.11.0", optional = true }
-ashpd = "0.11.0"
 drag = "2.1.0"
+
+[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+ashpd = "0.11.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 include_dir = "0.7.4"

--- a/packages/target-tauri/src-tauri/build.rs
+++ b/packages/target-tauri/src-tauri/build.rs
@@ -79,6 +79,7 @@ fn main() {
             "show_notification",
             "clear_notifications",
             "clear_all_notifications",
+            "drag_file_out",
         ]),
     ))
     .expect("failed to run tauri-build");

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -77,4 +77,6 @@ permissions = [
     "allow-show-notification",
     "allow-clear-notifications",
     "allow-clear-all-notifications",
+
+    "allow-drag-file-out",
 ]

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -15,6 +15,9 @@ permissions = [
     "store:allow-get",
     "store:allow-set",
     "store:allow-delete",
+    # events
+    "core:event:allow-listen",
+    "core:event:default",
     # borderless titlebar
     "core:window:allow-toggle-maximize",
     "core:window:allow-start-dragging",

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -17,7 +17,6 @@ permissions = [
     "store:allow-delete",
     # events - only used for drag and drop
     "core:event:allow-listen",
-    "core:event:default",
     # borderless titlebar
     "core:window:allow-toggle-maximize",
     "core:window:allow-start-dragging",

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -15,7 +15,7 @@ permissions = [
     "store:allow-get",
     "store:allow-set",
     "store:allow-delete",
-    # events
+    # events - only used for drag and drop
     "core:event:allow-listen",
     "core:event:default",
     # borderless titlebar

--- a/packages/target-tauri/src-tauri/capabilities/main-window.toml
+++ b/packages/target-tauri/src-tauri/capabilities/main-window.toml
@@ -17,6 +17,7 @@ permissions = [
     "store:allow-delete",
     # events - only used for drag and drop
     "core:event:allow-listen",
+    "core:event:allow-unlisten",
     # borderless titlebar
     "core:window:allow-toggle-maximize",
     "core:window:allow-start-dragging",

--- a/packages/target-tauri/src-tauri/src/drag_and_drop.rs
+++ b/packages/target-tauri/src-tauri/src/drag_and_drop.rs
@@ -1,0 +1,45 @@
+use std::path::PathBuf;
+
+use tauri::path::SafePathBuf;
+use tauri::WebviewWindow;
+
+#[tauri::command]
+pub(crate) fn drag_file_out(
+    window: WebviewWindow,
+    // should be absolute path
+    file_name: SafePathBuf,
+) -> Result<(), String> {
+    use drag::DragItem;
+
+    //#[cfg(not(feature = "flatpak"))]
+
+    let file_name: PathBuf = PathBuf::from(file_name.as_ref());
+
+    let preview_icon =
+        drag::Image::Raw(include_bytes!("../../../../images/electron-file-drag-out.png").to_vec());
+
+    drag::start_drag(
+        #[cfg(target_os = "linux")]
+        &window
+            .gtk_window()
+            .map_err(|err| format!("failed tp get window.gtk_window: {err:?}"))?,
+        #[cfg(not(target_os = "linux"))]
+        &window,
+        DragItem::Files(vec![file_name]),
+        preview_icon,
+        |result, position| log::info!("drag callback: {result:?} - {position:?}"),
+        drag::Options {
+            mode: drag::DragMode::Copy,
+            ..drag::Options::default()
+        },
+    )
+    .map_err(|err| format!("drag failed: {err:?}"))?;
+
+    // #[cfg(feature = "flatpak")] {
+    //     let transfer = ashpd::documents::FileTransfer::new()?;
+    //     transfer.start_transfer(false, true);
+    //     transfer.add_files();
+    // }
+
+    Ok(())
+}

--- a/packages/target-tauri/src-tauri/src/drag_and_drop.rs
+++ b/packages/target-tauri/src-tauri/src/drag_and_drop.rs
@@ -11,29 +11,6 @@ pub(crate) async fn drag_file_out(
 ) -> Result<(), String> {
     let file: PathBuf = PathBuf::from(file_name.as_ref());
 
-    // #[cfg(feature = "flatpak")]
-    // {
-    //     use std::os::fd::AsFd;
-    //     let file = std::fs::File::open(file).map_err(|err| format!("can't open file {err:?}"))?;
-
-    //     let transfer = ashpd::documents::FileTransfer::new()
-    //         .await
-    //         .map_err(|err| format!("fasiled to create transfer: {err:?}"))?;
-    //     let key = transfer
-    //         .start_transfer(false, true)
-    //         .await
-    //         .map_err(|err| format!("fasiled to start transfer: {err:?}"))?;
-    //     transfer
-    //         .add_files(&key, &[file])
-    //         .await
-    //         .map_err(|err| format!("failed add file to transfer: {err:?}"))?;
-
-    //     // TODO: somehow needs to replace the file with a file transfer file
-    //     // that contains the transfer key and is of mimetype "application/vnd.portal.filetransfer
-    //     //
-    //     // seems to not be supported yet, I suggest we add another DragItem type f
-    // }
-
     use drag::DragItem;
     let preview_icon =
         drag::Image::Raw(include_bytes!("../../../../images/electron-file-drag-out.png").to_vec());

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -42,6 +42,7 @@ mod blobs;
 mod cli;
 mod clipboard;
 mod deeplink;
+mod drag_and_drop;
 mod file_dialogs;
 mod help_window;
 mod html_window;
@@ -290,6 +291,7 @@ pub fn run() -> i32 {
             themes::commands::get_available_themes,
             themes::commands::get_theme,
             themes::commands::get_current_active_theme_address,
+            drag_and_drop::drag_file_out,
         ])
         .register_asynchronous_uri_scheme_protocol(
             "webxdc-icon",

--- a/packages/target-tauri/src-tauri/src/state/notification.rs
+++ b/packages/target-tauri/src-tauri/src/state/notification.rs
@@ -29,7 +29,7 @@ impl Notifications {
     pub fn new(app_id: String) -> Self {
         Self {
             manager: get_notification_manager(app_id, Some("dcnotification".to_owned())), // - windows: we don't have deeplinking yet and this makes windows ignore the handelers
-                                                                                           // manager: get_notification_manager(app_id, None),
+                                                                                          // manager: get_notification_manager(app_id, None),
         }
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,6 +240,9 @@ importers:
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
         version: 1.159.4(ws@8.18.0)
+      '@tauri-apps/api':
+        specifier: ^2.2.0
+        version: 2.5.0
 
   packages/shared:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,11 +7,11 @@ settings:
 catalogs:
   default:
     '@deltachat/jsonrpc-client':
-      specifier: 1.159.3
-      version: 1.159.3
+      specifier: 1.159.4
+      version: 1.159.4
     '@deltachat/stdio-rpc-server':
-      specifier: 1.159.3
-      version: 1.159.3
+      specifier: 1.159.4
+      version: 1.159.4
     '@types/mime-types':
       specifier: ^2.1.4
       version: 2.1.4
@@ -100,7 +100,7 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 1.159.3(ws@7.5.10)
+        version: 1.159.4(ws@7.5.10)
       '@deltachat/message_parser_wasm':
         specifier: ^0.13.0
         version: 0.13.0
@@ -239,13 +239,13 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 1.159.3(ws@8.18.0)
+        version: 1.159.4(ws@8.18.0)
 
   packages/shared:
     dependencies:
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 1.159.3(ws@8.18.0)
+        version: 1.159.4(ws@8.18.0)
       error-stack-parser:
         specifier: ^2.1.4
         version: 2.1.4
@@ -279,10 +279,10 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 1.159.3(ws@8.18.0)
+        version: 1.159.4(ws@8.18.0)
       '@deltachat/stdio-rpc-server':
         specifier: 'catalog:'
-        version: 1.159.3(@deltachat/jsonrpc-client@1.159.3(ws@8.18.0))
+        version: 1.159.4(@deltachat/jsonrpc-client@1.159.4(ws@8.18.0))
       '@types/express-session':
         specifier: ^1.18.0
         version: 1.18.0
@@ -328,10 +328,10 @@ importers:
     dependencies:
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 1.159.3(ws@7.5.10)
+        version: 1.159.4(ws@7.5.10)
       '@deltachat/stdio-rpc-server':
         specifier: 'catalog:'
-        version: 1.159.3(@deltachat/jsonrpc-client@1.159.3(ws@7.5.10))
+        version: 1.159.4(@deltachat/jsonrpc-client@1.159.4(ws@7.5.10))
       mime-types:
         specifier: 'catalog:'
         version: 2.1.35
@@ -395,7 +395,7 @@ importers:
         version: 34.0.1
       electron-builder:
         specifier: ^24.13.3
-        version: 24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+        version: 24.13.3(electron-builder-squirrel-windows@24.13.3)
       esbuild:
         specifier: ^0.19.8
         version: 0.19.12
@@ -432,7 +432,7 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 1.159.3(ws@8.18.0)
+        version: 1.159.4(ws@8.18.0)
       '@tauri-apps/cli':
         specifier: ^2.5.0
         version: 2.5.0
@@ -475,64 +475,64 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
-  '@deltachat/jsonrpc-client@1.159.3':
-    resolution: {integrity: sha512-VP7i3qAyBwA/U91d8XlAy8Zk+NN6+v/Em2oALhUG0NmLcQUPjDxqWVyhjqWfqdg0xqNpB7nnO00MH6V6VcRhVw==}
+  '@deltachat/jsonrpc-client@1.159.4':
+    resolution: {integrity: sha512-S2nPtlG+vNSScDjfnCip6JjdqoPighLe3KJaUEM4Jfy7LY/e9L+RRKsMsbUegso2ezHvqwwA9Cka2pEgPfy3kg==}
 
   '@deltachat/message_parser_wasm@0.13.0':
     resolution: {integrity: sha512-X5KhNzNm5gZ7A+V86yCowqN2OAMKzseUY2PLOLwohUlwmBTs6kTppprgHPiH6XOcjHeckaUtVs1u0Ttomvu0Ig==}
 
-  '@deltachat/stdio-rpc-server-android-arm64@1.159.3':
-    resolution: {integrity: sha512-I03cIKdR56GCXXKRK//Ejjpqc4OjA7Pe7Y/uaTgXPcKhr+uhXudIQHpe493DIS1eSqSw2vwMVhUlANerLkuNeQ==}
+  '@deltachat/stdio-rpc-server-android-arm64@1.159.4':
+    resolution: {integrity: sha512-C1TeSiYAYKe6FJmkAL3+CwG5zd7cqLKAVXHIps0hhwMWzUs1rU+yh2dATkoXvO4XjdNU+t2lqZft2/9nJkF5Fw==}
     cpu: [arm64]
     os: [android]
 
-  '@deltachat/stdio-rpc-server-android-arm@1.159.3':
-    resolution: {integrity: sha512-+1vLn31fupRL7GW2C6E4xMTvOK5yNqlox3x1C13c/bDWfmjrai74U8IA6cLR9huQvFi2vc5a4v6TbXpqG4k3/g==}
+  '@deltachat/stdio-rpc-server-android-arm@1.159.4':
+    resolution: {integrity: sha512-n1uyD9MpcrIdp3bnpIvOHPs7OfIi/MQPNcxHaC7DtOd6E9kq/ygY2ssKUmby8PUxViK+//+bt+cjDxQwQzFF2A==}
     cpu: [arm]
     os: [android]
 
-  '@deltachat/stdio-rpc-server-darwin-arm64@1.159.3':
-    resolution: {integrity: sha512-gqdwgWjDOmFGnW6LGGPy5Nse4YSAtCpWLOLq5mLrzJnjdrTH5C1QEhViz1X8uTudS4QdNXdQnA12teAtEtAOIg==}
+  '@deltachat/stdio-rpc-server-darwin-arm64@1.159.4':
+    resolution: {integrity: sha512-rsLDZtc74LNQtbfVdHCWSOcTOE21EwAI4DUF3uUO7OFbyqlTjvFXkI0HTR/6SlqFLzZV8nzqwcbC09i5wP0q9w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@deltachat/stdio-rpc-server-darwin-x64@1.159.3':
-    resolution: {integrity: sha512-PRgwdNgUmlwdV+OxGUPg1X9076chDoiUAeK4+ZuxnRdyFwLl3hWAyAVkiRxfIdtLdxljaGAwic1Xkd4bBMOD6Q==}
+  '@deltachat/stdio-rpc-server-darwin-x64@1.159.4':
+    resolution: {integrity: sha512-eB8m24YXSYcdBWs1OgTH27mMefWELf5TyGxrTHZAtFJxdrIiFMXKdIncHvGK1GQ2JnjPIlSWFDIDaA3OgfMh9A==}
     cpu: [x64]
     os: [darwin]
 
-  '@deltachat/stdio-rpc-server-linux-arm64@1.159.3':
-    resolution: {integrity: sha512-YvgN8hk8rpaU2Qnv/niAzfbXdeowN4BQmemoc3S9ewHi+paERInb7ZkjMxx/NDxG+MMXvjfcL6pCR6I/YP5NLA==}
+  '@deltachat/stdio-rpc-server-linux-arm64@1.159.4':
+    resolution: {integrity: sha512-qkqr8CCAMwrTWRnJJTtc6VJjGQeE7INnQ+/so59Hhb1QWNRJRMfaJXqxeaVHsnFenQqt5rghQpgizut3xzU25g==}
     cpu: [arm64]
     os: [linux]
 
-  '@deltachat/stdio-rpc-server-linux-arm@1.159.3':
-    resolution: {integrity: sha512-UMBXvzvtbShSCZx2V1SoY4DWrCJo5ZRsDMuGYQSqdELVXZthWlbRE4dvDS4dhQX/F5B0pb7L05191GX2cLZ8og==}
+  '@deltachat/stdio-rpc-server-linux-arm@1.159.4':
+    resolution: {integrity: sha512-AcSOGiAvCx5dLZhUuVU7QNWfHrvKliYCWNpAiABuclssXkW0b1yfBL6dLmIppWdiamSmQ2ZlsEyLd4vZV+FMFg==}
     cpu: [arm]
     os: [linux]
 
-  '@deltachat/stdio-rpc-server-linux-ia32@1.159.3':
-    resolution: {integrity: sha512-dYyxztegssgWi5fmJqHYDedCcwSrVkaM6n190Y9+bcLFK9HHxBTJT67+y+VoWjCvtR5z9beaHPkU59kmW/Wd8Q==}
+  '@deltachat/stdio-rpc-server-linux-ia32@1.159.4':
+    resolution: {integrity: sha512-N98FhXK9ckd0E4iZR0KoQ57akfSaoWg9BPO1/abocAMzK991mSkEuB3IG/hzMRTEIYSXnq1GRR+txiuEM4aeXw==}
     cpu: [ia32]
     os: [linux]
 
-  '@deltachat/stdio-rpc-server-linux-x64@1.159.3':
-    resolution: {integrity: sha512-9HuaxLJDmXK9NUBA9ggQO+aQ/duG8KiMsTMlkbEg4uFblaB5KJP79/8pvf7b/4a5Rbniw00HAdVDGv6i9JUU3g==}
+  '@deltachat/stdio-rpc-server-linux-x64@1.159.4':
+    resolution: {integrity: sha512-8uOZBRsrvJQ4pgeBbpobS8MuBm2dOybOCRnMBsSoQg5/kNgvLHM1iwDjQ+LmMOaDpM/nNP2EBj8HrtWBRiDXlQ==}
     cpu: [x64]
     os: [linux]
 
-  '@deltachat/stdio-rpc-server-win32-ia32@1.159.3':
-    resolution: {integrity: sha512-3gXSqc/xnomLtjCK1NhISQA1mrexxP35m0wYOwRx0Al1WL9kee/S8yMSYjBIRdHESuR9ansMqsxb6iUgQcqTLA==}
+  '@deltachat/stdio-rpc-server-win32-ia32@1.159.4':
+    resolution: {integrity: sha512-ursLDCwuIA/O43HzbAuDnuyvzYMkv4rKJQpkn/zEoP8CCur2xyaMNvONGz6Ec7FshCjQ3RjIzmrrq5cEpI6VpQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@deltachat/stdio-rpc-server-win32-x64@1.159.3':
-    resolution: {integrity: sha512-dqSqFsehbRuTvNzobBV6jyeiGD7IVybiSoQPD5/HvOZ1JIIus2mwkvBdW98qunnWdPcMz6a0R7ba4ySxWXoHqg==}
+  '@deltachat/stdio-rpc-server-win32-x64@1.159.4':
+    resolution: {integrity: sha512-U8rTl1n0TvGd+GbyzwGz5DRk/yjcTKtyAQ+ruKow5SjM4x6RzjXT0QZW66tk9hlzMHYQPNxmx7au8Bgy1sK0ew==}
     cpu: [x64]
     os: [win32]
 
-  '@deltachat/stdio-rpc-server@1.159.3':
-    resolution: {integrity: sha512-1uCargCd/O5M6fsAda4OmfKJRsWwjZzqsohFuBlJJ4h6MoS75yW1S6BDep3itro+a99UcFVbUQSGnzgeoUiIzg==}
+  '@deltachat/stdio-rpc-server@1.159.4':
+    resolution: {integrity: sha512-UXTj0qc3juHjgDRziRatOFKq37esmbTSsgvqhWHnAlyaVoeAo4jfONXiqDfrqcscrY5DupMzUxud0E64T7uqsQ==}
     peerDependencies:
       '@deltachat/jsonrpc-client': '*'
 
@@ -602,8 +602,8 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.25.3':
-    resolution: {integrity: sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==}
+  '@esbuild/aix-ppc64@0.25.4':
+    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
@@ -632,8 +632,8 @@ packages:
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.25.3':
-    resolution: {integrity: sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==}
+  '@esbuild/android-arm64@0.25.4':
+    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -662,8 +662,8 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.25.3':
-    resolution: {integrity: sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==}
+  '@esbuild/android-arm@0.25.4':
+    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
@@ -692,8 +692,8 @@ packages:
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.25.3':
-    resolution: {integrity: sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==}
+  '@esbuild/android-x64@0.25.4':
+    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -722,8 +722,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.25.3':
-    resolution: {integrity: sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==}
+  '@esbuild/darwin-arm64@0.25.4':
+    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
@@ -752,8 +752,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.3':
-    resolution: {integrity: sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==}
+  '@esbuild/darwin-x64@0.25.4':
+    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -782,8 +782,8 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.25.3':
-    resolution: {integrity: sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==}
+  '@esbuild/freebsd-arm64@0.25.4':
+    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
@@ -812,8 +812,8 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.3':
-    resolution: {integrity: sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==}
+  '@esbuild/freebsd-x64@0.25.4':
+    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -842,8 +842,8 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.25.3':
-    resolution: {integrity: sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==}
+  '@esbuild/linux-arm64@0.25.4':
+    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
@@ -872,8 +872,8 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.3':
-    resolution: {integrity: sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==}
+  '@esbuild/linux-arm@0.25.4':
+    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -902,8 +902,8 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.3':
-    resolution: {integrity: sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==}
+  '@esbuild/linux-ia32@0.25.4':
+    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
@@ -932,8 +932,8 @@ packages:
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.3':
-    resolution: {integrity: sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==}
+  '@esbuild/linux-loong64@0.25.4':
+    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -962,8 +962,8 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.3':
-    resolution: {integrity: sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==}
+  '@esbuild/linux-mips64el@0.25.4':
+    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
@@ -992,8 +992,8 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.3':
-    resolution: {integrity: sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==}
+  '@esbuild/linux-ppc64@0.25.4':
+    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -1022,8 +1022,8 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.3':
-    resolution: {integrity: sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==}
+  '@esbuild/linux-riscv64@0.25.4':
+    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
@@ -1052,8 +1052,8 @@ packages:
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.3':
-    resolution: {integrity: sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==}
+  '@esbuild/linux-s390x@0.25.4':
+    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -1082,8 +1082,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.3':
-    resolution: {integrity: sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==}
+  '@esbuild/linux-x64@0.25.4':
+    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -1100,8 +1100,8 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.25.3':
-    resolution: {integrity: sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==}
+  '@esbuild/netbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -1130,8 +1130,8 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.3':
-    resolution: {integrity: sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==}
+  '@esbuild/netbsd-x64@0.25.4':
+    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -1154,8 +1154,8 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.25.3':
-    resolution: {integrity: sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==}
+  '@esbuild/openbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -1184,8 +1184,8 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.3':
-    resolution: {integrity: sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==}
+  '@esbuild/openbsd-x64@0.25.4':
+    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -1214,8 +1214,8 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.25.3':
-    resolution: {integrity: sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==}
+  '@esbuild/sunos-x64@0.25.4':
+    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -1244,8 +1244,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.25.3':
-    resolution: {integrity: sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==}
+  '@esbuild/win32-arm64@0.25.4':
+    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -1274,8 +1274,8 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.3':
-    resolution: {integrity: sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==}
+  '@esbuild/win32-ia32@0.25.4':
+    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
@@ -1304,8 +1304,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.3':
-    resolution: {integrity: sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==}
+  '@esbuild/win32-x64@0.25.4':
+    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2424,8 +2424,8 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.25.3:
-    resolution: {integrity: sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==}
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -3956,7 +3956,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.9
     optional: true
 
-  '@deltachat/jsonrpc-client@1.159.3(ws@7.5.10)':
+  '@deltachat/jsonrpc-client@1.159.4(ws@7.5.10)':
     dependencies:
       '@deltachat/tiny-emitter': 3.0.0
       isomorphic-ws: 4.0.1(ws@7.5.10)
@@ -3966,7 +3966,7 @@ snapshots:
       - utf-8-validate
       - ws
 
-  '@deltachat/jsonrpc-client@1.159.3(ws@8.18.0)':
+  '@deltachat/jsonrpc-client@1.159.4(ws@8.18.0)':
     dependencies:
       '@deltachat/tiny-emitter': 3.0.0
       isomorphic-ws: 4.0.1(ws@8.18.0)
@@ -3978,65 +3978,65 @@ snapshots:
 
   '@deltachat/message_parser_wasm@0.13.0': {}
 
-  '@deltachat/stdio-rpc-server-android-arm64@1.159.3':
+  '@deltachat/stdio-rpc-server-android-arm64@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-android-arm@1.159.3':
+  '@deltachat/stdio-rpc-server-android-arm@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-darwin-arm64@1.159.3':
+  '@deltachat/stdio-rpc-server-darwin-arm64@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-darwin-x64@1.159.3':
+  '@deltachat/stdio-rpc-server-darwin-x64@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-linux-arm64@1.159.3':
+  '@deltachat/stdio-rpc-server-linux-arm64@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-linux-arm@1.159.3':
+  '@deltachat/stdio-rpc-server-linux-arm@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-linux-ia32@1.159.3':
+  '@deltachat/stdio-rpc-server-linux-ia32@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-linux-x64@1.159.3':
+  '@deltachat/stdio-rpc-server-linux-x64@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-win32-ia32@1.159.3':
+  '@deltachat/stdio-rpc-server-win32-ia32@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server-win32-x64@1.159.3':
+  '@deltachat/stdio-rpc-server-win32-x64@1.159.4':
     optional: true
 
-  '@deltachat/stdio-rpc-server@1.159.3(@deltachat/jsonrpc-client@1.159.3(ws@7.5.10))':
+  '@deltachat/stdio-rpc-server@1.159.4(@deltachat/jsonrpc-client@1.159.4(ws@7.5.10))':
     dependencies:
-      '@deltachat/jsonrpc-client': 1.159.3(ws@7.5.10)
+      '@deltachat/jsonrpc-client': 1.159.4(ws@7.5.10)
     optionalDependencies:
-      '@deltachat/stdio-rpc-server-android-arm': 1.159.3
-      '@deltachat/stdio-rpc-server-android-arm64': 1.159.3
-      '@deltachat/stdio-rpc-server-darwin-arm64': 1.159.3
-      '@deltachat/stdio-rpc-server-darwin-x64': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-arm': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-arm64': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-ia32': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-x64': 1.159.3
-      '@deltachat/stdio-rpc-server-win32-ia32': 1.159.3
-      '@deltachat/stdio-rpc-server-win32-x64': 1.159.3
+      '@deltachat/stdio-rpc-server-android-arm': 1.159.4
+      '@deltachat/stdio-rpc-server-android-arm64': 1.159.4
+      '@deltachat/stdio-rpc-server-darwin-arm64': 1.159.4
+      '@deltachat/stdio-rpc-server-darwin-x64': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-arm': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-arm64': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-ia32': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-x64': 1.159.4
+      '@deltachat/stdio-rpc-server-win32-ia32': 1.159.4
+      '@deltachat/stdio-rpc-server-win32-x64': 1.159.4
 
-  '@deltachat/stdio-rpc-server@1.159.3(@deltachat/jsonrpc-client@1.159.3(ws@8.18.0))':
+  '@deltachat/stdio-rpc-server@1.159.4(@deltachat/jsonrpc-client@1.159.4(ws@8.18.0))':
     dependencies:
-      '@deltachat/jsonrpc-client': 1.159.3(ws@8.18.0)
+      '@deltachat/jsonrpc-client': 1.159.4(ws@8.18.0)
     optionalDependencies:
-      '@deltachat/stdio-rpc-server-android-arm': 1.159.3
-      '@deltachat/stdio-rpc-server-android-arm64': 1.159.3
-      '@deltachat/stdio-rpc-server-darwin-arm64': 1.159.3
-      '@deltachat/stdio-rpc-server-darwin-x64': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-arm': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-arm64': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-ia32': 1.159.3
-      '@deltachat/stdio-rpc-server-linux-x64': 1.159.3
-      '@deltachat/stdio-rpc-server-win32-ia32': 1.159.3
-      '@deltachat/stdio-rpc-server-win32-x64': 1.159.3
+      '@deltachat/stdio-rpc-server-android-arm': 1.159.4
+      '@deltachat/stdio-rpc-server-android-arm64': 1.159.4
+      '@deltachat/stdio-rpc-server-darwin-arm64': 1.159.4
+      '@deltachat/stdio-rpc-server-darwin-x64': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-arm': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-arm64': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-ia32': 1.159.4
+      '@deltachat/stdio-rpc-server-linux-x64': 1.159.4
+      '@deltachat/stdio-rpc-server-win32-ia32': 1.159.4
+      '@deltachat/stdio-rpc-server-win32-x64': 1.159.4
 
   '@deltachat/tiny-emitter@3.0.0': {}
 
@@ -4123,7 +4123,7 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.0':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.3':
+  '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
   '@esbuild/android-arm64@0.19.12':
@@ -4138,7 +4138,7 @@ snapshots:
   '@esbuild/android-arm64@0.25.0':
     optional: true
 
-  '@esbuild/android-arm64@0.25.3':
+  '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm@0.19.12':
@@ -4153,7 +4153,7 @@ snapshots:
   '@esbuild/android-arm@0.25.0':
     optional: true
 
-  '@esbuild/android-arm@0.25.3':
+  '@esbuild/android-arm@0.25.4':
     optional: true
 
   '@esbuild/android-x64@0.19.12':
@@ -4168,7 +4168,7 @@ snapshots:
   '@esbuild/android-x64@0.25.0':
     optional: true
 
-  '@esbuild/android-x64@0.25.3':
+  '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.19.12':
@@ -4183,7 +4183,7 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.0':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.3':
+  '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
   '@esbuild/darwin-x64@0.19.12':
@@ -4198,7 +4198,7 @@ snapshots:
   '@esbuild/darwin-x64@0.25.0':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.3':
+  '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.19.12':
@@ -4213,7 +4213,7 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.0':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.3':
+  '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-x64@0.19.12':
@@ -4228,7 +4228,7 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.0':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.3':
+  '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/linux-arm64@0.19.12':
@@ -4243,7 +4243,7 @@ snapshots:
   '@esbuild/linux-arm64@0.25.0':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.3':
+  '@esbuild/linux-arm64@0.25.4':
     optional: true
 
   '@esbuild/linux-arm@0.19.12':
@@ -4258,7 +4258,7 @@ snapshots:
   '@esbuild/linux-arm@0.25.0':
     optional: true
 
-  '@esbuild/linux-arm@0.25.3':
+  '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-ia32@0.19.12':
@@ -4273,7 +4273,7 @@ snapshots:
   '@esbuild/linux-ia32@0.25.0':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.3':
+  '@esbuild/linux-ia32@0.25.4':
     optional: true
 
   '@esbuild/linux-loong64@0.19.12':
@@ -4288,7 +4288,7 @@ snapshots:
   '@esbuild/linux-loong64@0.25.0':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.3':
+  '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.19.12':
@@ -4303,7 +4303,7 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.0':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.3':
+  '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
   '@esbuild/linux-ppc64@0.19.12':
@@ -4318,7 +4318,7 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.0':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.3':
+  '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.19.12':
@@ -4333,7 +4333,7 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.0':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.3':
+  '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
   '@esbuild/linux-s390x@0.19.12':
@@ -4348,7 +4348,7 @@ snapshots:
   '@esbuild/linux-s390x@0.25.0':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.3':
+  '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-x64@0.19.12':
@@ -4363,7 +4363,7 @@ snapshots:
   '@esbuild/linux-x64@0.25.0':
     optional: true
 
-  '@esbuild/linux-x64@0.25.3':
+  '@esbuild/linux-x64@0.25.4':
     optional: true
 
   '@esbuild/netbsd-arm64@0.24.2':
@@ -4372,7 +4372,7 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.0':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.3':
+  '@esbuild/netbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/netbsd-x64@0.19.12':
@@ -4387,7 +4387,7 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.0':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.3':
+  '@esbuild/netbsd-x64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-arm64@0.23.1':
@@ -4399,7 +4399,7 @@ snapshots:
   '@esbuild/openbsd-arm64@0.25.0':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.3':
+  '@esbuild/openbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.19.12':
@@ -4414,7 +4414,7 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.0':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.3':
+  '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
   '@esbuild/sunos-x64@0.19.12':
@@ -4429,7 +4429,7 @@ snapshots:
   '@esbuild/sunos-x64@0.25.0':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.3':
+  '@esbuild/sunos-x64@0.25.4':
     optional: true
 
   '@esbuild/win32-arm64@0.19.12':
@@ -4444,7 +4444,7 @@ snapshots:
   '@esbuild/win32-arm64@0.25.0':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.3':
+  '@esbuild/win32-arm64@0.25.4':
     optional: true
 
   '@esbuild/win32-ia32@0.19.12':
@@ -4459,7 +4459,7 @@ snapshots:
   '@esbuild/win32-ia32@0.25.0':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.3':
+  '@esbuild/win32-ia32@0.25.4':
     optional: true
 
   '@esbuild/win32-x64@0.19.12':
@@ -4474,7 +4474,7 @@ snapshots:
   '@esbuild/win32-x64@0.25.0':
     optional: true
 
-  '@esbuild/win32-x64@0.25.3':
+  '@esbuild/win32-x64@0.25.4':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@8.57.0)':
@@ -5106,7 +5106,7 @@ snapshots:
 
   app-builder-bin@4.0.0: {}
 
-  app-builder-lib@24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
+  app-builder-lib@24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3):
     dependencies:
       '@develar/schema-utils': 2.6.5
       '@electron/notarize': 2.2.1
@@ -5554,7 +5554,7 @@ snapshots:
 
   dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       fs-extra: 10.1.0
@@ -5598,7 +5598,7 @@ snapshots:
 
   electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       archiver: 5.3.2
       builder-util: 24.13.1
       fs-extra: 10.1.0
@@ -5606,9 +5606,9 @@ snapshots:
       - dmg-builder
       - supports-color
 
-  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3)):
+  electron-builder@24.13.3(electron-builder-squirrel-windows@24.13.3):
     dependencies:
-      app-builder-lib: 24.13.3(dmg-builder@24.13.3(electron-builder-squirrel-windows@24.13.3))(electron-builder-squirrel-windows@24.13.3(dmg-builder@24.13.3))
+      app-builder-lib: 24.13.3(dmg-builder@24.13.3)(electron-builder-squirrel-windows@24.13.3)
       builder-util: 24.13.1
       builder-util-runtime: 9.2.4
       chalk: 4.1.2
@@ -5683,7 +5683,7 @@ snapshots:
 
   esbuild-plugin-inline-worker@0.1.1:
     dependencies:
-      esbuild: 0.25.3
+      esbuild: 0.25.4
       find-cache-dir: 3.3.2
 
   esbuild@0.19.12:
@@ -5795,33 +5795,33 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.0
       '@esbuild/win32-x64': 0.25.0
 
-  esbuild@0.25.3:
+  esbuild@0.25.4:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.3
-      '@esbuild/android-arm': 0.25.3
-      '@esbuild/android-arm64': 0.25.3
-      '@esbuild/android-x64': 0.25.3
-      '@esbuild/darwin-arm64': 0.25.3
-      '@esbuild/darwin-x64': 0.25.3
-      '@esbuild/freebsd-arm64': 0.25.3
-      '@esbuild/freebsd-x64': 0.25.3
-      '@esbuild/linux-arm': 0.25.3
-      '@esbuild/linux-arm64': 0.25.3
-      '@esbuild/linux-ia32': 0.25.3
-      '@esbuild/linux-loong64': 0.25.3
-      '@esbuild/linux-mips64el': 0.25.3
-      '@esbuild/linux-ppc64': 0.25.3
-      '@esbuild/linux-riscv64': 0.25.3
-      '@esbuild/linux-s390x': 0.25.3
-      '@esbuild/linux-x64': 0.25.3
-      '@esbuild/netbsd-arm64': 0.25.3
-      '@esbuild/netbsd-x64': 0.25.3
-      '@esbuild/openbsd-arm64': 0.25.3
-      '@esbuild/openbsd-x64': 0.25.3
-      '@esbuild/sunos-x64': 0.25.3
-      '@esbuild/win32-arm64': 0.25.3
-      '@esbuild/win32-ia32': 0.25.3
-      '@esbuild/win32-x64': 0.25.3
+      '@esbuild/aix-ppc64': 0.25.4
+      '@esbuild/android-arm': 0.25.4
+      '@esbuild/android-arm64': 0.25.4
+      '@esbuild/android-x64': 0.25.4
+      '@esbuild/darwin-arm64': 0.25.4
+      '@esbuild/darwin-x64': 0.25.4
+      '@esbuild/freebsd-arm64': 0.25.4
+      '@esbuild/freebsd-x64': 0.25.4
+      '@esbuild/linux-arm': 0.25.4
+      '@esbuild/linux-arm64': 0.25.4
+      '@esbuild/linux-ia32': 0.25.4
+      '@esbuild/linux-loong64': 0.25.4
+      '@esbuild/linux-mips64el': 0.25.4
+      '@esbuild/linux-ppc64': 0.25.4
+      '@esbuild/linux-riscv64': 0.25.4
+      '@esbuild/linux-s390x': 0.25.4
+      '@esbuild/linux-x64': 0.25.4
+      '@esbuild/netbsd-arm64': 0.25.4
+      '@esbuild/netbsd-x64': 0.25.4
+      '@esbuild/openbsd-arm64': 0.25.4
+      '@esbuild/openbsd-x64': 0.25.4
+      '@esbuild/sunos-x64': 0.25.4
+      '@esbuild/win32-arm64': 0.25.4
+      '@esbuild/win32-ia32': 0.25.4
+      '@esbuild/win32-x64': 0.25.4
 
   escalade@3.1.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -240,9 +240,6 @@ importers:
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
         version: 1.159.4(ws@8.18.0)
-      '@tauri-apps/api':
-        specifier: ^2.2.0
-        version: 2.5.0
 
   packages/shared:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,8 @@ packages:
   - packages/*
 catalog:
   # deltachat specific
-  '@deltachat/jsonrpc-client': 1.159.3
-  '@deltachat/stdio-rpc-server': 1.159.3
+  '@deltachat/jsonrpc-client': 1.159.4
+  '@deltachat/stdio-rpc-server': 1.159.4
   '@webxdc/types': ^2.1.2
 
   # dependencies


### PR DESCRIPTION
add drag in and drag out to tauri edition.

- accept drop one file in
- accept drop multiple files in
- drag out single file

original pr by @Septias: https://github.com/deltachat/deltachat-desktop/pull/4951

tested on macos, linux and windows.

on flatpak only dragging out seems to work on kde. dragging files in don't work.
I failed to understand how to utilize the file transfer portal - It should give us a file with a special mime type, but I can't figure out how to enable/trigger this behavior, in my test it still transferred the absolute path to the file, to which the flatpak app has no access to.