### PR TITLE
Open media view (gallery) in dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Added
+- open all media view (gallery) in an own dialog #5141 #5074
 
 ### Changed
 - update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.159.5`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - open all media view (gallery) in an own dialog #5141 #5074
+- show last apps in chat navbar
 
 ### Changed
 - update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.159.5`

--- a/_locales/ar.xml
+++ b/_locales/ar.xml
@@ -187,8 +187,6 @@
     <string name="pref_language">اللغة</string>
     <string name="pref_use_system_emoji">استخدام الرموز التعبيرية بالنظام</string>
     <string name="pref_use_system_emoji_explain"> Delta Chat تعطيل الرموز التعبيرية المدمجة في </string>
-    <!-- deprecated -->
-    <string name="pref_app_access">دخول البرنامج</string>
     <string name="pref_chats">المحادثات</string>
     <string name="pref_in_chat_sounds">أصوات خلال الدردش</string>
     <string name="pref_other">أخرى</string>

--- a/_locales/az.xml
+++ b/_locales/az.xml
@@ -317,8 +317,6 @@
     <string name="pref_manage_keys">Açar edarəetməsi</string>
     <string name="pref_use_system_emoji">Sistem emojisini istifadə edin</string>
     <string name="pref_use_system_emoji_explain">Emoji Delta chat üçün daxili dəstəyi bağlayın. </string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Daxil oldu</string>
     <string name="pref_chats">Çatlar</string>
     <string name="pref_in_chat_sounds">Çatda olan səslər</string>
     <string name="pref_view_log">Log-a bax</string>
@@ -361,11 +359,6 @@
     <string name="autocrypt_send_asm_button">Autocrypt Setup Message-ı göndər</string>
     <string name="autocrypt_send_asm_explain_after">Sizin açarınız sizə göndərildi. Başqa bir cihaza keçin və mesajın ayarını açın. Siz quraşdırma kodu daxil etməlisiniz. Orada aşağıdakı rəqəmləri daxil edin. Bitirən zaman, başqa bir cihazda Autocrypt istifadə üçün hazır olacaq.</string>
     <string name="autocrypt_prefer_e2ee">Ucdan-uca şifrələmə üstünlük təşkil edir</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt mesaj ayarı</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Bu, müvəqqəti quraşdırma üçün müştərilər arasında köçürmək üçün istifadə edilən Autocrypt Setup Mesajıdır. \n\nSenfikanızı çözmək və istifadə etmək üçün autocrypt uyğun müştəri içərisində mesajı açın və yaradan cihazda göstərilən quraşdırma kodunu daxil edin.</string>
-
 
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Qrupun adı \"%1$s\" - dən \"%2$s\" - yə deyişildi məndən. </string>
@@ -421,6 +414,7 @@
     <string name="perm_required_title">İzin tələb olunur</string>
     <string name="perm_continue">Davam edin</string>
     <string name="perm_explain_access_to_camera_denied">Delta Chat şəkillər və ya video çəkmək üçün kamera icazə tələb edir, lakin bu, əbədi imtina edilmişdir. Proqramın sistem ayarlarına gedib \"İcazələr\"-i seçin və \"kamera\" izni verin.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Delta Chat yer əlavə etmək üçün yer icazə tələb edir, lakin daimi olaraq rədd edilmişdir. \"İcazələr\"-i seçin və\"Yerləşmə\" izni verin. </string>
     <string name="perm_explain_access_to_storage_denied">Delta Chat, fotoşəkilləri, videoları və ya səsləri əlavə etmək və ya ixrac etmək üçün saxlama icazəsini tələb edir, lakin bu daimi olaraq rədd edildi. Xahiş edirik tətbiq ayarları menyusuna davam edin, \"İzinlər\" seçin və \"Yaddaş\" funksiyasını aktivləşdirin.</string>
     <string name="perm_explain_access_to_location_denied">Delta Chat yer əlavə etmək üçün yer icazə tələb edir, lakin daimi olaraq rədd edilmişdir. \"İcazələr\"-i seçin və\"Yerləşmə\" izni verin. </string>

--- a/_locales/bg.xml
+++ b/_locales/bg.xml
@@ -656,8 +656,6 @@
     <string name="pref_use_system_emoji_explain">Изключване на вградената поддръжка за Emoji на Delta Chat</string>
     <string name="pref_show_system_contacts">Прочитане на системната адресна книга</string>
     <string name="pref_show_system_contacts_explain">Да се предлага създаване на чатове с контакти от адресната книга. За някои доставчици е необходимо първо да се настрои криптиране от край до край.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Достъп до приложението</string>
     <string name="pref_chats">Чатове</string>
     <string name="pref_in_chat_sounds">Звуци в чата</string>
     <string name="pref_view_log">Разглеждане на дневника</string>
@@ -778,11 +776,6 @@
     <string name="autocrypt_send_asm_button">Изпращане на съобщението за настройка на Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Изпратихте Вашата настройка до себе си. Отворете съобщението за настройка в другото устройство. Би трябвало да Ви бъде поискан код за настройка. Въведете следните цифри:</string>
     <string name="autocrypt_prefer_e2ee">Да се предпочита криптиране \"от край до край\"</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Съобщение за настройка на Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Това е съобщението за настройка на Autocrypt, чрез което се прехвърля Вашата настройка за криптиране \"от край до край\" между различни клиенти.\n\nЗа да декриптирате и използвате Вашата настройка, отворете съобщението в клиент, съвместим с Autocrypt, и въведете кода за настройка, представен на генериращото устройство.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Това съобщение не може да бъде декриптирано.\n\n• Бихте могли просто да му отговорите и да помолите подателя да го изпрати отново.\n\n• Ако току-що сте преинсталирали Delta Chat, е най-добре да настроите приложението отново сега и да изберете \"Добавяне като второ устройство\" или да импортирате от архив.</string>
@@ -925,8 +918,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Настройката за %1$s е сменена.</string>
     <string name="verified_contact_required_explain">За да се гарантира криптирането от край до край, можете да добавяте в тази група само контакти, отбелязани със зелена отметка.\n\nБихте могли да се срещнете с лицата, с които желаете да контактувате, лично и да сканирате техните QR кодове, за да ги въведете.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">URL адресът от QR кода е копиран в клипборда</string>
     <string name="mailto_dialog_header_select_chat">Изберете чат, към който да бъде пратено съобщението</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s вече има съобщение чернова, искате ли да го замените?</string>
@@ -952,6 +943,7 @@
     <string name="perm_required_title">Изисква се позволение</string>
     <string name="perm_continue">Продължаване</string>
     <string name="perm_explain_access_to_camera_denied">За да правите снимки или заснемате видеоклипове, отидете в настройките на приложението, изберете \"Позволения\" и разрешете \"Камера\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">За да изпращате аудиосъобщения, отидете в настройките на приложението, изберете \"Позволения\" и разрешете \"Микрофон\".</string>
     <string name="perm_explain_access_to_storage_denied">За да получавате или изпращате файлове, отидете в настройките на приложението, изберете \"Позволения\" и разрешете \"Съхранение\".</string>
     <string name="perm_explain_access_to_location_denied">За да прикрепите информация за местоположението, отидете в настройките на приложението, изберете \"Позволения\" и разрешете \"Местоположение\".</string>

--- a/_locales/ca.xml
+++ b/_locales/ca.xml
@@ -741,8 +741,6 @@
     <string name="pref_use_system_emoji_explain">Desactiva el suport de sèrie per emojis a Delta Chat</string>
     <string name="pref_show_system_contacts">Llegeix la llibreta d\'adreces del sistema</string>
     <string name="pref_show_system_contacts_explain">Ofereix de crear xats amb els contactes de la llibreta d\'adreces. Alguns proveïdors necessiten de configurar abans el xifratge d\'extrem a extrem.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Accés a l\'aplicació</string>
     <string name="pref_chats">Xats</string>
     <string name="pref_in_chat_sounds">Sons d\'entrada</string>
     <string name="pref_view_log">Mostra el registre</string>
@@ -832,7 +830,7 @@
     <!-- %1$s will be replaced by an emoji. %2$s will be replaced by message summary (the summary is often long and whole string gets truncated; words after %2$s will often not being visible). Eg. 'You reacted 👍 to "Found my suitcase"'. Use less than 20 characters, otherwise the string will be truncated too soon and too few information are shown. Do not try to translate "reacted to" too strict. Depending on the language, "added 👍 to" or "gave 👍 to" or just "👍 to" may be shorter and/or clearer and work as well. -->
     <string name="reaction_by_you">Heu reaccionat amb %1$s a «%2$s»</string>
     <!-- %1$s will be replaced a name. %2$s will be replaced by an emoji. %3$s will be replaced by message summary (the summary is often long and whole string gets truncated; words after %3$s will often not being visible). Eg. 'Alice reacted 👍 to "Nice photos"'. Use less than 20 characters, otherwise the string will be truncated too soon and too few information are shown. Do not try to translate "reacted to" too strict. Depending on the language, "added 👍 to" or "gave 👍 to" or just "👍 to" may be shorter and/or clearer work as well. -->
-    <string name="reaction_by_other">%1$sha reaccionat %2$s a «%3$s»</string>
+    <string name="reaction_by_other">%1$s ha reaccionat %2$s a «%3$s»</string>
 
     <!-- automatically delete message -->
     <string name="delete_old_messages">Esborra els missatges antics</string>
@@ -865,11 +863,6 @@
     <string name="autocrypt_send_asm_button">Envia el missatge de configuració Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Se us ha enviat la vostra configuració. Canvieu a l\'altre dispositiu i obriu el missatge de configuració. Se us demanarà un codi de configuració. Introduïu els dígits següents a l\'indicador.\n\nUn cop fet, l\'altre dispositiu estarà llest per utilitzar Autocrypt.</string>
     <string name="autocrypt_prefer_e2ee">Prefereix l\'encriptació d\'extrem a extrem</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Missatge de configuració Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Aquest és el missatge de configuració Autocrypt que s’usa per a transferir la vostra configuració d\'extrem a extrem entre dispositius.\n\nPer a desxifrar i usar aquesta configuració, obriu el missatge en un dispositiu compatible amb Autocript i introduïu el codi de configuració que apareix al dispositiu primari.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Aquest missatge no es pot desxifrar.\n\n• Potser pot ajudar de respondre el missatge i demanar a l\'emissor que torni a enviar-lo,\n\n• Si acabeu de reinstal·lar Delta Chat, aleshores és millor de reconfigurar Delta Chat ara i triar «Afegeix un segon dispositiu» o importar una còpia de seguretat.</string>
@@ -1012,8 +1005,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Configuració canviada per %1$s</string>
     <string name="verified_contact_required_explain">Per a garantir el xifrat extrem a extrem, només podeu afegir a aquest grup contactes que tinguin la marca verda.\n\nPodeu trobar-vos en persona amb els contactes per a escanejar els seus codis QR i poder-los afegir. </string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">S\'ha copiat l\'URL del codi QR al porta-retalls</string>
     <string name="mailto_dialog_header_select_chat">Trieu el xat on enviar el missatge</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s ja té un missatge d\'esborrany, voleu substituir-lo?</string>
@@ -1039,6 +1030,7 @@
     <string name="perm_required_title">Es requereix permís</string>
     <string name="perm_continue">Continua</string>
     <string name="perm_explain_access_to_camera_denied">Delta Chat demana accés a la càmera per poder fer fotos o vídeos, però li ha estat denegat. Sisplau, vés al menú de configuració de l\'app, busca-hi els \"Permisos\" i habilita\'n la \"Càmera\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Delta Chat demana accés al micròfon per poder enviar missatges d\'àudio, però li ha estat denegat. Sisplau, vés al menú de configuració de l\'app, busca-hi els \"Permisos\" i habilita\'n el \"Micròfon\".</string>
     <string name="perm_explain_access_to_storage_denied">Per a rebre o enviar fitxers, aneu a la configuració de l\'aplicació, seleccioneu «Permisos» i activeu «Emmagatzematge».</string>
     <string name="perm_explain_access_to_location_denied">Per a adjuntar la ubicació, aneu a la configuració de l\'aplicació, trieu «Permisos» i activeu la «Ubicació».</string>

--- a/_locales/ckb.xml
+++ b/_locales/ckb.xml
@@ -402,8 +402,6 @@
     <string name="pref_manage_keys">بەڕێوەبردنی کلیلەکان</string>
     <string name="pref_use_system_emoji">بەکارهێنانی وێنۆچکەکانی سیستەم</string>
     <string name="pref_use_system_emoji_explain">ئیمۆجییە ناوخۆییەکانی دێڵتا چات، ناچالاک دەبێتەوە.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">ڕێگەپێدان</string>
     <string name="pref_chats">وتووێژەکان</string>
     <string name="pref_in_chat_sounds">دەنگەکانی نێو-وتووێژی</string>
     <string name="pref_other">کەسانی دی</string>
@@ -471,8 +469,7 @@
     <!-- autocrypt -->
     <string name="autocrypt_send_asm_title">هەناردنی پەیامی ڕێکخستنی ئۆتۆکریپت</string>
     <string name="autocrypt_prefer_e2ee">هەڵبژاردنی شفرەکردنی ئەمسەر-ئەوسەر</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">پەیامی ڕێکخستنی ئۆتۆکریپت</string>
+
     <string name="systemmsg_unknown_sender_for_chat">پەیامنێری ئەم وتووێژە نەناسراوە. بۆ وردەکاری زۆرتر سەیری \'زانیارییەکان\' بکە.</string>
     <string name="systemmsg_subject_for_new_contact">پەیام لەلایەن %1$s</string>
     <string name="systemmsg_failed_sending_to">هەناردنی پەیام بۆ %1$s سەرنەکەوت</string>
@@ -503,8 +500,6 @@
     <string name="contact_not_verified">%1$s پشتڕاست ناکرێتەوە.</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">ڕێکخستن بۆ %1$s گۆڕا.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">ناونیشانی وێبی QRەکە ڕوونووس کرا.</string>
     <!-- notifications  -->
     <string name="notify_reply_button">وەڵام دانەوە</string>
     <string name="notify_new_message">پەیامی نوێ</string>
@@ -518,6 +513,7 @@
     <string name="perm_required_title">ڕێدان پێویستە</string>
     <string name="perm_continue">بەردەوامبوون</string>
     <string name="perm_explain_access_to_camera_denied">بۆ فلیم و وێنە گرتن، بچۆ بەشی ڕێکخستنەکانی نەرمامێرەکە، لە بەشی \"ڕێگەپێدان\"دا، \"کامێرا\" چالاک بکەوە.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">بۆ هەناردنی پەیامی دەنگی، بچۆ بەشی ڕێکخستنەکانی نەرمامێرەکە، لە بەشی \"ڕێگەپێدان\"دا، \"مایک\" چالاک بکەوە.</string>
     <string name="perm_explain_access_to_storage_denied">بۆ هەناردن و وەرگرتنی پەڕگەکان، بچۆ بەشی ڕێکخستنەکانی نەرمامێرەکە، لە بەشی \"ڕێگەپێدان\"دا، \"بیرگە\" چالاک بکەوە.</string>
     <string name="perm_explain_access_to_location_denied">بۆ لکاندنی شوێنێک، بچۆ بەشی ڕێکخستنەکانی نەرمامێرەکە، لە بەشی \"ڕێگەپێدان\"دا، \"شوێن\" چالاک بکەوە.</string>

--- a/_locales/cs.xml
+++ b/_locales/cs.xml
@@ -202,6 +202,10 @@
     <string name="images_and_videos">Obrázky a videa</string>
     <string name="file">Soubor</string>
     <string name="files">Soubory</string>
+    <string name="files_attach_hint">Odeslat původní soubory a nekomprimované obrázky</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Vybrat ze Souborů</string>
+    <string name="choose_from_gallery">Vybrat z Galerie</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Aplikace</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
@@ -773,8 +777,6 @@
     <string name="pref_use_system_emoji_explain">Vypnout vestavěná emoji Data Chatu</string>
     <string name="pref_show_system_contacts">Čtení systémových kontaktů</string>
     <string name="pref_show_system_contacts_explain">Nabízet vytváření chatů s kontakty z adresáře. Pro některé poskytovatele je nejprve nutné nastavit koncové šifrování.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Přístup aplikace</string>
     <string name="pref_chats">Chaty</string>
     <string name="pref_in_chat_sounds">Zvuky v rámci chatu</string>
     <string name="pref_view_log">Zobrazit protokol</string>
@@ -897,11 +899,6 @@
     <string name="autocrypt_send_asm_button">Odeslat nastavení Autocryptu</string>
     <string name="autocrypt_send_asm_explain_after">Vaše nastavení bylo odesláno. Vezměte si zařízení, kam si přejete nastavení přenést, a zprávu na něm otevřete. Mělo by se objevit pole pro zadání kódu. Do něj vložte následující číslice:</string>
     <string name="autocrypt_prefer_e2ee">Upřednostňovat koncové šifrování</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Zpráva s nastavením Autocryptu</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Tato zpráva obsahuje nastavení Autocryptu. S její pomocí lze přenést nastavení koncového šifrování mezi klienty.\n\nK dešifrování a použití nastavení otevřete klient podporující Autocrypt a zadejte do něj kód zobrazený na zařízení, které zprávu vygenerovalo.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Tuto zprávu nelze dešifrovat.\n\n• Již nyní by mohlo pomoci jednoduše odpovědět na tuto zprávu a požádat odesílatele, aby ji odeslal znovu.\n\n• Pokud jste právě přeinstalovali Delta Chat, bude nejlepší, když jej znovu nastavíte a zvolíte \"Přidat jako další zařízení\" nebo importujete zálohu.</string>
@@ -1045,8 +1042,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Nastavení pro uživatele %1$s změněno.</string>
     <string name="verified_contact_required_explain">Aby mohlo být garantováno koncové šifrování, můžete do této skupiny přidávat pouze uživatele se zeleným zaškrtávátkem.\n\nSe svými kontakty se můžete setkat osobně a naskenovat jejich QR kód, abyste je ověřili.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Adresa URL z QR kódu zkopírována do schránky</string>
     <string name="mailto_dialog_header_select_chat">Vyberte chat, do kterého chcete zprávu poslat</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s již obsahuje rozepsanou zprávu, přejete si ji přepsat?</string>
@@ -1072,6 +1067,7 @@
     <string name="perm_required_title">Oprávnění vyžadováno</string>
     <string name="perm_continue">Pokračovat</string>
     <string name="perm_explain_access_to_camera_denied">Pro focení a natáčení přejděte do nastavení aplikace, vyberte \"Oprávnění\" a povolte oprávnění \"Fotoaparát\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Pro posílání zvukových zpráv přejděte do nastavení aplikace, vyberte \"Oprávnění\" a povolte oprávnění \"Mikrofon\".</string>
     <string name="perm_explain_access_to_storage_denied">Pro příjem a posílání souborů přejděte do nastavení aplikace, vyberte \"Oprávnění\" a povolte oprávnění \"Fotky a videa\".</string>
     <string name="perm_explain_access_to_location_denied">Pro posílání polohy přejděte do nastavení aplikace, vyberte \"Oprávnění\" a povolte oprávnění \"Poloha\".</string>

--- a/_locales/da.xml
+++ b/_locales/da.xml
@@ -462,8 +462,6 @@
     <string name="pref_manage_keys">Håndtér nøgler</string>
     <string name="pref_use_system_emoji">Brug system emoji</string>
     <string name="pref_use_system_emoji_explain">Deaktiver Delta Chat\'s indbygget emoji understøttelse</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Programadgang</string>
     <string name="pref_chats">Samtaler</string>
     <string name="pref_in_chat_sounds">In-chat-lyde</string>
     <string name="pref_view_log">Visningslog</string>
@@ -549,11 +547,6 @@
     <string name="autocrypt_send_asm_button">Send autocrypt-opsætningsbesked</string>
     <string name="autocrypt_send_asm_explain_after">Opsætning er sendt til dig selv. Skift til den anden enhed og åben opsætning beskeden. Der skulle blive spurgt til opsætning kode. Indtast følgende cifre i prompt.\n\nNår færdig vil den anden enhed være klar til at bruge Autocrypt.</string>
     <string name="autocrypt_prefer_e2ee">Foretræk end-to-end kryptering</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt opsætningsbesked</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Dette er Autocrypt opsætning besked brugt til at overføre ende-til-ende opsætning mellem klienter.\n\nFor at af kryptere og bruge opsætning åben beskeden i en Autocrypt kompatibel klient og indtast opsæt koden vist på den genererende enhed.</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">Ukent afsender af denne chat. Se \'info\' for flere detaljer.</string>
     <string name="systemmsg_subject_for_new_contact">Besked fra %1$s</string>
@@ -643,8 +636,6 @@
     <string name="contact_not_verified">Kan ikke bekræfte %1$s</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Ændret opsætning for %1$s</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Kopieret QR url til udklipsholder</string>
     <!-- notifications  -->
     <string name="notify_reply_button">Svar</string>
     <string name="notify_new_message">Ny besked</string>
@@ -658,6 +649,7 @@
     <string name="perm_required_title">Tilladelse påkrævet</string>
     <string name="perm_continue">Fortsæt</string>
     <string name="perm_explain_access_to_camera_denied">Delta Chat kræver kamera tilladelse for at tage billeder eller video men det er blevet afvist permanent. Fortsæt til program opsætning menu og vælg \"Tilladelser\" og aktivere \"Kamera\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Delta Chat kræver mikrofon tilladelse for at sende lydbeskeder, men den er blevet nægtet permanent. Fortsæt til program indstillinger, vælg \"Tilladelser\" og aktiver \"Mikrofon\".</string>
     <string name="perm_explain_access_to_storage_denied">Delta Chat kræver lagring tilladelse for at vedhæfte eller eksportere billeder, video eller lyd, men det er blevet afvist permanent. Fortsæt til program indstillings-menuen, vælg \"Tilladelser\" og aktiver \"Lagring\".</string>
     <string name="perm_explain_access_to_location_denied">Delta Chat kræver placering tilladelse for at kunne vedhæfte placering, men det er blevet afvist permanent. Fortsæt til program indstillings-menuen, vælg \"Tilladelser\" og aktiver \"Placering\".</string>

--- a/_locales/de.xml
+++ b/_locales/de.xml
@@ -56,6 +56,7 @@
     <string name="save">Speichern</string>
     <string name="chat">Chat</string>
     <string name="media">Medien</string>
+    <string name="apps_and_media">Apps &amp; Medien</string>
     <string name="profile">Profil</string>
     <string name="main_menu">Hauptmenü</string>
     <string name="start_chat">Chat starten</string>
@@ -184,12 +185,17 @@
     <string name="images_and_videos">Bilder und Videos</string>
     <string name="file">Datei</string>
     <string name="files">Dateien</string>
+    <string name="files_attach_hint">Originaldateien und -bilder senden</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Aus Dateien wählen</string>
+    <string name="choose_from_gallery">Aus Galerie wählen</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">App</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">Apps</string>
     <string name="webxdc_store_url">App-Picker-URL</string>
     <string name="webxdc_store_url_explain">Wenn gesetzt, wird diese URL als App-Picker anstelle der Voreinstellung verwendet.</string>
+    <string name="webxdc_draft_hint">Zum Teilen auf \"Senden\" klicken</string>
     <string name="home">Start</string>
     <string name="games">Spiele</string>
     <string name="tools">Tools</string>
@@ -271,6 +277,7 @@
     <string name="menu_export_attachment">Datei exportieren</string>
     <string name="menu_export_attachments">Dateien exportieren</string>
     <string name="menu_all_media">Alle Medien</string>
+    <string name="all_apps_and_media">Alle Apps &amp; Medien</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Im Chat zeigen</string>
     <string name="show_app_in_chat">App im Chat zeigen</string>
@@ -462,7 +469,7 @@
     <!-- title shown above a list contacts where one should be selected (eg. when a webxdc attempts to send a message to a chat) -->
     <string name="send_message_to">Nachricht senden an…</string>
     <string name="enable_realtime">Echtzeit-Apps</string>
-    <string name="enable_realtime_explain">Aktiviert Echtzeitverbindungen für in Chats verwendeten Apps. Wenn aktiviert, können Chat-Partner möglicherweise Ihre IP-Adresse ermitteln, wenn Sie eine App starten.</string>
+    <string name="enable_realtime_explain">Aktiviert Echtzeitverbindungen für an Chats angehängte Apps. Wenn aktiviert, können Chat-Partner möglicherweise Ihre IP-Adresse ermitteln, wenn Sie eine App starten.</string>
 
     <!-- map -->
     <string name="filter_map_on_time">Standorte im Zeitrahmen anzeigen</string>
@@ -514,12 +521,12 @@
     <string name="tab_docs">Dokumente</string>
     <string name="tab_links">Links</string>
     <string name="tab_map">Karte</string>
-    <string name="tab_gallery_empty_hint">In diesem Chat geteilte Bilder und Videos werden hier angezeigt.</string>
-    <string name="tab_docs_empty_hint">In diesem Chat geteilte Dokumente und Dateien werden hier angezeigt.</string>
-    <string name="tab_image_empty_hint">In diesem Chat geteilte Bilder werden hier angezeigt.</string>
-    <string name="tab_video_empty_hint">In diesem Chat geteilte Videos werden hier angezeigt.</string>
-    <string name="tab_audio_empty_hint">In diesem Chat geteilte Audiodateien und Sprachnachrichten werden hier angezeigt.</string>
-    <string name="tab_webxdc_empty_hint">In diesem Chat geteilte Apps werden hier angezeigt.</string>
+    <string name="tab_gallery_empty_hint">Diesem Chat angehängte Bilder und Videos werden hier angezeigt.</string>
+    <string name="tab_docs_empty_hint">Diesem Chat angehängte Dokumente und Dateien werden hier angezeigt.</string>
+    <string name="tab_image_empty_hint">Diesem Chat angehängte Bilder werden hier angezeigt.</string>
+    <string name="tab_video_empty_hint">Diesem Chat angehängte Videos werden hier angezeigt.</string>
+    <string name="tab_audio_empty_hint">Diesem Chat angehängte Audiodateien und Sprachnachrichten werden hier angezeigt.</string>
+    <string name="tab_webxdc_empty_hint">Diesem Chat angehängte Apps werden hier angezeigt.</string>
     <string name="tab_all_media_empty_hint">Medien aus allen Chats werden hier angezeigt.</string>
     <string name="all_files_empty_hint">Dokumente und Dateien aus allen Chats werden hier angezeigt.</string>
     <string name="all_apps_empty_hint">Apps aus allen Chats werden hier angezeigt.</string>
@@ -741,8 +748,6 @@
     <string name="pref_use_system_emoji_explain">Eingebaute Emoji-Unterstützung von Delta Chat deaktivieren</string>
     <string name="pref_show_system_contacts">System-Adressbuch lesen</string>
     <string name="pref_show_system_contacts_explain">Anbieten, Chats mit Kontakten aus dem Adressbuch zu erstellen.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">App-Zugriff</string>
     <string name="pref_chats">Chats</string>
     <string name="pref_in_chat_sounds">In-Chat-Klänge</string>
     <string name="pref_view_log">Protokoll anzeigen</string>
@@ -865,11 +870,6 @@
     <string name="autocrypt_send_asm_button">Autocrypt-Setup-Nachricht senden</string>
     <string name="autocrypt_send_asm_explain_after">Das Setup wurde an Sie geschickt. Nun zum anderen Gerät wechseln und die Setup-Nachricht öffnen. Den Anweisungen folgen und den folgenden Setup-Code eingeben:</string>
     <string name="autocrypt_prefer_e2ee">Ende-zu-Ende-Verschlüsselung bevorzugen</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt-Setup-Nachricht</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Dies ist die Autocrypt-Setup-Nachricht, um das Ende-zu-Ende-Setup von einem Gerät auf das andere zu übertragen.\n\nUm das Setup zu entschlüsseln und zu verwenden, öffnen Sie diese Nachricht in einer Autocrypt-kompatiblen App und geben Sie den Setup-Code ein, der auf dem anderen Gerät angezeigt wurde.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Diese Nachricht kann nicht entschlüsselt werden.\n\n• Es kann bereits helfen, auf diese Nachricht zu antworten und den Absender zu bitten, die Nachricht noch einmal zu senden.\n\n• Wenn Sie Delta Chat gerade neu installiert haben, ist es am besten, wenn Sie Delta Chat mit \"Als Zweitgerät hinzufügen\" neu einrichten oder ein Backup importieren.</string>
@@ -1004,7 +1004,7 @@
     <string name="secure_join_wait">Garantierte Ende-zu-Ende-Verschlüsselung wird aufgebaut, bitte warten...</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Noch konnte keine garantierte Ende-zu-Ende-Verschlüsselung aufgebaut werden, aber Sie können bereits eine Nachricht senden.</string>
-    <string name="secure_join_takes_longer">Das scheint länger zu dauern, vielleicht ist der Kontakt oder Sie offline.\n\nDer Prozess läuft jedoch im Hintergrund weiter, Sie können etwas anderes tun...</string>
+    <string name="secure_join_takes_longer">Der Kontakt muss online sein, um fortzufahren.\n\nDieser Vorgang wird automatisch im Hintergrund fortgesetzt.</string>
     <string name="contact_verified">%1$s eingeführt.</string>
     <string name="contact_not_verified">Kann keine garantierte Ende-zu-Ende-Verschlüsselung mit %1$s herstellen.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1013,8 +1013,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Geändertes Setup für %1$s</string>
     <string name="verified_contact_required_explain">Um Ende-zu-Ende-Verschlüsselung zu gewährleisten, können nur Kontakte mit grünem Häkchen zu dieser Gruppe hinzugefügt werden.\n\nSie könne Kontakte persönlich treffen und ihren QR-Code scannen, um sie einzuführen.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">QR-Code auf die Zwischenablage kopiert</string>
     <string name="mailto_dialog_header_select_chat">Wählen Sie den Chat, an den die Nachricht gesendet werden soll</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s hat bereits einen Entwurft. Möchten Sie diesen ersetzen?</string>
@@ -1040,7 +1038,8 @@
     <string name="perm_required_title">Berechtigung erforderlich</string>
     <string name="perm_continue">Weiter</string>
     <string name="perm_explain_access_to_camera_denied">Um Fotos oder Videos aufzunehmen, bitte in den System-Einstellungen DeltaChat den Zugriff auf die Kamera erlauben. </string>
-    <string name="perm_explain_access_to_mic_denied">Um Audio-Nachrichten zu senden, bitte in den System-Einstellungen DeltaChat den Zugriff auf das Mikrophon erlauben.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">Um Audio-Nachrichten zu senden, bitte in den System- oder App-Einstellungen den Zugriff auf das Mikrophon erlauben.</string>
     <string name="perm_explain_access_to_storage_denied">Um Dateien zu empfangen oder zu versenden, bitte in den System-Einstellungen Delta Chat den Zugriff auf den Speicher erlauben.</string>
     <string name="perm_explain_access_to_location_denied">Um einen Standort anzuhängen, bitte in den Systemeinstellungen DeltaChat den Zugriff auf \"Standort\" erlauben.</string>
     <string name="perm_explain_access_to_notifications_denied">Um Benachrichtigungen zu erhalten, öffnen Sie \"Systemeinstellungen / Apps / Delta Chat\" und aktivieren Sie \"Benachrichtigungen\".</string>

--- a/_locales/el.xml
+++ b/_locales/el.xml
@@ -559,8 +559,6 @@
     <string name="pref_manage_keys">Διαχείριση Κλειδιών</string>
     <string name="pref_use_system_emoji">Χρήση emoji συστήματος</string>
     <string name="pref_use_system_emoji_explain">Απενεργοποίηση της ενσωματωμένης υποστήριξης για emoji του Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Πρόσβαση εφαρμογής</string>
     <string name="pref_chats">Συνομιλίες</string>
     <string name="pref_in_chat_sounds">Ήχοι μέσα στη συνομιλία</string>
     <string name="pref_view_log">Προβολή Αρχείου Καταγραφής</string>
@@ -663,11 +661,6 @@
     <string name="autocrypt_send_asm_button">Αποστολή μηνύματος ρύθμισης αυτόματης κρυπτογράφησης</string>
     <string name="autocrypt_send_asm_explain_after">Η ρύθμισή σας έχει σταλεί στον εαυτό σας. Μεταβείτε στην άλλη συσκευή και ανοίξτε το μήνυμα ρύθμισης. Θα πρέπει να σας ζητηθεί κωδικός ρύθμισης. Εισαγάγετε τα ακόλουθα ψηφία:</string>
     <string name="autocrypt_prefer_e2ee">Προτιμήστε την κρυπτογράφηση από άκρο σε άκρο</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Μήνυμα ρύθμισης αυτόματης κρυπτογράφησης</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Αυτό είναι το μήνυμα ρύθμισης αυτόματης κρυπτογράφησης που χρησιμοποιείται για τη μεταφορά της ρύθμισής σας από άκρο σε άκρο μεταξύ πελατών.\n\nΓια να αποκρυπτογραφήσετε και να χρησιμοποιήσετε τη ρύθμισή σας, ανοίξτε το μήνυμα σε ένα πρόγραμμα-πελάτη συμβατό με Αυτόματη κρυπτογράφηση και εισαγάγετε τον κωδικό ρύθμισης που παρουσιάζεται στη συσκευή δημιουργίας.</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">Άγνωστος αποστολέας για αυτήν τη συνομιλία. Δείτε \"πληροφορίες\" για περισσότερες λεπτομέρειες.</string>
     <string name="systemmsg_subject_for_new_contact">Μήνυμα από τον/την %1$s</string>
@@ -786,8 +779,6 @@
     <string name="contact_not_verified">Αδυναμία επαλήθευσης %1$s.</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Άλλαξε η ρύθμιση για %1$s.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Αντιγράφηκε το QR url στο πρόχειρο</string>
     <string name="mailto_dialog_header_select_chat">Επιλέξτε συνομιλία για να στείλετε το μήνυμα</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s έχει ήδη ένα πρόχειρο μήνυμα, θέλετε να το αντικαταστήσετε;</string>
@@ -806,6 +797,7 @@
     <string name="perm_required_title">Χρειάζονται δικαιώματα πρόσβασης</string>
     <string name="perm_continue">Συνέχεια</string>
     <string name="perm_explain_access_to_camera_denied">Για να τραβήξετε φωτογραφίες ή να τραβήξετε βίντεο, μεταβείτε στις ρυθμίσεις της εφαρμογής, επιλέξτε \"Άδειες\" και ενεργοποιήστε την \"Κάμερα\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Για να στείλετε μηνύματα ήχου, μεταβείτε στις ρυθμίσεις της εφαρμογής, επιλέξτε \"Άδειες\" και ενεργοποιήστε το \"Μικρόφωνο\".</string>
     <string name="perm_explain_access_to_storage_denied">Για να λάβετε ή να στείλετε αρχεία, μεταβείτε στις ρυθμίσεις της εφαρμογής, επιλέξτε \"Άδειες\" και ενεργοποιήστε την \"Αποθήκευση\".</string>
     <string name="perm_explain_access_to_location_denied">Για να επισυνάψετε μια τοποθεσία, μεταβείτε στις ρυθμίσεις της εφαρμογής, επιλέξτε \"Άδειες\" και ενεργοποιήστε την \"Τοποθεσία\".</string>

--- a/_locales/en.xml
+++ b/_locales/en.xml
@@ -56,6 +56,7 @@
     <string name="save">Save</string>
     <string name="chat">Chat</string>
     <string name="media">Media</string>
+    <string name="apps_and_media">Apps &amp; Media</string>
     <string name="profile">Profile</string>
     <string name="main_menu">Main Menu</string>
     <string name="start_chat">Start Chat</string>
@@ -184,12 +185,17 @@
     <string name="images_and_videos">Images and Videos</string>
     <string name="file">File</string>
     <string name="files">Files</string>
