### PR TITLE
tauri: prevent moving around of the whole app with the touchpad gestures on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - translate "Emoji" and "Sticker" in emoji & sticker picker
 - tauri: fix webxdc apps not receiving `visibilitychange`, `beforeunload` and `pagehide` when the window gets closed (except on macOS) #5065
 - tauri: save zoom level between webxdc app launches #5163
+- tauri: prevent moving around of the whole app with the touchpad gestures on windows
 
 <a id="1_59_1"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - translate "Emoji" and "Sticker" in emoji & sticker picker
 - tauri: fix webxdc apps not receiving `visibilitychange`, `beforeunload` and `pagehide` when the window gets closed (except on macOS) #5065
 - tauri: save zoom level between webxdc app launches #5163
-- tauri: prevent moving around of the whole app with the touchpad gestures on windows
+- tauri: prevent moving around of the whole app with the touchpad gestures on windows #5182
 
 <a id="1_59_1"></a>
 

--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -28,6 +28,12 @@ body {
     --font-family: var(--fonts-system);
     font-family: var(--font-family);
   }
+
+  /*
+  prevent moving around of the whole app with the touchpad gestures on tauri windows
+  see https://github.com/deltachat/deltachat-desktop/issues/5075
+  */
+  overscroll-behavior: none;
 }
 
 #color-input-wrapper {


### PR DESCRIPTION
closes #5075