### PR TITLE
fix: crash in "View Group" dialog on adding member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Changed
 
 ### Fixed
-
+- crash when a member gets added to a group and "View Group" dialog is open #5111
 
 <a id="1_58_2"></a>
 

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -81,6 +81,16 @@ export const useGroup = (accountId: number, chat: T.FullChat) => {
   }
 
   type GroupContacts = typeof group.contacts
+  /**
+   * Why setGroupContacts & setGroupMembers?
+   * setGroupMembers triggers a modifiyGroup in the backend and is called after
+   * changes triggered by the user while setGroupContacts is only called after
+   * changes from "outside" (not on this client) after DCEvent "ContactsChanged"
+   * to update the group in local state
+   *
+   * It takes a "setter" argument to make sure, the update always happens
+   * on the latest group state
+   */
   const setGroupContacts = useCallback(
     (setter: (oldContacts: GroupContacts) => GroupContacts) => {
       setGroup(group => {


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5111.

Related issues and MRs that have to do with updating members list:
- https://github.com/deltachat/deltachat-desktop/pull/4894.
- https://github.com/deltachat/deltachat-desktop/issues/4646.
- https://github.com/deltachat/deltachat-desktop/pull/4531.
- https://github.com/deltachat/deltachat-desktop/pull/4353.

I have tested this for a bit. Adding, removing, blocking, unblocking members from the current and another device. I have not encountered any issues.
Although I don't claim that this is fool-proof. This could potentially surface another bug.
My biggest concern is that this commit makes it no longer re-fetch the entire list of contacts, so it might be that we're sometimes not updating when we should.