### PR TITLE
Handle click event on context menu layer

### DIFF
--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -131,7 +131,8 @@ export function ContextMenuLayer({
     setPosition({ top, left })
   }, [])
 
-  const cancel = useCallback(() => {
+  const cancel = useCallback((evt: React.MouseEvent) => {
+    evt.preventDefault()
     window.__setContextMenuActive(false)
     setCurrentItems([])
     layerRef.current?.close()


### PR DESCRIPTION
resolves #5169

This PR at least avoids that a second right click (with opened context menu) on a QR code opens the default electron context menu. It probably fixes also the issue reported in #5169 


#skip-changelog