### PR TITLE
tauri: fix: ignore dcnotification: when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 - crash when a member gets added to a group and "View Group" dialog is open #5111
 - show appropriate state in AddMemberDialog #5114
+- tauri: fix: ignore `dcnotification:` deep-link when the app is already running
 
 <a id="1_58_2"></a>
 


### PR DESCRIPTION
This only affects Windows.

`dcnotification:` is only needed when the app is not already running.

This is also an additional security measure.

Related: https://github.com/deltachat/deltachat-desktop/pull/5134.

I have tested this, and notifications still work, both when the app is initially closed and when it is running.