### PR TITLE
fix: a11y: focus being locked on message input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - accessibility: don't re-announce message input (composer) after sending every message #5049
 - accessibility: correct `aria-posinset` for chat list #5044
 - don't close context menues on window resize #5418
+- tauri: accessibility: fix focus always being locked on the message input #5125
 
 <a id="2_11_1"></a>
 

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -251,20 +251,6 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     [hasOpenDialogs]
   )
 
-  const onSelectionChange = useCallback(() => {
-    const selection = window.getSelection()
-
-    if (
-      selection?.type === 'Caret' ||
-      (selection?.type === 'Range' && selection.rangeCount > 0)
-    )
-      return
-
-    // Only one of these is actually rendered at any given moment.
-    regularMessageInputRef.current?.focus()
-    editMessageInputRef.current?.focus()
-  }, [])
-
   const onEscapeKeyUp = useCallback((ev: KeyboardEvent) => {
     if (ev.code === 'Escape') {
       // Only one of these is actually rendered at any given moment.
@@ -275,7 +261,6 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   useEffect(() => {
     window.addEventListener('mouseup', onMouseUp)
-    document.addEventListener('selectionchange', onSelectionChange)
     window.addEventListener('keyup', onEscapeKeyUp)
 
     // Only one of these is actually rendered at any given moment.
@@ -284,10 +269,9 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
     return () => {
       window.removeEventListener('mouseup', onMouseUp)
-      document.removeEventListener('selectionchange', onSelectionChange)
       window.removeEventListener('keyup', onEscapeKeyUp)
     }
-  }, [onMouseUp, onEscapeKeyUp, onSelectionChange])
+  }, [onMouseUp, onEscapeKeyUp])
 
   const settingsStore = useSettingsStore()[0]
   // If you want to update this, don't forget to update


### PR DESCRIPTION
On Linux and macOS.
Such that you'd be unable to focus anything else
by using the Tab key.

Closes https://github.com/deltachat/deltachat-desktop/issues/5097.
Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/4590.

This also affects Electron on all platforms and Tauri for Windows:
now we will not re-focus the composer
after you un-select some text in a message.
This can be considered a downside,
but I was not able to come up with a simple soltuion
that I am sure is also good accessibility-wise.

On WebKit, the `selectionchange` event fires pretty much every time
something is clicked or when focus changes.
Namely, it fires when the focus exits the composer,
which is what caused the bug.

## Motivation

Although this is gonna be a bit annoying for mouse users
that they now have to click the composer manually
after certain actions, I am afraid we can't keep
the approach of always keeping it in focus by default.
Instead we should only focus it only in some concrete cases,
where we are sure it is appropriate.

The majority of the "always keep composer in focus" code
has been introduced in 199ea232539e77ea9b4c903451b90a56dc880554
(https://github.com/deltachat/deltachat-desktop/pull/2007).
The idea was to keep it in focus _by default_,
except some specific cases:
> Maybe we should rather listen for the blur event
> on the composer text area and check there
> if we want to give up the focus.

Some other issues related to composer re-focusing:
- 5dfc265c98563c87bd6f774d47c131bd839d90c9.
- 24510e95c5b865ce9b3372200e8b6d7692e1beb0.
- 5f54cb71829cd0f70070d1cccb5e848fba154dbb.
  (https://github.com/deltachat/deltachat-desktop/pull/3313,
  https://github.com/deltachat/deltachat-desktop/issues/3286).