+    <string name="files_attach_hint">Send original files and uncompressed images</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Choose from Files</string>
+    <string name="choose_from_gallery">Choose from Gallery</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">App</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">Apps</string>
     <string name="webxdc_store_url">App Picker URL</string>
     <string name="webxdc_store_url_explain">If set, the URL will be used as the App Picker instead of the default one</string>
+    <string name="webxdc_draft_hint">Tap \"Send\" to share</string>
     <string name="home">Home</string>
     <string name="games">Games</string>
     <string name="tools">Tools</string>
@@ -271,6 +277,7 @@
     <string name="menu_export_attachment">Export Attachment</string>
     <string name="menu_export_attachments">Export Attachments</string>
     <string name="menu_all_media">All Media</string>
+    <string name="all_apps_and_media">All Apps &amp; Media</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Show in Chat</string>
     <string name="show_app_in_chat">Show App in Chat</string>
@@ -462,7 +469,7 @@
     <!-- title shown above a list contacts where one should be selected (eg. when a webxdc attempts to send a message to a chat) -->
     <string name="send_message_to">Send Message to…</string>
     <string name="enable_realtime">Real-Time Apps</string>
-    <string name="enable_realtime_explain">Enable real-time connections for apps shared in chats. If enabled, chat partners may be able to discover your IP address when you start an app.</string>
+    <string name="enable_realtime_explain">Enable real-time connections for apps attached to chats. If enabled, chat partners may be able to discover your IP address when you start an app.</string>
 
     <!-- map -->
     <string name="filter_map_on_time">Show locations in time frame</string>
@@ -514,15 +521,15 @@
     <string name="tab_docs">Docs</string>
     <string name="tab_links">Links</string>
     <string name="tab_map">Map</string>
-    <string name="tab_gallery_empty_hint">Images and videos shared in this chat will appear here.</string>
-    <string name="tab_docs_empty_hint">Documents and other files shared in this chat will appear here.</string>
-    <string name="tab_image_empty_hint">Images shared in this chat will appear here.</string>
-    <string name="tab_video_empty_hint">Videos shared in this chat will appear here.</string>
-    <string name="tab_audio_empty_hint">Audio files and voice messages shared in this chat will appear here.</string>
-    <string name="tab_webxdc_empty_hint">Apps shared in this chat will appear here.</string>
-    <string name="tab_all_media_empty_hint">Media shared in any chat will appear here.</string>
-    <string name="all_files_empty_hint">Documents and other files shared in any chat will appear here.</string>
-    <string name="all_apps_empty_hint">Apps shared in any chat will appear here.</string>
+    <string name="tab_gallery_empty_hint">Images and videos attached to this chat will appear here.</string>
+    <string name="tab_docs_empty_hint">Documents and other files attached to this chat will appear here.</string>
+    <string name="tab_image_empty_hint">Images attached to this chat will appear here.</string>
+    <string name="tab_video_empty_hint">Videos attached to this chat will appear here.</string>
+    <string name="tab_audio_empty_hint">Audio files and voice messages attached to this chat will appear here.</string>
+    <string name="tab_webxdc_empty_hint">Apps attached to this chat will appear here.</string>
+    <string name="tab_all_media_empty_hint">Media attached to any chat will appear here.</string>
+    <string name="all_files_empty_hint">Documents and other files attached to any chat will appear here.</string>
+    <string name="all_apps_empty_hint">Apps attached to any chat will appear here.</string>
     <string name="media_preview">Media Preview</string>
     <!-- option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :) -->
     <string name="aspect_ratio_grid">Aspect Ratio Grid</string>
@@ -741,8 +748,6 @@
     <string name="pref_use_system_emoji_explain">Turn off Delta Chat\'s built-in emoji support</string>
     <string name="pref_show_system_contacts">Read System Address Book</string>
     <string name="pref_show_system_contacts_explain">Offer to create chats with contacts from the address book.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">App Access</string>
     <string name="pref_chats">Chats</string>
     <string name="pref_in_chat_sounds">In-Chat Sounds</string>
     <string name="pref_view_log">View Log</string>
@@ -865,11 +870,6 @@
     <string name="autocrypt_send_asm_button">Send Autocrypt Setup Message</string>
     <string name="autocrypt_send_asm_explain_after">Your setup has been sent to yourself. Switch to the other device and open the setup message. You should be asked for a setup code. Enter the following digits:</string>
     <string name="autocrypt_prefer_e2ee">Prefer End-To-End Encryption</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt Setup Message</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">This is the Autocrypt Setup Message used to transfer your end-to-end setup between clients.\n\nTo decrypt and use your setup, open the message in an Autocrypt-compliant client and enter the setup code presented on the generating device.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">This message cannot be decrypted.\n\n• It might already help to simply reply to this message and ask the sender to send the message again.\n\n• If you just re-installed Delta Chat then it is best if you re-setup Delta Chat now and choose "Add as second device" or import a backup.</string>
@@ -1004,7 +1004,7 @@
     <string name="secure_join_wait">Establishing guaranteed end-to-end encryption, please wait…</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Could not yet establish guaranteed end-to-end encryption, but you may already send a message.</string>
-    <string name="secure_join_takes_longer">That seems to take longer, maybe the contact or you are offline.\n\nHowever, the process continues in background, you can do something else…</string>
+    <string name="secure_join_takes_longer">The contact must be online to proceed.\n\nThis process will continue automatically in background.</string>
     <string name="contact_verified">%1$s introduced.</string>
     <string name="contact_not_verified">Cannot establish guaranteed end-to-end encryption with %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1013,8 +1013,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Changed setup for %1$s.</string>
     <string name="verified_contact_required_explain">To guarantee end-to-end-encryption, you can only add contacts with a green checkmark to this group.\n\nYou may meet contacts in person and scan their QR Code to introduce them.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Copied QR url to clipboard</string>
     <string name="mailto_dialog_header_select_chat">Select chat to send the message to</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s already has a draft message, do you want to replace it?</string>
@@ -1040,7 +1038,8 @@
     <string name="perm_required_title">Permission required</string>
     <string name="perm_continue">Continue</string>
     <string name="perm_explain_access_to_camera_denied">To take photos or capture videos, go to the app settings, select \"Permissions\", and enable \"Camera\".</string>
-    <string name="perm_explain_access_to_mic_denied">To send audio messages, go to the app settings, select \"Permissions\", and enable \"Microphone\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">To send audio messages, go to system or app settings, select "Permissions" or "Privacy &amp; Security", and enable \"Microphone\".</string>
     <string name="perm_explain_access_to_storage_denied">To receive or send files, go to the app settings, select \"Permissions\", and enable \"Storage\".</string>
     <string name="perm_explain_access_to_location_denied">To attach a location, go to the app settings, select \"Permissions\", and enable \"Location\".</string>
     <string name="perm_explain_access_to_notifications_denied">To receive notifications, go to \"System Settings / Apps / Delta Chat\" and enable \"Notifications\".</string>

--- a/_locales/eo.xml
+++ b/_locales/eo.xml
@@ -406,8 +406,6 @@
     <string name="pref_manage_keys">Administri ŝlosilojn</string>
     <string name="pref_use_system_emoji">Uzi sisteman emoĝiaron</string>
     <string name="pref_use_system_emoji_explain">Malebligi emoĝiaron de Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Aliro al aplikaĵo</string>
     <string name="pref_chats">Interparoloj</string>
     <string name="pref_in_chat_sounds">Sonoj dum interparolado</string>
     <string name="pref_view_log">Vidi protokolon</string>
@@ -432,6 +430,7 @@
     <string name="pref_send_copy_to_self">Sendi kopion al mi mem</string>
     <string name="pref_show_emails_all">Ĉiuj</string>
     <string name="autocrypt_prefer_e2ee">Preferi tutvojan ĉifradon</string>
+
     <!-- notifications  -->
     <string name="notify_reply_button">Respondi</string>
     <string name="notify_new_message">Nova mesaĝo</string>

--- a/_locales/es.xml
+++ b/_locales/es.xml
@@ -193,6 +193,10 @@
     <string name="images_and_videos">Imágenes y videos</string>
     <string name="file">Archivo</string>
     <string name="files">Archivos</string>
+    <string name="files_attach_hint">Enviar archivos originales e imágenes sin comprimir</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Elejir de Archivos</string>
+    <string name="choose_from_gallery">Elejir de Galería</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Aplicación</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
@@ -757,8 +761,6 @@
     <string name="pref_use_system_emoji_explain">Deshabilitar el soporte de emoji integrado de Delta Chat</string>
     <string name="pref_show_system_contacts">Leer la libreta de direcciones del sistema</string>
     <string name="pref_show_system_contacts_explain">Ofrecer crear chats con contactos de la libreta de direcciones. Algunos proveedores necesitan primero una configuración de cifrado de extremo a extremo.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Acceso a la aplicación</string>
     <string name="pref_chats">Chats</string>
     <string name="pref_in_chat_sounds">Sonidos en el chat</string>
     <string name="pref_view_log">Ver log</string>
@@ -881,11 +883,6 @@
     <string name="autocrypt_send_asm_button">Enviar Mensaje de Configuración de Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Se le ha enviado su configuración. Cambie al otro dispositivo y abra el mensaje de configuración. Se le debe solicitar un código de configuración. Escriba los siguientes dígitos:.\n\nUna vez que haya terminado, su otro dispositivo estará listo para usar Autocrypt.</string>
     <string name="autocrypt_prefer_e2ee">Preferir el cifrado de extremo a extremo</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Mensaje de Configuración de Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Este es el Mensaje de Configuración de Autocrypt utilizado para transferir su configuración de extremo a extremo entre clientes.\n\nPara descifrar y usar su configuración, abra el mensaje en un cliente compatible con Autocrypt e ingrese el código de configuración presentado en el dispositivo que lo generó.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Este mensaje no se puede descifrar.\n\n• Podría ayudar simplemente responder a este mensaje y pedir al remitente que lo envíe de nuevo.\n\n• Si acabas de reinstalar Delta Chat, es mejor que configures Delta Chat de nuevo y elijas \"Agregar como segundo dispositivo\" o importes una copia de seguridad.</string>
@@ -1020,6 +1017,7 @@
     <string name="secure_join_wait">Estableciendo cifrado de extremo a extremo garantizado, por favor, espere...</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">No se pudo aún establecer el cifrado de extremo a extremo garantizado, pero ya puede enviar mensajes.</string>
+    <string name="secure_join_takes_longer">El contacto debe estar en línea para continuar.\n\nEste proceso continuará automáticamente en segundo plano.</string>
     <string name="contact_verified">%1$s verificado.</string>
     <string name="contact_not_verified">No se pudo verificar %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1028,8 +1026,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Configuración cambiada para %1$s.</string>
     <string name="verified_contact_required_explain">Para garantizar el cifrado de extremo a extremo, solo puedes añadir contactos con una marca de verificación verde</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">URL del código QR copiado al portapapeles</string>
     <string name="mailto_dialog_header_select_chat">Seleccione el chat para enviar el mensaje</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s ya tiene un mensaje borrador, ¿quieres reemplazarlo?</string>
@@ -1055,6 +1051,7 @@
     <string name="perm_required_title">Permiso requerido</string>
     <string name="perm_continue">Continuar</string>
     <string name="perm_explain_access_to_camera_denied">Para tomar fotos o videos, vaya a la configuración de aplicaciones, seleccione \"Permisos\" y habilite \"Cámara\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Para enviar mensajes de audio, vaya al menú de configuración de aplicaciones, seleccione \"Permisos\" y habilite \"Micrófono\".</string>
     <string name="perm_explain_access_to_storage_denied">Para adjuntar o exportar fotos, videos o audio, vaya al menú de configuración de aplicaciones, seleccione \"Permisos\" y habilite \"Almacenamiento\".</string>
     <string name="perm_explain_access_to_location_denied">Para adjuntar una ubicación, vaya al menú de configuración de aplicaciones, seleccione \"Permisos\" y habilite \"Ubicación\".</string>

--- a/_locales/eu.xml
+++ b/_locales/eu.xml
@@ -349,8 +349,6 @@
     <string name="pref_manage_keys">Kudeatu gakoak</string>
     <string name="pref_use_system_emoji">Erabili sistemako emojiak</string>
     <string name="pref_use_system_emoji_explain">Desgaitu Delta Chat-en barne emoji euskarria</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Aplikazio sarbidea</string>
     <string name="pref_chats">Txatak</string>
     <string name="pref_in_chat_sounds">Txat bitarteko soinuak</string>
     <string name="pref_view_log">Ikusi egunkaria</string>
@@ -408,11 +406,6 @@
     <string name="autocrypt_send_asm_button">Bidali Autocrypt ezarpen mezua</string>
     <string name="autocrypt_send_asm_explain_after">Zure ezarpena zuri bidali zaizu. Aldatu beste gailura eta ireki ezarpen mezua. Ezarpen kode bat eskatuko zaizu, Idatzi honako zenbaki hauek han.\n\nBehin bukatuta, zure beste gailua Autocrypt erabiltzeko prest egongo da.</string>
     <string name="autocrypt_prefer_e2ee">Hobetsi muturretik muturrerako zifratzea</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt ezarpen mezua</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Hau Autocrypt ezarpen mezua da, zure muturretik muturrerako ezarpena bezeroen artean pasatzeko erabilia.\n\n Zure ezarpena deszifratu eta erabiltzeko, ireki mezua Autocrypt onartzen duen bezero batean eta sartu gailu sortzailean agertutako ezarpen kodea.</string>
-
 
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Nik: Taldearen izena \"%1$s\" izatetik \"%2$s\" izatera aldatu da</string>
@@ -472,6 +465,7 @@
     <string name="perm_required_title">Baimena behar da</string>
     <string name="perm_continue">Jarraitu</string>
     <string name="perm_explain_access_to_camera_denied">Delta Chat-ek kamerara sarbidea behar du argazkiak edo bideoak ateratzeko, baina behin betiko ukatu zaio. Joan aplikazioaren ezarpen menura, hautatu \"Baimenak\" eta gaitu \"Kamera\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Delta Chat-ek mikrofonoa erabiltzeko baimena behar du ahots-mezuak bidali ahal izateko, baina behin betiko ukatu zaio. Joan aplikazioaren ezarpenetara, hautatu \"Baimenak\" eta gaitu \"Mikrofonoa\".</string>
     <string name="perm_explain_access_to_storage_denied">Delta Chat-ek biltegiratze baimena behar du argazkiak, bideoak edo audioa erantsi edo esportatzeko, baina behin betiko ukatu zaio. Joan aplikazioaren ezarpen menura, hautatu \"baimenak\", eta gaitu \"Biltegiratzea\"</string>
     <string name="perm_explain_access_to_location_denied">Delta Chat-ek kokaleku aatzitzeko baimena behar du kokalekua eransteko, baina behin betiko ukatu zaio. Joan aplikazioaren ezarpen menura, hautatu \"baimenak\", eta gaitu \"Kokalekua\".</string>

--- a/_locales/fa.xml
+++ b/_locales/fa.xml
@@ -39,6 +39,7 @@
     <string name="close_window">بستن پنجره</string>
     <string name="forward">هدایت</string>
     <string name="create">ایجاد</string>
+    <string name="reset">بازنشانی</string>
     <string name="later">بعدا</string>
     <!-- "Resend" means "Sending the selected message(s) again to the same chat". The string is used in a menu and should be as short as possible. Resending may be needed after failures or to repost old messages to new members. -->
     <string name="resend">ارسال مجدد</string>
@@ -51,10 +52,11 @@
     <string name="mute">سکوت</string>
     <string name="muted">بی‌صدا</string>
     <string name="ephemeral_messages">پیام‌های ناپدید شونده</string>
-    <string name="ephemeral_messages_hint">روی تمام اعضای این گپ، اگر از دلتاچت استفاده کنند، اعمال می‌شود؛ ولی همچنان می‌توانند پیام‌ها را رونوشت، ذخیره و هدایت کنند یا از کارخواه‌های رایانامهٔ دیگر استفاده کنند.</string>
+    <string name="ephemeral_messages_hint">این روی تمام عضو‌های این گپ، اگر از دلتاچت استفاده کنند، اعمال می‌شود. ولی همچنان می‌توانند پیام‌ها را رونوشت، ذخیره و هدایت کنند.</string>
     <string name="save">ذخیره</string>
     <string name="chat">گپ</string>
     <string name="media">رسانه</string>
+    <string name="apps_and_media">برنامه‌ها و رسانه‌ها</string>
     <string name="profile">نمایه</string>
     <string name="main_menu">فهرست اصلی</string>
     <string name="start_chat">شروع گپ</string>
@@ -183,10 +185,15 @@
     <string name="images_and_videos">تصاویر و فیلم‌ها</string>
     <string name="file">پوشه</string>
     <string name="files">پرونده‌ها</string>
+    <string name="files_attach_hint">ارسال پرونده‌های اصلی و تصویر‌های فشرده‌نشده</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">انتخاب از میان پرونده‌ها</string>
+    <string name="choose_from_gallery">انتخاب از گالری</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">برنامه</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">برنامه‌ها</string>
+    <string name="webxdc_draft_hint">برای به اشتراک گذاری روی «ارسال» بزنید</string>
     <string name="home">خانه</string>
     <string name="games">بازی‌ها</string>
     <string name="tools">ابزار</string>
@@ -270,6 +277,7 @@
     <string name="menu_export_attachment">صادر کردن ضمیمه</string>
     <string name="menu_export_attachments">صادر کردن ضمیمه</string>
     <string name="menu_all_media">همه رسانه‌ها</string>
+    <string name="all_apps_and_media">همهٔ برنامه‌ها و رسانه‌ها</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">نمایش در گپ</string>
     <string name="show_app_in_chat">نمایش برنامه در گفتگو</string>
@@ -304,14 +312,15 @@
     <string name="menu_learn_spelling">یادگرفتن املا </string>
     <string name="menu_chat_audit_log">گزارش بررسی گپ</string>
     <string name="jump_to_message">رفتن به پیام</string>
+    <string name="jump_to_original_message">پرش به پیام اصلی</string>
     <string name="copy_json">JSON رونوشت برداری از </string>
     <string name="replace_draft">جایگزین کردن پیش‌نویس</string>
     <string name="title_share_location">اشتراک موقعیت مکانی با همه اعضای گروه</string>
     <string name="device_talk">پیام‌های دستگاه</string>
     <string name="device_talk_subtitle">پیام‌های  داخلی</string>
     <string name="device_talk_explain">پیام‌ها در این گپ به صورت داخلی و توسط نرم‌افزار دلتاچت تولید شده‌اند. سازنده‌ها از این محل برای اعلان به روز‌رسانی‌ها و مشکلات پیش آمده حین کار استفاده می‌کنند. </string>
-    <string name="device_talk_welcome_message2">برقراری مکالمه!\n\n
-روی «کد QR» در صفحهٔ اصلی هر دو دستگاه بزنید. روی یکی از دستگاه‌ها «اسکن کد QR» را انتخاب کنید و با آن روی دستگاه دیگر بگیرید\n\nاگر در یک مکان نیستید، از طریق تماس تصویری اسکن کنید یا این‌که یک پیوند دعوت از «اسکن کد QR» به اشتراک بگذارید.\n\n.سپس از تجربه کردن پیام‌رسان بر روی بزرگترین شبکهٔ نامتمرکزی که تا به حال وجود داشته یعنی رایانامه لذت ببرید. در مقایسه با دیگر پیام‌رسان‌های محبوب، دلتاچت هیچ کنترل مرکزی‌ای ندارد. و شما، دوستهایتان، همکارهایتان یا خانواده‌هایتان را ردیابی نمی‌کند یا این‌که به سازمان‌های بزرگ نمی‌فروشد.</string>
+    <string name="device_talk_welcome_message2">مکالمه برقرار کنید!\n\n
+روی «کد کیوآر» در صفحهٔ اصلی هر دو دستگاه بزنید. روی یکی از دستگاه‌ها «اسکن کد کیوآر» را انتخاب کنید و با آن روی دستگاه دیگر بگیرید\n\nاگر در یک مکان نیستید، از طریق تماس تصویری اسکن کنید یا این‌که یک پیوند دعوت از «اسکن کد کیوآر» به اشتراک بگذارید.\n\n.سپس از تجربه کردن پیام‌رسان بر روی بزرگ‌ترین شبکهٔ نامتمرکزی که تا به حال وجود داشته یعنی رایانامه لذت ببرید. در مقایسه با دیگر پیام‌رسان‌های محبوب، دلتاچت هیچ کنترل مرکزی‌ای ندارد.  شما، دوست‌هایتان، همکارهایتان یا خانواده‌هایتان را ردیابی نمی‌کند یا این‌که داده‌هایتان را به سازمان‌های بزرگ نمی‌فروشد.</string>
     <string name="edit_contact">ویرایش مخاطب</string>
     <!-- Verb "to pin", making something sticky, not a noun or abbreviation for "pin number". -->
     <string name="pin_chat">سنجاق کردن گپ</string>
@@ -367,18 +376,28 @@ https://meet.jit.si/$ROOM
 
     <!-- get confirmations -->
     <string name="ask_leave_group">مطمئن هستید می‌خواهید این گروه را ترک کنید؟</string>
-    <string name="ask_delete_named_chat">حذف گفتگو «%1$s» از همه‌ی دستگاه‌های شما؟</string>
-    <string name="ask_delete_message">می‌خواهید این پیام را از همه‌ی دستگاه‌هایتان حذف کنید؟</string>
+    <plurals name="ask_delete_chat">
+        <item quantity="one">آیا می‌خواهید از روی همهٔ دستگاه‌هایتان %d گپ را حذف کنید؟</item>
+        <item quantity="other">آیا می‌خواهید از روی همهٔ دستگاه‌هایتان %d گپ را حذف کنید؟</item>
+    </plurals>
+    <string name="ask_delete_named_chat">حذف گفتگوی «%1$s» از همه‌ی دستگاه‌های شما؟</string>
+    <string name="ask_delete_message">می‌خواهید این پیام را از همهٔ دستگاه‌هایتان حذف کنید؟</string>
+    <plurals name="ask_delete_messages">
+        <item quantity="one">آیا می‌خواهید از روی تمام دستگاه‌هایتان %d پیام را حذف کنید؟</item>
+        <item quantity="other">آیا می‌خواهید از روی تمام دستگاه‌هایتان %d پیام را حذف کنید؟</item>
+    </plurals>
     <!-- Used for the deletion of Device messages -->
     <plurals name="ask_delete_messages_simple">
         <item quantity="one">می‌خواهید %dپیام پاک شود؟</item>
         <item quantity="other">می‌خواهید %d پیام پاک شود؟</item>
     </plurals>
-    <string name="ask_forward">پیام‌ها به %1$sهدایت شوند؟</string>
+    <string name="ask_forward">پیام‌ها به %1$s هدایت شوند؟</string>
     <string name="ask_forward_multiple">انتقال پیام‌ها به %1$d گپ؟</string>
     <string name="ask_export_attachment">ضمیمه صادر شود؟ صادر کردن ضمیمه باعث می‌شود دیگر نرم‌افزارهای روی دستگاه شما بتوانند به آن دسترسی داشته باشند. \n\nادامه می‌دهید؟</string>
-    <string name="ask_block_contact">مخاطب مسدود شود؟ شما دیگر پیامی از این مخاطب دریافت نخواهید کرد.</string>
-    <string name="ask_unblock_contact">رفع مسدودیت مخاطب؟ دوباره قادر خواهید بود پیام‌های ارسال شده توسط این مخاطب را دریافت کنید.</string>
+    <string name="ask_block_contact">مخاطب مسدود شود؟\n\n
+شما دیگر پیامی به صورت مستقیم از این مخاطب دریافت نخواهید کرد. همچنین گروه‌های ایجاد شده توسط این مخاطب نمایش داده نخواهند شد.\n\n
+با این وجود، گروه‌هایی که این مخاطب در آن حضور دارند نمایش داده خواهد شد.</string>
+    <string name="ask_unblock_contact">رفع مسدودیت این مخاطب؟</string>
     <string name="ask_delete_contacts">مخاطبین حذف شوند؟\n\nمخاطبینی که گپ فعال دارند و مخاطبینی که در دفتر تلفن سامانه هستند را نمی‌توان به صورت دائمی حذف کرد. </string>
     <string name="ask_delete_contact">حذف مخاطب %1$s؟ \n\nمخاطبین با گپ فعال و مخاطبینی که در دفتر تلفن سامانه هستند را نمی‌توان به صورت دائمی حذف کرد. </string>
     <string name="ask_start_chat_with">گپ زدن با %1$s؟</string>
@@ -500,6 +519,8 @@ https://meet.jit.si/$ROOM
     <string name="profile_encryption">رمزگذاری</string>
     <string name="profile_shared_chats">گپ‌های هم‌رسانده</string>
     <string name="related_chats">گفتگوهای مرتبط</string>
+    <!-- Separator between the list of actual members and past members -->
+    <string name="past_members">عضو‌های پیشین</string>
     <string name="tab_contact">مخاطب</string>
     <string name="tab_group">گروه</string>
     <string name="tab_gallery">گالری</string>
@@ -508,12 +529,12 @@ https://meet.jit.si/$ROOM
     <string name="tab_map">نقشه</string>
     <string name="tab_gallery_empty_hint">تصاویر و ویدیوهای هم‌رسانده در این گپ اینجا نمایش داده می‌شوند.</string>
     <string name="tab_docs_empty_hint">اسناد و پرونده‌های هم‌رساندهٔ دیگر در این گپ اینجا نمایش داده می‌شوند.</string>
-    <string name="tab_image_empty_hint">تصاویر هم‌رسانده در این گپ اینجا نمایش داده می‌شوند.</string>
+    <string name="tab_image_empty_hint">تصویر‌های هم‌رسانده در این گپ اینجا نمایش داده می‌شوند.</string>
     <string name="tab_video_empty_hint">ویدیوهای هم‌رسانده در این گپ اینجا نمایش داده می‌شوند.</string>
     <string name="tab_audio_empty_hint">پرونده‌های صوتی و پیام‌های صوتی هم‌رسانده در این گپ اینجا نمایش داده می‌شوند.</string>
-    <string name="tab_webxdc_empty_hint">برنامه‌هایی که در این چت به اشتراک گذاشته شده‌اند، این‌جا نمایش داده خواهند شد.</string>
-    <string name="tab_all_media_empty_hint">رسانه‌های به اشتراک گذاشته شده همه چت‌ها در اینجا ظاهر می‌شود.</string>
-    <string name="all_apps_empty_hint">برنامه‌هایی که در هر گفتگویی ارسال شده باشند در اینجا ظاهر خواهند شد.</string>
+    <string name="tab_webxdc_empty_hint">برنامه‌هایی که در این گپ به اشتراک گذاشته شده‌اند، این‌جا نمایش داده خواهند شد.</string>
+    <string name="tab_all_media_empty_hint">رسانه‌های به اشتراک گذاشته شده همهٔ چت‌ها در اینجا ظاهر می‌شود.</string>
+    <string name="all_apps_empty_hint">برنامه‌های ارسال شده در همهٔ گپ‌ها اینجا ظاهر خواهند شد.</string>
     <string name="media_preview">نمایش رسانه</string>
     <!-- option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :) -->
     <string name="aspect_ratio_grid">حفظ مقیاس تصویر</string>
@@ -636,7 +657,7 @@ https://meet.jit.si/$ROOM
     <string name="login_info_oauth2_title">با تنظیم‌ها ساده‌ شده ادامه می‌دهید؟</string>
     <string name="login_info_oauth2_text">نشانی رایانامه وارد شده از تنظیم‌های ساده پشتیبانی می‌کند
 (OAuth 2.0).\n\nIn
- لطفا در مرحله بعد، به دلتاچت اجازه دهید که به عنوان نرم‌افزار رایانامه شما عمل نماید\n\n دلتاچت سرور ندارد؛ داده‌های شما در دستگاه خودتان باقی می‌ماند. </string>
+ لطفا در مرحله بعد، به دلتاچت اجازه دهید که به عنوان نرم‌افزار رایانامه شما عمل نماید\n\n دلتاچت کارساز(سرور) ندارد؛ داده‌های شما در دستگاه خودتان باقی می‌ماند. </string>
     <string name="login_certificate_checks">بررسی‌های گواهینامه</string>
     <string name="login_error_mail">لطفاً یک نشانی رایانامهٔ معتبر وارد کنید</string>
     <string name="login_error_server">لطفا یک کارساز / نشانی آی‌پی صحیح وارد کنید</string>
@@ -646,12 +667,15 @@ https://meet.jit.si/$ROOM
     <string name="import_backup_ask">نسخه پشتیبانی در\"%1$s\" پیدا شد.\n\n آیا می‌خواهید همه داده‌ها و تنظیم‌ها از آن وارد شود؟</string>
     <string name="import_backup_no_backup_found">نسخه پشتیبانی پیدا نشد.\n\n نسخه پشتیبانی را در\"%1$s\" کپی کرده و دوباره امتحان کنید. در غیر این صورت می‌توانید \"شروع پیام‌رسانی\" را فشار دهید دا فرایند به صورت عادی ادامه یابد. </string>
     <!-- %1$s will be replaced by the failing address -->
-    <string name="login_error_cannot_login">نتوانست به عنوان «%1$s» وارد شود. لطفاً صحت نشانی رایانامه و گذرواژه را بررسی کنید. </string>
+    <string name="login_error_cannot_login">نمی‌توانیم به عنوان «%1$s» وارد شویم. لطفاً درستی نشانی رایانامه و گذرواژه را بررسی کنید. </string>
     <!-- TLS certificate checks -->
     <string name="accept_invalid_certificates">پذیرش گواهینامه‌های نامعتبر</string>
     <string name="switch_account">تغییر حساب کاربری</string>
     <string name="add_account">افزودن حساب کاربری</string>
+    <!-- for translations, you can also think of "Profile Tag" or "Profile Description" as the source string -->
+    <string name="profile_tag">برچسب حساب</string>
     <string name="profile_tag_hint">مثل «کار» یا «خانواده»</string>
+    <string name="profile_tag_explain">یک برچسب انتخاب کنید که تنها به شما نمایش داده می‌شود. این به شما کمک می‌کند حساب‌های مختلف خود را از هم تشخیص دهید.</string>
     <string name="delete_account">حذف حساب کاربری</string>
     <string name="delete_account_ask">آیا از حذف حساب کاربری اطمینان دارید؟</string>
     <string name="delete_account_explain_with_name">همه اطلاعات حساب مربوط به «%s» روی این دستگاه پاک می‌شود. این شامل تنظیم‌های رمزگذاری سراسری، مخاطبین، گفتگوها، پیام‌ها و رسانه‌ها می‌شود. این عمل قابل بازگردانی نیست.</string>
@@ -696,6 +720,7 @@ https://meet.jit.si/$ROOM
     <string name="pref_screen_security_explain">درخواست مسدود کردن عکس گرفتن از صفحه در لیست اخیر و درون نرم‌افزار</string>
     <string name="pref_screen_security_please_restart_hint">برای اعمال کردن تنظیم‌های امنیت صفحه لطفا نرم‌افزار را بسته و دوباره باز کنید.</string>
     <string name="pref_notifications">اعلان‌ها</string>
+    <string name="pref_mention_notifications_explain">در گروه‌های بی‌صدا شده، برای پیام‌های مستقیم به خودتان، مانند پاسخ‌ها یا واکنش‌ها، اعلان دریافت کنید.</string>
     <string name="pref_notifications_show">نمایش</string>
     <string name="pref_notifications_priority">اولویت</string>
     <string name="pref_notifications_explain">فعال کردن اعلان‌های سیستم برای پیام‌های جدید</string>
@@ -713,7 +738,7 @@ https://meet.jit.si/$ROOM
     <string name="pref_appearance">ظاهر</string>
     <string name="pref_theme">قالب</string>
     <string name="pref_language">زبان</string>
-    <string name="pref_use_system_ui_font">استفاده از فونت سیستم</string>
+    <string name="pref_use_system_ui_font">استفاده از قلم سیستم</string>
     <string name="pref_incognito_keyboard">صفحه کلید ناشناس</string>
     <!-- Translators: Must indicate that there is no guarantee as the system may not honor our request. -->
     <string name="pref_incognito_keyboard_explain">درخواست دهید که صفحه کلید رفتارهای شخصی شما را یاد نگیرد</string>
@@ -725,8 +750,6 @@ https://meet.jit.si/$ROOM
     <string name="pref_use_system_emoji">استفاده از شکلک‌های سیستم</string>
     <string name="pref_use_system_emoji_explain">غیرفعال کردن شکلک‌های داخلی دلتاچت</string>
     <string name="pref_show_system_contacts">خواندن دفترچه آدرس دستگاه</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">دسترسی نرم‌افزار</string>
     <string name="pref_chats">گپ‌ها</string>
     <string name="pref_in_chat_sounds">صداهای درون‌گپی</string>
     <string name="pref_view_log">نمایش گزارش</string>
@@ -824,9 +847,9 @@ https://meet.jit.si/$ROOM
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
     <string name="autodel_device_ask">آیا می‌خواهید %1$d پیام جدید و دریافت شده را در زمان%2$s در آینده پاک کنید؟\n\n• این شامل همه رسانه‌ها هم می‌شود\n\n•  پیام‌ها جدای از اینکه دیده شده باشند یا نه پاک می‌شوند. \"پیام های ذخیره شده\" شامل این پاک کردن محلی نمی‌شوند. </string>
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
-    <string name="autodel_server_ask">آیا می‌خواهید %1$dپیام را اکنون و تمام پیام‌های آیندهٔ «%2$s»  را پاک کنید؟/n/n⚠️ این شامل رایانامه‌ها، رسانه و «پیام‌های ذخیره شده» در همه پوشه‌های کارساز می‌شود/n/n⚠️ اگر می‌خواهید داده‌ها در کارساز باقی بمانند از این قابلیت استفاده نکنید/n/n⚠️ اگر به‌جز دلتاچت از دیگر نرم‌افزارهای رایانامه هم استفاده می‌کنید این قابلیت را به کار نگیرید.</string>
+    <string name="autodel_server_ask">آیا می‌خواهید %1$d پیام را اکنون و تمام پیام‌های آیندهٔ «%2$s»  را پاک کنید؟/n/n⚠️ این شامل رایانامه‌ها، رسانه و «پیام‌های ذخیره شده» در همه پوشه‌های کارساز(سرور) می‌شود/n/n⚠️ اگر می‌خواهید داده‌ها در کارساز باقی بمانند از این قابلیت استفاده نکنید/n/n⚠️ اگر به‌جز دلتاچت از دیگر نرم‌افزارهای رایانامه هم استفاده می‌کنید این قابلیت را به کار نگیرید.</string>
     <!-- shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact -->
-    <string name="autodel_server_enabled_hint">این شامل رایانامه‌ها، رسانه و «پیام‌های ذخیره شده» در تمام پوشه‌های کارساز می‌شود. اگر می‌خواهید داده‌ها را در کارساز نگه دارید از این قابلیت استفاده نکنید. اگر از دیگر نرم‌افزارهای رایانامه به‌جز دلتاچت استفاده می‌کنید از این قابلیت استفاده نکنید.</string>
+    <string name="autodel_server_enabled_hint">این شامل رایانامه‌ها، رسانه‌ها و «پیام‌های ذخیره شده» در تمام پوشه‌های کارساز(سرور) می‌شود. اگر می‌خواهید داده‌ها را در کارساز نگه دارید از این قابلیت استفاده نکنید. اگر از دیگر نرم‌افزارهای رایانامه به‌جز دلتاچت استفاده می‌کنید از این قابلیت استفاده نکنید.</string>
     <string name="autodel_confirm">متوجه هستم، همه پیام‌ها حذف شوند</string>
     <!-- "At once" in the meaning of "Immediately", without any intervening time. -->
     <string name="autodel_at_once">یک بار بعد از بارگیری</string>
