### PR TITLE
tauri: fix: messagelist crashing due to `<audio>`

### DIFF
--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -193,7 +193,7 @@ class TauriRuntime implements Runtime {
       enableRelatedChats: false,
       galleryImageKeepAspectRatio: false,
       isMentionsEnabled: false,
-      inChatSoundsVolume: 50,
+      inChatSoundsVolume: 0.5,
       useSystemUIFont: false,
     } satisfies Partial<DesktopSettingsType>
 


### PR DESCRIPTION
The bug was introduced in cc130b47ab7d9241eb980033909c36bcb63ff83a
(https://github.com/deltachat/deltachat-desktop/pull/5143).
It does not affect Electron.

The workaround is to go to Settings -> Notifications
and set "In-Chat Sounds" to any other value.

#skip-changelog because this has not been released yet.
