### PR TITLE
fix: "Copy Selected Text" on message not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 
 ### Fixed
+- fix "Copy Selected Text" item never appearing in message context menu
 - fix `runtime.isDroppedFileFromOutside` is not working as indended #5165
 - tauri: fix drag and drop on macOS #5165
 - translate "Emoji" and "Sticker" in emoji & sticker picker

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -855,7 +855,6 @@ export default function Message(props: {
         />
       )}
       <div
-        onContextMenu={showContextMenu}
         className='msg-container'
         style={{ borderColor: message.sender.color }}
         ref={messageContainerRef}


### PR DESCRIPTION
Well, to be precise, it did work sometimes,
but only when you click outside `.msg-container`
but inside `.message`.

For some reason we had two even listeners
from the very start
(bc0112ed6f07f91c829e6a00ee1a950a33abae6b,
https://github.com/deltachat/deltachat-desktop/pull/690).
But the issue with this is that `buildContextMenu`
gets invoked twice, and on the second run
`window.getSelection()` always returns an empty selection.

Looking at d48c8490b459c120f87ffb94d29f0f0501453a6d
(https://github.com/deltachat/deltachat-desktop/pull/2015),
it appears that this worked properly at least at some point,
but it's not clear when it broke.
Possibly with a React or Electron upgrade.

This commit should also make the context menu appear faster,
due to not having to do the work twice.