@@ -842,22 +865,17 @@ https://meet.jit.si/$ROOM
 
     <!-- autocrypt -->
     <string name="autocrypt_send_asm_title">ارسال پیام برپاسازی اتوکریپت</string>
-    <string name="autocrypt_send_asm_explain_before">پیام برپاسازی اتوکریپت تنظیم‌های رمزگذاری سرتاسر شما را به شکلی امن با دیگر برنامه‌ها به اشتراک می‌گذارد.\n\n تنظیم‌ها با یک کد برپاسازی که در اینجا نمایش داده می‌شود رمزگذاری می‌شوند و باید در دستگاه دیگر تایپ شود. </string>
+    <string name="autocrypt_send_asm_explain_before">پیام برپاسازی آتوکریپت تنظیم‌های رمزگذاری سراسری شما را به شکلی امن با دیگر برنامه‌ها به اشتراک می‌گذارد.\n\n تنظیم‌ها با یک کد برپاسازی که در اینجا نمایش داده می‌شود رمزگذاری می‌شوند و باید در دستگاه دیگر تایپ شود. </string>
     <string name="autocrypt_send_asm_button">ارسال پیام برپاسازی اتوکریپت</string>
     <string name="autocrypt_send_asm_explain_after">تنظیم‌های شما برای خودتان ارسال شدند. پیام تنظیم‌ها را در دستگاه دیگر باز کنید. یک کد نصب از شما خواسته می‌شود. این ارقام را وارد کنید</string>
     <string name="autocrypt_prefer_e2ee">ترجیح رمزگذاری گیرنده به گیرنده</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">پیام برپاسازی اتوکریپت</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">این پیام برپاسازی اتوکریپت است و تنظیم‌های مربوط به رمزگذاری سرتاسر شما را بین دستگاه‌ها جابه‌جا می‌کند.\n\n برای رمزگشایی و استفاده از آن، پیام را در یک سامانه که با اتوکریپت همخوانی دارد باز کنید و کد برپاسازی که در دستگاه تولیدکنندهٔ پیام، به شما داده می‌شود را وارد نمایید. </string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">این پیام قابل رمزگشایی نیست.
 می‌توانید با پاسخ به این پیام از فرستنده درخواست کنید پیام را مجدد ارسال کند.
-اگر دلتاچت را به تازگی دوباره نصب کرده‌اید بهتر است آن را مجدد راه‌اندازی کرده و از گزینه‌ی «افزودن به عنوان دستگاه دوم» استفاده کنید یا از نسخه‌ی پشتیبان بازیابی کنید.</string>
+اگر دلتاچت را به تازگی دوباره نصب کرده‌اید بهتر است آن را مجدد راه‌اندازی کرده و از گزینه‌ی «افزودن به عنوان دستگاه دوم» استفاده کنید، یا از نسخه‌ی پشتیبان بازیابی کنید.</string>
     <string name="systemmsg_unknown_sender_for_chat">فرستنده در این گفت و گو ناشناس است. برای جزئیات بیشتر به \"اطلاعات\" مراجعه کنید.</string>
-    <string name="systemmsg_subject_for_new_contact">پیام از%1$s</string>
+    <string name="systemmsg_subject_for_new_contact">پیام از %1$s</string>
     <string name="systemmsg_failed_sending_to">ارسال ناموفق پیام به %1$s.</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">شما نام گروه را از «%1$s» به «%2$s»  تغییر دادید. </string>
@@ -924,7 +942,7 @@ https://meet.jit.si/$ROOM
     <!-- this may be shown instead of the chat's input field, with buttons "More Info" and "OK" -->
     <string name="chat_protection_broken">%1$s پیامی را از دستگاه دیگری ارسال کرد.</string>
     <string name="chat_protection_enabled_tap_to_learn_more">رمزنگاری سرتاسر پیام ها از این به بعد تضمین می شود. برای اطلاعات بیشتر ضربه بزنید.</string>
-    <string name="chat_protection_enabled_explanation">رمزنگاری سراسری پیام‌های این گفتگو اکنون تضمین می‌شود. رمزنگاری سراسری باعث می‌شود پیام‌هایتان بین شما و مخاطبین شما محرمانه بماند. حتی ارائه‌دهنده رایانامه شما هم نمی‌تواند آن‌ها را بخواند.</string>
+    <string name="chat_protection_enabled_explanation">رمزنگاری سراسری پیام‌های این گفتگو اکنون تضمین می‌شود. رمزنگاری سراسری باعث می‌شود پیام‌هایتان بین شما و مخاطبین شما محرمانه بماند. حتی ارائه‌دهندهٔ رایانامه شما هم نمی‌تواند آن‌ها را بخواند.</string>
     <string name="chat_protection_broken_tap_to_learn_more">%1$s پیامی را از دستگاه دیگری ارسال کرد. برای اطلاعات بیشتر ضربه بزنید.</string>
     <string name="invalid_unencrypted_tap_to_learn_more">⚠️ %1$s به رمزنگاری سراسری نیاز دارد که هنوز برای این گپ پیکره‌بندی نشده است. برای یادگیری بیش‌تر این‌جا بزنید.</string>
     <string name="learn_more">بیشتر بدانید</string>
@@ -952,15 +970,15 @@ https://meet.jit.si/$ROOM
     <string name="qrscan_failed">امکان رمزگشایی کد کیوآر وجود ندارد</string>
     <string name="qrscan_ask_join_group">آیا می خواهید به گروه\"%1$s\" ملحق شوید؟</string>
     <string name="qrscan_fingerprint_mismatch">اثرانگشت اسکن شده با انچه که برای %1$sمشاهده شده بود انطباق ندارد. </string>
-    <string name="qrscan_no_addr_found">این کیوآر حاوی یک شناساگر است ولی ادرس رایانامه‌ای در آن نیست. \n\n برای یک تأییدیه به روش‌های دیگر لطفا ابتدا یک ارتباط رمزگذاری شده با دریافت کننده برقرار کنید. </string>
+    <string name="qrscan_no_addr_found">این کیوآر حاوی یک شناساگر است. ولی آدرس رایانامه‌ای در آن نیست. \n\n برای یک تأییدیه به روش‌های دیگر لطفا ابتدا یک ارتباط رمزگذاری شده با دریافت کننده برقرار کنید. </string>
     <string name="qrscan_contains_text">کیوآر کد اسکن شده:\n\n %1$s</string>
     <string name="qrscan_contains_url">آدرس اینترنتی کیوآر اسکن شده:\n\n %1$s</string>
     <string name="qrscan_fingerprint_label">اثر انگشت</string>
     <string name="withdraw_verifycontact_explain">دیگران برای ارتباط با شما می‌توانند این کد کیوآر را اسکن کنند. \n\n می‌توان کد کیوآر را در اینجا غیر فعال کنید و با اسکن کردن مجدد، آن را فعال کنید. </string>
-    <string name="withdraw_verifygroup_explain">این کد کیوآر می‌تواند توسط دیگران و برای پیوستن به گروه \"%1$s\" اسکن شود.\n\n شما می‌تواند این کد کیوآر را در اینجا غیرفعال کنید و با اسکن کردن مجدد، آن را فعال نمایید. </string>
+    <string name="withdraw_verifygroup_explain">این کد کیوآر می‌تواند توسط دیگران و برای پیوستن به گروه «%1$s» اسکن شود.\n\n شما می‌تواند این کد کیوآر را در اینجا غیرفعال کنید و با اسکن کردن مجدد، آن را فعال نمایید. </string>
     <string name="withdraw_qr_code">غیرفعال کردن کد کیوآر</string>
-    <string name="revive_verifycontact_explain">دیگران برای تماس با شما می‌توانند این کد کیوآر را اسکن کنند. \n\n این کد کیوآر در این دستگاه فعال نیست. </string>
-    <string name="revive_verifygroup_explain">دیگران می‌توانند برای پیوستن به گروه \"%1$s\" این کد کیوآر را اسکن کنند. این کد کیوآر روی این دستگاه فعال نیست. </string>
+    <string name="revive_verifycontact_explain">این کد کیو‌آر بازنشانی شده است و دیگر فعال نیست.</string>
+    <string name="revive_verifygroup_explain">این کد کیوآر برای پیوستن به گروه «%1$s» بازنشانی شده‌است و دیگر فعال نیست.</string>
     <string name="revive_qr_code">فعال کردن کد کیوآر</string>
     <string name="qrshow_title">کد دعوت کیوآر</string>
     <string name="qrshow_x_joining">%1$sعضو شد.</string>
@@ -999,8 +1017,6 @@ https://meet.jit.si/$ROOM
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">تنظیم‌ها برای %1$s تغییر کرد. </string>
     <string name="verified_contact_required_explain">برای تضمین رمزنگاری سراسری شما تنها می‌توانید مخاطب‌هایی که یک تیک سبز دارند به این گروه اضافه کنید.\n\nمی‌توانید با مخاطب‌هایتان حضوری ملاقات کنید و برای معرفی، کد QR آن‌ها را اسکن کنید.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">آدرس کیوآر در حافظه ذخیر شد</string>
     <string name="mailto_dialog_header_select_chat">گپ را برای ارسال پیام انتخاب کنید</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s هم‌اکنون هم یک پیام پیش‌نویس دارد؛ آیا می‌خواهید آن را جایگزین کنید؟</string>
@@ -1032,7 +1048,8 @@ https://meet.jit.si/$ROOM
 را انتخاب کرده و 
 \"Camera\" 
 را فعال کنید.  </string>
-    <string name="perm_explain_access_to_mic_denied">برای ارسال پیام صوتی به تنظیم‌های نرم‌افزار رفته و پس از انتخاب «دسترسی‌ها»
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">برای ارسال پیام صوتی به تنظیم‌های نرم‌افزار یا سیستم رفته و پس از انتخاب «دسترسی‌ها» یا «اجازه‌ها»
  گزینه «میکروفن»
  را فعال نمایید. </string>
     <string name="perm_explain_access_to_storage_denied">برای دریافت یا ارسال پرونده به تنظیم‌های برنامه بروید، «اجازه‌ها» را برگزینید و «ذخیره‌گاه» را به کار بیندازید.</string>
@@ -1078,6 +1095,8 @@ GNU GPL ورژن ۳
     <string name="global_menu_view_developer_desktop">برنامه‌نویس</string>
     <string name="global_menu_view_developer_tools_desktop">ابزار برنامه نویس</string>
     <string name="global_menu_help_desktop">کمک</string>
+    <string name="delta_chat_homepage">صفحهٔ خانگی دلتاچت</string>
+    <string name="contribute">مشارکت</string>
     <string name="global_menu_help_report_desktop">گزارش یک مشکل</string>
     <string name="global_menu_help_about_desktop">درباره دلتاچت</string>
     <string name="global_menu_file_open_desktop">بازکردن دلتاچت</string>
@@ -1148,12 +1167,13 @@ GNU GPL ورژن ۳
     <string name="notifications_avg_minutes">به صورت متوسط هر%1$d دقیقه</string>
     <string name="notifications_avg_hours">به صورت متوسط هر %1$d ساعت</string>
     <string name="last_check_at">بررسی شده در %1$s</string>
+    <string name="system_settings">تنظیم‌های سیستم</string>
     <!-- iOS shortcut widget -->
     <!-- use the same translation for "Shortcuts" as the system is using, often the term "Shortcut" stays untranslated; check eg. how the "Shortcuts" system app is called in your locale -->
     <string name="shortcuts_widget_title">میانبرها</string>
     <!-- iOS permissions, copy from "deltachat-ios/Info.plist", which is used on missing translations in "deltachat-ios/LANG.lproj/InfoPlist.strings" -->
     <string name="InfoPlist_NSCameraUsageDescription">دلتاچت برای گرفتن و ارسال عکس و فیلم و برای اسکن کردن کیوآر کد از دوربین شما استفاده می‌کند. </string>
-    <string name="InfoPlist_NSContactsUsageDescription">دلتاچت از مخاطبین شما برای نمایش فهرست رایانامه‌هایی که می‌توانید برایشان پیام ارسال کنید استفاده می‌کند. دلتاچت کارساز ندارد، مخاطبین شما به جایی ارسال نمی‌شوند. </string>
+    <string name="InfoPlist_NSContactsUsageDescription">دلتاچت از مخاطبین شما برای نمایش فهرست رایانامه‌هایی که می‌توانید برایشان پیام ارسال کنید استفاده می‌کند. دلتاچت کارساز(سرور) ندارد، مخاطبین شما به جایی ارسال نمی‌شوند. </string>
     <string name="InfoPlist_NSLocationAlwaysAndWhenInUseUsageDescription">دلتاچت برای  هم‌رسانی مکان شما در زمانی که آن به کار انداخته‌اید، به مجوز نیاز دارد. </string>
     <string name="InfoPlist_NSLocationWhenInUseUsageDescription">دلتاچت برای اشتراک موقعیت مکانی شما در زمانی که اشتراک موقعیت مکانی را فعال کرده‌ باشید به مجوز نیاز دارد. </string>
     <string name="InfoPlist_NSMicrophoneUsageDescription">دلتاچت از میکروفون برای ذخیره و ارسال پیام صوتی یا فیلم دارای صدا استفاده می‌کند.</string>
@@ -1166,7 +1186,7 @@ GNU GPL ورژن ۳
     <string name="pref_reliable_service">اجبار کردن اتصال پس‌زمینه</string>
     <string name="pref_reliable_service_explain">اعلانی دائمی نشان می‌دهد</string>
 
-    <string name="pref_background_notifications_rationale">برای حفظ ارتباطتان با سرور رایانامه و دریافت پیامها در پیش زمینه، در گام بعدی، تنظیم‌های بهینه سازی باتری را نادیده بگیرید. \n\n دلتاچت از منابع کمی استفاده میکند و مراقب است باتری شما را بیش از حد مصرف نکند. </string>
+    <string name="pref_background_notifications_rationale">برای حفظ ارتباطتان با کارساز(سرور) رایانامه و دریافت پیامها در پیش زمینه، در گام بعدی، تنظیم‌های بهینه سازی باتری را نادیده بگیرید. \n\n دلتاچت از منابع کمی استفاده میکند و مراقب است باتری شما را بیش از حد مصرف نکند. </string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="perm_enable_bg_reminder_title">برای دریافت پیام‌ها به صورت پس زمینه در دلتاچت این جا را ضربه بزنید. </string>
     <string name="perm_enable_bg_already_done">قبلا اجازه دسترسی به فعالیت در پس زمینه را به دلتاچت داده‌اید. \n\n اگر پیام‌ها هنوز هم در شرایط پس زمینه نمی‌آمد لطفا تنظیم‌های سیستم را نیز بررسی نمایید. </string>

--- a/_locales/fi.xml
+++ b/_locales/fi.xml
@@ -656,8 +656,6 @@
     <string name="pref_use_system_emoji_explain">Poista Delta Chatin sisäänrakennettu emoji -tuki käytöstä</string>
     <string name="pref_show_system_contacts">Lue laitteen osoitekirja</string>
     <string name="pref_show_system_contacts_explain">Tarjoa keskustelujen avaamista yhteystietojen perusteella. Jotkin palveluntarjoajat vaativat ensin päästä-päähän salauksen käyttöönottoa. </string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Sovelluksen pääsy</string>
     <string name="pref_chats">Keskustelut</string>
     <string name="pref_in_chat_sounds">Keskustelunaikaiset äänet</string>
     <string name="pref_view_log">Näytä loki</string>
@@ -778,11 +776,6 @@
     <string name="autocrypt_send_asm_button">Lähetä Autocrypt -käyttöönottoviesti</string>
     <string name="autocrypt_send_asm_explain_after">Käyttöönottoviesti on lähetetty sinulle itsellesi. Avaa viesti toisella laitteella. Sinulta pyydetään käyttöönottokoodia. Anna seuraavat numerot:</string>
     <string name="autocrypt_prefer_e2ee">Suosi päästä-päähän -salausta</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt -käyttöönottoviesti</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Tätä Autocrypt -käyttöönottoviestiä käytetään päästä-päähän -salauksen asetusten siirtämiseksi toiselle laitteelle.\n\nSaat purettua salauksia ja käytettyä määrittelyä avaamalla viestin Autocrypt -yhteensopivassa päätesovelluksessa, generoivalla laitteella näytetyn pin koodin syöttämisen jälkeen.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Viestin salausta ei voitu purkaa.\n\n• Voi olla että vastaamalla tähän ja pyytämällä lähettäjää lähettämään viesti uudelleen ongelma ratkeaa.\n\n• Jos juuri uudelleenasensit Delta Chatin, lienee parasta että otat sovelluksen uudelleen käyttöön ja valitset \"Lisää toisena laitteena\" tai palauta varmuuskopiosta.</string>
@@ -925,8 +918,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Asetukset muutettu kohteessa %1$s.</string>
     <string name="verified_contact_required_explain">Päästä-päähän -salauksen takaamiseksi, voit lisätä ryhmään ainoastaan yhteystietoja joilla on vihreä \"oikein\" -merkki.\n\nVoit tavata yhteystietoja kasvotusten ja skannata heidän QR -koodinsa niin saat lisättyä salauksen käyttöön</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">QR -osoite kopioitu leikepöydälle</string>
     <string name="mailto_dialog_header_select_chat">Valitse keskustelu viestien lähettämiseen</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">Keskustelussa %1$s on jo luonnos. Haluatko korvata sen?</string>
@@ -952,6 +943,7 @@
     <string name="perm_required_title">Pääsylupa vaaditaan</string>
     <string name="perm_continue">Jatka</string>
     <string name="perm_explain_access_to_camera_denied">Ottaaksesi kuvia tai videoita mene sovelluksen asetuksiin, valitse \"Käyttöluvat\" ja kytke päälle \"Kamera\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Lähettääksesi ääniviestin mene sovelluksen asetuksiin, valitse \"Käyttöluvat\" ja kytke päälle \"Mikrofoni\".</string>
     <string name="perm_explain_access_to_storage_denied">Lähettääksesi tai vastaanottaaksesi tiedostoja mene sovelluksen asetuksiin, valitse \"Käyttöluvat\" ja kytke päälle \"Tallennustila\".</string>
     <string name="perm_explain_access_to_location_denied">Jakaaksesi sijaintisi mene sovelluksen asetuksiin, valitse \"Käyttöluvat\" ja kytke päälle \"Sijainti\".</string>

--- a/_locales/fr.xml
+++ b/_locales/fr.xml
@@ -740,8 +740,6 @@
     <string name="pref_use_system_emoji_explain">Désactiver la prise en charge des émojis intégrés de Delta Chat</string>
     <string name="pref_show_system_contacts">Lire le carnet d\'adresses du système</string>
     <string name="pref_show_system_contacts_explain">Permet de créer des conversations avec des contacts du carnet d\'adresse. Certains fournisseurs doivent d\'abord mettre en place un chiffrement de bout-en-bout.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Accès à l\'application</string>
     <string name="pref_chats">Discussions</string>
     <string name="pref_in_chat_sounds">Sons de messages entrants</string>
     <string name="pref_view_log">Voir le journal</string>
@@ -862,11 +860,6 @@
     <string name="autocrypt_send_asm_button">Envoyer le message de configuration Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Votre configuration vous a été envoyée. Passez à l\'autre appareil et ouvrez le message de configuration. Un code de configuration devrait vous être demandé. Tapez les chiffres suivants :</string>
     <string name="autocrypt_prefer_e2ee">Préférez le chiffrement de bout en bout</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Message de configuration Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Ceci est le message de configuration Autocrypt utilisé pour transférer votre configuration de bout en bout entre clients. Pour déchiffrer et utiliser votre configuration, ouvrez le message dans un client compatible Autocrypt et entrez le code de configuration présenté sur le périphérique de génération.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Ce message ne peut pas être déchiffré.\n\n• Essayez de demander à l\'expéditeur de vous l\'envoyer à nouveaux.\n\n• Si vous venez de réinstaller Delta Chat il serait bien de le reconfigurer en sélectionnant \"Ajouter un deuxième appareil\" ou d\'importer une sauvegarde.</string>
@@ -1009,8 +1002,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Configuration modifiée pour %1$s</string>
     <string name="verified_contact_required_explain">Pour garantir le chiffrement de bout en bout, vous pouvez ajouter à ce groupe uniquement les contacts avec un badge vert.\n\nVous pouvez rencontrer ces contacts en personne pour scanner leur code QR et les ajouter à votre liste de contacts connus.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">L\'URL du code QR a été copié dans le presse-papiers</string>
     <string name="mailto_dialog_header_select_chat">Sélectionnez une discussion à qui envoyer le message</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$sa déjà un message en brouillon, voulez-vous le remplacer?</string>
@@ -1036,6 +1027,7 @@
     <string name="perm_required_title">Autorisation requise</string>
     <string name="perm_continue">Continuez</string>
     <string name="perm_explain_access_to_camera_denied">Pour prendre des photos ou filmer des vidéos, aller au menu Paramètres de l\'application, sélectionnez \"Autorisations\" et autorisez \"Appareil photo\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Pour envoyer des messages audio, aller dans les paramètres de l\'application, sélectionner \"Autorisations\" et autoriser \"Microphone\".</string>
     <string name="perm_explain_access_to_storage_denied">Pour recevoir ou envoyer des fichiers, aller dans les Paramètres de l\'application, sélectionner \"Autorisations\" et autoriser \"Stockage\".</string>
     <string name="perm_explain_access_to_location_denied">Pour joindre une position, aller au menu paramètres de l\'application, sélectionnez \"Autorisations\" et activez \"Position\".</string>

--- a/_locales/gl.xml
+++ b/_locales/gl.xml
@@ -717,8 +717,6 @@
     <string name="pref_manage_keys">Xestión das chaves</string>
     <string name="pref_use_system_emoji">Utilizar emoji do sistema</string>
     <string name="pref_use_system_emoji_explain">Desactivar o soporte interno para emoji de Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Acceso a app</string>
     <string name="pref_chats">Conversas</string>
     <string name="pref_in_chat_sounds">Sons na conversa</string>
     <string name="pref_view_log">Ver rexistro</string>
@@ -821,11 +819,6 @@
     <string name="autocrypt_send_asm_button">Enviar Mensaxe de Configuración Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Os axustes envíanse a ti mesma. Vaite ao outro dispositivo e abre a mensaxe de configuración. Debería solicitarche un código. Introduce os seguintes díxitos:</string>
     <string name="autocrypt_prefer_e2ee">Preferir cifrado extremo-a-extremo</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Mensaxe de Configuración Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Esta é a Mensaxe de Configuración Autocrypt utilizado para transferir os teus axustes de cifrado de extremo-a-extremo entre clientes.\n\nPara descifrar e utilizar os axustes abre a mensaxe nun cliente compatible con Autocrypt e introduce o código mostrado no dispositivo de orixe.</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">Remitente descoñecido para esta convers. Mira en \'info\' para saber máis.</string>
     <string name="systemmsg_subject_for_new_contact">Mensaxe de %1$s</string>
@@ -913,8 +906,6 @@
     <string name="contact_not_verified">Non se puido verificar %1$s.</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Cambiaron os axustes para %1$s.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Copiado o url do QR ao portapapeis</string>
     <string name="mailto_dialog_header_select_chat">Elexir chat ao que enviar a mensaxe</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s xa ten un borrador, queres susbstituílo?</string>
@@ -933,6 +924,7 @@
     <string name="perm_required_title">Permiso requerido</string>
     <string name="perm_continue">Continuar</string>
     <string name="perm_explain_access_to_camera_denied">Para facer fotos ou vídeos, vaite aos axustes da app, escolle \"Permisos\", e activa \"Cámara\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Para enviar mensaxes de voz, vaite aos axustes da app, escolle \"Permisos\" e activa \"Micrófono\".</string>
     <string name="perm_explain_access_to_storage_denied">Para recibir ou enviar ficheiros, vaite aos axustes da app, escolle \"Permisos\" e activa \"Almacenaxe\".</string>
     <string name="perm_explain_access_to_location_denied">Para engadir a localización, vaite aos axustes da app, escolle \"Permisos\" e activa \"Localización\".</string>

--- a/_locales/hr.xml
+++ b/_locales/hr.xml
@@ -206,8 +206,6 @@
     <string name="pref_read_receipts_explain">Ukoliko ste onemogućili potvrdu čitanja kod sebe, nećete moći vidjeti potvrde čitanja od drugih.</string>
     <string name="pref_use_system_emoji">Koristi emotikone sustava</string>
     <string name="pref_use_system_emoji_explain">Onemogući ugrađenu Delta Chat podršku za emotikone</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Pristup aplikaciji</string>
     <string name="pref_chats">Razgovori</string>
     <string name="pref_in_chat_sounds">Zvuk unutar razgovora</string>
     <string name="pref_other">Ostalo</string>

--- a/_locales/hu.xml
+++ b/_locales/hu.xml
@@ -24,7 +24,7 @@
     <string name="open">Megnyitás</string>
     <string name="download">Letöltés</string>
     <string name="downloading">Letöltés…</string>
-    <string name="open_attachment">Csatolmány megnyitása</string>
+    <string name="open_attachment">Melléklet megnyitása</string>
     <string name="join">Csatlakozás</string>
     <string name="rejoin">Újracsatlakozás</string>
     <string name="delete">Törlés</string>
@@ -33,7 +33,7 @@
     <string name="info">Információk</string>
     <string name="update">Frissítés</string>
     <string name="emoji">Emodzsi</string>
-    <string name="attachment">Csatolmány</string>
+    <string name="attachment">Melléklet</string>
     <string name="back">Vissza</string>
     <string name="close">Bezárás</string>
     <string name="close_window">Ablak bezárása</string>
@@ -56,6 +56,7 @@
     <string name="save">Mentés</string>
     <string name="chat">Csevegés</string>
     <string name="media">Média</string>
+    <string name="apps_and_media">Alkalmazások &amp; média</string>
     <string name="profile">Profil</string>
     <string name="main_menu">Főmenü</string>
     <string name="start_chat">Csevegés indítása</string>
@@ -184,6 +185,10 @@
     <string name="images_and_videos">Képek és videók</string>
     <string name="file">Fájl</string>
     <string name="files">Fájlok</string>
+    <string name="files_attach_hint">Eredeti fájlok és tömörítetlen képek küldése</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Kiválasztás a „Fájlokból”</string>
+    <string name="choose_from_gallery">Kiválasztás a „Galériából”</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Alkalmazás</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
@@ -243,7 +248,7 @@
     <string name="menu_show_global_map">Az összes helyszín megjelenítése</string>
     <string name="menu_archive_chat">Csevegés archiválása</string>
     <string name="menu_unarchive_chat">Archiválás visszavonása</string>
-    <string name="menu_add_attachment">Fájl csatolása</string>
+    <string name="menu_add_attachment">Fájl mellékelése</string>
     <string name="menu_leave_group">Csoport elhagyása</string>
     <string name="menu_delete_chat">Csevegés törlése</string>
     <!-- Command to delete all messages in a chat. The chat itself will not be deleted but will be empty afterwards, so make sure to be different from "Delete Chat" here. "Clear" is a verb here, "Empty Chat" would also be fine (eg. in German "Chat leeren") -->
@@ -268,9 +273,10 @@
     <string name="menu_reply">Válasz az üzenetre</string>
     <string name="menu_mute">Értesítések némítása</string>
     <string name="menu_unmute">Némítás megszüntetése</string>
-    <string name="menu_export_attachment">Csatolmány exportálása</string>
-    <string name="menu_export_attachments">Csatolmányok exportálása</string>
+    <string name="menu_export_attachment">Melléklet exportálása</string>
+    <string name="menu_export_attachments">Mellékletek exportálása</string>
     <string name="menu_all_media">Összes média</string>
+    <string name="all_apps_and_media">Összes alkalmazás &amp; média</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Megjelenítés a csevegésben</string>
     <string name="show_app_in_chat">Alkalmazás megjelenítése a csevegésben</string>
@@ -435,7 +441,7 @@
     <string name="chat_self_talk_subtitle">Magamnak küldött üzenetek</string>
     <string name="archive_empty_hint">Az archivált csevegések itt fognak megjelenni.</string>
     <string name="saved_messages">Mentett üzenetek</string>
-    <string name="saved_messages_explain">• Üzenetek továbbítása az egyszerű hozzáférés érdekében\n\n• Jegyzetek vagy hangjegyzetek készítése\n\n• Médiaanyagok csatolása a mentéshez</string>
+    <string name="saved_messages_explain">• Üzenetek továbbítása az egyszerű hozzáférés érdekében\n\n• Jegyzetek vagy hangjegyzetek készítése\n\n• Médiaanyagok mellékelése a mentéshez</string>
     <!-- Should match "Saved" from "Saved messages" -->
     <string name="saved">Mentett</string>
     <string name="save_as">Mentés  mint</string>
@@ -444,7 +450,7 @@
     <string name="messaging_disabled_not_in_group">A csoport tagjának kell lennie ahhoz, hogy üzenetet hagyhasson ebben a csoportban. A csatlakozáshoz kérje meg a csoport egyik tagját.</string>
     <string name="messaging_disabled_mailing_list">A levelezési listákon történő üzenetküldés még nem támogatott</string>
     <string name="cannot_display_unsuported_file_type">Ezt a fájltípust nem lehet megjeleníteni: %s</string>
-    <string name="attachment_failed_to_load">Nem sikerült betölteni a csatolmányt</string>
+    <string name="attachment_failed_to_load">Nem sikerült betölteni a mellékletet</string>
     <!-- For recording Voice messages: Description for the "Lock" button allowing to lift the thumb from the record button while recording continues -->
     <string name="lock_recording">Felvétel zárolása</string>
 
@@ -681,7 +687,7 @@
     <!-- first placeholder is replaced by the number of files (always 2 or more); second placeholder is replaced by a chat name -->
     <string name="ask_send_files_to_chat">%1$d fájl elküldése „%2$s” számára?</string>
     <string name="ask_send_files_to_selected_chats">%1$d fájl megosztása a vele való csevegésben: %2$d?</string>
-    <string name="videos_sent_without_recoding">(A videók eredeti, nagyméretű fájlként kerülnek elküldésre. Amennyiben azt szeretné, hogy a videók kisebb fájlként kerüljenek elküldésre, csatolja őket külön-külön)</string>
+    <string name="videos_sent_without_recoding">(A videók eredeti, nagyméretű fájlként kerülnek elküldésre. Amennyiben azt szeretné, hogy a videók kisebb fájlként kerüljenek elküldésre, mellékelje őket külön-külön)</string>
     <string name="share_text_multiple_chats">Megosztja ezt a szöveget a vele való csevegésben: %1$d?\n\n„%2$s”</string>
     <string name="share_abort">A megosztás megszakadt a hiányzó engedélyek miatt.</string>
 
@@ -741,8 +747,6 @@
     <string name="pref_use_system_emoji_explain">A Delta Chat beépített emodzsi-támogatásának letiltása</string>
     <string name="pref_show_system_contacts">A rendszer névjegyzékének olvasása</string>
     <string name="pref_show_system_contacts_explain">Csevegések létrehozása a névjegyzékéből származó partnereivel. Egyes szolgáltatóknál először a végpontok közötti titkosítás beállítására van szükség.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Alkalmazás-hozzáférés</string>
     <string name="pref_chats">Csevegések</string>
     <string name="pref_in_chat_sounds">Csevegésen belüli hangok</string>
     <string name="pref_view_log">Naplófájl megtekintése</string>
@@ -865,11 +869,6 @@
     <string name="autocrypt_send_asm_button">Autocryptbeállító-üzenet küldése</string>
     <string name="autocrypt_send_asm_explain_after">A beállításokat elküldtük önnek. Váltson a másik eszközre, és nyissa meg a beállítási üzenetet. Meg kell adnia a beállítási kódot. Írja be a következő számjegyeket:</string>
     <string name="autocrypt_prefer_e2ee">Végpontok közötti titkosítás előnyben részesítése</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocryptbeállító-üzenet</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Ez az autocryptbeállító-üzenet a végpontok közötti beállítások kliensek közötti átvitelére szolgál.\n\nA beállítások visszafejtéséhez és használatához nyissa meg az üzenetet egy autocrypt-kompatibilis kliensben, és írja be az előállító eszközön megjelenő beállítási kódot.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Ez az üzenet nem dekódolható.\n\n• Már az is segíthet, ha egyszerűen válaszol erre az üzenetre, és megkéri a feladóját, hogy küldje el újra az üzenetet.\n\n• Ha most telepítette újra a Delta Chatet, akkor a legjobb, ha most újraindítja a Delta Chatet, és kiválasztja a „Második eszközként való hozzáadás” lehetőséget, vagy importál egy biztonsági mentést.</string>
@@ -1013,8 +1012,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Megváltoztatta a beállításokat %1$s számára.</string>
     <string name="verified_contact_required_explain">A végpontok közötti titkosítás garantálása érdekében csak zöld jelöléssel rendelkező névjegyeket adhat hozzá ehhez a csoporthoz.\n\n Személyesen is találkozhat a partnereivel és beolvashatja a QR-kódjukat, hogy bemutassa őket.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">QR-kód-webcím másolása a vágólapra</string>
     <string name="mailto_dialog_header_select_chat">Válassza ki a csevegést az üzenet elküldéséhez</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">Már létezik egy piszkozat a következő szöveggel: %1$s, biztosan le akarja cserélni?</string>
@@ -1040,9 +1037,10 @@
     <string name="perm_required_title">Engedély szükséges</string>
     <string name="perm_continue">Folytatás</string>
     <string name="perm_explain_access_to_camera_denied">A fényképek-, videók- vagy QR-kódok rögzítéséhez lépjen a rendszer beállításaiba, válassza ki a „Alkalmazások és értesítések” menüpontot, válassza ki az DeltaChat alkalmazást, majd koppintson az „Engedélyek” menüpontra, és engedélyezze a hozzáférést a „Kamerához”.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">A hangüzenetek küldéséhez lépjen a rendszer beállításaiba, válassza ki az „Alkalmazások és értesítések” menüpontot, válassza ki a DeltaChat alkalmazást, majd koppintson az „Engedélyek” menüpontra, és engedélyezze a hozzáférést a „Mikrofonhoz”.</string>
     <string name="perm_explain_access_to_storage_denied">A fájlok fogadásához vagy küldéséhez lépjen a rendszer beállításaiba, válassza ki az „Alkalmazások és értesítések” menüpontot, válassza ki a DeltaChat alkalmazást, majd koppintson az „Engedélyek” menüpontra, és engedélyezze a hozzáférést a „Tárhelyhez”.</string>
-    <string name="perm_explain_access_to_location_denied">A helyszín csatolásához lépjen a rendszer beállításaiba, válassza ki az „Alkalmazások és értesítések” menüpontot, válassza ki a DeltaChat alkalmazást, majd koppintson az „Engedélyek” menüpontra, és engedélyezze a hozzáférést a „Helyadatokhoz”.</string>
+    <string name="perm_explain_access_to_location_denied">A helyszín mellékeléséhez lépjen a rendszer beállításaiba, válassza ki az „Alkalmazások és értesítések” menüpontot, válassza ki a DeltaChat alkalmazást, majd koppintson az „Engedélyek” menüpontra, és engedélyezze a hozzáférést a „Helyadatokhoz”.</string>
     <string name="perm_explain_access_to_notifications_denied">Az értesítések fogadásához lépjen a rendszer beállításaiba, válassza ki az „Alkalmazások és értesítések” menüpontot, válassza ki a DeltaChat alkalmazást, majd koppintson az „Engedélyek” menüpontra, és engedélyezze a hozzáférést a „Értesítésekhez”.</string>
 
     <!-- ImageEditorHud -->

