### PR TITLE
improvement: notify on msg in all non-curr chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
+- show a notification when receiving a message in any chat except the currently open one, instead of only showing notifications for other accounts
 - add a sound effect that plays when a message gets received in the currently open chat (can be turned off)
 
 ### Changed

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -73,6 +73,7 @@ export const ChatProvider = ({
   const cancelPendingSetChat = useRef<(() => void) | undefined>(undefined)
 
   const [chatId, setChatId] = useState<number | undefined>()
+  window.__selectedChatId = chatId
 
   const setChatView = useCallback<SetView>((nextView: ChatView) => {
     setActiveView(nextView)

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -11,6 +11,7 @@ declare global {
     __changeScreen: (screen: Screens) => void
     __selectAccount: (accountId: number) => Promise<void>
     readonly __selectedAccountId: number | undefined
+    __selectedChatId: number | undefined
     __screen: Screens
     readonly __contextMenuActive: boolean
     __setContextMenuActive: (newVal: boolean) => void

--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -103,10 +103,25 @@ function incomingMessageHandler(
     return
   }
 
-  if (document.hasFocus() && accountId === window.__selectedAccountId) {
-    // window has focus don't send notification for the selected account
+  if (chatId === window.__selectedChatId && document.hasFocus()) {
+    // window has focus don't send notification for the selected chat
+    //
+    // It is important for accessibility to notify the user of all new messages,
+    // no matter what chat or account they belong to.
+    // For the current chat we might utilize `aria-live` on the messages list,
+    // or a simple sound effect
+    // (https://github.com/deltachat/deltachat-desktop/pull/5143).
+    // For other chats, let's use OS notifications for this.
+    // See https://github.com/deltachat/deltachat-desktop/issues/4743.
+    //
+    // Additionally, one has to remember that we have the "narrow screen mode",
+    // where the list of chats is not shown,
+    // thus there is no indication of a new message,
+    // besides the unread badge counter increasing.
+    //
+    // This is also in line with other messengers, such as Telegram.
     log.debug(
-      'notification ignored: window has focus and account of the notification is selected'
+      'notification ignored: window has focus and chat of the notification is selected'
     )
     return
   }


### PR DESCRIPTION
Instead of only showing notifications for messages
of other accounts, when the window is focused.

This is mainly for accessibility, but is also in line with
other messengers.

Together with https://github.com/deltachat/deltachat-desktop/pull/5143,
this concludes fixing accessibility issues related to
screen reader users not being notified of new messages.

There has been a bit of a discussion regarding when to show and when not to show notifications in https://github.com/deltachat/deltachat-desktop/pull/3680.