### PR TITLE
refactor: add comments about `composer.focus()`

### DIFF
--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -138,6 +138,9 @@ export default class ComposerMessageInput extends React.Component<
         )
       ) {
         // Focus on the current selection, hack for focusing on newlines
+        // TODO this pretty much doesn't work,
+        // because you can't focus an element that is covered by a dialog.
+        // See the comment in `onMouseUp` in `MessageListAndComposer`.
         if (this.context.hasOpenDialogs) {
           this.textareaRef.current.blur()
           this.textareaRef.current.focus()

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -239,6 +239,22 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         return
       }
 
+      // TODO this function pretty much never works, because of this condition.
+      // trying to focus the composer while a dialog is open
+      // is impossible, because the dialog will keep focus inside of it.
+      //
+      // The condition was probably meant to be the opposite
+      // (i.e. do nothing if a dialog is open),
+      // but it only incidentally fixed the bug that it was intended to fix
+      // (https://github.com/deltachat/deltachat-desktop/issues/3286),
+      // while at the same time breaking the function.
+      //
+      // However, we probably should not fix this function
+      // and remove it instead, for accessibility reasons, laid out here:
+      // https://github.com/deltachat/deltachat-desktop/issues/4590.
+      //
+      // The same goes for the check in
+      // `ComposerMessageInput.componentDidUpdate`.
       if (!hasOpenDialogs) {
         return
       }


### PR DESCRIPTION
Related to https://github.com/deltachat/deltachat-desktop/issues/4590.