--- a/_locales/id.xml
+++ b/_locales/id.xml
@@ -456,8 +456,6 @@
     <string name="pref_manage_keys">Kelola kunci</string>
     <string name="pref_use_system_emoji">Gunakan emoji sistem</string>
     <string name="pref_use_system_emoji_explain">Matikan dukungan emoji Delta Chat yang ada</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Akes Aplikasi</string>
     <string name="pref_chats">Obrolan</string>
     <string name="pref_in_chat_sounds">Suara dalam obrolan</string>
     <string name="pref_view_log">Lihat catatan</string>
@@ -525,11 +523,6 @@
     <string name="autocrypt_send_asm_button">Kirim Pengaturan Pesan Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Pengaturan Anda sudah dikirim ke Anda sendiri. Lihat pesan pengaturan di perangkat yang lain. Seharusnya Anda akan diminta kode pengaturan. Masukkan angka berikut:</string>
     <string name="autocrypt_prefer_e2ee">Lebih baik enkripsi ujung ke ujung</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Pengaturan Pesan Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Inilah Autocrypt Setup Message yang digunakan utuk mentransfer pengaturan ujung ke ujung Anda antar pelanggan.\n\nUntuk membuka enkirpsi dan menggunakan pengaturan Anda, bukan pesan di Autocrypt-compliant pelanggan dan masukkan kode pengaturan yang ditampikan untuk perangkat terkait.</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">Pengirim tidak dikenal untuk obrolan ini. Lihat \'info\' untuk lebih jelasnya.</string>
     <string name="systemmsg_subject_for_new_contact">Pesan dari %1$s</string>
@@ -579,8 +572,6 @@
     <string name="contact_not_verified">Tidak bisa memverifikasi %1$s.</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Ubah pengaturan untuk %1$s.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Salin QR url ke papan klip</string>
     <!-- notifications  -->
     <string name="notify_reply_button">Balasan</string>
     <string name="notify_new_message">Pesan baru</string>
@@ -594,6 +585,7 @@
     <string name="perm_required_title">Perlu izin</string>
     <string name="perm_continue">Lanjutkan</string>
     <string name="perm_explain_access_to_camera_denied">Untuk mengambil foto atau merekam video, lihat pengaturan aplikasi, pilih \"Perizinan\", dan aktifkan \"Kamera\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Untuk mengirim pesan audio, lihat pengaturan aplikasi, pilih \"Perizinan\", dan aktifkan \"Mikrofon\".</string>
     <string name="perm_explain_access_to_storage_denied">Untuk menerima atau mengirim berkas, pergi ke pengaturan aplikasi, pilih \"Perizinan\", dan fungsikan \"Penyimpanan\".</string>
     <string name="perm_explain_access_to_location_denied">Untuk melampirkan lokasi, lihat pengaturan aplikasi, pilih \"Perizinan\", dan aktifkan \"Lokasi\".</string>

--- a/_locales/it.xml
+++ b/_locales/it.xml
@@ -52,10 +52,11 @@
     <string name="mute">Silenzia</string>
     <string name="muted">Disattivato</string>
     <string name="ephemeral_messages">Messaggi a Scomparsa</string>
-    <string name="ephemeral_messages_hint">Si applica a tutti i membri di questa chat se utilizzano Delta Chat; possono comunque copiare, salvare e inoltrare messaggi o utilizzare altri client e-mail.</string>
+    <string name="ephemeral_messages_hint">Si applica a tutti i membri di questa chat; possono comunque copiare, salvare e inoltrare i messaggi.</string>
     <string name="save">Salva</string>
     <string name="chat">Chat</string>
     <string name="media">Media</string>
+    <string name="apps_and_media">App &amp; Media</string>
     <string name="profile">Profilo</string>
     <string name="main_menu">Menu Principale</string>
     <string name="start_chat">Inizia Chat</string>
@@ -192,11 +193,15 @@
     <string name="gallery">Galleria</string>
     <string name="images_and_videos">Immagini e Video</string>
     <string name="file">File</string>
-    <string name="files">Files</string>
+    <string name="files">File</string>
+    <string name="files_attach_hint">Manda file originali e immagini non compresse</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Scegli da File</string>
+    <string name="choose_from_gallery">Scegli da Galleria</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">App</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
-    <string name="webxdc_apps">Apps</string>
+    <string name="webxdc_apps">App</string>
     <string name="webxdc_store_url">URL Selettore App</string>
     <string name="webxdc_store_url_explain">Se impostato, l\'URL verrà utilizzato come Selettore App anziché quello predefinito</string>
     <string name="home">Inizio</string>
@@ -280,6 +285,7 @@
     <string name="menu_export_attachment">Esporta Allegato</string>
     <string name="menu_export_attachments">Esporta Allegati</string>
     <string name="menu_all_media">Tutti i Media</string>
+    <string name="all_apps_and_media">Tutte le App &amp; Media</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Mostra in Chat</string>
     <string name="show_app_in_chat">Mostra App in Chat</string>
@@ -477,8 +483,8 @@
     <string name="send_file_to">Invia \"%1$s\" a…</string>
     <!-- title shown above a list contacts where one should be selected (eg. when a webxdc attempts to send a message to a chat) -->
     <string name="send_message_to">Invia Messaggio a...</string>
-    <string name="enable_realtime">Apps in Tempo Reale</string>
-    <string name="enable_realtime_explain">Abilitando connessioni in tempo reale per app condivise nelle chat. Se abilitato, i partner della chat potrebbero essere in grado di scoprire il tuo indirizzo IP quando avvii un\'app.</string>
+    <string name="enable_realtime">App in Tempo Reale</string>
+    <string name="enable_realtime_explain">Abilita connessioni in tempo reale per app condivise nelle chat. Se abilitato, i partner della chat potrebbero essere in grado di scoprire il tuo indirizzo IP quando avvii un\'app.</string>
 
     <!-- map -->
     <string name="filter_map_on_time">Mostra le posizioni nell\'intervallo di tempo</string>
@@ -503,7 +509,7 @@
     <!-- search -->
     <string name="search">Cerca</string>
     <string name="search_in_chat">Cerca nella Chat</string>
-    <string name="search_files">Cerca Files</string>
+    <string name="search_files">Cerca File</string>
     <string name="search_explain">Cerca chat, contatti e messaggi</string>
     <string name="search_no_result_for_x">Nessun risultato trovato per \"%s\"</string>
     <!-- Adjective, as in "Show Unread Messages" -->
@@ -531,14 +537,14 @@
     <string name="tab_links">Collegamenti</string>
     <string name="tab_map">Mappa</string>
     <string name="tab_gallery_empty_hint">Immagini e video condivisi in questa chat verranno mostrate qui.</string>
-    <string name="tab_docs_empty_hint">Documenti e altri files condivisi in questa chat verranno mostrate qui.</string>
+    <string name="tab_docs_empty_hint">Documenti e altri file condivisi in questa chat verranno mostrate qui.</string>
     <string name="tab_image_empty_hint">Le immagini condivise in questa chat verranno mostrate qui.</string>
     <string name="tab_video_empty_hint">I video condivisi in questa chat verranno mostrate qui.</string>
-    <string name="tab_audio_empty_hint">I files audio e i messaggi vocali condivisi in questa chat verranno mostrati qui.</string>
+    <string name="tab_audio_empty_hint">I file audio e i messaggi vocali condivisi in questa chat verranno mostrati qui.</string>
     <string name="tab_webxdc_empty_hint">Le app condivise in questa chat verranno mostrate qui.</string>
     <string name="tab_all_media_empty_hint">I media condivisi in qualsiasi chat verranno mostrate qui.</string>
     <string name="all_files_empty_hint">Qui verranno visualizzati i documenti e gli altri file condivisi in qualsiasi chat.</string>
-    <string name="all_apps_empty_hint">Le apps condivise in qualsiasi chat appariranno qui.</string>
+    <string name="all_apps_empty_hint">Le app condivise in qualsiasi chat appariranno qui.</string>
     <string name="media_preview">Anteprima Media</string>
     <!-- option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :) -->
     <string name="aspect_ratio_grid">Aspetto Griglia Proporzioni</string>
@@ -660,7 +666,7 @@
     <string name="proxy_share_link">Condividi Collegamento</string>
 
     <string name="login_info_oauth2_title">Continuare con la configurazione semplificata?</string>
-    <string name="login_info_oauth2_text">L\'indirizzo e-mail inserito supporta una configurazione semplificata (OAuth 2.0).\n\nNel passaggio successivo, per piacere consenti a Delta Chat di fungere da app Chat tramite e-mail.\n\nDelta Chat non raccoglie dati utente, tutto rimane sul tuo dispositivo.</string>
+    <string name="login_info_oauth2_text">L\'indirizzo e-mail inserito supporta una configurazione semplificata (OAuth 2.0).\n\nNel passaggio successivo, per favore consenti a Delta Chat di inviare e ricevere messaggi.\n\nDelta Chat non raccoglie dati utente, tutto rimane sul tuo dispositivo.</string>
     <string name="login_certificate_checks">Controlli Certificato</string>
     <string name="login_error_mail">Per piacere Inserisci un indirizzo e-mail valido</string>
     <string name="login_error_server">Per piacere inserisci un server / indirizzo IP valido</string>
@@ -670,7 +676,7 @@
     <string name="import_backup_ask">Backup trovato in \"%1$s\".\n\nVuoi importarlo e usare tutti i dati e le impostazioni salvate?</string>
     <string name="import_backup_no_backup_found">Nessun backup trovato\n\nCopia il backup in \"%1$s\" e riprova ancora. Altimenti premi \"Inizia a messaggiare\" per procedere con le impostazioni normali.</string>
     <!-- %1$s will be replaced by the failing address -->
-    <string name="login_error_cannot_login">Impossibile accedere come \"%1$s\". Per piacere verifica che l\'indirizzo e-mail e la password siano corretti.</string>
+    <string name="login_error_cannot_login">Impossibile accedere come \"%1$s\". Per favore verifica che l\'indirizzo e-mail e la password siano corretti.</string>
     <!-- TLS certificate checks -->
     <string name="accept_invalid_certificates">Accetta certificati non validi</string>
     <string name="switch_account">Cambia Profilo</string>
@@ -695,7 +701,7 @@
     <!-- Translators: shown above a chat/contact list when selecting recipients to forward messages -->
     <string name="forward_to">Inoltra a…</string>
     <!-- first placeholder is replaced by the number of files (always 2 or more); second placeholder is replaced by a chat name -->
-    <string name="ask_send_files_to_chat">Inviare %1$d files a \"%2$s\"?</string>
+    <string name="ask_send_files_to_chat">Inviare %1$d file a \"%2$s\"?</string>
     <string name="ask_send_files_to_selected_chats">Invia %1$d file(s) a %2$d chat?</string>
     <string name="videos_sent_without_recoding">(I video vengono inviati come file originali, di grandi dimensioni. Per inviare i video come file più piccoli, allegali separatamente)</string>
     <string name="share_text_multiple_chats">Invia questo testo a %1$d chat?\n\n\"%2$s\"</string>
@@ -756,9 +762,7 @@
     <string name="pref_use_system_emoji">Usa Emoji di Sistema</string>
     <string name="pref_use_system_emoji_explain">Disattiva il supporto delle emoji integrato in Delta Chat</string>
     <string name="pref_show_system_contacts">Leggi Rubrica di Sistema</string>
-    <string name="pref_show_system_contacts_explain">Offri la possibilità di creare chat con i contatti della rubrica. Alcuni provider necessitano prima della configurazione della crittografia end-to-end.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Accesso App</string>
+    <string name="pref_show_system_contacts_explain">Offri la possibilità di creare chat con i contatti della rubrica.</string>
     <string name="pref_chats">Chats</string>
     <string name="pref_in_chat_sounds">Suoni In-Chat</string>
     <string name="pref_view_log">Vedi Registro</string>
@@ -857,9 +861,9 @@
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
     <string name="autodel_device_ask">Vuoi eliminare %1$d messaggi ora e tutti i nuovi messaggi recuperati \"%2$s\" d\'ora in poi?\n\n• Questo include tutti i media\n\n• I messaggi verranno eliminati anche se non sono stati letti\n\n• I \"Messaggi salvati\" vengono preservati dalla cancellazione locale.</string>
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
-    <string name="autodel_server_ask">Vuoi eliminare %1$d messaggi ora e tutti i messaggi appena recuperati \"%2$s\" d\'ora in poi?\n\n⚠️ Ciò include e-mails, contenuti multimediali e \"Messaggi salvati\" in tutte le cartelle del server\n\n⚠️ Non utilizzare questa funzione se vuoi mantenere i dati sul server\n\n⚠️ Non utilizzare questa funzione se stai utilizzando altri client e-mail oltre a Delta Chat</string>
+    <string name="autodel_server_ask">Vuoi eliminare %1$d messaggi ora e tutti i messaggi non appena recuperati \"%2$s\" d\'ora in poi?\n\n⚠️ Ciò include e-mails, contenuti multimediali e \"Messaggi salvati\" in tutte le cartelle del server\n\n⚠️ Non utilizzare questa funzione se vuoi mantenere i dati sul server o se stai utilizzando anche altri client e-mail</string>
     <!-- shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact -->
-    <string name="autodel_server_enabled_hint">Questo include e-mail, media e \"Messaggi salvati\" in tutte le cartelle del server. Non utilizzare questa funzione se desideri mantenere i dati sul server o se stai utilizzando altri client e-mail oltre a Delta Chat.</string>
+    <string name="autodel_server_enabled_hint">Questo include e-mail, media e \"Messaggi salvati\" in tutte le cartelle del server. Non utilizzare questa funzione se desideri mantenere i dati sul server o se stai utilizzando anche altri client e-mail</string>
     <string name="autodel_server_warn_multi_device_title">Attiva l\'eliminazione immediata</string>
     <string name="autodel_server_warn_multi_device">Se abiliti l\'eliminazione immediata non potrai utilizzare questo profilo su più dispositivi.</string>
     <string name="autodel_confirm">Ho capito, elimina tutti questi messaggi</string>
@@ -877,15 +881,10 @@
 
     <!-- autocrypt -->
     <string name="autocrypt_send_asm_title">Invia Messaggio Configurazione Autocrypt</string>
-    <string name="autocrypt_send_asm_explain_before">Un Messaggio Configurazione Autocrypt condivide in modo sicuro la configurazione end-to-end con altre app compatibili con Autocrypt.\n\nLa configurazione verrà crittografata tramite un codice di configurazione visualizzato qui e dovrà essere digitato sull\'altro dispositivo.</string>
+    <string name="autocrypt_send_asm_explain_before">Un Messaggio Configurazione Autocrypt condivide in modo sicuro la configurazione end-to-end con altre app compatibili con Autocrypt.\n\nSe usi Delta Chat anche su altri dispositivi usa invece \"Impostazioni / Aggiungi Secondo Dispositivo\".</string>
     <string name="autocrypt_send_asm_button">Invia Messaggio Configurazione Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">La tua configurazione ti è stata inviata. Passa all\'altro dispositivo e apri il messaggio. Dovrebbe venirti richiesto un codice. Inserisci il seguente codice:</string>
     <string name="autocrypt_prefer_e2ee">Preferisci Cifratura End-To-End</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Messaggio Configurazione Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Questo è il Messaggio Configurazione Autocrypt utilizzato per trasferire la configurazione end-to-end tra i client.\n\nPer decifrare e utilizzare la configurazione, aprire il messaggio in un client compatibile con Autocrypt e immettere il codice di configurazione presentato sul dispositivo di generazione.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Questo messaggio non può essere decrittografato.\n\n• Potrebbe essere già utile rispondere semplicemente a questo messaggio e chiedere al mittente d\'inviare nuovamente il messaggio.\n\n• Se hai appena reinstallato Delta Chat, è meglio se riconfiguri ora Delta Chat e scegli \"Aggiungi come secondo dispositivo\" o importa un backup.</string>
@@ -957,7 +956,7 @@
     <!-- this may be shown instead of the chat's input field, with buttons "More Info" and "OK" -->
     <string name="chat_protection_broken">%1$s ha inviato un messaggio da un altro dispositivo.</string>
     <string name="chat_protection_enabled_tap_to_learn_more">D\'ora in poi i messaggi saranno garantiti crittografati end-to-end.  Tocca per saperne di più.</string>
-    <string name="chat_protection_enabled_explanation">Ora è garantito che tutti i messaggi in questa chat siano cifrati end-to-end.\n\nLa crittografia end-to-end mantiene i messaggi privati ​​tra te e i tuoi partner di chat. Nemmeno il tuo provider email può leggerli.</string>
+    <string name="chat_protection_enabled_explanation">Ora è garantito che tutti i messaggi in questa chat siano cifrati end-to-end.\n\nLa crittografia end-to-end mantiene privati i messaggi ​​tra te e i tuoi partner di chat. Nemmeno il server, il fornitore o il trasmettitore di e-mail può leggerli.</string>
     <string name="chat_protection_broken_tap_to_learn_more">%1$s ha inviato un messaggio da un altro dispositivo. Tocca per saperne di più.</string>
     <string name="chat_protection_broken_explanation">La crittografia end-to-end non può più essere garantita, probabilmente perché %1$s ha reinstallato Delta Chat o inviato un messaggio da un altro dispositivo.\n\nPuoi incontrarlo di persona e scansionare nuovamente il suo Codice QR per ristabilire la crittografia end-to-end garantita.</string>
     <string name="invalid_unencrypted_tap_to_learn_more">⚠️ %1$s richiede la crittografia end-to-end che non è ancora configurata per questa chat. Tocca per saperne di più.</string>
@@ -983,7 +982,7 @@
     <string name="qrscan_failed">Impossibile decodificare il codice QR</string>
     <string name="qrscan_ask_join_group">Vuoi entrare nel gruppo \"%1$s\"?</string>
     <string name="qrscan_fingerprint_mismatch">L\'impronta digitale scansionata non corrisponde all\'ultima visualizzata per %1$s.</string>
-    <string name="qrscan_no_addr_found">Questo codice QR contiene un\'impronta digitale, ma non un indirizzo email.\n\nPer una verifica a due fattori efficace, per piacere prima stabilisci una connessione cifrata col destinatario.</string>
+    <string name="qrscan_no_addr_found">Questo codice QR contiene un\'impronta ma non un indirizzo email.\n\nPer una verifica efficace, per favore prima stabilisci una connessione cifrata col destinatario.</string>
     <string name="qrscan_contains_text">Testo codice QR scansionato:\n\n%1$s</string>
     <string name="qrscan_contains_url">URL del codice QR scansionato:\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">Impronta digitale</string>
@@ -1020,7 +1019,7 @@
     <string name="secure_join_wait">Creazione della crittografia end-to-end garantita, per piacere attendere...</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Non è ancora possibile stabilire la crittografia end-to-end garantita, ma potresti già inviare un messaggio.</string>
-    <string name="secure_join_takes_longer">Sembra metterci molto, forse tu o il contatto non siete in linea.\n\nComunque, il processo continua in sottofondo, puoi fare qualcos\'altro...</string>
+    <string name="secure_join_takes_longer">Il contatto deve essere in linea per proseguire.\n\nQuesto processo continuerà automaticamente in sottofondo.</string>
     <string name="contact_verified">%1$s verificato.</string>
     <string name="contact_not_verified">Impossibile stabilire una crittografia end-to-end garantita con %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1029,8 +1028,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Impostazioni modificate per %1$s</string>
     <string name="verified_contact_required_explain">Per garantire la crittografia end-to-end, puoi aggiungere a questo gruppo solo i contatti con un segno di spunta verde.\n\nPuoi incontrare i contatti di persona e scansionare il loro Codice QR per verificarli.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Url QR copiato negli appunti</string>
     <string name="mailto_dialog_header_select_chat">Seleziona la chat a cui inviare il messaggio</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s ha già una bozza di messaggio, vuoi sostituirla?</string>
@@ -1056,8 +1053,9 @@
     <string name="perm_required_title">Autorizzazione richiesta</string>
     <string name="perm_continue">Continua</string>
     <string name="perm_explain_access_to_camera_denied">Per scattare foto o registrare video, vai alle impostazioni dell\'app, seleziona \"Autorizzazioni\" e abilita \"Fotocamera\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Per inviare messaggi audio, vai alle impostazioni dell\'app, seleziona \"Autorizzazioni\" e abilita \"Microfono\".</string>
-    <string name="perm_explain_access_to_storage_denied">Per ricevere o inviare files, vai alle impostazioni dell\'app, seleziona \"Autorizzazioni\" e abilita \"Archiviazione\".</string>
+    <string name="perm_explain_access_to_storage_denied">Per ricevere o inviare file, vai alle impostazioni dell\'app, seleziona \"Autorizzazioni\" e abilita \"Archiviazione\".</string>
     <string name="perm_explain_access_to_location_denied">Per allegare una posizione, vai alle impostazioni dell\'app, seleziona \"Autorizzazioni\" e abilita \"Posizione\".</string>
     <string name="perm_explain_access_to_notifications_denied">Per ricevere le notifiche, vai su \"Impostazioni di Sistema / App / Delta Chat\" e attiva \"Notifiche\".</string>
 
@@ -1180,7 +1178,7 @@
     <string name="add_to_widget">Aggiungi al Widget</string>
     <!-- iOS permissions, copy from "deltachat-ios/Info.plist", which is used on missing translations in "deltachat-ios/LANG.lproj/InfoPlist.strings" -->
     <string name="InfoPlist_NSCameraUsageDescription">Delta Chat utilizza la tua fotocamera per scattare e inviare foto e video e per scansionare i codici QR.</string>
-    <string name="InfoPlist_NSContactsUsageDescription">Delta Chat usa i tuoi contatti per mostrare una lista di indirizzi e-mail a cui puoi scrivere. Delta Chat non ha un server, i tuoi contatti non vengono inviati da nessuna parte.</string>
+    <string name="InfoPlist_NSContactsUsageDescription">Delta Chat usa i tuoi contatti per mostrare una lista di indirizzi e-mail a cui puoi scrivere. Delta Chat non ha alcun server, i tuoi contatti non vengono inviati da nessuna parte.</string>
     <string name="InfoPlist_NSLocationAlwaysAndWhenInUseUsageDescription">Delta Chat necessita dell\'autorizzazione per condividere la tua posizione per il periodo di tempo in cui hai abilitato la condivisione della posizione.</string>
     <string name="InfoPlist_NSLocationWhenInUseUsageDescription">Delta Chat ha bisogno dell\'autorizzazione di localizzazione per condividere la vostra posizione per il periodo di tempo in cui avete abilitato la condivisione della posizione.</string>
     <string name="InfoPlist_NSMicrophoneUsageDescription">Delta Chat utilizza il tuo microfono per registrare e inviare messaggi vocali e video con audio.</string>
@@ -1196,7 +1194,7 @@
     <string name="pref_reliable_service">Forza Connessione Secondo Piano</string>
     <string name="pref_reliable_service_explain">Provoca una notifica permanente</string>
 
-    <string name="pref_background_notifications_rationale">Per mantenere la connessione al tuo server e-mail e ricevere messaggi in secondo piano, ignora le ottimizzazioni della batteria nel passaggio successivo.\n\nDelta Chat utilizza poche risorse e fa attenzione a non consumare la tua batteria.</string>
+    <string name="pref_background_notifications_rationale">Per mantenere la connessione in sottofondo e ricevere messaggi, ignora le ottimizzazioni della batteria nel prossimo passaggio.\n\nDelta Chat utilizza poche risorse e fa in modo di non prosciugarti la batteria.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="perm_enable_bg_reminder_title">Tocca qui per ricevere messaggi mentre Delta Chat è in secondo piano.</string>
     <string name="perm_enable_bg_already_done">Hai già autorizzato Delta Chat a ricevere messaggi in secondo piano.\n\nSe i messaggi non arrivano in secondo piano, per piacere controlla anche le impostazioni di sistema.</string>

--- a/_locales/ja_JP.xml
+++ b/_locales/ja_JP.xml
@@ -442,8 +442,6 @@
     <string name="pref_manage_keys">暗号鍵の管理</string>
     <string name="pref_use_system_emoji">システムの絵文字を使う</string>
     <string name="pref_use_system_emoji_explain">Delta Chat独自の絵文字機能を無効にする</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">アプリのアクセス</string>
     <string name="pref_chats">チャット</string>
     <string name="pref_in_chat_sounds">着信音</string>
     <string name="pref_view_log">ログの表示</string>
@@ -521,8 +519,7 @@
     <string name="autocrypt_send_asm_explain_before">｢自動暗号化設定用メッセージ｣は安全に一対一暗号化設定を対応するアプリケーションとの間に設定します｡\n \n 受信側は設定時に表示されるパスコードを入力する必要が有ります｡</string>
     <string name="autocrypt_send_asm_button">自動暗号化設定用ﾒｯｾｰｼﾞを送信する</string>
     <string name="autocrypt_prefer_e2ee">エンドツーエンド暗号化を好む</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">自動暗号化設定用ﾒｯｾｰｼﾞ</string>
+
     <string name="systemmsg_subject_for_new_contact">%1$sさんからのメッセージ</string>
     <string name="systemmsg_failed_sending_to">%1$sさんへのメッセージ送信に失敗しました。</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->

--- a/_locales/km.xml
+++ b/_locales/km.xml
@@ -504,8 +504,6 @@
     <string name="pref_manage_keys">កាន់កាប់គ្រាប់​ចុច</string>
     <string name="pref_use_system_emoji">ប្រើប្រាស់រូបសញ្ញាអារម្មណ៍របសប្រពន្ធ័</string>
     <string name="pref_use_system_emoji_explain">បិទការប្រើប្រាស់រូបសញ្ញាអារម្មណ៍ ពិសា Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">ចូលដំណើរការកម្មវិធី</string>
     <string name="pref_chats">សន្ទនា</string>
     <string name="pref_in_chat_sounds">សម្លេងនៅក្នុងសន្ទនា</string>
     <string name="pref_view_log">មើលកំណត់ហេតុ</string>
@@ -602,11 +600,6 @@
     <string name="autocrypt_send_asm_button">ផ្ញើសារអ៊ិនគ្រីបស្វ័យប្រវត្តិសម្រាប់ការរៀបចំ</string>
     <string name="autocrypt_send_asm_explain_after">ការរៀបចំរបស់អ្នកត្រូវបានផ្ញើទៅខ្លួនឯងហើយ។ ប្តូរឆ្លាស់ឧបករណ៍ផ្សេង និងបើកសារការរៀបចំ។ អ្នកនឹងទទួលសំណួរពីកូដរៀបចំ។ បញ្ចូលលេខដូចខាងក្រោម:</string>
     <string name="autocrypt_prefer_e2ee">ចូលចិត្តការអ៊ិនគ្រីបច្រើនជាង</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">ផ្ញើសារអ៊ិនគ្រីបស្វ័យប្រវត្តិសម្រាប់ការរៀបចំ</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">នេះជាសាររៀបចំចាក់អ៊ិនគ្រីបស្វ័យប្រវត្តិសម្រាប់ចែកចាយចាត់ការរៀបចំចាក់ឧបករណ៍ដល់ឧបករណ៍ជាមួយឧបករណ៍ផ្សេងទៀត។\n\nដើម្បីឌិគ្រីប (ការទទួលសារដែលបានធ្វើជាសារសញ្ញាសម្ងាត់ដល់អាចអានបានវិញ) និងប្រើប្រាសការរៀបចំចាក់របសអ្នក បើកសារនៅក្នុងកម្មវិធីដែលស្គាល់អ៊ិនគ្រីបស្វ័យប្រវត្តិ និងកូដការរៀបចំដែលបានអំណោយពីឧបករណ៍បានបង្កើតវា។</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">មិនស្គាល់អ្នកផ្ញើការសន្ទនានេះ។ មើល \'ពត៌មាន\' សម្រាប់ពត៌មានលំអិត</string>
     <string name="systemmsg_subject_for_new_contact">សារពី %1$s</string>
@@ -710,8 +703,6 @@
     <string name="contact_not_verified">មិនអាចផ្ទៀងផ្ទាត់ %1$s</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">បានដូរការរៀបចំសម្រាប់ %1$s</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">បានចម្លង QR-url ទៅក្តារខ្ទាស់</string>
     <string name="mailto_dialog_header_select_chat">ជ្រើសរើសការជជែក ដើម្បីផ្ញើសារទៅកាន់</string>
     <string name="mailto_link_could_not_be_decoded">សំបុត្រទៅតំណភ្ជាប់ មិនអាចឌិកូដទេ: %1$s</string>
 
@@ -728,6 +719,7 @@
     <string name="perm_required_title">ត្រូវបានការអនុញ្ញាត</string>
     <string name="perm_continue">បន្ត</string>
     <string name="perm_explain_access_to_camera_denied">ដើម្បីថតរូប រឺថតវីដេអូ ចូលទៅកាន់ការកំណត់កម្មវិធី ជ្រើសរើស \" ការអនុញ្ញាត\" និងបើកដំណើរការ \"ម៉ាសុីនថត\"។</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">ដើម្បីផ្ញើ សារសំឡេង ចូលទៅកាន់ការកំណត់កម្មវិធី ជ្រើសរើស \"ការអនុញ្ញាត\" និងបើកដំណើរការ \"មីក្រូហ្វូន\"។</string>
     <string name="perm_explain_access_to_storage_denied">ដើម្បីទទួល រឺផ្ញើឯកសារ ចូលទៅកាន់ការកំណត់កម្មវិធី ជ្រើសរើស \"ការអនុញ្ញាត\" និងបើកដំណើរការ \"ការផ្ទុក\"។</string>
     <string name="perm_explain_access_to_location_denied">ដើម្បីភ្ជាប់ទីតាំង ចូលទៅកាន់ការកំណត់កម្មវិធី ជ្រើសរើស\"ការកំណត់\" និងបើកដំណើរការ \"ទីតាំង\"។</string>

--- a/_locales/ko.xml
+++ b/_locales/ko.xml
@@ -537,8 +537,6 @@
     <string name="pref_manage_keys">키 관리</string>
     <string name="pref_use_system_emoji">시스템 이모티콘 사용</string>
     <string name="pref_use_system_emoji_explain">Delta Chat 이모티콘 사용 중지</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">앱 접근</string>
     <string name="pref_chats">채팅</string>
     <string name="pref_in_chat_sounds">앱 내 알림</string>
     <string name="pref_view_log">로그 보기</string>
@@ -630,12 +628,6 @@
     <string name="autocrypt_send_asm_explain_before">자동 암호화 설치 메시지는 사용자의 설정을 다른 자동 암호화 호환 앱과 안전하게 공유합니다.\n\n설치는 여기에 표시된 설치 코드에 의해 암호화되며 다른 장치에 입력해야 합니다.</string>
     <string name="autocrypt_send_asm_button">자동 암호화 설정된 메시지 전송</string>
     <string name="autocrypt_send_asm_explain_after">설정이 사용자 자신에게 전송되었습니다. 다른 장치로 전환하고 설정 메시지를 엽니다. 설정 코드를 입력하라는 메시지가 표시됩니다. 다음 숫자를 입력합니다.</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">자동 암호화 설정 메시지</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">클라이언트 간에 종단 간 설정을 전송하는 데 사용되는 자동 암호화 설정 메시지입니다.\n\n설치를 해독하고 사용하려면 자동 암호화 호환 클라이언트에서 메시지를 열고 생성 장치에 표시된 설치 코드를 입력하십시오.</string>
-
-
     <string name="systemmsg_unknown_sender_for_chat">이 채팅의 발신자를 알 수 없습니다. 자세한 내용은 \'info\'를 확인하세요.</string>
     <string name="systemmsg_subject_for_new_contact">%1$s가 보낸 메시지</string>
     <string name="systemmsg_failed_sending_to">%1$s에게 메시지를 보내지 못했습니다.</string>
@@ -751,8 +743,6 @@
     <string name="contact_not_verified">%1$s 확인할 수 없음</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">%1$s에 대한 설정이 변경되었습니다.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">QR url을 클립보드에 복사했습니다</string>
     <string name="mailto_dialog_header_select_chat">메시지를 보내려면 채팅을 선택하십시오</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s에 이미 임시 저장된 메시지가 있습니다. 바꾸시겠습니까?</string>
@@ -771,6 +761,7 @@
     <string name="perm_required_title">권한 필요</string>
     <string name="perm_continue">계속</string>
     <string name="perm_explain_access_to_camera_denied">사진을 찍거나 동영상을 캡처하려면 앱 설정으로 이동하여 \"권한\"을 선택하고 \"카메라\"를 활성화하십시오.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">오디오 메시지를 보내려면 앱 설정으로 이동하여 \"권한\"을 선택하고 \"마이크\"를 활성화하십시오.</string>
     <string name="perm_explain_access_to_storage_denied">파일을 수신하거나 보내려면 앱 설정으로 이동하여 \"사용 권한\"을 선택하고 \"스토리지\"를 활성화하십시오.</string>
     <string name="perm_explain_access_to_location_denied">위치를 첨부하려면 앱 설정으로 이동하여 \"권한\"을 선택하고 \"위치\"를 활성화하십시오.</string>

--- a/_locales/lt.xml
+++ b/_locales/lt.xml
@@ -565,8 +565,6 @@
     <string name="pref_manage_keys">Tvarkyti raktus</string>
     <string name="pref_use_system_emoji">Naudoti sistemos šypsniukus</string>
     <string name="pref_use_system_emoji_explain">Išjungti Delta Chat įtaisytąjį šypsniukų palaikymą</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Prieiga prie programėlės</string>
     <string name="pref_chats">Pokalbiai</string>
     <string name="pref_in_chat_sounds">Garsai pokalbiuose</string>
     <string name="pref_view_log">Rodyti žurnalą</string>
@@ -666,11 +664,6 @@
     <string name="autocrypt_send_asm_button">Siųsti Autocrypt sąrankos žinutę</string>
     <string name="autocrypt_send_asm_explain_after">Jūsų sąranka buvo išsiųsta jums. Persijukite į kitą įrenginį ir atverkite sąrankos žinutę. Jūsų turėtų būti paprašyta sąrankos kodo. Į užklausą įrašykite šiuos skaitmenis.\n\nJums užbaigus, kitas įrenginys bus paruoštas naudoti Autocrypt.</string>
     <string name="autocrypt_prefer_e2ee">Teikti pirmenybę ištisiniam šifravimui</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt sąrankos žinutė</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Tai yra Autocrypt sąrankos žinutė, kuri yra naudojama perduoti jūsų ištisinę sąranką tarp klientų.\n\nNorėdami iššifruoti ir naudoti savo sąranką, atverkite žinutę su Autocrypt suderinamame kliente ir įveskite generuojančiame įrenginyje rodomą sąrankos kodą.</string>
-
 
     <string name="systemmsg_subject_for_new_contact">Žinutė nuo %1$s</string>
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
@@ -760,8 +753,6 @@
     <string name="contact_not_verified">Nepavyksta patvirtinti %1$s</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Pakeista sąranka, skirta %1$s.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">QR kodo URL adresas nukopijuotas į iškarpinę</string>
     <string name="mailto_dialog_header_select_chat">Pasirinkite pokalbį, į kurį siųsti žinutę</string>
     <string name="mailto_link_could_not_be_decoded">nepavyko dekoduoti mailto nuorodos: %1$s</string>
 

--- a/_locales/nb.xml
+++ b/_locales/nb.xml
@@ -321,8 +321,6 @@
     <string name="pref_manage_keys">Behandle nøkler</string>
     <string name="pref_use_system_emoji">Bruk systemets emoji</string>
     <string name="pref_use_system_emoji_explain">Slå av innebygd emoji-støtte i Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Programtilgang</string>
     <string name="pref_chats">Sludringer</string>
     <string name="pref_in_chat_sounds">Merknader i programmet</string>
     <string name="pref_view_log">Vis logg</string>
