### PR TITLE
No image context menu on app icons

### DIFF
--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -464,6 +464,7 @@ function AppIcons({
             className={styles.webxdcIcon}
             src={runtime.getWebxdcIconURL(accountId, app.id)}
             alt={app.webxdcInfo?.name}
+            onContextMenu={(e: React.MouseEvent) => e.preventDefault()}
           />
         </Button>
       ))}


### PR DESCRIPTION
Avoid "default" electron context menu for images on App Icons:

![image](https://github.com/user-attachments/assets/58ff1c17-f93f-4609-b2c7-67816a4fdf77)

#skip-changelog

(reported by @hpk42 )
