### PR TITLE
Import chokidar only when needed

### DIFF
--- a/bin/build-shared-convert-translations.mjs
+++ b/bin/build-shared-convert-translations.mjs
@@ -1,7 +1,6 @@
 //@ts-check
 import { xml2js } from 'xml-js'
 import { extname, join } from 'path'
-import chokidar from 'chokidar'
 import { readdir, readFile, writeFile } from 'fs/promises'
 
 function removeJunk(input) {
@@ -84,7 +83,8 @@ async function convertTranslationsFromXMLToJSON(pathLocales, watch = false) {
   console.log(`+ converted ${count_converted} files in ${time} ms\n`)
 
   if (watch === true) {
-    const watcher = chokidar.watch(join(pathLocales, '*.xml'), {
+    const { watch: _watch } = await import('chokidar')
+    const watcher = _watch(join(pathLocales, '*.xml'), {
       persistent: true,
     })
 

--- a/bin/copy.js
+++ b/bin/copy.js
@@ -2,7 +2,6 @@
 //@ts-check
 import { copyFile, mkdir, readdir, stat } from 'fs/promises'
 import { join } from 'path'
-import { watch as _watch } from 'chokidar'
 
 async function copyRecursive(source, destination) {
   if ((await stat(source)).isDirectory()) {
@@ -47,6 +46,8 @@ async function copy(source, destination, watch = false) {
   let scheduled = undefined
 
   if (watch === true) {
+    // Dynamically import chokidar only when watch is true
+    const { watch: _watch } = await import('chokidar')
     const watcher = _watch(source)
     watcher.on('ready', () => {
       watcher.on('all', (event, path) => {


### PR DESCRIPTION
#skip-changelog

It seems the default import of chokidar (which is only used in watch mode) causes trouble in the build process sometimes.

`
file:///build/deltachat-desktop/src/deltachat-desktop/node_modules/.pnpm/[chokidar@3.6.0](mailto:chokidar@3.6.0)/node_modules/chokidar/esm/index.js:6
import { readdirp } from 'readdirp';
         ^^^^^^^^
SyntaxError: Named export 'readdirp' not found. The requested module 'readdirp' is a CommonJS module, which may not support all module.exports as named exports.
`

Since the build process doesn't need the watch parameter we can avoid the 