@@ -341,11 +339,6 @@
     <string name="autocrypt_send_asm_button">Igangsett Autocrypt-nøkkeloverføring</string>
     <string name="autocrypt_send_asm_explain_after">Nøkkelen din har blitt sendt til deg selv. Bytt til den andre enheten og åpne oppsettsmeldingen. Du bør bli forespurt om å oppgi en oppsettskode. Skriv in følgende siffer.\n\nNår du er ferdig, vil din andre enhet også kunne bruke Autocrypt.</string>
     <string name="autocrypt_prefer_e2ee">Foretrekk ende-til-ende -kryptering</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt-nøkkeloverføring</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Dette er Autocrypt-oppsettsmeldingen brukt til å overføre nøkkelen din mellom klienter.\n\nFor å dekryptere å bruke din nøkkel, åpne meldingen i en Autocrypt-kompatibel klient og skriv inn oppsettskoden som vises på enheten som genererer den.</string>
-
 
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">Gruppenavn endret fra \"%1$s\" til \"%2$s\" av meg.</string>

--- a/_locales/nl_NL.xml
+++ b/_locales/nl_NL.xml
@@ -56,6 +56,7 @@
     <string name="save">Opslaan</string>
     <string name="chat">Gesprek</string>
     <string name="media">Media</string>
+    <string name="apps_and_media">Apps en media</string>
     <string name="profile">Profiel</string>
     <string name="main_menu">Hoofdmenu</string>
     <string name="start_chat">Gesprek beginnen</string>
@@ -184,12 +185,17 @@
     <string name="images_and_videos">Foto\'s en video\'s</string>
     <string name="file">Bestand</string>
     <string name="files">Bestanden</string>
+    <string name="files_attach_hint">Bestanden en foto\'s in oorspronkelijke kwaliteit versturen</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Kiezen uit bestanden</string>
+    <string name="choose_from_gallery">Kiezen uit galerij</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Privé-app</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">Privé-apps</string>
     <string name="webxdc_store_url">Appkiezer-url</string>
     <string name="webxdc_store_url_explain">Stel in om apps te kiezen vanaf een url in plaats van de standaard appkiezer</string>
+    <string name="webxdc_draft_hint">Druk op ‘versturen’ om te delen</string>
     <string name="home">Overzicht</string>
     <string name="games">Games</string>
     <string name="tools">Hulpmiddelen</string>
@@ -271,6 +277,7 @@
     <string name="menu_export_attachment">Bijlage exporteren</string>
     <string name="menu_export_attachments">Bijlagen exporteren</string>
     <string name="menu_all_media">Alle media</string>
+    <string name="all_apps_and_media">Alle apps en media</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Tonen in bijbehorend gesprek</string>
     <string name="show_app_in_chat">App tonen in gesprek</string>
@@ -741,8 +748,6 @@
     <string name="pref_use_system_emoji_explain">Schakel Delta Chats ingebouwde emojiondersteuning uit</string>
     <string name="pref_show_system_contacts">Adresboek uitlezen</string>
     <string name="pref_show_system_contacts_explain">Bied aan om gesprekken te beginnen met contactpersonen uit het adresboek. Let op: voor sommige providers is eind-tot-eindversleuteling benodigd.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Apptoegang</string>
     <string name="pref_chats">Gesprekken</string>
     <string name="pref_in_chat_sounds">Gespreksgeluiden</string>
     <string name="pref_view_log">Logboek bekijken</string>
@@ -865,11 +870,6 @@
     <string name="autocrypt_send_asm_button">Autocrypt-instelbericht versturen</string>
     <string name="autocrypt_send_asm_explain_after">Je instellingen zijn aan jezelf verstuurd. Schakel over naar het andere apparaat en open het instelbericht. Je zou nu moeten worden gevraagd om een code. Typ de volgende getallen in het invoerveld:</string>
     <string name="autocrypt_prefer_e2ee">Voorkeur voor eind-tot-eindversleuteling</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt-instelbericht</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Dit is het Autocrypt-instelbericht dat wordt gebruikt om je instellingen over te zetten.\n\nOm te ontsleutelen en te gebruiken, open je het bericht in een met Autocrypt compatibele app en voer je de code in die wordt getoond op het apparaat dat de code heeft gegenereerd.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Dit bericht kan niet worden ontsleuteld.\n\n• Het kan helpen dit bericht te beantwoorden en de afzender te vragen het opnieuw te versturen.\n\n• Als je Delta Chat of een andere e-mailapp opnieuw hebt geïnstalleerd, voeg het dan toe als tweede apparaat of importeer een reservekopie.</string>
@@ -1004,7 +1004,7 @@
     <string name="secure_join_wait">Bezig met opzetten van eind-tot-eindversleuteling…</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Er kan nog geen eind-tot-eindversleuteling worden gegarandeerd, maar je kunt wel alvast een bericht sturen.</string>
-    <string name="secure_join_takes_longer">Het lijkt langer te duren dan verwacht - wellicht is een van jullie offline.\n\nHet proces wordt echter op de achtergrond voortgezet, dus je kunt gerust iets anders gaan doen…</string>
+    <string name="secure_join_takes_longer">Het lijkt langer te duren dan verwacht - wellicht is een van jullie offline.\n\nHet proces wordt echter op de achtergrond voortgezet.</string>
     <string name="contact_verified">%1$s is goedgekeurd.</string>
     <string name="contact_not_verified">Er kan geen eind-tot-eindversleuteling met %1$s worden gegarandeerd.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1013,8 +1013,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Gewijzigde instellingen voor %1$s</string>
     <string name="verified_contact_required_explain">Om de eind-tot-eindversleuteling te garanderen, kun je alleen contactpersonen met een groen vinkje toevoegen aan deze groep.\n\nVan niet-goedgekeurde contactpersonen kun je de QR-code scannen om ze goed te keuren.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">De QR-url is gekopieerd naar het klembord</string>
     <string name="mailto_dialog_header_select_chat">Kies in welk gesprek je dit bericht wilt delen</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s bevat al een concept. Wil je dit vervangen?</string>
@@ -1040,7 +1038,8 @@
     <string name="perm_required_title">Recht vereist</string>
     <string name="perm_continue">Doorgaan</string>
     <string name="perm_explain_access_to_camera_denied">Delta Chat wil foto\'s en video\'s kunnen maken. Ga naar de app-instellingen, kies ‘Rechten’ en schakel ‘Camera’ in.</string>
-    <string name="perm_explain_access_to_mic_denied">Delta Chat wil spraakberichten versturen. Ga naar de app-instellingen, kies ‘Rechten’ en schakel ‘Microfoon’ in.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">Delta Chat wil spraakberichten versturen. Ga naar de app-instellingen, kies ‘Rechten’ of ‘Privacy en beveiliging’ en schakel ‘Microfoon’ in.</string>
     <string name="perm_explain_access_to_storage_denied">Delta Chat wil bestanden kunnen ontvangen en versturen. Ga naar de app-instellingen, kies ‘Rechten’ en schakel ‘Opslag’ in.</string>
     <string name="perm_explain_access_to_location_denied">Delta Chat wil je locatie kunnen delen. Ga naar de app-instellingen, kies ‘Rechten’ en schakel ‘Locatie’ in.</string>
     <string name="perm_explain_access_to_notifications_denied">Open Systeeminstellingen → Apps → Delta Chat en schakel meldingen in.</string>

--- a/_locales/pl.xml
+++ b/_locales/pl.xml
@@ -202,6 +202,10 @@
     <string name="images_and_videos">Obrazy i wideo</string>
     <string name="file">Plik</string>
     <string name="files">Pliki</string>
+    <string name="files_attach_hint">Wyślij oryginalne pliki i nieskompresowane obrazy</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Wybierz z plików</string>
+    <string name="choose_from_gallery">Wybierz z galerii</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Prywatna aplikacja</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
@@ -773,8 +777,6 @@
     <string name="pref_use_system_emoji_explain">Wyłącza wbudowaną obsługę emoji Delta Chat</string>
     <string name="pref_show_system_contacts">Odczytaj systemową książkę adresową</string>
     <string name="pref_show_system_contacts_explain">Zaproponuj tworzenie czatów z kontaktami z książki adresowej.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Dostęp do aplikacji</string>
     <string name="pref_chats">Czaty</string>
     <string name="pref_in_chat_sounds">Dźwięki w czacie</string>
     <string name="pref_view_log">Wyświetl dziennik</string>
@@ -897,11 +899,6 @@
     <string name="autocrypt_send_asm_button">Wyślij wiadomość konfiguracyjną Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Klucz został wysłany do ciebie. Przejdź do innego urządzenia i otwórz wiadomość konfiguracyjną. Zostanie wyświetlona prośba o podanie kodu konfiguracyjnego. Wpisz następujące cyfry w podpowiedzi.\n\nGdy skończysz, drugie urządzenie będzie gotowe do użycia funkcji automatycznego szyfrowania.</string>
     <string name="autocrypt_prefer_e2ee">Preferuj szyfrowanie typu end-to-end</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Wiadomość konfiguracyjna automatycznego szyfrowania</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Jest to wiadomość konfiguracyjna automatycznego szyfrowania typu end-to-end służąca do przesyłania klucza między klientami.\n\nAby odszyfrować i użyć klucza, otwórz wiadomość w kliencie zgodnym z automatycznym szyfrowaniem i wprowadź kod konfiguracyjny przedstawiony na urządzeniu generującym.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Tej wiadomości nie można odszyfrować.\n\n• Możesz teraz pomóc odpowiadając po prostu na tą wiadomość i poprosić nadawcę o ponowne wysłanie wiadomości.\n\n• Jeśli właśnie ponownie zainstalowałeś Delta Chat, najlepiej będzie, jeśli ponownie skonfigurujesz Delta Chat teraz i wybierzesz „Dodaj jako drugie urządzenie” lub zaimportujesz kopię zapasową.</string>
@@ -1036,7 +1033,7 @@
     <string name="secure_join_wait">Ustanawiam gwarantowane szyfrowanie typu end-to-end, proszę czekać…</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Nie można jeszcze ustanowić gwarantowanego szyfrowania typu end-to-end, ale być może już wysłałeś wiadomość.</string>
-    <string name="secure_join_takes_longer">Wydaje się, że to trwa dłużej, może kontakt lub ty jesteś offline.\n\nJednak proces trwa w tle, możesz zrobić coś innego…</string>
+    <string name="secure_join_takes_longer">Aby kontynuować, kontakt musi być online.\n\nTen proces będzie kontynuowany automatycznie w tle.</string>
     <string name="contact_verified">Kontakt %1$s zweryfikowany.</string>
     <string name="contact_not_verified">Nie można zweryfikować szyfrowania typu end-to-end %1$s</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1045,8 +1042,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Zmieniono konfigurację dla %1$s</string>
     <string name="verified_contact_required_explain">Aby zagwarantować szyfrowanie end-to-end, do tej grupy możesz dodawać wyłącznie kontakty oznaczone zielonym znacznikiem wyboru.\n\nMożesz spotkać się z kontaktami osobiście i zeskanować ich kod QR, aby je przedstawić.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Skopiowano adres kodu QR do schowka</string>
     <string name="mailto_dialog_header_select_chat">Wybierz czat, do którego chcesz wysłać wiadomość</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">Na czacie %1$s jest już wersja robocza wiadomości, czy chcesz ją zastąpić?</string>
@@ -1072,7 +1067,8 @@
     <string name="perm_required_title">Wymagane zezwolenie</string>
     <string name="perm_continue">Kontynuuj</string>
     <string name="perm_explain_access_to_camera_denied">Delta Chat wymaga pozwolenia na używanie aparatu, aby robić zdjęcia lub nagrywać filmy, ale zostało ono trwale odrzucone. Przejdź do menu ustawień aplikacji, wybierz „Uprawnienia” i włącz „Aparat”.</string>
-    <string name="perm_explain_access_to_mic_denied">Delta Chat wymaga zezwolenia użycia mikrofonu, aby wysyłać wiadomości audio, ale zostało ono trwale odrzucone. Przejdź do ustawień aplikacji, wybierz „Uprawnienia” i włącz „Mikrofon”.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">Aby wysyłać wiadomości audio, przejdź do ustawień aplikacji, wybierz „Uprawnienia” lub „Prywatność i bezpieczeństwo” i włącz „Mikrofon”.</string>
     <string name="perm_explain_access_to_storage_denied">Delta Chat wymaga uprawnienia do przechowywania, aby dołączyć lub wyeksportować zdjęcia, filmy lub dźwięk, ale zostało ono trwale odrzucone. Przejdź do menu ustawień aplikacji, wybierz „Uprawnienia” i włącz „Pamięć”.</string>
     <string name="perm_explain_access_to_location_denied">Delta Chat wymaga zezwolenia na lokalizację, aby dołączyć lokalizację, ale zostało ono trwale odrzucone. Przejdź do menu ustawień aplikacji, wybierz „Uprawnienia” i włącz „Lokalizacja”.</string>
     <string name="perm_explain_access_to_notifications_denied">Aby odbierać powiadomienia, przejdź do „Ustawienia » Aplikacje » Delta Chat” i włącz „Powiadomienia”.</string>

--- a/_locales/pt.xml
+++ b/_locales/pt.xml
@@ -261,8 +261,6 @@
     <string name="pref_manage_keys">Gerir teclas</string>
     <string name="pref_use_system_emoji">Utilizar o emoji do sistema</string>
     <string name="pref_use_system_emoji_explain">Desactivar o suporte integrado de emojis no Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Acesso à App</string>
     <string name="pref_chats">chats</string>
     <string name="pref_in_chat_sounds">Sons na chat</string>
     <string name="pref_view_log">Ver o log</string>
@@ -295,11 +293,6 @@
     <string name="autocrypt_send_asm_button">Enviar mensagem com a definição da encriptação automática</string>
     <string name="autocrypt_send_asm_explain_after">A sua configuração foi-lhe enviada. Entre no outro dispositivo e abra a mensagem de configuração. Deve ser solicitado a fornecer um código de configuração. Digite os seguintes dígitos no prompt.\n\n Assim que estiver concluido, o outro dispositivo estará pronto para usar o Autocrypt.</string>
     <string name="autocrypt_prefer_e2ee">Preferir encriptação ponta a ponta</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Mensagem de configuração do Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Esta é a Mensagem de Configuração de Autocrypt usada para transferir sua configuração de ponta a ponta entre clientes (dispositivos). \n\nPara descriptar e usar, abra a mensagem em um cliente compatível com Autocrypt e insira o código de configuração apresentado no dispositivo de geração.</string>
-
 
     <!-- %1$s will be replaced by the old group name, %2$s will be replaced by the new group name -->
     <string name="group_name_changed_by_you">O nome do grupo mudou de \"%1$s\" para \"%2$s\" por mim.</string>
@@ -354,6 +347,7 @@
     <string name="perm_required_title">Permissão necessária</string>
     <string name="perm_continue">Continuar</string>
     <string name="perm_explain_access_to_camera_denied">O Delta Chat necessita de permissão de acesso à Câmera para tirar fotos ou vídeos, mas o acesso foi negado permanentemente. Por favor, continue no menu de configurações do aplicativo, selecione \"Permissões\" e active \"Câmera\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">O Delta Chat necessita de permissão de  acesso ao microfone para enviar mensagens de áudio, mas foi negado. Por favor, continue com as configurações do aplicativo, selecione \"Permissões\" e active \"Microfone\".</string>
     <string name="perm_explain_access_to_storage_denied">O Delta Chat necessita da permissão de armazenamento para anexar ou exportar fotos, vídeos ou áudio, mas foi negado. Por favor, continue no menu de configurações do aplicativo, seleccione \"Permissões\" e active \"Armazenamento\".</string>
     <string name="perm_explain_access_to_location_denied">O Delta Chat necessita permissão de acesso à localização para anexar um local, mas ele negado. Por favor, continue no menu de configurações do aplicativo, selecione \"Permissões \"e ative \"Localização\".</string>

--- a/_locales/pt_BR.xml
+++ b/_locales/pt_BR.xml
@@ -617,8 +617,6 @@
     <string name="pref_manage_keys">Gerenciar chaves</string>
     <string name="pref_use_system_emoji">Usar emojis do sistema</string>
     <string name="pref_use_system_emoji_explain">Desabilitar emojis do Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Acesso do aplicativo</string>
     <string name="pref_chats">Conversas</string>
     <string name="pref_in_chat_sounds">Sons da conversa</string>
     <string name="pref_view_log">Ver relatório</string>
@@ -721,11 +719,6 @@
     <string name="autocrypt_send_asm_button">Enviar \"mensagem de configuração do Autocrypt\"?</string>
     <string name="autocrypt_send_asm_explain_after">Sua chave foi enviada para você mesmo. Abra a mensagem de configuração no seu outro dispositivo. Lá será exibido uma solicitação de código. Digite-o lá.\n\nDepois disso, seu dispositivo estará pronto para usar o Autocrypt.</string>
     <string name="autocrypt_prefer_e2ee">Preferir criptografia ponta a ponta</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Mensagem de configuração do Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Esta é uma \"mensagem de configuração do Autocrypt\" que serve para transferir suas chaves entre dispositivos diferentes.\n\nPara descriptografar sua chave abra esta mensagem num cliente compatível e digite o código exibido no dispositivo de origem.</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">Remetente desconhecido para esta conversa. Veja \'informações\' para mais detalhes.</string>
     <string name="systemmsg_subject_for_new_contact">Mensagem de %1$s</string>
@@ -846,8 +839,6 @@
     <string name="verified_by">Verificado por %1$s</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">A configuração Autocrypt mudou para %1$s</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Endereço do código QR copiado para a área de transferência</string>
     <string name="mailto_dialog_header_select_chat">Selecione o bate-papo para enviar a mensagem</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s já tem um rascunho de mensagem, deseja substituí-lo?</string>
@@ -866,6 +857,7 @@
     <string name="perm_required_title">Permissão necessária</string>
     <string name="perm_continue">Continuar</string>
     <string name="perm_explain_access_to_camera_denied">O Delta Chat precisa acessar sua câmera para tirar fotos e gravar vídeos, mas o acesso foi negado. Por favor, habilite a câmera nas configurações de permissões do aplicativo.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">O Delta Chat precisa acessar seu microfone para que você possa enviar mensagens de voz, mas o acesso foi negado. Por favor, habilite o microfone nas configurações de permissões do aplicativo.</string>
     <string name="perm_explain_access_to_storage_denied">Para receber o enviar arquivos, vai nas configurações do aplicativo, escolhe \"Permissões\", e ativar \"Armazenamento\".</string>
     <string name="perm_explain_access_to_location_denied">O Delta Chat precisa acessar sua localização para que você possa enviá-la, mas o acesso foi negado. Por favor, habilite o seu acesso nas configurações de permissões do aplicativo.</string>

--- a/_locales/ru.xml
+++ b/_locales/ru.xml
@@ -56,6 +56,7 @@
     <string name="save">Сохранить</string>
     <string name="chat">Чат</string>
     <string name="media">Медиафайлы</string>
+    <string name="apps_and_media">Приложения и медиафайлы</string>
     <string name="profile">Профиль</string>
     <string name="main_menu">Главное меню</string>
     <string name="start_chat">Начать чат</string>
@@ -202,12 +203,17 @@
     <string name="images_and_videos">Изображения и видео</string>
     <string name="file">Файл</string>
     <string name="files">Файлы</string>
+    <string name="files_attach_hint">Отправить оригинальные файлы и несжатые изображения</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Выбрать из файлов</string>
+    <string name="choose_from_gallery">Выбрать из галереи</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Приложение</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">Приложения</string>
     <string name="webxdc_store_url">URL селектора приложений</string>
     <string name="webxdc_store_url_explain">Если установлено, URL будет использоваться в качестве селектора приложений вместо стандартного</string>
+    <string name="webxdc_draft_hint">Нажмите \"Отправить\", чтобы поделиться</string>
     <string name="home">Домой</string>
     <string name="games">Игры</string>
     <string name="tools">Инструменты</string>
@@ -289,6 +295,7 @@
     <string name="menu_export_attachment">Экспорт вложения</string>
     <string name="menu_export_attachments">Экспорт вложений</string>
     <string name="menu_all_media">Все медиафайлы</string>
+    <string name="all_apps_and_media">Все приложения и медиафайлы</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Показать в чате</string>
     <string name="show_app_in_chat">Показать приложение в чате</string>
@@ -546,15 +553,15 @@
     <string name="tab_docs">Документы</string>
     <string name="tab_links">Ссылки</string>
     <string name="tab_map">Карта</string>
-    <string name="tab_gallery_empty_hint">Здесь можно просмотреть изображения и видео, отправленные в этом чате.</string>
-    <string name="tab_docs_empty_hint">Здесь можно просмотреть документы и другие файлы, отправленные в этом чате.</string>
-    <string name="tab_image_empty_hint">Здесь можно просмотреть изображения, отправленные в этом чате.</string>
-    <string name="tab_video_empty_hint">Здесь можно просмотреть видео, отправленные в этом чате.</string>
-    <string name="tab_audio_empty_hint">Здесь можно просмотреть аудиофайлы и голосовые сообщения, отправленные в этом чате.</string>
-    <string name="tab_webxdc_empty_hint">Здесь можно просмотреть приложения, отправленные в этом чате.</string>
-    <string name="tab_all_media_empty_hint">Здесь можно просмотреть медиафайлы, отправленные в любом чате.</string>
-    <string name="all_files_empty_hint">Здесь можно просмотреть документы и другие файлы, отправленные в любом чате.</string>
-    <string name="all_apps_empty_hint">Здесь можно просмотреть приложения, полученные или отправленные в любом чате.</string>
+    <string name="tab_gallery_empty_hint">Изображения и видео, прикреплённые к этому чату, будут показаны здесь.</string>
+    <string name="tab_docs_empty_hint">Документы и прочие файлы, прикреплённые к этому чату, будут показаны здесь.</string>
+    <string name="tab_image_empty_hint">Изображения, прикреплённые к этому чату, будут показаны здесь.</string>
+    <string name="tab_video_empty_hint">Видео, прикреплённые к этому чату, будут показаны здесь.</string>
+    <string name="tab_audio_empty_hint">Аудиофайлы и голосовые сообщения, прикреплённые к этому чату, будут показаны здесь.</string>
+    <string name="tab_webxdc_empty_hint">Приложения, прикреплённые к этому чату, будут показаны здесь.</string>
+    <string name="tab_all_media_empty_hint">Медиафайлы, из всех ваших чатов, будут показаны здесь.</string>
+    <string name="all_files_empty_hint">Документы и прочие вложения, из всех ваших чатов, будут показаны здесь.</string>
+    <string name="all_apps_empty_hint">Приложения, из всех ваших чатов, будут показаны здесь.</string>
     <string name="media_preview">Предпросмотр медиафайлов</string>
     <!-- option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :) -->
     <string name="aspect_ratio_grid">Сетка с соотношением сторон</string>
@@ -773,8 +780,6 @@
     <string name="pref_use_system_emoji_explain">Отключить поддержку встроенных эмодзи Delta Chat</string>
     <string name="pref_show_system_contacts">Чтение системной адресной книги</string>
     <string name="pref_show_system_contacts_explain">Предлагать создать чаты с контактами из адресной книги.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Доступ приложения</string>
     <string name="pref_chats">Чаты</string>
     <string name="pref_in_chat_sounds">Звуки в чате</string>
     <string name="pref_view_log">Открыть журнал</string>
@@ -897,11 +902,6 @@
     <string name="autocrypt_send_asm_button">Сообщение с параметрами Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Ваши настройки были оправлены вам. Переключитесь на другое устройство и откройте сообщение с настройкой. Вам будет предложено ввести код настройки. Введите следующие цифры:</string>
     <string name="autocrypt_prefer_e2ee">Предпочитать сквозное шифрование</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Сообщение с параметрами Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">\"Сообщение с параметрами Autocrypt\" служит для передачи параметров сквозного шифрования между клиентами.\n\nЧтобы расшифровать и использовать параметры откройте это сообщение в приложении, поддерживающем Autocrypt и введите код настройки, показанный на исходном устройстве.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Это сообщение не может быть расшифровано.\n\n• Попробуйте просто ответить на это сообщение и попросить отправителя отправить его снова.\n\n• Если вы только что переустановили Delta Chat, то лучше сейчас заново настроить Delta Chat и выбрать \"Добавить как второе устройство\" или импортировать резервную копию.</string>
@@ -1036,7 +1036,7 @@
     <string name="secure_join_wait">Устанавливается гарантированное сквозное шифрование, пожалуйста, подождите...</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Не удалось установить гарантированное сквозное шифрование, но вы уже можете отправить сообщение.</string>
-    <string name="secure_join_takes_longer">Похоже, это длится дольше, чем ожидалось, возможно, из-за проблем с подключением или того, что один из вас сейчас офлайн.\n\nПри этом процесс будет продолжен в фоновом режиме, поэтому вы можете заняться другими делами…</string>
+    <string name="secure_join_takes_longer">Контакт должен быть в режиме онлайн, чтобы продолжить.\n\nЭтот процесс будет автоматически продолжен в фоновом режиме.</string>
     <string name="contact_verified">%1$s подтверждён.</string>
     <string name="contact_not_verified">Невозможно установить гарантированное сквозное шифрование с %1$s.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1045,8 +1045,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Изменены настройки для %1$s</string>
     <string name="verified_contact_required_explain">Чтобы обеспечить сквозное шифрование, вы можете добавлять в эту группу только контакты с зеленой галочкой.\n\nВы можете встретиться с контактами лично и отсканировать их QR-код, чтобы подтвердить их личность.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Ссылка из QR-кода скопирована в буфер обмена</string>
     <string name="mailto_dialog_header_select_chat">Выберите чат, чтобы отправить сообщение</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s уже имеет черновик, вы хотите его заменить?</string>
@@ -1072,7 +1070,8 @@
     <string name="perm_required_title">Требуется разрешение</string>
     <string name="perm_continue">Продолжить</string>
     <string name="perm_explain_access_to_camera_denied">Чтобы делать фотографии, снимать видео, откройте настройки приложения, выберите \"Разрешения\" и включите \"Камера\".</string>
-    <string name="perm_explain_access_to_mic_denied">Чтобы отправлять аудиосообщения, откройте настройки приложения, выберите \"Разрешения\" и включите \"Микрофон\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">Чтобы отправлять аудиосообщения, откройте настройки приложения, выберите \"Разрешения\" или \"Конфиденциальность и безопасность\" и включите \"Микрофон\".</string>
     <string name="perm_explain_access_to_storage_denied">Чтобы получать или отправлять файлы, откройте настройки приложения, выберите \"Разрешения\" и включите \"Хранилище\".</string>
     <string name="perm_explain_access_to_location_denied">Чтобы прикрепить местоположение, откройте настройки приложения, выберите \"Разрешения\" и включите \"Местоположение\".</string>
     <string name="perm_explain_access_to_notifications_denied">Для получения уведомлений, перейдите в \"Настройки системы / Приложения / Delta Chat\" и включите \"Уведомления\".</string>

--- a/_locales/sc.xml
+++ b/_locales/sc.xml
@@ -396,8 +396,6 @@
     <string name="pref_manage_keys">Amministra sas craes</string>
     <string name="pref_use_system_emoji">Imprea sas emoji de sistema</string>
     <string name="pref_use_system_emoji_explain">Istuda su suportu de sas emoji incorporadu in Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Atzessu a s\'aplicatzione</string>
     <string name="pref_chats">Tzarradas</string>
     <string name="pref_in_chat_sounds">Sonos in sa tzarrada</string>
     <string name="pref_view_log">Pòmpia su registru</string>
@@ -466,8 +464,7 @@
     <string name="autocrypt_send_asm_button">Imbia unu messàgiu de impostatzione de Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Ti ses imbiadu sa configuratzione tua. Cola a s\'àteru dispositivu e aberi su messàgiu de configuratzione. Ti diat dèpere èssere pedidu unu còdighe de configuratzione. Inserta custas tzifras:</string>
     <string name="autocrypt_prefer_e2ee">Preferi sa tzifradura a nodu terminale (end-to-end)</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Messàgiu de configuratzione de Autocrypt</string>
+
     <string name="write_message_desktop">Iscrie unu messàgiu</string>
     <string name="encryption_info_title_desktop">Informatziones de tzifradura</string>
     <string name="more_info_desktop">Àteras informatziones</string>

--- a/_locales/sk.xml
+++ b/_locales/sk.xml
@@ -580,8 +580,6 @@
     <string name="pref_manage_keys">Správa kľúčov</string>
     <string name="pref_use_system_emoji">Používajte systémové emodži</string>
     <string name="pref_use_system_emoji_explain">Vypnite vstavanú podporu emodži v aplikácii Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Prístup k aplikácii</string>
     <string name="pref_chats">Konverzácie</string>
     <string name="pref_in_chat_sounds">Zvuky v konverzáciách</string>
     <string name="pref_view_log">Prezrieť záznam</string>
@@ -684,11 +682,6 @@
     <string name="autocrypt_send_asm_button">Pošlite správu s nastavením autokryptovania</string>
     <string name="autocrypt_send_asm_explain_after">Vaše nastavenie bolo odoslané vám. Prepnite na druhé zariadenie a otvorte správu o nastavení. Mali by ste byť požiadaní o nastavovací kód. Zadajte nasledujúce číslice:</string>
     <string name="autocrypt_prefer_e2ee">Preferovať šifrovanie typu end-to-end</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Správa o nastavení automatického šifrovania</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Toto je správa o nastavení automatického šifrovania, ktorá sa používa na prenos komplexného nastavenia medzi klientmi.\n\nAk chcete dešifrovať a použiť svoje nastavenie, otvorte správu v klientovi kompatibilnom s automatickým šifrovaním a zadajte inštalačný kód uvedený na generujúcom zariadení.</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">Neznámy odosielateľ pre túto konverzáciu. Ďalšie informácie nájdete v časti „Informácie“.</string>
     <string name="systemmsg_subject_for_new_contact">Správa od %1$s</string>
@@ -805,8 +798,6 @@
     <string name="contact_not_verified">Cannot verify %1$s.</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Zmena nastavenia pre %1$s.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Skopírovaná adresa URL QR do schránky</string>
     <string name="mailto_dialog_header_select_chat">Vyberte konverzáciu, kam bude správa odoslaná</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s už má koncept správy, chcete ho nahradiť?</string>
@@ -825,6 +816,7 @@
     <string name="perm_required_title">Vyžaduje sa povolenie</string>
     <string name="perm_continue">ďalej</string>
     <string name="perm_explain_access_to_camera_denied">Ak chcete fotografovať alebo snímať videá, prejdite do nastavení aplikácie, vyberte možnosť „Povolenia“ a povoľte možnosť „Fotoaparát“.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Ak chcete odosielať zvukové správy, prejdite do nastavení aplikácie, vyberte možnosť „Povolenia“ a povoľte možnosť „Mikrofón“.</string>
     <string name="perm_explain_access_to_storage_denied">Ak chcete prijímať alebo odosielať súbory, prejdite do nastavení aplikácie, vyberte možnosť „Povolenia“ a povoľte možnosť „Úložisko“.</string>
     <string name="perm_explain_access_to_location_denied">Ak chcete pripojiť miesto, prejdite do nastavení aplikácie, vyberte možnosť Povolenia a povoľte možnosť Poloha.</string>

--- a/_locales/sq.xml
+++ b/_locales/sq.xml
@@ -55,6 +55,7 @@
     <string name="save">Ruaje</string>
     <string name="chat">Fjalosje</string>
     <string name="media">Media</string>
+    <string name="apps_and_media">Aplikacione &amp; Media</string>
     <string name="profile">Profil</string>
     <string name="main_menu">Menuja Kryesore</string>
     <string name="start_chat">Nisni Fjalosje</string>
@@ -181,12 +182,17 @@
     <string name="images_and_videos">Figura dhe Video</string>
     <string name="file">Kartelë</string>
     <string name="files">Kartela</string>
+    <string name="files_attach_hint">Dërgo kartela origjinale dhe figura të pangjeshura</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Zgjidhni prej Kartelash</string>
+    <string name="choose_from_gallery">Zgjidhni prej Galerie</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Aplikacion</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">Aplikacione</string>
     <string name="webxdc_store_url">URL Marrësi Aplikacioni</string>
     <string name="webxdc_store_url_explain">Në u ujdistë, URL-ja do të përdoret si Marrës Aplikacioni, në vend të atij parazgjedhje</string>
+    <string name="webxdc_draft_hint">Për ta ndarë me të tjerë, prekni “Dërgoje”</string>
     <string name="home">Kreu</string>
     <string name="games">Lojëra</string>
     <string name="tools">Mjete</string>
@@ -267,6 +273,7 @@
     <string name="menu_export_attachment">Eksporto Bashkëngjitje</string>
     <string name="menu_export_attachments">Eksporto Bashkëngjitje</string>
     <string name="menu_all_media">Krejt Mediat</string>
+    <string name="all_apps_and_media">Krejt Aplikacionet &amp; Mediat</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Shfaqe në Fjalosje</string>
     <string name="show_app_in_chat">Shfaqe Aplikacionin në Fjalosje</string>
@@ -857,11 +864,6 @@
     <string name="autocrypt_send_asm_button">Dërgo Mesazh Rregullimi Autocrypt-i</string>
     <string name="autocrypt_send_asm_explain_after">Rregullimi juaj u dërgua te ju. Kaloni te pajisja tjetër dhe hapni mesazhin e rregullimit. Do t\’ju kërkohet një kod rregullimi. Shtypni atje shifrat vijuese.\n\nPasi të keni mbaruar, pajisja juaj tjetër do të jetë gati të përdorë Autocrypt-in.</string>
     <string name="autocrypt_prefer_e2ee">Parapëlqe Fshehtëzim Skaj-Më-Skaj</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Mesazh Rregullimi Autocrypt-i</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Ky është Mesazhi i Rregullimit të Autocrypt-it i përdorur për të shpërngulur rregullimin tuaj skaj-më-skaj në klientë të tjerë.\n\nQë ta shfshehtëzoni rregullimin tuaj, hapeni mesazhin te një klient që mund të përdorë Autocrypt-in dhe jepni kodin e rregullimit të treguar te pajisja që e prodhoi.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Ky mesazh s’mund të shfshehtëzohet.\n\n• Mundet t’ju ndihë thjesht t’i përgjigjeni këtij mesazhi dhe t’i kërkoni dërguesit ta ridërgojë mesazhin.\n\n• Nëse sapo riinstaluat Delta Chat-in, atëherë më e mira është të riujdisni Delta Chat-in tani dhe të zgjidhni “Shtoje si pajisje të dytë”, ose të importoni një kopjeruajtje.</string>
@@ -1005,8 +1007,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">U ndryshua udjisja për %1$s</string>
     <string name="verified_contact_required_explain">Që të garantohet fshehtëzim skaj-më-skaj, mund të shtoni në këtë grup vetëm kontakte me shenjën e gjelbër të verifikimit.\n\nMund të takoheni drejtpërsëdrejti me kontakte të paverifikuar dhe të skanoni kodin e tyre QR për t’i verifikuar ata.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">URL-ja QR u kopjua në të papastër</string>
     <string name="mailto_dialog_header_select_chat">Përzgjidhni fjalosje ku të dërgohet mesazhi</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s përmban tashmë një skicë mesazhi, doni të zëvendësohet?</string>
@@ -1032,6 +1032,7 @@
     <string name="perm_required_title">Lypset leje</string>
     <string name="perm_continue">Vazhdo</string>
     <string name="perm_explain_access_to_camera_denied">Që të mund të bëhen foto apo video, kaloni te rregullimet e aplikacionit, përzgjidhni “Leje” dhe aktivizoni “Kamerën”.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Që të mund të dërgohen mesazhe audio, kaloni te rregullime aplikacioni, përzgjidhni “Leje” dhe aktivizoni “Mikrofonin”.</string>
     <string name="perm_explain_access_to_storage_denied">Që të merren apo dërgohen kartela, kaloni te rregullime aplikacioni, përzgjidhni “Leje” dhe aktivizoni “Depozitimin”.</string>
     <string name="perm_explain_access_to_location_denied">Që të mund të bashkëngjitet një vendndodhje, kaloni te rregullimet e aplikacionit, përzgjidhni “Leje” dhe aktivizoni “Vendndodhjen”.</string>

