### PR TITLE
improvement: reverse recent webxdcs order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Zoom In/Out with Ctrl +/- #890
 
 ### Changed
+- reverse order of recent webxdc apps in chat header (last item means last message)
 
 ### Fixed
 - fix `runtime.isDroppedFileFromOutside` is not working as indended #5165

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -160,7 +160,6 @@ export default function MainScreen({ accountId }: Props) {
         null,
         null
       )
-      mediaIds.reverse() // newest first
       const mediaLoadResult = await BackendRemote.rpc.getMessages(
         accountId,
         mediaIds.slice(0, maxIcons)


### PR DESCRIPTION
See https://github.com/deltachat/deltachat-desktop/pull/5151#issuecomment-2909576653.
The argument for the original order (with `mediaIds.reverse()`)
was that the order matches the order in the gallery dialog.
However, I don't think that this matching is important.
What's more important is that it's more intuitive that
the items that is the last one (the rightmost) corresponds to the
message that was sent the last.
Otherwise I personally need to think really really hard
which app I'm about to open (I have several instances
of the same app).
