### PR TITLE
Adapt margins in profiles

### DIFF
--- a/packages/frontend/scss/dialogs/_group-styles.scss
+++ b/packages/frontend/scss/dialogs/_group-styles.scss
@@ -73,12 +73,11 @@ input.group-name-input {
   }
 }
 
+// same padding as contacts here
 .group-related-chats-list-wrapper {
-  margin-left: 20px;
-  margin-right: 10px;
-}
-
-.group-member-contact-list-wrapper {
-  margin-left: 10px;
-  margin-right: 5px;
+  margin-top: 8px;
+  .chat-list-item,
+  .pseudo-chat-list-item {
+    padding-inline-start: 20px;
+  }
 }

--- a/packages/frontend/src/components/dialogs/ViewProfile/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/ViewProfile/styles.module.scss
@@ -51,11 +51,5 @@
 }
 
 .mutualChats {
-  margin-inline-start: 22px;
-  margin-inline-end: 20px;
   margin-top: 8px;
-  flex-grow: 1;
-  .chat-list-item {
-    padding: 0px 20px;
-  }
 }


### PR DESCRIPTION
In group profile: Avoid white margins in pinned chats and on hover. 

Before:
![image](https://github.com/user-attachments/assets/1827877d-d05e-4a50-b500-6bed722f2846)

After:
![image](https://github.com/user-attachments/assets/d627e337-0562-44cd-b438-a55379725d09)

TBD: we have different margins in chat lists (10px) and contact lists (20px). So in a group profile we have to adapt either the one or the other.
Should we change that to have the same margin for both? Chat list needs as much space as possible so we probably should go for 10px for both.



#skip-changelog