--- a/_locales/sr.xml
+++ b/_locales/sr.xml
@@ -583,8 +583,6 @@
     <string name="pref_manage_keys">Управљај кључевима</string>
     <string name="pref_use_system_emoji">Користи системски емоџи</string>
     <string name="pref_use_system_emoji_explain">Искључи уграђене Delta Chat-ове емоџије</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Приступ апликацији</string>
     <string name="pref_chats">Ћаскања</string>
     <string name="pref_in_chat_sounds">Звуци ћаскања</string>
     <string name="pref_view_log">Погледај дневник</string>
@@ -687,11 +685,6 @@
     <string name="autocrypt_send_asm_button">Пошаљите поруку поставки за аутошифровање</string>
     <string name="autocrypt_send_asm_explain_after">Ваше подешавање вам је послато. Пређите на други уређај и отворите поруку за подешавање. На другом уређају од се вас очекује да унесете код за подешавање. Унесите следеће цифре:</string>
     <string name="autocrypt_prefer_e2ee">Преферирај с-краја-на-крај шифровање</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Порука поставки за аутошфровање</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Ово је порука подешавања аутоматског шифровања која се користи за пренос вашег с-краја-на-крај подешавања између клијената.\n\nДа бисте дешифровали и користили своје подешавање, отворите поруку на клијенту који је компатибилан са аутоматским шифровањем и унесите кôд за подешавање приказан на уређају који га је генерисао.</string>
-
 
     <string name="systemmsg_unknown_sender_for_chat">Непознати пошиљалац за ово ћаскање. Погледајте „информације“ за више детаља.</string>
     <string name="systemmsg_subject_for_new_contact">Поруке од %1$s</string>
@@ -812,8 +805,6 @@
     <string name="verified_by">Проверено од %1$s</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Подешавања су се променила за %1$s.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Бар-кôд везе је копиран у клипборд</string>
     <string name="mailto_dialog_header_select_chat">Изабери ћаскање у које желите да пошаљете поруку</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s већ има нацрт поруке, да ли желите да је замените?</string>
@@ -832,6 +823,7 @@
     <string name="perm_required_title">Дозвола је потребна</string>
     <string name="perm_continue">Настави</string>
     <string name="perm_explain_access_to_camera_denied">Да бисте снимили фотографије или видео снимке, идите на подешавања апликације, изаберите „Дозволе“ и омогућите „Камеру“.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Да бисте послали звучне записе, идите на подешавања апликације, изаберите „Дозволе“ и омогућите „Микрофон“.</string>
     <string name="perm_explain_access_to_storage_denied">Да бисте примали или слали датотеке, идите на подешавања апликације, изаберите „Дозволе“ и омогућите „Складиштење“.</string>
     <string name="perm_explain_access_to_location_denied">Да приложите положај, идите у подешавања апликације и изаберите „Дозволе“ и омогућите „Положај/Локацију“.</string>

--- a/_locales/sv.xml
+++ b/_locales/sv.xml
@@ -662,8 +662,6 @@
     <string name="pref_use_system_emoji_explain">Inaktivera Delta Chat\'s inbyggda emojier</string>
     <string name="pref_show_system_contacts">Läs systemets adressbok</string>
     <string name="pref_show_system_contacts_explain">Erbjud att skapa chattar med kontakter från adressboken. Vissa leverantörer behöver först konfigureras för totalsträckskryptering.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Programåtkomst</string>
     <string name="pref_chats">Chattar</string>
     <string name="pref_in_chat_sounds">Ljud i konversationer</string>
     <string name="pref_view_log">Visa logg</string>
@@ -786,11 +784,6 @@
     <string name="autocrypt_send_asm_button">Skicka Autocrypt inställningsmeddelande</string>
     <string name="autocrypt_send_asm_explain_after">Dina inställningar har skickats till dig själv. Byt till den andra enheten och öppna inställningsmeddelandet. Du kommer att tillfrågas om en inställningskod. Ange följande siffror:</string>
     <string name="autocrypt_prefer_e2ee">Föredra slutpunkt-till-slutpunkt-kryptering</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Inställningsmeddelande för Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Detta är inställningsmeddelandet för Autocrypt som används för att skicka nycklar mellan klienter.\n\nFör att kunna avkryptera och använda din nyckel, öppnar du meddelandet i en Autocrypt-kompatibel klient och skriver in inställningskoden som visats på den genererande enheten.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Det här meddelandet kan inte dekrypteras.\n\n- Det kan hjälpa att helt enkelt svara på det här meddelandet och be avsändaren att skicka meddelandet igen.\n\n- Om du just har installerat om Delta Chat är det bäst om du konfigurerar om Delta Chat nu och väljer \"Lägg till som en andra enhet\" eller importerar en säkerhetskopia.</string>
@@ -933,8 +926,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Ändrade inställningarna för %1$s.</string>
     <string name="verified_contact_required_explain">För att garantera totalsträckskryptering  kan du bara lägga till kontakter med en grön bock i den här gruppen.\n\nDu kan träffa kontakter personligen och skanna deras QR-kod för att introducera dem.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Kopierade QR-URL till urklipp.</string>
     <string name="mailto_dialog_header_select_chat">Välj chatt för att skicka meddelandet till</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s redan har ett utkast till meddelande, vill du ersätta det?</string>
@@ -960,6 +951,7 @@
     <string name="perm_required_title">Behörighet krävs</string>
     <string name="perm_continue">Fortsätt</string>
     <string name="perm_explain_access_to_camera_denied">Gå till programinställningarna och aktivera \"Kamera\" under \"Behörighet\", för att ta foton eller filma.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Gå till programinställningarna och aktivera \"Mikrofon\" under \"Behörighet\", för att skicka röstmeddelanden.</string>
     <string name="perm_explain_access_to_storage_denied">Gå till programinställningarna och aktivera \"Lagring\" under \"Behörighet\", för att ta emot eller skicka filer.</string>
     <string name="perm_explain_access_to_location_denied">Gå till programinställningarna och aktivera \"Plats\" under \"Behörighet\", för att bifoga en plats.</string>

--- a/_locales/ta.xml
+++ b/_locales/ta.xml
@@ -210,8 +210,6 @@
     <string name="pref_read_receipts_explain">வாசிப்பு ரசீதுகள் முடக்கப்பட்டிருந்தால், மற்றவர்களிடமிருந்து வாசிப்பு ரசீதுகளை நீங்கள் </string>
     <string name="pref_use_system_emoji">கணினி ஈமோஜியைப் பயன்படுத்தவும்</string>
     <string name="pref_use_system_emoji_explain">Delta Chat உள்ளமைக்கப்பட்ட ஈமோஜி ஆதரவை முடக்கு</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">பயன்பாடு அணுகல்</string>
     <string name="pref_chats">அரட்டைகள்</string>
     <string name="pref_in_chat_sounds">௨ள்ளார்ந்த செயலி அறிவிப்புகள்</string>
     <string name="pref_other">மற்றவை</string>

--- a/_locales/te.xml
+++ b/_locales/te.xml
@@ -178,8 +178,6 @@
     <string name="pref_read_receipts_explain">చదివే రసీదులను నిలిపివేస్తే, మీరు ఇతరుల నుండి చదివే రసీదులను చూడలేరు.</string>
     <string name="pref_use_system_emoji">యంత్రము యొక్క  ఎమొజిలను  ఉపయొగించు</string>
     <string name="pref_use_system_emoji_explain">Delta Chat యొక్క అంతర్నిర్మిత ఎమోజి మద్దతును నిలిపివేయి</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">అనువర్తన ప్రాప్యత</string>
     <string name="pref_chats">చాట్లు</string>
     <string name="pref_in_chat_sounds">యాప్-లోపల నోటిఫికేషన్లు</string>
     <string name="pref_other">ఇతర</string>

--- a/_locales/tr.xml
+++ b/_locales/tr.xml
@@ -56,6 +56,7 @@
     <string name="save">Kaydet</string>
     <string name="chat">Sohbet</string>
     <string name="media">Ortam</string>
+    <string name="apps_and_media">Uygulamalar ve Ortamlar</string>
     <string name="profile">Profil</string>
     <string name="main_menu">Ana Menü</string>
     <string name="start_chat">Sohbet Başlat</string>
@@ -184,12 +185,17 @@
     <string name="images_and_videos">Görseller ve Videolar</string>
     <string name="file">Dosya</string>
     <string name="files">Dosyalar</string>
+    <string name="files_attach_hint">Özgün dosyalar ve sıkıştırılmayan görseller gönder</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Dosyalardan Seç</string>
+    <string name="choose_from_gallery">Galeriden Seç</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Uygulama</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">Uygulamalar</string>
     <string name="webxdc_store_url">Uygulama Seçici URL\'si</string>
     <string name="webxdc_store_url_explain">Ayarlanırsa URL, varsayılan birinin yerine Uygulama Seçici olarak kullanılacak</string>
+    <string name="webxdc_draft_hint">Paylaşmak için “Gönder”e dokunun</string>
     <string name="home">Ana Sayfa</string>
     <string name="games">Oyunlar</string>
     <string name="tools">Araçlar</string>
@@ -271,6 +277,7 @@
     <string name="menu_export_attachment">İlişiği Dışa Aktar</string>
     <string name="menu_export_attachments">İlişikleri Dışa Aktar</string>
     <string name="menu_all_media">Tüm Ortamlar</string>
+    <string name="all_apps_and_media">Tüm Uygulamalar ve Ortamlar</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">Sohbette Göster</string>
     <string name="show_app_in_chat">Uygulamayı Sohbette Göster</string>
@@ -462,7 +469,7 @@
     <!-- title shown above a list contacts where one should be selected (eg. when a webxdc attempts to send a message to a chat) -->
     <string name="send_message_to">İletiyi gönder…</string>
     <string name="enable_realtime">Gerçek Zamanlı Uygulamalar</string>
-    <string name="enable_realtime_explain">Sohbetlerde paylaşılan uygulamalar için gerçek zamanlı bağlantıları etkinleştirin. Etkinleştirilirse, bir uygulama başlattığınızda sohbet ortakları IP adresinizi bulabilir.</string>
+    <string name="enable_realtime_explain">Sohbetlere iliştirilen uygulamalar için gerçek zamanlı bağlantıları etkinleştirin. Etkinleştirilirse, bir uygulamayı başlattığınızda sohbet ortakları IP adresinizi keşfedebilir.</string>
 
     <!-- map -->
     <string name="filter_map_on_time">Konumları zaman çerçevesinde göster</string>
@@ -514,15 +521,15 @@
     <string name="tab_docs">Belgeler</string>
     <string name="tab_links">Bağlantılar</string>
     <string name="tab_map">Harita</string>
-    <string name="tab_gallery_empty_hint">Bu sohbette paylaşılan görseller ve videolar burada görünecek.</string>
-    <string name="tab_docs_empty_hint">Bu sohbette paylaşılan belgeler ve diğer dosyalar burada görünecek.</string>
-    <string name="tab_image_empty_hint">Bu sohbette paylaşılan görseller burada görünecek.</string>
-    <string name="tab_video_empty_hint">Bu sohbette paylaşılan videolar burada görünecek.</string>
-    <string name="tab_audio_empty_hint">Bu sohbette paylaşılan ses dosyaları ve sesli iletiler burada görünecek.</string>
-    <string name="tab_webxdc_empty_hint">Bu sohbette paylaşılan uygulamalar burada görünecek.</string>
-    <string name="tab_all_media_empty_hint">Herhangi bir sohbette paylaşılan ortamlar burada görünecek.</string>
-    <string name="all_files_empty_hint">Herhangi bir sohbette paylaşılan belgeler ve diğer dosyalar burada görünecek.</string>
-    <string name="all_apps_empty_hint">Herhangi bir sohbette paylaşılan uygulamalar burada görünecek.</string>
+    <string name="tab_gallery_empty_hint">Bu sohbete iliştirilen görseller ve videolar burada görünecek.</string>
+    <string name="tab_docs_empty_hint">Bu sohbete iliştirilen belgeler ve diğer dosyalar burada görünecek.</string>
+    <string name="tab_image_empty_hint">Bu sohbete iliştirilen görseller burada görünecek.</string>
+    <string name="tab_video_empty_hint">Bu sohbete iliştirilen videolar burada görünecek.</string>
+    <string name="tab_audio_empty_hint">Bu sohbete iliştirilen ses dosyaları ve sesli iletiler burada görünecek.</string>
+    <string name="tab_webxdc_empty_hint">Bu sohbete iliştirilen uygulamalar burada görünecek.</string>
+    <string name="tab_all_media_empty_hint">Herhangi bir sohbete iliştirilen ortamlar burada görünecek.</string>
+    <string name="all_files_empty_hint">Herhangi bir sohbete iliştirilen belgeler ve diğer dosyalar burada görünecek.</string>
+    <string name="all_apps_empty_hint">Herhangi bir sohbete iliştirilen uygulamalar burada görünecek.</string>
     <string name="media_preview">Ortam Önizlemesi</string>
     <!-- option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :) -->
     <string name="aspect_ratio_grid">En Boy Oranı Izgarası</string>
@@ -741,8 +748,6 @@
     <string name="pref_use_system_emoji_explain">Delta Chat\'in gömülü emoji desteğini kapat</string>
     <string name="pref_show_system_contacts">Sistem Adres Defterini Oku</string>
     <string name="pref_show_system_contacts_explain">Adres defterinden gelen kişilerle sohbetler oluşturmayı teklif edin.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Uygulama Erişimi</string>
     <string name="pref_chats">Sohbetler</string>
     <string name="pref_in_chat_sounds">Sohbet İçi Sesler</string>
     <string name="pref_view_log">Günlüğü Görüntüle</string>
@@ -778,7 +783,7 @@
     <string name="pref_auto_folder_moves">DeltaChat Klasörüne Otomatik Olarak Taşı</string>
     <string name="pref_auto_folder_moves_explain">Sohbet görüşmeleri, Gelen Kutusu\'ndaki dağınıklığı önlemek için taşınır</string>
     <string name="pref_only_fetch_mvbox_title">Yalnızca DeltaChat Klasöründen Getir</string>
-    <string name="pref_only_fetch_mvbox_explain">Diğer klasörleri yok sayar. Sunucunuzun sohbet iletilerini DeltaChat klasörüne taşımasını gerektirir.</string>
+    <string name="pref_only_fetch_mvbox_explain">Diğer klasörleri yoksayar. Sunucunuzun sohbet iletilerini DeltaChat klasörüne taşımasını gerektirir.</string>
     <string name="pref_show_emails">Klasik E-Postaları Göster</string>
     <string name="pref_show_emails_no">Hayır, yalnızca sohbetler</string>
     <string name="pref_show_emails_accepted_contacts">Kabul edilen kişiler için</string>
@@ -861,15 +866,10 @@
 
     <!-- autocrypt -->
     <string name="autocrypt_send_asm_title">Autocrypt Ayarlama İletisi Gönder</string>
-    <string name="autocrypt_send_asm_explain_before">Bir Autocrypt Ayarlama İletisi, uçtan uca ayarlamanızı diğer Autocrypt uyumlu uygulamalarla güvenli olarak paylaşır.\n\nAyarlama, burada görüntülenen ve diğer aygıtta yazılması gereken bir ayarlama kodu tarafından şifrelenecek.</string>
+    <string name="autocrypt_send_asm_explain_before">Bir Autocrypt Ayarlama İletisi, uçtan uca ayarlamanızı diğer Autocrypt uyumlu uygulamalarla güvenli olarak paylaşır.\n\nDelta Chat\'i diğer aygıtta da kullanmak istiyorsanız, bunun yerine “Ayarlar / İkinci Aygıt Ekle”yi kullanın.</string>
     <string name="autocrypt_send_asm_button">Autocrypt Ayarlama İletisi Gönder</string>
     <string name="autocrypt_send_asm_explain_after">Ayarlamanız kendinize gönderildi. Diğer aygıta geçin ve ayarlama iletisini açın. Size bir ayarlama kodu sorulmalı. Aşağıdaki sayıları girin:</string>
     <string name="autocrypt_prefer_e2ee">Uçtan Uca Şifrelemeyi Yeğle</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt Ayarlama İletisi</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Bu, uçtan uca ayarlamanızı istemciler arasında aktarmak için kullanılan Autocrypt Ayarlama İletisi\'dir.\n\nŞifreyi çözmek ve ayarlamanızı kullanmak için iletiyi Autocrypt uyumlu bir istemcide açın ve oluşturan aygıtta sunulan ayarlama kodunu girin.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Bu ileti şifresi çözülemiyor.\n\n• Bu iletiye basitçe yanıt vermek ve gönderenden iletiyi yeniden göndermesini istemek zaten yardımcı olabilir.\n\n• Delta Chat\'i yeni kurduysanız, Delta Chat\'i şimdi yeniden ayarlayıp “İkinci Aygıt Olarak Ekle”yi seçmeniz ya da bir yedeği içe aktarmanız en iyisidir.</string>
@@ -1004,7 +1004,7 @@
     <string name="secure_join_wait">Güvencelenen uçtan uca şifreleme kuruluyor, lütfen bekleyin…</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Henüz güvencelenen uçtan uca şifreleme kurulamadı; ama zaten bir ileti gönderebilirsiniz.</string>
-    <string name="secure_join_takes_longer">Bu daha uzun sürüyor gibi görünüyor, belki kişi ya da siz çevrimdışısınız.\n\nAncak işlem arka planda sürüyor, başka bir şey yapabilirsiniz…</string>
+    <string name="secure_join_takes_longer">Sürdürmek için kişi çevrimiçi olmalıdır.\n\nBu işlem, arka planda otomatik olarak sürecek.</string>
     <string name="contact_verified">%1$s tanıtıldı.</string>
     <string name="contact_not_verified">%1$s ile güvencelenen uçtan uca şifreleme kurulamıyor.</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -1013,8 +1013,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">%1$s için ayarlama değiştirildi.</string>
     <string name="verified_contact_required_explain">Uçtan uca şifrelemeyi güvencelemek için bu öbeğe yalnızca yeşil bir onay imi olan kişileri ekleyebilirsiniz.\n\nDoğrulanmayan kişilerle kişisel olarak tanışabilir ve onları tanıtmak için onların QR kodunu tarayabilirsiniz.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">QR URL\'si panoya kopyalandı</string>
     <string name="mailto_dialog_header_select_chat">İletiyi göndermek için sohbet seçin</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s zaten bir taslak ileti; onu değiştirmek istiyor musunuz?</string>
@@ -1040,7 +1038,8 @@
     <string name="perm_required_title">İzin gerekli</string>
     <string name="perm_continue">Sürdür</string>
     <string name="perm_explain_access_to_camera_denied">Fotoğraflar çekmek ya da videolar yakalamak için uygulama ayarlarına gidin, “İzinler”i seçin ve “Kamera”yı etkinleştirin.</string>
-    <string name="perm_explain_access_to_mic_denied">Sesli iletiler göndermek için uygulama ayarlarına gidin, “İzinler”i seçin ve “Mikrofon”u etkinleştirin.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">Sesli iletiler göndermek için sistem ya da uygulama ayarlarına gidin, “İzinler”i ya da “Gizlilik ve Güvenlik”i seçin ve “Mikrofon”u etkinleştirin.</string>
     <string name="perm_explain_access_to_storage_denied">Dosyalar almak ya da göndermek için uygulama ayarlarına gidin, “İzinler”i seçin ve “Depolama”yı etkinleştirin.</string>
     <string name="perm_explain_access_to_location_denied">Bir konum iliştirmek için uygulama ayarlarına gidin, “İzinler”i seçin ve “Konum”u etkinleştirin.</string>
     <string name="perm_explain_access_to_notifications_denied">Bildirimler almak için “Sistem Ayarları / Uygulamalar / Delta Chat”e gidin ve “Bildirimler”i etkinleştirin.</string>
@@ -1176,11 +1175,11 @@
     <!-- android specific strings, developers: please take care to remove strings that are no longer used! -->
     <string name="pref_instant_delivery">Anında Teslimat</string>
     <string name="pref_background_notifications">Arka Plan Bağlantısı Kullan</string>
-    <string name="pref_background_notifications_explain">Pil iyileştirmelerinin yok sayılmasını gerektirir, bildirimler zamanında gelmezse kullanın</string>
+    <string name="pref_background_notifications_explain">Pil iyileştirmelerinin yoksayılmasını gerektirir, bildirimler zamanında gelmezse kullanın</string>
     <string name="pref_reliable_service">Arka Plan Bağlantısını Zorla</string>
     <string name="pref_reliable_service_explain">Kalıcı bir bildirime neden olur</string>
 
-    <string name="pref_background_notifications_rationale">Bağlantıyı sürdürmek ve arka planda iletileri almak için sonraki adımda pil iyileştirmelerini yok sayın.\n\nDelta Chat, az kaynak kullanır ve pilinizi boşaltmamaya özen gösterir.</string>
+    <string name="pref_background_notifications_rationale">Bağlantıyı sürdürmek ve arka planda iletileri almak için sonraki adımda pil iyileştirmelerini yoksayın.\n\nDelta Chat, az kaynak kullanır ve pilinizi boşaltmamaya özen gösterir.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="perm_enable_bg_reminder_title">Delta Chat arka plandayken iletileri almak için buraya dokunun.</string>
     <string name="perm_enable_bg_already_done">Delta Chat\'in arka planda iletileri almasına zaten izin verdiniz.\n\nİletiler arka planda hâlâ gelmiyorsa, lütfen sistem ayarlarınızı da denetleyin.</string>

--- a/_locales/uk.xml
+++ b/_locales/uk.xml
@@ -29,6 +29,7 @@
     <string name="rejoin">Заново приєднатися</string>
     <string name="delete">Видалити</string>
     <string name="delete_for_me">Видалити для мене</string>
+    <string name="delete_for_everyone">Видалити для всіх</string>
     <string name="info">Інформація</string>
     <string name="update">Оновити</string>
     <string name="emoji">Емодзі</string>
@@ -51,7 +52,7 @@
     <string name="mute">Вимкнути сповіщення</string>
     <string name="muted">Вимкнено</string>
     <string name="ephemeral_messages">Зникаючі повідомлення</string>
-    <string name="ephemeral_messages_hint">Ці налаштування застосовуються до всіх учасників, що використовують DeltaChat. Однак вони можуть копіювати, зберігати та пересилати повідомлення або використовувати інші клієнти електронної пошти.</string>
+    <string name="ephemeral_messages_hint">Застосовується до всіх учасників цього чату; вони все ще можуть копіювати, зберігати та пересилати повідомлення.</string>
     <string name="save">Зберегти</string>
     <string name="chat">Чат</string>
     <string name="media">Медіа</string>
@@ -108,8 +109,8 @@
     <!-- Refers to the time a contact was last seen. Shown below contact name in the profile. The placeholder will be replaced by date or time, resulting in "Last seen at 12:13 AM" or "Last seen Nov 12" -->
     <string name="last_seen_at">З\'являвся зʼявлялася востаннє %1$s</string>
     <!-- Refers to the time a contact was last seen. Shown below contact name in the profile. The placeholder will be replaced by a relative point in time as "3 minutes ago" (see https://momentjs.com for more examples and languages)-->
-    <string name="last_seen_relative">З\'являвся (зʼявлялася) востаннє %1$s</string>
-    <string name="last_seen_unknown">Невідомо коли з\'являвся (зʼявлялася) востаннє</string>
+    <string name="last_seen_relative">Останній раз бачили %1$s</string>
+    <string name="last_seen_unknown">Останній раз бачили: Невідомо.</string>
     <!-- Shown beside messages that are "N minutes old". Prefer short strings, or well-known abbreviations. -->
     <plurals name="n_minutes">
         <item quantity="one">%d хвилину</item>
@@ -201,6 +202,10 @@
     <string name="images_and_videos">Зображення та відео</string>
     <string name="file">Файл</string>
     <string name="files">Файли</string>
+    <string name="files_attach_hint">Надсилати оригінальні файли та нестиснуті зображення</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">Вибрати з Файлів</string>
+    <string name="choose_from_gallery">Вибрати з Галереї</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">Застосунок</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
@@ -322,6 +327,7 @@
     <string name="menu_learn_spelling">Вчити правопис</string>
     <string name="menu_chat_audit_log">Журнал аудиту чату</string>
     <string name="jump_to_message">Перейти до повідомлення</string>
+    <string name="jump_to_original_message">Перейти до оригінального повідомлення</string>
     <string name="copy_json">Копіювати JSON</string>
     <string name="replace_draft">Замінити чернетку</string>
     <string name="title_share_location">Ділитися геоданими з усіма членами групи</string>
@@ -375,7 +381,7 @@
     <string name="videochat_instance">Відео чат</string>
     <string name="videochat_instance_placeholder">Ваш відео чат</string>
     <!-- Do not translate "$ROOM", since it is a fixed token Delta Chat will replace with a generated room ID like "aOclju5eCky" -->
-    <string name="videochat_instance_example">Приклади: https://meet.jit.si/$ROOM або basicwebrtc:https://your-server</string>
+    <string name="videochat_instance_example">Приклад: https://your-server.org/$ROOM</string>
     <string name="videochat_instance_explain_2">Якщо ввімкнено, Ви можете почати відеочат із кожного чату. Обидві сторони повинні встановити сумісний додаток або браузер.</string>
     <string name="videochat_instance_from_qr">Використовувати \"%1$s\" аби запросити інших у відеочат?\n\nПісля встановлення Ви можете розпочати відеочат із кожного індивідуального чату. Це замінить попереднє налаштування для відеочату, якщо воно є.</string>
     <string name="videochat_invitation">Запрошення до відео чату</string>
@@ -385,7 +391,7 @@
     <string name="ask_leave_group">Ви впевнені, що хочете залишити цю групу?</string>
     <plurals name="ask_delete_chat">
         <item quantity="one">Видалити %d чат на всіх ваших пристроях?</item>
-        <item quantity="few">Видалити %d чата на всіх ваших пристроях?</item>
+        <item quantity="few">Видалити %d чати на всіх ваших пристроях?</item>
         <item quantity="many">Видалити %d чатів на всіх ваших пристроях?</item>
         <item quantity="other">Видалити %d чатів на всіх ваших пристроях?</item>
     </plurals>
@@ -569,7 +575,7 @@
     <!-- "Second Device" can also be translated as "Another Device", if that is catchier in the destination language. However, make sure to use the term consistently. -->
     <string name="multidevice_title">Додати другий пристрій</string>
     <string name="multidevice_same_network_hint">Переконайтеся, що обидва пристрої підключено до однієї мережі Wi-Fi</string>
-    <string name="multidevice_this_creates_a_qr_code">Це створить QR-код, який другий пристрій може сканувати, щоб скопіювати обліковий запис.</string>
+    <string name="multidevice_this_creates_a_qr_code">Це створить QR-код, який другий пристрій зможе відсканувати, щоб скопіювати профіль.\n\nПереконайтеся, що жоден небажаний спостерігач або камера не зможе побачити наступний екран.</string>
     <string name="multidevice_install_dc_on_other_device">Установіть Delta Chat на Ваш інший пристрій (https://get.delta.chat)</string>
     <!-- "I Already Have a Profile / Add as Second Device” should be the same text as defined by the keys onboarding_alternative_logins and multidevice_receiver_title -->
     <string name="multidevice_tap_scan_on_other_device">Запустіть Delta Chat, торкніться \"Я вже маю профіль / Додати як другий пристрій\" і відскануйте код, показаний тут</string>
@@ -577,12 +583,13 @@
     <string name="multidevice_qr_subtitle">Скануйте, щоб налаштувати другий пристрій %1$s</string>
     <string name="multidevice_receiver_title">Додати як другий пристрій</string>
     <string name="multidevice_open_settings_on_other_device">На першому пристрої перейдіть до «Налаштування / Додати другий пристрій» і відскануйте показаний там код</string>
-    <string name="multidevice_receiver_scanning_ask">Скопіювати обліковий запис з іншого пристрою на цей?</string>
+    <string name="multidevice_receiver_scanning_ask">Скопіювати профіль з іншого пристрою на цей?</string>
+    <string name="multidevice_receiver_needs_update">Профіль, який ви хочете імпортувати, належить до новішої версії Delta Chat.\n\nЩоб продовжити налаштування другого пристрою, будь ласка, оновіть його до останньої версії Delta Chat.</string>
     <string name="multidevice_abort">Скасувати налаштування другого пристрою?</string>
     <string name="multidevice_abort_will_invalidate_copied_qr">Це зробить недійсним QR-код, скопійований у буфер обміну.</string>
-    <string name="multidevice_transfer_done_devicemsg">ℹ️ Обліковий запис перенесено на ваш другий пристрій.</string>
+    <string name="multidevice_transfer_done_devicemsg">ℹ️ Профіль перенесено на ваш другий пристрій.</string>
     <!-- Shown beside progress bar, stay short -->
-    <string name="preparing_account">Підготовка облікового запису…</string>
+    <string name="preparing_account">Підготовка профілю…</string>
     <!-- Shown beside progress bar, stay short -->
     <string name="transferring">Передача…</string>
     <string name="troubleshooting">Вирішення проблем</string>
@@ -614,9 +621,9 @@
 
     <!-- welcome and login -->
     <!-- Primary button on the welcome screen, allows to create an instant profile -->
-    <string name="onboarding_create_instant_account">Почнемо!</string>
+    <string name="onboarding_create_instant_account">Створити новий профіль</string>
     <!-- Secondary button on the welcome screen, allows to "Add as Second Device", "Restore from Backup"  -->
-    <string name="onboarding_alternative_logins">У мене вже є логін</string>
+    <string name="onboarding_alternative_logins">У мене вже є профіль</string>
     <!-- Button, allows to log in to existing email accounts, setting ports, passwords and so on -->
     <string name="manual_account_setup_option">Класичний вхід до електронної пошти</string>
     <!-- Instant onboarding title (there is not more to do than to set name and avatar) -->
@@ -673,7 +680,7 @@
     <string name="proxy_share_link">Поділитися посиланням</string>
 
     <string name="login_info_oauth2_title">Продовжити спрощене налаштування?</string>
-    <string name="login_info_oauth2_text">Введена адреса електронної пошти підтримує спрощене налаштування (OAuth 2.0).\n\nНа наступному кроці дозвольте, будь ласка, Delta Chat виступати в якості Вашого додатку для чату за допомогою електронної пошти.\n\nУ Delta Chat немає серверів, Ваші дані залишаються на Вашому пристрої!</string>
+    <string name="login_info_oauth2_text">Введена адреса підтримує спрощене налаштування (OAuth 2.0).\n\nНа наступному кроці, будь ласка, дозвольте Delta Chat надсилати та отримувати повідомлення.\n\nDelta Chat не збирає дані користувача, все залишається на вашому пристрої.</string>
     <string name="login_certificate_checks">Перевірки сертифікатів</string>
     <string name="login_error_mail">Вкажіть дійсну адресу електронної пошти</string>
     <string name="login_error_server">Вкажіть дійсний сервер / IP-адресу</string>
@@ -686,16 +693,19 @@
     <string name="login_error_cannot_login">Не вдалося увійти як \"%1$s\". Будь ласка, перевірте правильність адреси електронної пошти та паролю.</string>
     <!-- TLS certificate checks -->
     <string name="accept_invalid_certificates">Приймати недійсні сертифікати</string>
-    <string name="switch_account">Перемкнути обліковий запис</string>
-    <string name="add_account">Додати обліковий запис</string>
+    <string name="switch_account">Перемкнути профіль</string>
+    <string name="add_account">Додати профіль</string>
+    <!-- for translations, you can also think of "Profile Tag" or "Profile Description" as the source string -->
+    <string name="profile_tag">Опис профілю</string>
     <string name="profile_tag_hint">наприклад \"Робота\", \"Сім\'я\"</string>
+    <string name="profile_tag_explain">Встановіть мітку, яку бачитимете лише ви, це допоможе вам розрізняти ваші профілі.</string>
     <!-- Menu entry to sort an item to the beginning of a list. Only "To Top" may do as well in some translations, if that helps to stay shorter. -->
     <string name="move_to_top">Перемістити на початок</string>
-    <string name="delete_account">Видалити обліковий запис</string>
-    <string name="delete_account_ask">Ви впевнені, що хочете видалити дані вашого облікового запису?</string>
-    <string name="delete_account_explain_with_name">Дані облікового запису \"%s\" на цьому пристрої будуть видалені, включаючи налаштування наскрізного шифрування, контакти, чати, повідомлення та медіа. Ця дія не може бути скасована.</string>
-    <string name="unconfigured_account">Неналаштований обліковий запис</string>
-    <string name="unconfigured_account_hint">Відкрити обліковий запис для налаштування.</string>
+    <string name="delete_account">Видалити профіль</string>
+    <string name="delete_account_ask">Ви впевнені, що хочете видалити дані вашого профілю?</string>
+    <string name="delete_account_explain_with_name">Дані профілю \"%s\" на цьому пристрої будуть видалені, включаючи налаштування наскрізного шифрування, контакти, чати, повідомлення та медіа. Ця дія не може бути скасована.</string>
+    <string name="unconfigured_account">Неналаштований профіль</string>
+    <string name="unconfigured_account_hint">Відкрити профіль для налаштування.</string>
     <string name="try_connect_now">Спробувати підключитися негайно</string>
     <string name="sync_all">Синхронізувати все</string>
     <!-- Translations: %1$s will be replaced by a more detailed error message -->
@@ -716,7 +726,7 @@
     <string name="pref_using_custom">Використовувати персоналізовано: %s</string>
     <string name="pref_using_default">Використовувати за замовчуванням: %s</string>
     <string name="pref_profile_info_headline">Ваш профіль</string>
-    <string name="pref_profile_photo">Фото профілю</string>
+    <string name="pref_profile_photo">Зображення профілю</string>
     <string name="pref_blocked_contacts">Заблоковані контакти</string>
     <string name="blocked_empty_hint">Заблоковані Вами контакти будуть відображені тут.</string>
     <string name="pref_password_and_account_settings">Пароль та обліковий запис</string>
@@ -766,9 +776,7 @@
     <string name="pref_use_system_emoji">Використовувати системні емодзі</string>
     <string name="pref_use_system_emoji_explain">Вимкнути вбудовану підтримку емодзі</string>
     <string name="pref_show_system_contacts">Прочитати адресну книгу системи</string>
-    <string name="pref_show_system_contacts_explain">Пропозиція створювати чати з контактами з адресної книги. Деякі провайдери потребують попереднього налаштування наскрізного шифрування.</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Доступ додатку</string>
+    <string name="pref_show_system_contacts_explain">Пропонувати створювати чати з контактами з адресної книги.</string>
     <string name="pref_chats">Чати</string>
     <string name="pref_in_chat_sounds">Звуки в чаті</string>
     <string name="pref_view_log">Переглянути журнал</string>
@@ -782,7 +790,7 @@
     <!-- the placeholder will be replaced by the profile name -->
     <string name="pref_backup_export_x">Експортувати %1$s</string>
     <!-- the placeholder will be replaced by the number of profiles to export; the number is always larger than 1 -->
-    <string name="pref_backup_export_all">Експортувати всі %1$d облікові записи</string>
+    <string name="pref_backup_export_all">Експортувати всі %1$d профілі</string>
     <string name="pref_backup_export_start_button">Почати резервне копіювання</string>
     <string name="pref_backup_written_to_x">Резервна копія успішно записана на %1$s</string>
     <string name="pref_managekeys_menu_title">Управління ключами</string>
@@ -863,16 +871,16 @@
     <!-- automatically delete message -->
     <string name="delete_old_messages">Видалити старі повідомлення</string>
     <string name="autodel_device_title">Видалити повідомлення з пристрою</string>
-    <string name="autodel_server_title">Видалити повідомлення на сервері</string>
+    <string name="autodel_server_title">Видалити повідомлення з сервера</string>
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
     <string name="autodel_device_ask">Ви хочете видалити %1$d повідомлень зараз і всі нові повідомлення \"%2$s\" у майбутньому?\n\n- Це включає всі медіа\n\n- Повідомлення буде видалено незалежно від того, чи були вони переглянуті чи ні\n\n- \"Збережені повідомлення\" буде пропущено при локальному видаленні</string>
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
-    <string name="autodel_server_ask">Ви хочете видалити %1$dповідомлень зараз і всі нові повідомлення \"%2$s\" в майбутньому?\n\n⚠️ Сюди входять електронні листи, медіа та \"Збережені повідомлення\" у всіх папках сервера\n\n⚠️ Не використовуйте цю функцію, якщо Ви хочете зберегти дані на сервері\n\n⚠️ Не використовуйте цю функцію, якщо користуєтеся ще й іншими поштовими клієнтами крім Delta Chat</string>
+    <string name="autodel_server_ask">Ви хочете видалити %1$d повідмолень зараз і всі нові повідомлення \"%2$s\" в майбутньому?\n\n⚠️ Сюди входять електронні листи, медіа та \"Збережені повідомлення\" у всіх папках сервера\n\n⚠️ Не використовуйте цю функцію, якщо ви хочете зберегти дані на сервері або якщо ви також використовуєте класичні поштові клієнти</string>
     <!-- shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact -->
-    <string name="autodel_server_enabled_hint">Це стосується повідомлень електронної пошти, медіа та \"Збережених повідомлень\" у всіх серверних папках. Не використовуйте цю функцію, якщо хочете зберегти дані на сервері або якщо користуєтесь іншими клієнтами електронної пошти крім Delta Chat.</string>
+    <string name="autodel_server_enabled_hint">Сюди входять електронні листи, медіафайли та \"Збережені повідомлення\" у всіх папках сервера. Не використовуйте цю функцію, якщо ви хочете зберігати дані на сервері або якщо ви використовуєте класичні поштові клієнти</string>
     <string name="autodel_server_warn_multi_device_title">Увімкнути одномоментне видалення</string>
     <string name="autodel_server_warn_multi_device">Якщо ви ввімкнули одномоментне видалення, ви не зможете використовувати кілька пристроїв у цьому профілі.</string>
-    <string name="autodel_confirm">Я все розумію, видалити всі повідомлення</string>
+    <string name="autodel_confirm">Я розумію, видалити всі ці повідомлення</string>
     <!-- "At once" in the meaning of "Immediately", without any intervening time. -->
     <string name="autodel_at_once">Відразу після завантаження</string>
     <string name="after_30_seconds">Через 30 секунд</string>
@@ -887,15 +895,10 @@
 
     <!-- autocrypt -->
     <string name="autocrypt_send_asm_title">Надіслати повідомлення з налаштуваннями Autocrypt</string>
-    <string name="autocrypt_send_asm_explain_before">Повідомлення з налаштуваннямм Autocrypt слугує безпечній передачі параметрів наскрізного шифрування між власними додатками для роботи з електронною поштою, що підтримують протокол Autocrypt.\n\nЦі параметри шифруються з використанням спеціального інсталяційного коду, що показаний тут і має бути введений на іншому пристрої.</string>
+    <string name="autocrypt_send_asm_explain_before">Повідомлення про налаштування Autocrypt безпечно передає ваші налаштування наскрізного шифрування іншим програмам, що підтримують Autocrypt.\n\nЯкщо ви використовуєте Delta Chat і на іншому пристрої, скористайтеся \"Налаштування / Додати другий пристрій\" замість цього.</string>
     <string name="autocrypt_send_asm_button">Надіслати повідомлення з налаштуваннями Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Налаштування було Вам надіслано. Перейдіть на інший пристрій і відкрийте повідомлення про налаштування. У Вас має з\'явитися запит на введення коду налаштування. Введіть наступні цифри:</string>
     <string name="autocrypt_prefer_e2ee">Віддавати перевагу наскрізному шифруванню</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Повідомлення з налаштуваннями Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Це повідомлення з налаштуваннями Autocrypt, що слугує для передачі параметрів наскрізного шифрування між пристроями.\n\nДля розшифрування параметрів відкрийте це повідомлення в додатку, що підтримує Autocrypt і введіть інсталяційний код, показаний на початковому пристрої.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Це повідомлення неможливо розшифрувати.\n\n- Можливо, допоможе просто відповісти на це повідомлення і попросити відправника надіслати повідомлення ще раз.\n\n- Якщо ви щойно переінсталювали Delta Chat, то краще за все переналаштувати Delta Chat зараз і вибрати \"Додати як другий пристрій\" або імпортувати резервну копію.</string>
@@ -925,7 +928,7 @@
     <string name="group_left_by_other">%1$s залишив (-ла) групу.</string>
     <string name="group_image_deleted_by_you">Ви видалили зображення групи.</string>
     <!-- %1$s will be replaced by name and address of the contact -->
-    <string name="group_image_deleted_by_other">%1$s видалив (-ла) зображення групи.</string>
+    <string name="group_image_deleted_by_other">Зображення групи видалено користувачем %1$s.</string>
     <string name="location_enabled_by_you">Ви увімкнули стримінг геоданих.</string>
     <!-- %1$s will be replaced by name and address of the contact -->
     <string name="location_enabled_by_other">%1$s увімкнув (-ла) стримінг геоданих.</string>
@@ -967,7 +970,7 @@
     <!-- this may be shown instead of the chat's input field, with buttons "More Info" and "OK" -->
     <string name="chat_protection_broken">%1$s відправив (-ла) повідомлення з іншого пристрою.</string>
     <string name="chat_protection_enabled_tap_to_learn_more">Відтепер повідомлення гарантовано будуть мати наскрізне шифрування. Торкніться, щоб дізнатися більше.</string>
-    <string name="chat_protection_enabled_explanation">Тепер гарантовано, що всі повідомлення в цьому чаті матимуть наскрізне шифрування.\n\nНаскрізне шифрування зберігає конфіденційність повідомлень між Вами та партнерами по чату. Навіть Ваш провайдер електронної пошти не може їх прочитати.</string>
+    <string name="chat_protection_enabled_explanation">Тепер гарантовано, що всі повідомлення в цьому чаті наскрізь зашифровані.\n\nНаскрізне шифрування зберігає конфіденційність повідомлень між вами і вашими партнерами по чату. Навіть сервери, провайдери або ретранслятори не можуть їх прочитати.</string>
     <string name="chat_protection_broken_tap_to_learn_more">%1$s відправив (-ла) повідомлення з іншого пристрою. Торкніться, щоб дізнатися більше.</string>
     <string name="chat_protection_broken_explanation">Наскрізне шифрування більше не гарантується, імовірно, через те, що %1$s перевстановив (-ла) Delta Chat або надіслав (-ла) повідомлення з іншого пристрою.\n\nВи можете зустрітися з ним (нею) особисто та знову відсканувати його (її) QR-код, щоб відновити гарантоване наскрізне шифрування.</string>
     <string name="invalid_unencrypted_tap_to_learn_more">⚠️ %1$s вимагає наскрізного шифрування, яке ще не налаштоване для цього чату. Натисніть, щоб дізнатися більше.</string>
@@ -993,7 +996,7 @@
     <string name="qrscan_failed">Неможливо декодувати QR-код</string>
     <string name="qrscan_ask_join_group">Приєднатися до групи «%1$s»?</string>
     <string name="qrscan_fingerprint_mismatch">Відсканований відбиток не збігається з останнім відомим відбитком %1$s</string>
-    <string name="qrscan_no_addr_found">QR-код містить відбиток, але не містить адресу електронної пошти.\n\nДля перевірки автентичності з використанням альтернативного каналу зв\'язку слід спочатку встановити з одержувачем захищене з\'єднання.</string>
+    <string name="qrscan_no_addr_found">Цей QR-код містить відбиток пальця, але не адресу.\n\nДля позасмугової перевірки, будь ласка, спочатку встановіть зашифроване з\'єднання з одержувачем.</string>
     <string name="qrscan_contains_text">Текст з QR-коду:\n\n%1$s</string>
     <string name="qrscan_contains_url">URL з QR-коду:\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">Відбиток</string>
@@ -1014,15 +1017,15 @@
     <!-- This text is shown inside the "QR code card" with very limited space; please formulate the text as short as possible therefore. The placeholder will be replaced by name and address eg. "Scan to chat with Alice (alice@example.org)" -->
     <string name="qrshow_join_contact_hint">Відскануйте код, щоб спілкуватись з %1$s</string>
     <string name="qrshow_join_contact_no_connection_toast">Відсутнє інтернет з\'єднання, не вдалося налаштувати QR-код.</string>
-    <string name="qraccount_ask_create_and_login">Створити нову електронну адресу на \"%1$s\" та увійти у неї?</string>
-    <string name="qraccount_ask_create_and_login_another">Створити нову електронну адресу на \"%1$s\" та увійти у неї?\n\nВаш поточний обліковий запис не буде видалено. Використовуйте \"Перемкнути обліковий запис\".</string>
+    <string name="qraccount_ask_create_and_login">Створити новий профіль на \"%1$s\" і увійти в нього?</string>
+    <string name="qraccount_ask_create_and_login_another">Створити новий профіль на \"%1$s\" і увійти в нього?\n\nВаш поточний профіль не буде видалено. Використовуйте \"Перемкнути профіль\".</string>
     <string name="set_name_and_avatar_explain">Встановіть ім’я, яке зможуть розпізнати Ваші контакти. Ви також можете встановити зображення профілю.</string>
     <string name="please_enter_name">Будь ласка, введіть ім\'я.</string>
-    <string name="qraccount_qr_code_cannot_be_used">Вісканований QR-код не може бути використаний для створення нового облікового запису.</string>
+    <string name="qraccount_qr_code_cannot_be_used">Вісканований QR-код не може бути використаний для створення нового профілю.</string>
     <!-- the placeholder will be replaced by the address of the profile -->
     <string name="qrlogin_ask_login">Увійти до \"%1$s\"?</string>
     <!-- the placeholder will be replaced by the address of the profile -->
-    <string name="qrlogin_ask_login_another">Увійти до \"%1$s\"?\n\nВаш обліковий запис, що вже існує, не буде видалено. Використовуйте \"Перемкнути обліковий запис\" для переключання між обліковими записами.</string>
+    <string name="qrlogin_ask_login_another">Увійти до \"%1$s\"?\n\nВаш профіль, що вже існує, не буде видалено. Використовуйте \"Перемкнути профіль\" для переключання між профілями.</string>
     <!-- first placeholder will be replaced by name and address of the inviter, second placeholder will be replaced by the name of the inviter. -->
     <string name="secure_join_started">%1$s запросив (-ла) Вас приєднатися до цієї групи.\n\nОчікуємо на відповідь від пристрою %2$s…</string>
     <!-- placeholder will be replaced by the name of the inviter. -->
@@ -1030,16 +1033,15 @@
     <string name="secure_join_wait">Встановлення гарантованого наскрізного шифрування, будь ласка, зачекайте...</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">Ще не вдалося встановити гарантоване наскрізне шифрування, але ви вже можете надсилати повідомлення.</string>
+    <string name="secure_join_takes_longer">Щоб продовжити, контакт повинен бути онлайн.\n\nЦей процес продовжиться автоматично у фоновому режимі.</string>
     <string name="contact_verified">%1$s представив (-ла).</string>
     <string name="contact_not_verified">Не вдається встановити гарантоване наскрізне шифрування з %1$s</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
-    <string name="verified_by">Представлений (-а) %1$s</string>
-    <string name="verified_by_you">Представлений (-а) Вами</string>
+    <string name="verified_by">Представлено %1$s</string>
+    <string name="verified_by_you">Представлено мною</string>
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Змінені параметри для %1$s</string>
     <string name="verified_contact_required_explain">Щоб гарантувати наскрізне шифрування, Ви можете додавати до цієї групи лише контакти із зеленою галочкою.\n\nВи можете зустрітися з контактами особисто та відсканувати їхній QR-код, щоб представити їх.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">URL з QR-коду скопійовано в буфер</string>
     <string name="mailto_dialog_header_select_chat">Виберіть чат, куди потрібно надіслати повідомлення</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s уже містить чернетку повідомлення, бажаєте її замінити?</string>
@@ -1065,7 +1067,8 @@
     <string name="perm_required_title">Потрібен дозвіл</string>
     <string name="perm_continue">Продовжити</string>
     <string name="perm_explain_access_to_camera_denied">Для зйомки фотографій або відео додатку потрібен дозвіл на використання камери, але зараз його не надано. Для надання дозволу перейдіть у системне меню налаштувань, у розділі \"Додатки\" знайдіть Delta Chat і надайте доступ до камери.</string>
-    <string name="perm_explain_access_to_mic_denied">Для надсилання голосових повідомлень додатку потрібен дозвіл на використання мікрофону, але зараз його не надано. Для надання дозволу перейдіть у системне меню налаштувань, у розділі \"Додатки\" знайдіть Delta Chat і надайте доступ до мікрофону.</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">Щоб надсилати аудіоповідомлення, перейдіть до налаштувань системи або програми, виберіть \"Дозволи\" або \"Конфіденційність і Безпека\" та увімкніть \"Мікрофон\".</string>
     <string name="perm_explain_access_to_storage_denied">Для збереження або передавання фотографій перейдіть до налаштувань додатку, оберіть \"Дозволи\" та ввімкніть \"Сховище\"</string>
     <string name="perm_explain_access_to_location_denied">Щоб передати місцезнаходження, додатку потрібен доступ до геоданих пристрою, але зараз його не надано. Для надання доступу перейдіть у системне меню налаштувань, у розділі \"Додатки\" знайдіть Delta Chat, оберіть \"Дозволи\" і надайте доступ до місцезнаходження пристрою.</string>
     <string name="perm_explain_access_to_notifications_denied">Щоб отримувати сповіщення зайдіть у \"Налаштування системи / Застосунки / Delta Chat\" і увімкніть \"Сповіщення\"</string>
@@ -1158,7 +1161,7 @@
     <string name="a11y_voice_message_hint_ios">Після запису двічі торкніться для відправки. Щоб скинути запис, проведіть двома пальцями.</string>
     <string name="a11y_connectivity_hint">Двічі торкніться, щоб переглянути деталі підключення.</string>
     <string name="login_error_no_internet_connection">Немає підключення до Інтернету, не вдалося ввійти.</string>
-    <string name="share_account_not_configured">Обліковий запис не налаштовано.</string>
+    <string name="share_account_not_configured">Профіль не налаштовано.</string>
     <string name="cannot_play_audio_file">Неможливо відтворити аудіофайл.</string>
     <!-- iOS camera permission alert -->
     <string name="perm_ios_explain_access_to_camera_denied">Щоб фотографувати, знімати відео або використовувати сканер QR-коду, відкрийте налаштування системи та ввімкніть камеру.</string>
@@ -1189,7 +1192,7 @@
     <string name="add_to_widget">Додати у віджет</string>
     <!-- iOS permissions, copy from "deltachat-ios/Info.plist", which is used on missing translations in "deltachat-ios/LANG.lproj/InfoPlist.strings" -->
     <string name="InfoPlist_NSCameraUsageDescription">Delta Chat використовує вашу камеру для знімання та надсилання фото та відео, а також для сканування QR-кодів.</string>
-    <string name="InfoPlist_NSContactsUsageDescription">Delta Chat використовує Ваші контакти аби показати список адрес ел.пошти, на які Ви можете написати. Delta Chat не має серверів, тож Ваші контакти нікуди не надсилаються.</string>
+    <string name="InfoPlist_NSContactsUsageDescription">Delta Chat використовує ваші контакти, щоб показати список адрес, на які ви можете писати. Delta Chat не має сервера, ваші контакти нікуди не надсилаються.</string>
     <string name="InfoPlist_NSLocationAlwaysAndWhenInUseUsageDescription">Delta Chat потребує дозволу на доступ до геоданих, щоб ділитися місцезнаходженням протягом часу, який Ви встановили в налаштуваннях місцезнаходження.</string>
     <string name="InfoPlist_NSLocationWhenInUseUsageDescription">Delta Chat потребує дозволу на доступ до геоданих, щоб ділитися вашим місцезнаходженням протягом часу, який Ви встановили в налаштуваннях місцезнаходження.</string>
     <string name="InfoPlist_NSMicrophoneUsageDescription">Delta Chat використовує Ваш мікрофон для запису й надсилання голосових повідомлень та відео зі звуком.</string>
@@ -1205,12 +1208,12 @@
     <string name="pref_reliable_service">Примусове фонове підключення</string>
     <string name="pref_reliable_service_explain">Призводить до постійного сповіщення</string>
 
-    <string name="pref_background_notifications_rationale">Для підтримки з\'єднання з Вашим сервером електронної пошти й отримання повідомлень у фоновому режимі вимкніть оптимізацію батареї на наступному кроці.\n\nDelta Chat використовує небагато ресурсів і намагається не витрачати Вашу батарею.</string>
+    <string name="pref_background_notifications_rationale">Для підтримки з\'єднання й отримання повідомлень у фоновому режимі ігноруйте оптимізацію батареї на наступному кроці.\n\nDelta Chat використовує небагато ресурсів і намагається не витрачати Вашу батарею.</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="perm_enable_bg_reminder_title">Натисніть тут, щоб отримувати повідомлення, коли Delta Chat знаходиться у фоновому режимі.</string>
     <string name="perm_enable_bg_already_done">Ви вже дозволили Delta Chat отримувати повідомлення у фоновому режимі.\n\nЯкщо повідомлення досі не приходять у фоновому режимі, перевірте налаштування системи.</string>
 
     <!-- device messages for updates -->
     <string name="update_1_50_android">Що нового? \n\n❤️‍🔥 Новий вибірник емодзі з більшою кількістю смайликів \n\n🎮 Покращені програми в чаті: отримуйте сповіщення та відкривайте додатки безпосередньо в контексті, наприклад, доданий запис у календарі \n\n👍 Отримуйте сповіщення про реакції на ваші повідомлення \n\n... 🛠️ ВИПРАВЛЕННЯ та ЩЕ БІЛЬШЕ на %1$s</string>
-    <string name="update_switch_profile_placement">ℹ️ Опцію \"Переключити профіль\" переміщено: Торкніться зображення свого профілю у верхньому кутку головного екрану, щоб додати або переключити профіль 💡.</string>
+    <string name="update_switch_profile_placement">ℹ️ Опцію \"Перемкнути профіль\" переміщено: Торкніться зображення свого профілю у верхньому кутку головного екрану, щоб додати або перемкнути профіль 💡.</string>
 </resources>

--- a/_locales/vi.xml
+++ b/_locales/vi.xml
@@ -608,8 +608,6 @@
     <string name="pref_manage_keys">Quản lý khóa</string>
     <string name="pref_use_system_emoji">Sử dụng Emoji hệ thống</string>
     <string name="pref_use_system_emoji_explain">Tắt tính năng hỗ trợ emoji tích hợp của Delta Chat</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">Quyền truy cập ứng dụng</string>
     <string name="pref_chats">Trò chuyện</string>
     <string name="pref_in_chat_sounds">Âm thanh trong cuộc trò chuyện</string>
     <string name="pref_view_log">Xem nhật ký</string>
@@ -720,11 +718,6 @@
     <string name="autocrypt_send_asm_button">Gửi tin nhắn thiết lập Autocrypt</string>
     <string name="autocrypt_send_asm_explain_after">Thiết lập của bạn đã được gửi cho chính bạn. Chuyển sang thiết bị khác và mở thông báo thiết lập. Bạn sẽ được yêu cầu nhập mã thiết lập. Nhập các chữ số sau:</string>
     <string name="autocrypt_prefer_e2ee">Ưu tiên mã hóa đầu cuối</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Thông báo thiết lập Autocrypt</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">Đây là Thông báo Thiết lập Autocrypt được sử dụng để truyền thiết lập hai đầu của bạn giữa các máy khách.\n\nĐể giải mã và sử dụng thiết lập của bạn, hãy mở tin nhắn trong một ứng dụng khách tương thích với Autocrypt và nhập mã thiết lập được trình bày trên thiết bị tạo.</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">Không thể giải mã tin nhắn này.\n\n• Bạn chỉ cần trả lời tin nhắn này và yêu cầu người gửi gửi lại tin nhắn là đủ.\n\n• Nếu bạn vừa cài đặt lại Delta Chat thì tốt nhất bạn nên cài đặt lại thiết lập lại Delta Chat ngay bây giờ và chọn "Thêm làm thiết bị thứ hai" hoặc nhập bản sao lưu.</string>
@@ -859,8 +852,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">Đã thay đổi thiết lập cho %1$s.</string>
     <string name="verified_contact_required_explain">Để đảm bảo mã hóa hai đầu, bạn chỉ có thể thêm những người liên hệ có dấu kiểm màu xanh lục vào nhóm này.\n\nBạn có thể gặp trực tiếp những người liên hệ và quét Mã QR của họ để giới thiệu họ.</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">Đã sao chép url QR vào clipboard</string>
     <string name="mailto_dialog_header_select_chat">Chọn trò chuyện để gửi tin nhắn tới</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s đã có tin nhắn nháp, bạn có muốn thay thế nó không?</string>
@@ -884,6 +875,7 @@
     <string name="perm_required_title">Cần có sự cho phép</string>
     <string name="perm_continue">Tiếp tục</string>
     <string name="perm_explain_access_to_camera_denied">Để chụp ảnh hoặc quay video, hãy chuyển tới cài đặt ứng dụng, chọn \"Quyền\" và bật \"Máy ảnh\".</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">Để gửi tin nhắn âm thanh, hãy chuyển tới cài đặt ứng dụng, chọn \"Quyền\" và bật \"Micrô\".</string>
     <string name="perm_explain_access_to_storage_denied">Để nhận hoặc gửi tệp, hãy đi tới cài đặt ứng dụng, chọn \"Quyền\" và bật \"Bộ nhớ\".</string>
     <string name="perm_explain_access_to_location_denied">Để đính kèm một vị trí, hãy đi tới cài đặt ứng dụng, chọn \"Quyền\" và bật \"Vị trí\".</string>

--- a/_locales/zh_CN.xml
+++ b/_locales/zh_CN.xml
@@ -52,10 +52,11 @@
     <string name="mute">静音</string>
     <string name="muted">已静音</string>
     <string name="ephemeral_messages">消息定时销毁</string>
-    <string name="ephemeral_messages_hint">适用于此聊天内使用 Delta Chat 的所有成员；这些成员仍然可以复制、保存和转发消息，或使用其他电子邮件客户端。</string>
+    <string name="ephemeral_messages_hint">适用于此聊天的所有成员；他们仍然可以复制、保存和转发消息。</string>
     <string name="save">保存</string>
     <string name="chat">聊天</string>
     <string name="media">媒体</string>
+    <string name="apps_and_media">应用和媒体</string>
     <string name="profile">账号</string>
     <string name="main_menu">主菜单</string>
     <string name="start_chat">开始聊天</string>
@@ -144,7 +145,7 @@
 
     <string name="self">我</string>
     <string name="draft">草稿</string>
-    <string name="image">图像</string>
+    <string name="image">图片</string>
     <!-- Used in summaries as "Draft: Reply", similar as "Draft: Image". Use a noun here, not a verb (not: "to reply") -->
     <string name="reply_noun">回复</string>
     <string name="gif">Gif</string>
@@ -153,7 +154,7 @@
     <string name="add_to_sticker_collection">添加到贴纸收藏集</string>
     <string name="add_stickers_instructions">要添加贴纸，请点击“打开贴纸文件夹”，为贴纸包创建一个子文件夹，然后将图片和贴纸文件拖动到那里</string>
     <string name="open_sticker_folder">打开贴纸文件夹</string>
-    <string name="images">图像</string>
+    <string name="images">图片</string>
     <string name="audio">音频</string>
     <string name="voice_message">语音消息</string>
     <string name="forwarded">转发了</string>
@@ -172,19 +173,24 @@
     <string name="location">位置</string>
     <string name="locations">位置</string>
     <string name="gallery">图库</string>
-    <string name="images_and_videos">图像和视频</string>
+    <string name="images_and_videos">图片和视频</string>
     <string name="file">文件</string>
     <string name="files">文件</string>
+    <string name="files_attach_hint">发送原始文件和未压缩的图片</string>
+    <!-- "Files" here means the "Files Selector App" or "Files Manager App" -->
+    <string name="choose_from_files">从文件中选择</string>
+    <string name="choose_from_gallery">从图库中选择</string>
     <!-- "App" is used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_app">私人应用</string>
     <!-- plural of "App"; used to present "Webxdc App" (https://webxdc.org) in a user friendly way. Please stay close to the original term and keep it short (it is used in menus with few screen space). -->
     <string name="webxdc_apps">私人应用</string>
-    <string name="webxdc_store_url">\"应用选择器“ URL</string>
+    <string name="webxdc_store_url">应用选择器 URL</string>
     <string name="webxdc_store_url_explain">设置后，该 URL 而不是默认的 URL 将被用作“应用选择器”</string>
+    <string name="webxdc_draft_hint">轻按“发送”分享</string>
     <string name="home">首页</string>
     <string name="games">游戏</string>
     <string name="tools">工具</string>
-    <string name="app_size">尺寸</string>
+    <string name="app_size">大小</string>
     <string name="app_date_published">已发布</string>
     <string name="add_to_chat">添加到聊天</string>
     <!-- short for "Browse through the App Picker/Store/Catalogue"; could also be translated as "Discover" or "Search" -->
@@ -194,10 +200,10 @@
     <string name="green">绿色</string>
     <string name="red">红色</string>
     <string name="blue">蓝色</string>
-    <string name="orange">橘黄色</string>
-    <string name="cyan">蓝绿色</string>
+    <string name="orange">橙色</string>
+    <string name="cyan">青色</string>
     <string name="purple">紫色</string>
-    <string name="magenta">洋红色</string>
+    <string name="magenta">紫红色</string>
     <string name="white">白色</string>
 
     <string name="zoom">缩放</string>
@@ -262,6 +268,7 @@
     <string name="menu_export_attachment">导出附件</string>
     <string name="menu_export_attachments">导出附件</string>
     <string name="menu_all_media">所有媒体</string>
+    <string name="all_apps_and_media">所有应用和媒体</string>
     <!-- Command to jump to the original message corresponding to a gallery image or document -->
     <string name="show_in_chat">在聊天中显示</string>
     <string name="show_app_in_chat">在聊天中显示应用</string>
@@ -370,8 +377,8 @@
     <string name="ask_forward">将消息转发给 %1$s？</string>
     <string name="ask_forward_multiple">转发消息到 %1$d 个聊天？</string>
     <string name="ask_export_attachment">导出附件将允许您设备上的其他应用程序访问这些附件。\n\n是否继续？</string>
-    <string name="ask_block_contact">屏蔽此联系人？您将不再收到此联系人的消息。</string>
-    <string name="ask_unblock_contact">取消屏蔽此联系人？您将再次能收到此联系人的消息。</string>
+    <string name="ask_block_contact">屏蔽此联系人？\n\n被屏蔽的联系人所创建的直接消息或群组将不会显示。\n\n被屏蔽的联系人所创建的其他群组仍将显示他们的消息。</string>
+    <string name="ask_unblock_contact">取消屏蔽此联系人？</string>
     <string name="ask_delete_contacts">删除联系人？\n\n仍有在进行中的聊天的联系人和在系统通讯录中的联系人无法被永久删除。</string>
     <string name="ask_delete_contact">删除联系人 %1$s?\n\n仍有在进行中的聊天的联系人和在系统通讯录中的联系人无法被永久删除。</string>
     <string name="ask_start_chat_with">与 %1$s 聊天？</string>
@@ -446,7 +453,7 @@
     <!-- title shown above a list contacts where one should be selected (eg. when a webxdc attempts to send a message to a chat) -->
     <string name="send_message_to">发送消息到...</string>
     <string name="enable_realtime">实时应用</string>
-    <string name="enable_realtime_explain">为聊天中共享的应用启用实时连接。如果启用，聊天伙伴可能能够在您启动应用时发现您的 IP 地址。</string>
+    <string name="enable_realtime_explain">为聊天中附加的应用启用实时连接。如果启用，聊天伙伴可能会在您启动应用时发现您的 IP 地址。</string>
 
     <!-- map -->
     <string name="filter_map_on_time">显示时间范围内的位置</string>
@@ -498,15 +505,15 @@
     <string name="tab_docs">文档</string>
     <string name="tab_links">链接</string>
     <string name="tab_map">地图</string>
-    <string name="tab_gallery_empty_hint">在此聊天中分享的图像和视频将显示于此。</string>
-    <string name="tab_docs_empty_hint">在此聊天中分享的文档、音乐和其他文件将显示于此。</string>
-    <string name="tab_image_empty_hint">此聊天中分享的图片将显示在这里</string>
-    <string name="tab_video_empty_hint">此聊天中分享的视频将显示在这里</string>
-    <string name="tab_audio_empty_hint">此聊天中分享的音频文件和语音消息将显示在这里。</string>
-    <string name="tab_webxdc_empty_hint">在此聊天中分享的私人应用会出现在这里</string>
-    <string name="tab_all_media_empty_hint">任何聊天中分享的媒体文件都将出现在这里</string>
-    <string name="all_files_empty_hint">在任何聊天中分享的文档和其他文件会出现在这里。</string>
-    <string name="all_apps_empty_hint">任何聊天中接收或发送的私人应用都会出现在这里。</string>
+    <string name="tab_gallery_empty_hint">此聊天附加的图片和视频将显示在此处。</string>
+    <string name="tab_docs_empty_hint">此聊天附加的文档和其他文件将显示在此处。</string>
+    <string name="tab_image_empty_hint">此聊天附加的图片将显示在此处。</string>
+    <string name="tab_video_empty_hint">此聊天附加的视频将显示在此处。</string>
+    <string name="tab_audio_empty_hint">此聊天附加的音频文件和语音消息将显示在此处。</string>
+    <string name="tab_webxdc_empty_hint">此聊天附加的应用将显示在此处。</string>
+    <string name="tab_all_media_empty_hint">任何聊天附加的媒体都将显示在此处。</string>
+    <string name="all_files_empty_hint">任何聊天附加的文档和其他文件都将显示在此处。</string>
+    <string name="all_apps_empty_hint">任何聊天附加的应用都将显示在此处。</string>
     <string name="media_preview">媒体预览</string>
     <!-- option to show images in the gallery with the correct width/height aspect (instead of square); other gallery apps may be a source of inspiration for translation :) -->
     <string name="aspect_ratio_grid">宽高比网格</string>
@@ -523,7 +530,7 @@
     <!-- "Second Device" can also be translated as "Another Device", if that is catchier in the destination language. However, make sure to use the term consistently. -->
     <string name="multidevice_title">添加第二台设备</string>
     <string name="multidevice_same_network_hint">让两台设备连接相同的 Wi-Fi 或网络</string>
-    <string name="multidevice_this_creates_a_qr_code">这将创建第二台设备可以扫描用于复制此账号的二维码。</string>
+    <string name="multidevice_this_creates_a_qr_code">这将创建一个二维码，第二台设备可以扫描该二维码来复制配置文件。\n\n请确保没有不必要的观察者或摄像机可以看到以下屏幕。</string>
     <string name="multidevice_install_dc_on_other_device">在你的其他设备上安装 Delta Chat (https://get.delta.chat)</string>
     <!-- "I Already Have a Profile / Add as Second Device” should be the same text as defined by the keys onboarding_alternative_logins and multidevice_receiver_title -->
     <string name="multidevice_tap_scan_on_other_device">启动 Delta Chat，点击“我已有账号/添加为第二台设备”，扫描此处显示的二维码</string>
@@ -628,7 +635,7 @@
     <string name="proxy_share_link">分享链接</string>
 
     <string name="login_info_oauth2_title">使用简易设置继续？</string>
-    <string name="login_info_oauth2_text">输入的电子邮件地址支持简化设置（OAuth 2.0）。\n\n在下一步中，请允许 Delta Chat 充当您的“通过电子邮件聊天”应用程序。\n\n不存在 Delta Chat 服务器，您的数据保留于您的设备！</string>
+    <string name="login_info_oauth2_text">输入的电子邮件地址支持简化设置（OAuth 2.0）。\n\n下一步，请允许 Delta Chat 发送和接收消息。\n\nDelta Chat 不会收集用户数据，所有内容都保留在您的设备上。</string>
     <string name="login_certificate_checks">证书检查</string>
     <string name="login_error_mail">请输入有效的电子邮件地址</string>
     <string name="login_error_server">请输入有效的服务器 / IP 地址</string>
@@ -724,9 +731,7 @@
     <string name="pref_use_system_emoji">使用系统 emoji</string>
     <string name="pref_use_system_emoji_explain">关闭 Delta Chat 内置 emoji 支持</string>
     <string name="pref_show_system_contacts">读取系统通讯录</string>
-    <string name="pref_show_system_contacts_explain">从通讯录建立和联系人的聊天。一些邮件服务商需要先行设置才能进行端到端加密的聊天。</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">应用程序访问</string>
+    <string name="pref_show_system_contacts_explain">提供与通讯录中的联系人创建聊天的功能。</string>
     <string name="pref_chats">聊天</string>
     <string name="pref_in_chat_sounds">聊天音</string>
     <string name="pref_view_log">查看日志</string>
@@ -825,11 +830,11 @@
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
     <string name="autodel_device_ask">您是否要立即删除 %1$d 条消息，并在之后于消息收到 %2$s 删除它们？\n\n• 这包括所有媒体文件\n\n• 无论消息是否被浏览过，它们都将被删除\n\n• 在本地删除中，“保存的消息”将被跳过</string>
     <!-- %1$d will be replaced by the number of messages, you can assume plural/lots here. %2$s will be replaced by a timespan option. -->
-    <string name="autodel_server_ask">您是否要立即删除 %1$d 条消息，并在之后于消息收到 %2$s 删除它们？\n\n⚠️ 这包括服务器所有文件夹中的电子邮件、媒体和“保存的消息”\n\n⚠️ 如果您想在服务器上保留数据，请不要使用此功能\n\n⚠️ 如果您正在使用 Delta Chat 之外的电子邮件客户端，请不要使用此功能</string>
+    <string name="autodel_server_ask">您是否要立即删除 %1$d 条消息，并在之后于消息收到 %2$s 删除它们？\n\n⚠️ 这包括服务器所有文件夹中的电子邮件、媒体和“保存的消息”\n\n⚠️ 如果您想在服务器上保留数据或使用传统电子邮件客户端，请勿使用此功能</string>
     <!-- shown below enabled autodel_server-option, should be a summary of autodel_server_ask and remind about the impact -->
-    <string name="autodel_server_enabled_hint">这包括所有服务器文件夹中的电子邮件、媒体和\"保存的消息\"。如果您想在服务器上保存数据，或者您正在使用除 Delta Chat 之外的其他电子邮件客户端，请不要使用此功能。</string>
+    <string name="autodel_server_enabled_hint">这包括所有服务器文件夹中的电子邮件、媒体和“保存的消息”。如果您想在服务器上保留数据，或者也使用传统电子邮件客户端，请勿使用此功能</string>
     <string name="autodel_server_warn_multi_device_title">开启一次性删除</string>
-    <string name="autodel_server_warn_multi_device">如果您启用一次删除，则无法在此配置文件中使用多个设备。</string>
+    <string name="autodel_server_warn_multi_device">如果您启用一次删除，则无法在此配置文件中使用多台设备。</string>
     <string name="autodel_confirm">我了解，将这些消息全部删除</string>
     <!-- "At once" in the meaning of "Immediately", without any intervening time. -->
     <string name="autodel_at_once">下载后立即</string>
@@ -845,15 +850,10 @@
 
     <!-- autocrypt -->
     <string name="autocrypt_send_asm_title">发送 Autocrypt 设置消息</string>
-    <string name="autocrypt_send_asm_explain_before">Autocrypt 设置消息安全地共享您的端到端设置至其他兼容 Autocrypt 的应用程序。\n\n该设置将通过在此显示的、必须在另一台设备上输入的设置码进行加密。</string>
+    <string name="autocrypt_send_asm_explain_before">Autocrypt 设置消息可与其他兼容 Autocrypt 的应用安全地共享您的端到端设置。\n\n如果您也在其他设备上使用 Delta Chat，请改用“设置/添加第二台设备”。</string>
     <string name="autocrypt_send_asm_button">发送 Autocrypt 设置消息</string>
     <string name="autocrypt_send_asm_explain_after">您的设置已发送给您自己。切换到另一台设备并打开该设置消息。 您将被要求输入设置码。 输入以下数字：</string>
     <string name="autocrypt_prefer_e2ee">优先使用端到端加密</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt 设置消息</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">这是用于在客户端之间传输端到端设置的 Autocrypt 设置消息。\n\n要解密并使用您的设置，请在兼容 Autocrypt 的客户端中打开本消息，然后输入生成设备上显示的设置码。</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">无法解密此消息。\n\n• 简化对此消息的回复并请求发送方再次发送消息可能会有帮助。\n\n•  如果你刚重新安装 Delta Chat，你最好立即重新设置 Delta Chat 并选择“添加为第二台设备”或导入备份文件。</string>
@@ -925,7 +925,7 @@
     <!-- this may be shown instead of the chat's input field, with buttons "More Info" and "OK" -->
     <string name="chat_protection_broken">%1$s 从另一台设备发送了消息</string>
     <string name="chat_protection_enabled_tap_to_learn_more">从现在起，消息保证都是端到端加密。轻按了解更多。</string>
-    <string name="chat_protection_enabled_explanation">现在此聊天中的所有消息保证都是端到端加密的。\n\n端到端加密使消息保持私密状态，只有你和你的聊天伙伴知道内容。即便是你的电子邮件服务提供商也无法读取它们。</string>
+    <string name="chat_protection_enabled_explanation">现在可以保证此聊天中的所有消息都是端到端加密的。\n\n端到端加密可确保您和您的聊天伙伴之间的消息私密性。即使是服务器、提供者或中继也无法读取它们。</string>
     <string name="chat_protection_broken_tap_to_learn_more">%1$s 从另一台设备发送了一则消息。轻按了解更多。</string>
     <string name="chat_protection_broken_explanation">无法再确保端到端加密，可能的原因是 %1$s 重新安装了 Delta Chat 或从其他设备发送了一则消息。\n\n你可以和联系人线下见面并再次扫描联系人的二维码重新建立端到端加密的通信。</string>
     <string name="invalid_unencrypted_tap_to_learn_more">⚠️ %1$s要求端到端加密，而此聊天尚未建立端到端加密。轻按了解更多。</string>
@@ -951,15 +951,15 @@
     <string name="qrscan_failed">二维码无法被解码</string>
     <string name="qrscan_ask_join_group">您要加入群组“%1$s”吗？</string>
     <string name="qrscan_fingerprint_mismatch">扫描到的指纹与上次见到的 %1$s 的指纹不匹配。</string>
-    <string name="qrscan_no_addr_found">此二维码包含指纹但没有电子邮件地址。\n\n对于带外验证，请先与接收者建立加密连接。</string>
+    <string name="qrscan_no_addr_found">此二维码包含指纹，但没有电子邮件地址。\n\n对于带外验证，请先与接收者建立加密连接。</string>
     <string name="qrscan_contains_text">已扫描到的二维码文本：\n\n%1$s</string>
     <string name="qrscan_contains_url">已扫描到的二维码 URL：\n\n%1$s</string>
     <string name="qrscan_fingerprint_label">指纹</string>
-    <string name="withdraw_verifycontact_explain">其他人可以扫描此二维码与您联系。\n\n您可以在此处停用二维码并通过再次扫描来重新激活它。</string>
-    <string name="withdraw_verifygroup_explain">其他人可以扫描此二维码加入群组 “%1$s”。\n\n您可以在此处停用二维码并通过再次扫描来重新激活它。</string>
+    <string name="withdraw_verifycontact_explain">其他人可以扫描此二维码与您联系。\n\n您可以重置它，这样现有的二维码或邀请链接将不再有效。</string>
+    <string name="withdraw_verifygroup_explain">其他人可以扫描此二维码以加入群组“%1$s”。\n\n您可以重置它，这样现有的二维码或邀请链接将不再有效。</string>
     <string name="withdraw_qr_code">重置二维码</string>
-    <string name="revive_verifycontact_explain">其他人可扫描此二维码以与您联系。\n\n此设备上的二维码未激活。</string>
-    <string name="revive_verifygroup_explain">其他人可扫描此二维码加入群组“%1$s”。\n\n此设备上的二维码未激活。</string>
+    <string name="revive_verifycontact_explain">此二维码已重置，不再有效。</string>
+    <string name="revive_verifygroup_explain">加入群组“%1$s”的二维码已重置，不再有效。</string>
     <string name="revive_qr_code">激活二维码</string>
     <string name="qrshow_title">邀请二维码</string>
     <string name="qrshow_x_joining">添加 %1$s。</string>
@@ -988,7 +988,7 @@
     <string name="secure_join_wait">正在建立有保证的端到端加密，请稍候…</string>
     <!-- deprecated -->
     <string name="secure_join_wait_timeout">无法建立有保证的端到端加密，但您可能已经发送了一条消息。</string>
-    <string name="secure_join_takes_longer">这可能需要较长时间，可能是对方或您已离线。\n\n但该过程仍在后台继续，您可以先做其他事情…</string>
+    <string name="secure_join_takes_longer">联系人必须在线才能继续。\n\n此过程将在后台自动继续。</string>
     <string name="contact_verified">%1$s 已验证。</string>
     <string name="contact_not_verified">无法与 %1$s 建立有保证的端到端加密。</string>
     <!-- Shown in contact profile. The placeholder will be replaced by the name of the contact that introduced the contact. -->
@@ -997,8 +997,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">%1$s 的加密设置已更改。</string>
     <string name="verified_contact_required_explain">要确保端到端加密，你只能将带有绿色验证标识的联系人到此群中。\n\n你可以亲自和未验证联系人线下碰面并扫描联系人二维码来验证。</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">已复制二维码链接到剪贴板</string>
     <string name="mailto_dialog_header_select_chat">选择要发送消息的聊天</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s 已经有一条草稿信息，要替换它吗？</string>
@@ -1024,7 +1022,8 @@
     <string name="perm_required_title">需要权限</string>
     <string name="perm_continue">继续</string>
     <string name="perm_explain_access_to_camera_denied">要拍照或录像，请转至应用设置，选择“权限”，然后启用“相机”。</string>
-    <string name="perm_explain_access_to_mic_denied">要发送音频消息，请转至应用设置，选择“权限”，然后启用“麦克风”。</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
+    <string name="perm_explain_access_to_mic_denied">要发送音频消息，请转到系统或应用设置，选择“权限”或“隐私和安全”，然后启用“麦克风”。</string>
     <string name="perm_explain_access_to_storage_denied">要发送或接收文件，请转至应用设置，选择“权限”，然后启用“存储”。</string>
     <string name="perm_explain_access_to_location_denied">要附加位置，请转至应用设置，选择“权限”，然后启用“位置”。</string>
     <string name="perm_explain_access_to_notifications_denied">要接收通知，请转到“系统设置/应用/Delta Chat\"并开启”通知“。</string>
@@ -1148,7 +1147,7 @@
     <string name="add_to_widget">添加到微件</string>
     <!-- iOS permissions, copy from "deltachat-ios/Info.plist", which is used on missing translations in "deltachat-ios/LANG.lproj/InfoPlist.strings" -->
     <string name="InfoPlist_NSCameraUsageDescription">Delta Chat 使用相机来拍摄、发送照片和视频以及扫描二维码。</string>
-    <string name="InfoPlist_NSContactsUsageDescription">Delta Chat 使用您的联系人来显示您可以写信到的电子邮件地址列表。 Delta Chat 没有服务器，您的联系人不会被发送到任何地方。</string>
+    <string name="InfoPlist_NSContactsUsageDescription">Delta Chat 使用您的联系人列表来显示您可以发送消息的电子邮件地址。Delta Chat 没有服务器，您的联系人不会被发送到任何地方。</string>
     <string name="InfoPlist_NSLocationAlwaysAndWhenInUseUsageDescription">Delta Chat 需要位置权限，以便在你启用位置共享的时间范围内共享你的位置。</string>
     <string name="InfoPlist_NSLocationWhenInUseUsageDescription">Delta Chat 需要位置权限，以便在你启用位置共享的时间范围内共享你的位置。</string>
     <string name="InfoPlist_NSMicrophoneUsageDescription">Delta Chat 使用麦克风来录制、发送语音消息和带有声音的视频。</string>
@@ -1164,7 +1163,7 @@
     <string name="pref_reliable_service">强制后台连接</string>
     <string name="pref_reliable_service_explain">会形成永久通知</string>
 
-    <string name="pref_background_notifications_rationale">要保持到电子邮件服务器的连接并在后台接收消息，请在下一步中忽略电池优化。\n\nDelta Chat 仅使用少量的资源并且会注意不去耗尽电池电量。</string>
+    <string name="pref_background_notifications_rationale">为了保持连接并在后台接收消息，请在下一步中忽略电池优化。\n\nDelta Chat 使用的资源很少，并且会注意不去耗尽电池电量。</string>
     <!-- disabling "Reliable service" will hide a the maybe annoying permanent-notification with the drawback that new-message-notifications get potentially unreliable -->
     <string name="perm_enable_bg_reminder_title">点击此处以在 Delta Chat 处于后台时接收消息。</string>
     <string name="perm_enable_bg_already_done">您已允许 Delta Chat 在后台接收消息。\n\n若 Delta Chat 在后台时消息仍未到达，请检查系统设置。</string>

--- a/_locales/zh_TW.xml
+++ b/_locales/zh_TW.xml
@@ -725,8 +725,6 @@
     <string name="pref_use_system_emoji_explain">停用 Delta Chat 內建的表情符號</string>
     <string name="pref_show_system_contacts">讀取系統通訊錄</string>
     <string name="pref_show_system_contacts_explain">建議與通訊錄中的聯絡人建立聊天。一些供應商需要先進行端到端加密設置。</string>
-    <!-- deprecated -->
-    <string name="pref_app_access">App 存取</string>
     <string name="pref_chats">對話</string>
     <string name="pref_in_chat_sounds">對話內的音效</string>
     <string name="pref_view_log">觀看系統紀錄</string>
@@ -849,11 +847,6 @@
     <string name="autocrypt_send_asm_button">傳送AutoCrypt設定訊息</string>
     <string name="autocrypt_send_asm_explain_after">你的設定已經傳送給你自己了。請到其它支援自動加密設定的裝置，開啟設定訊息，並輸入以下的設定碼\n\n輸入完之後，你的其它裝置就可以使用AutoCrypt了。</string>
     <string name="autocrypt_prefer_e2ee">偏好端到端加密</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_subject">Autocrypt Setup Message</string>
-    <!-- deprecated -->
-    <string name="autocrypt_asm_general_body">本信件包含AutoCrypt設定訊息。\n\n請使用其它裝置上支援AutoCrypt設定的應用程式開啟本訊息，並輸入設定碼，以便匯入自動加密設定。</string>
-
 
     <!-- system messages -->
     <string name="systemmsg_cannot_decrypt">此消息無法解密。\n\n• 簡要回覆此消息並要求發件者再次發送消息可能已有所幫助。\n\n• 如果您剛剛重新安裝了 Delta Chat，那麼最好立即重新設置 Delta Chat，然後選擇「添加為第二台裝置」或導入備份。</string>
@@ -996,8 +989,6 @@
     <!-- translators: "setup" is the "encryption setup" here, as in "Autocrypt Setup Message" -->
     <string name="contact_setup_changed">已爲%1$s更改設定。</string>
     <string name="verified_contact_required_explain">為了保證端到端加密，您只能將帶有綠色驗證標識的聯絡人添加到此群組。\n\n您可以當面掃描聯絡人的QR碼以介紹他們。</string>
-    <!-- deprecated -->
-    <string name="copy_qr_data_success">已將 QR碼的URL複製到剪貼簿</string>
     <string name="mailto_dialog_header_select_chat">選擇要將消息發送到的聊天</string>
     <!-- first placeholder is the name of the chat -->
     <string name="confirm_replace_draft">%1$s已有草稿消息，是否要替換它？</string>
@@ -1023,6 +1014,7 @@
     <string name="perm_required_title">需要權限</string>
     <string name="perm_continue">繼續</string>
     <string name="perm_explain_access_to_camera_denied">要拍照或攝錄影片，請轉到應用程式設定，選擇「存取權」，然後啟用「相機」。</string>
+    <!-- give the user an idea where to find the "Microphone" option. the hint is only shown if access was initially denied by the user. pick up wordings really used on the systems, but do not be overly precise: things shift around often and there are too many system we support to track every detail and click path -->
     <string name="perm_explain_access_to_mic_denied">要傳送音訊消息，請轉到應用程式設定，選擇「存取權」，然後啟用「麥克風」。</string>
     <string name="perm_explain_access_to_storage_denied">要接收或發送文件，請轉到應用程式設定，選擇「存取權」，然後啟用「存儲」。</string>
     <string name="perm_explain_access_to_location_denied">要附加位置，請轉到應用程式設定，選擇「存取權」，然後啟用「位置」。</string>

--- a/packages/frontend/scss/gallery/_media-attachment.scss
+++ b/packages/frontend/scss/gallery/_media-attachment.scss
@@ -203,7 +203,6 @@
 
   display: flex;
   flex-direction: row;
-  width: 300px;
   margin: 3.5px 3px;
 
   &:hover {
@@ -257,4 +256,9 @@
       color: var(--colorDanger);
     }
   }
+}
+
+#gallery-tabpanel-webxdc_apps .item {
+  overflow: hidden;
+  padding-right: 3px;
 }

--- a/packages/frontend/scss/gallery/_media.scss
+++ b/packages/frontend/scss/gallery/_media.scss
@@ -77,6 +77,7 @@ $tab-height: 46px;
       background: transparent;
       color: var(--textPrimary);
       outline: none;
+      margin-right: 20px;
     }
   }
 }

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -63,7 +63,7 @@ const MediaTabs: Readonly<{
   },
 }
 
-type Props = { chatId: number | 'all'; onUpdateView?: () => void }
+type Props = { chatId: number | 'all' }
 
 const getCurrentDocumentVerticalScrollbarWidth = () => {
   const outer = document.createElement('div')
@@ -225,7 +225,6 @@ export default class Gallery extends Component<
           loading: false,
         })
         this.forceUpdate()
-        this.props.onUpdateView?.()
       })
       .catch(log.error.bind(log))
   }
@@ -430,7 +429,7 @@ export default class Gallery extends Component<
                   let itemHeight = itemWidth
 
                   if (currentTab === 'webxdc_apps') {
-                    itemHeight = 59
+                    itemHeight = 61
                   } else if (currentTab === 'audio') {
                     itemHeight = 94
                   }

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -430,7 +430,7 @@ export default class Gallery extends Component<
                   let itemHeight = itemWidth
 
                   if (currentTab === 'webxdc_apps') {
-                    itemHeight = 61
+                    itemHeight = 59
                   } else if (currentTab === 'audio') {
                     itemHeight = 94
                   }

--- a/packages/frontend/src/components/MessageListView.tsx
+++ b/packages/frontend/src/components/MessageListView.tsx
@@ -15,10 +15,7 @@ export default function MessageListView({
   if (chatWithLinger && accountId) {
     return (
       <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
-        <MessageListAndComposer
-          accountId={accountId}
-          chat={chatWithLinger}
-        />
+        <MessageListAndComposer accountId={accountId} chat={chatWithLinger} />
       </RecoverableCrashScreen>
     )
   }

--- a/packages/frontend/src/components/MessageListView.tsx
+++ b/packages/frontend/src/components/MessageListView.tsx
@@ -1,57 +1,25 @@
 import React from 'react'
 
-import Gallery from './Gallery'
 import MessageListAndComposer from './message/MessageListAndComposer'
 import NoChatSelected from './NoChatSelected'
 import useChat from '../hooks/chat/useChat'
-import { ChatView } from '../contexts/ChatContext'
 import { RecoverableCrashScreen } from './screens/RecoverableCrashScreen'
-
-import type { AlternativeView } from '../contexts/ChatContext'
-
-type Props = {
-  accountId?: number
-  alternativeView: AlternativeView
-  galleryRef: any
-  onUpdateGalleryView: () => void
-}
 
 export default function MessageListView({
   accountId,
-  galleryRef,
-  alternativeView,
-  onUpdateGalleryView,
-}: Props) {
-  const { activeView, chatWithLinger } = useChat()
+}: {
+  accountId?: number
+}): React.JSX.Element {
+  const { chatWithLinger } = useChat()
 
   if (chatWithLinger && accountId) {
-    switch (activeView) {
-      case ChatView.Media:
-        return (
-          <Gallery
-            ref={galleryRef}
-            chatId={chatWithLinger.id}
-            onUpdateView={onUpdateGalleryView}
-          />
-        )
-      case ChatView.MessageList:
-      default:
-        return (
-          <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
-            <MessageListAndComposer
-              accountId={accountId}
-              chat={chatWithLinger}
-            />
-          </RecoverableCrashScreen>
-        )
-    }
-  } else if (alternativeView === 'global-gallery') {
     return (
-      <Gallery
-        chatId={'all'}
-        ref={galleryRef}
-        onUpdateView={onUpdateGalleryView}
-      />
+      <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
+        <MessageListAndComposer
+          accountId={accountId}
+          chat={chatWithLinger}
+        />
+      </RecoverableCrashScreen>
     )
   }
 

--- a/packages/frontend/src/components/ThreeDotMenu.tsx
+++ b/packages/frontend/src/components/ThreeDotMenu.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from 'react'
 
 import { Timespans } from '../../../shared/constants'
 import { ContextMenuItem } from './ContextMenu'
-import SettingsStoreInstance, { useSettingsStore } from '../stores/settings'
+import { useSettingsStore } from '../stores/settings'
 import { BackendRemote } from '../backend-com'
 import { ActionEmitter, KeybindAction } from '../keybindings'
 import useChat from '../hooks/chat/useChat'
@@ -19,7 +19,6 @@ import type { T } from '@deltachat/jsonrpc-client'
 
 export function useThreeDotMenu(
   selectedChat?: T.FullChat,
-  mode: 'chat' | 'gallery' = 'chat'
 ) {
   const { openDialog } = useDialog()
   const { openContextMenu } = useContext(ContextMenuContext)
@@ -199,23 +198,6 @@ export function useThreeDotMenu(
       {
         label: tx('menu_delete_chat'),
         action: onDeleteChat,
-      },
-    ]
-  }
-
-  if (mode == 'gallery' && settingsStore?.desktopSettings) {
-    const { galleryImageKeepAspectRatio } = settingsStore.desktopSettings
-    menu = [
-      {
-        label: tx(
-          galleryImageKeepAspectRatio ? 'square_grid' : 'aspect_ratio_grid'
-        ),
-        action: async () => {
-          await SettingsStoreInstance.effect.setDesktopSetting(
-            'galleryImageKeepAspectRatio',
-            !galleryImageKeepAspectRatio
-          )
-        },
       },
     ]
   }

--- a/packages/frontend/src/components/ThreeDotMenu.tsx
+++ b/packages/frontend/src/components/ThreeDotMenu.tsx
@@ -17,9 +17,7 @@ import { unmuteChat } from '../backend/chat'
 
 import type { T } from '@deltachat/jsonrpc-client'
 
-export function useThreeDotMenu(
-  selectedChat?: T.FullChat,
-) {
+export function useThreeDotMenu(selectedChat?: T.FullChat) {
   const { openDialog } = useDialog()
   const { openContextMenu } = useContext(ContextMenuContext)
   const [settingsStore] = useSettingsStore()

--- a/packages/frontend/src/components/dialogs/MediaView/index.tsx
+++ b/packages/frontend/src/components/dialogs/MediaView/index.tsx
@@ -20,14 +20,8 @@ export default function MediaView(
   const onUpdateView = () => setGalleryUpdated(!galleryUpdated)
 
   return (
-    <Dialog
-      onClose={onClose}
-      className={styles.mediaViewDialog}
-    >
-      <DialogHeader
-        title={tx('menu_all_media')}
-        onClose={onClose}
-      />
+    <Dialog onClose={onClose} className={styles.mediaViewDialog}>
+      <DialogHeader title={tx('menu_all_media')} onClose={onClose} />
       <DialogBody className={styles.mediaViewDialogBody}>
         <Gallery chatId={chatId} onUpdateView={onUpdateView} />
       </DialogBody>

--- a/packages/frontend/src/components/dialogs/MediaView/index.tsx
+++ b/packages/frontend/src/components/dialogs/MediaView/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import Gallery from '../../Gallery'
 import Dialog, { DialogBody, DialogHeader } from '../../Dialog'
 import useTranslationFunction from '../../../hooks/useTranslationFunction'
@@ -15,15 +15,11 @@ export default function MediaView(
   const { onClose, chatId } = props
   const tx = useTranslationFunction()
 
-  // This will update the gallery view when needed
-  const [galleryUpdated, setGalleryUpdated] = useState(false)
-  const onUpdateView = () => setGalleryUpdated(!galleryUpdated)
-
   return (
     <Dialog onClose={onClose} className={styles.mediaViewDialog}>
       <DialogHeader title={tx('menu_all_media')} onClose={onClose} />
       <DialogBody className={styles.mediaViewDialogBody}>
-        <Gallery chatId={chatId} onUpdateView={onUpdateView} />
+        <Gallery chatId={chatId} />
       </DialogBody>
     </Dialog>
   )

--- a/packages/frontend/src/components/dialogs/MediaView/index.tsx
+++ b/packages/frontend/src/components/dialogs/MediaView/index.tsx
@@ -14,10 +14,12 @@ export default function MediaView(
 ) {
   const { onClose, chatId } = props
   const tx = useTranslationFunction()
+  const headerString =
+    chatId === 'all' ? tx('all_apps_and_media') : tx('apps_and_media')
 
   return (
     <Dialog onClose={onClose} className={styles.mediaViewDialog}>
-      <DialogHeader title={tx('menu_all_media')} onClose={onClose} />
+      <DialogHeader title={headerString} onClose={onClose} />
       <DialogBody className={styles.mediaViewDialogBody}>
         <Gallery chatId={chatId} />
       </DialogBody>

--- a/packages/frontend/src/components/dialogs/MediaView/index.tsx
+++ b/packages/frontend/src/components/dialogs/MediaView/index.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react'
+import Gallery from '../../Gallery'
+import Dialog, { DialogBody, DialogHeader } from '../../Dialog'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+
+import type { DialogProps } from '../../../contexts/DialogContext'
+import type { T } from '@deltachat/jsonrpc-client'
+
+import styles from './styles.module.scss'
+
+export default function MediaView(
+  props: {
+    chat: T.FullChat
+  } & DialogProps
+) {
+  const { onClose, chat } = props
+  const tx = useTranslationFunction()
+
+  // This will update the gallery view when needed
+  const [galleryUpdated, setGalleryUpdated] = useState(false)
+  const onUpdateView = () => setGalleryUpdated(!galleryUpdated)
+
+  return (
+    <Dialog
+      onClose={onClose}
+      className={styles.mediaViewDialog}
+    >
+      <DialogHeader
+        title={tx('menu_all_media')}
+        onClose={onClose}
+      />
+      <DialogBody className={styles.mediaViewDialogBody}>
+        <Gallery chatId={chat.id} onUpdateView={onUpdateView} />
+      </DialogBody>
+    </Dialog>
+  )
+}

--- a/packages/frontend/src/components/dialogs/MediaView/index.tsx
+++ b/packages/frontend/src/components/dialogs/MediaView/index.tsx
@@ -4,16 +4,15 @@ import Dialog, { DialogBody, DialogHeader } from '../../Dialog'
 import useTranslationFunction from '../../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../../contexts/DialogContext'
-import type { T } from '@deltachat/jsonrpc-client'
 
 import styles from './styles.module.scss'
 
 export default function MediaView(
   props: {
-    chat: T.FullChat
+    chatId: number | 'all'
   } & DialogProps
 ) {
-  const { onClose, chat } = props
+  const { onClose, chatId } = props
   const tx = useTranslationFunction()
 
   // This will update the gallery view when needed
@@ -30,7 +29,7 @@ export default function MediaView(
         onClose={onClose}
       />
       <DialogBody className={styles.mediaViewDialogBody}>
-        <Gallery chatId={chat.id} onUpdateView={onUpdateView} />
+        <Gallery chatId={chatId} onUpdateView={onUpdateView} />
       </DialogBody>
     </Dialog>
   )

--- a/packages/frontend/src/components/dialogs/MediaView/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/MediaView/styles.module.scss
@@ -9,4 +9,5 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  margin-bottom: 0;
 }

--- a/packages/frontend/src/components/dialogs/MediaView/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/MediaView/styles.module.scss
@@ -1,0 +1,12 @@
+.mediaViewDialog {
+  max-width: 90vw !important;
+  width: 90vw !important;
+  height: 90vh;
+}
+
+.mediaViewDialogBody {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -35,6 +35,7 @@ import { selectedAccountId } from '../../../ScreenController'
 import { openMapWebxdc } from '../../../system-integration/webxdc'
 import { ChatView } from '../../../contexts/ChatContext'
 import { ScreenContext } from '../../../contexts/ScreenContext'
+import MediaView from '../../dialogs/MediaView'
 
 import type { T } from '@deltachat/jsonrpc-client'
 import CreateChat from '../../dialogs/CreateChat'
@@ -258,7 +259,7 @@ export default function MainScreen({ accountId }: Props) {
             )}
             {chatWithLinger && <ChatHeading chat={chatWithLinger} />}
           </div>
-          {chatWithLinger && <ChatNavButtons />}
+          {chatWithLinger && <ChatNavButtons chat={chatWithLinger} />}
           {(chatWithLinger || alternativeView === 'global-gallery') && (
             <span
               style={{
@@ -400,10 +401,17 @@ function ChatHeading({ chat }: { chat: T.FullChat }) {
   )
 }
 
-function ChatNavButtons() {
+function ChatNavButtons({ chat }: { chat: T.FullChat }) {
   const tx = useTranslationFunction()
-  const { activeView, setChatView, chatId } = useChat()
+  const { chatId } = useChat()
   const settingsStore = useSettingsStore()[0]
+  const { openDialog } = useDialog()
+
+  const openMediaViewDialog = useCallback(() => {
+    openDialog(MediaView, {
+      chat,
+    })
+  }, [openDialog, chat])
 
   return (
     <>
@@ -415,26 +423,8 @@ function ChatNavButtons() {
       >
         <Button
           role='tab'
-          id='tab-message-list-view'
-          onClick={() => setChatView(ChatView.MessageList)}
-          active={activeView === ChatView.MessageList}
-          aria-selected={activeView === ChatView.MessageList}
-          // FYI there are 2 components that use this ID,
-          // but they're not supposed to be rendered at the same time.
-          aria-controls='message-list-and-composer'
-          aria-label={tx('chat')}
-          title={tx('chat')}
-          className='navbar-button'
-          styling='borderless'
-        >
-          <Icon coloring='navbar' icon='chats' size={18} />
-        </Button>
-        <Button
-          role='tab'
           id='tab-media-view'
-          onClick={() => setChatView(ChatView.Media)}
-          active={activeView === ChatView.Media}
-          aria-selected={activeView === ChatView.Media}
+          onClick={openMediaViewDialog}
           aria-controls='media-view'
           aria-label={`${tx('webxdc_apps')} & ${tx('media')}`}
           title={`${tx('webxdc_apps')} & ${tx('media')}`}

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -378,8 +378,8 @@ function ChatNavButtons({ chat }: { chat: T.FullChat }) {
           id='tab-media-view'
           onClick={openMediaViewDialog}
           aria-controls='media-view'
-          aria-label={`${tx('webxdc_apps')} & ${tx('media')}`}
-          title={`${tx('webxdc_apps')} & ${tx('media')}`}
+          aria-label={tx('apps_and_media')}
+          title={tx('apps_and_media')}
           className='navbar-button'
           styling='borderless'
         >

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -51,12 +51,7 @@ export default function MainScreen({ accountId }: Props) {
   const [queryStr, setQueryStr] = useState('')
   const [queryChatId, setQueryChatId] = useState<null | number>(null)
   const [archivedChatsSelected, setArchivedChatsSelected] = useState(false)
-  const {
-    chatId,
-    chatWithLinger,
-    selectChat,
-    unselectChat,
-  } = useChat()
+  const { chatId, chatWithLinger, selectChat, unselectChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
   // Small hack/misuse of keyBindingAction to setArchivedChatsSelected from
@@ -68,10 +63,8 @@ export default function MainScreen({ accountId }: Props) {
     setArchivedChatsSelected(false)
   )
 
-  const chatListShouldBeHidden =
-    smallScreenMode && chatId !== undefined
-  const messageSectionShouldBeHidden =
-    smallScreenMode && chatId === undefined
+  const chatListShouldBeHidden = smallScreenMode && chatId !== undefined
+  const messageSectionShouldBeHidden = smallScreenMode && chatId === undefined
 
   const onBackButton = () => {
     unselectChat()
@@ -147,7 +140,7 @@ export default function MainScreen({ accountId }: Props) {
 
   useKeyBindingAction(KeybindAction.GlobalGallery_Open, () => {
     openDialog(MediaView, {
-      chatId: 'all'
+      chatId: 'all',
     })
   })
 
@@ -156,9 +149,7 @@ export default function MainScreen({ accountId }: Props) {
     SettingsStoreInstance.effect.load()
   }, [])
 
-  const onClickThreeDotMenu = useThreeDotMenu(
-    chatWithLinger,
-  )
+  const onClickThreeDotMenu = useThreeDotMenu(chatWithLinger)
   const isSearchActive = queryStr.length > 0 || queryChatId !== null
   const showArchivedChats = !isSearchActive && archivedChatsSelected
 
@@ -230,7 +221,7 @@ export default function MainScreen({ accountId }: Props) {
             {chatWithLinger && <ChatHeading chat={chatWithLinger} />}
           </div>
           {chatWithLinger && <ChatNavButtons chat={chatWithLinger} />}
-          {chatWithLinger  && (
+          {chatWithLinger && (
             <span
               style={{
                 marginLeft: 0,
@@ -250,9 +241,7 @@ export default function MainScreen({ accountId }: Props) {
             </span>
           )}
         </nav>
-        <MessageListView
-          accountId={accountId}
-        />
+        <MessageListView accountId={accountId} />
       </section>
       {!chatListShouldBeHidden && <ConnectivityToast />}
     </div>

--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -93,7 +93,6 @@
     }
 
     :global(.views) {
-      margin-right: 15px;
       display: flex;
       height: 100%;
     }
@@ -112,4 +111,14 @@
       border-radius: 100%;
     }
   }
+}
+
+.webxdcIcons img {
+  width: 25px;
+  height: 25px;
+  margin-right: 10px;
+  margin-top: 4px;
+  cursor: pointer;
+  border-radius: 3px;
+  background-color: #fff;
 }

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -1,14 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { ActionEmitter, KeybindAction } from '../keybindings'
-import useKeyBindingAction from '../hooks/useKeyBindingAction'
 import { markChatAsSeen, saveLastChatId } from '../backend/chat'
 import { BackendRemote } from '../backend-com'
 
 import type { MutableRefObject, PropsWithChildren } from 'react'
 import type { T } from '@deltachat/jsonrpc-client'
-
-export type AlternativeView = 'global-gallery' | null
 
 export enum ChatView {
   Media,
@@ -33,7 +30,6 @@ export type ChatContextValue = {
    */
   chatWithLinger?: T.FullChat
   chatId?: number
-  alternativeView: AlternativeView
   // The resolve value of the promise is unused at the time of writing.
   // And the Promise itself doesn't seem to be used that much.
   // Maybe we can make it just return `void`, or need to reconsider
@@ -77,7 +73,6 @@ export const ChatProvider = ({
   const cancelPendingSetChat = useRef<(() => void) | undefined>(undefined)
 
   const [chatId, setChatId] = useState<number | undefined>()
-  const [alternativeView, setAlternativeView] = useState<AlternativeView>(null)
 
   const setChatView = useCallback<SetView>((nextView: ChatView) => {
     setActiveView(nextView)
@@ -117,7 +112,6 @@ export const ChatProvider = ({
       }
 
       // Already set known state
-      setAlternativeView(null)
       setActiveView(ChatView.MessageList)
       setChatId(nextChatId)
 
@@ -192,18 +186,12 @@ export const ChatProvider = ({
   }, [accountId, chatId])
 
   const unselectChat = useCallback<UnselectChat>(() => {
-    setAlternativeView(null)
     setActiveView(ChatView.MessageList)
     setChatId(undefined)
     setChatWithLinger(undefined)
   }, [])
 
   unselectChatRef.current = unselectChat
-
-  useKeyBindingAction(KeybindAction.GlobalGallery_Open, () => {
-    unselectChat()
-    setAlternativeView('global-gallery')
-  })
 
   // Subscribe to events coming from the core
   useEffect(() => {
@@ -260,7 +248,6 @@ export const ChatProvider = ({
     activeView,
     chatWithLinger,
     chatId,
-    alternativeView,
     selectChat,
     setChatView,
     unselectChat,

--- a/packages/frontend/src/contexts/DialogContext.tsx
+++ b/packages/frontend/src/contexts/DialogContext.tsx
@@ -98,6 +98,8 @@ export const DialogContextProvider = ({ children }: PropsWithChildren<{}>) => {
     openDialogIds,
   }
 
+  window.__closeAllDialogs = closeAllDialogs
+
   return (
     <DialogContext.Provider value={value}>
       {children}

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -73,5 +73,6 @@ declare global {
      */
     __internal_current_message_list_instance_id?: symbol
     __updateAccountListSidebar: (() => void) | undefined
+    __closeAllDialogs: () => void | undefined
   }
 }

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -123,6 +123,7 @@ export default function useMessage() {
         ],
       }
       window.__internal_check_jump_to_message?.()
+      window.__closeAllDialogs?.()
     },
     [chatId, selectChat, setChatView]
   )

--- a/packages/frontend/src/hooks/chat/useSelectLastChat.ts
+++ b/packages/frontend/src/hooks/chat/useSelectLastChat.ts
@@ -14,9 +14,9 @@ export default function useSelectLastChat(accountId?: number) {
   const { smallScreenMode } = useContext(ScreenContext)
   const hasAccountIdChanged = useHasChanged(accountId)
   const hasSmallScreenModeChanged = useHasChanged(smallScreenMode)
-  const { selectChat, chatId, alternativeView } = useChat()
+  const { selectChat, chatId } = useChat()
 
-  const smallScreenModeChatListVisible = !(chatId || alternativeView)
+  const smallScreenModeChatListVisible = !chatId
 
   const selectLastChat = useCallback(async () => {
     if (!accountId) {


### PR DESCRIPTION
resolves #5074 and step2 of #5141 

- exposes "CloseAllDialogs" globally and closes all dialogs in jumpToMessage
- removes AlternateView from MessageList

TBD:
- so far the galleryImageKeepAspectRatio is not implemented (needs a 3dot menu or an icon): do we really need it?
- we could show some more information (like total number of items) (can also be done in #4868 )

We should show the chat name in this dialog, since it is not visible anymore. 

Maybe add it to the headline?

![image](https://github.com/user-attachments/assets/f9e95f53-5878-4c64-ab70-89e81d0df36a)
