### PR TITLE
fix: a11y: fix incorrect gallery "tab" role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - fix `runtime.isDroppedFileFromOutside` is not working as indended #5165
+- accessibility: fix incorrect "Gallery" button "tab" role, introduced in 1.59.0
 - tauri: fix drag and drop on macOS #5165
 - translate "Emoji" and "Sticker" in emoji & sticker picker
 - tauri: fix webxdc apps not receiving `visibilitychange`, `beforeunload` and `pagehide` when the window gets closed (except on macOS) #5065

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -302,18 +302,8 @@ export default class Gallery extends Component<
     const showDateHeader =
       currentTab !== 'files' && currentTab !== 'webxdc_apps'
 
-    // FYI the role="tablist" element is not rendered when
-    // `props.chatId === 'all'`.
-    // Would be nice to DRY this somehow.
-    const isTabpanel = this.props.chatId !== 'all'
-
     return (
-      <div
-        role={isTabpanel ? 'tabpanel' : undefined}
-        aria-labelledby={isTabpanel ? 'tab-media-view' : undefined}
-        id='media-view'
-        className='media-view'
-      >
+      <div className='media-view'>
         <ul ref={this.tabListRef} className='tab-list .modifier' role='tablist'>
           <RovingTabindexProvider
             wrapperElementRef={this.tabListRef}

--- a/packages/frontend/src/components/NoChatSelected.tsx
+++ b/packages/frontend/src/components/NoChatSelected.tsx
@@ -13,16 +13,7 @@ export default function NoChatSelected() {
     : {}
 
   return (
-    <div
-      role='tabpanel'
-      // See MessageListAndComposer as to why this is commented out.
-      // aria-labelledby='tab-message-list-view'
-
-      // The main MessageListAndComposer also has this ID and class.
-      id='message-list-and-composer'
-      className='message-list-and-composer'
-      style={style}
-    >
+    <div className='message-list-and-composer' style={style}>
       <div
         className='message-list-and-composer__message-list'
         style={{ display: 'flex' }}

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -292,18 +292,6 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   return (
     <div
-      role='tabpanel'
-      // Techically we must apply `aria-labelledby` to `tabpanel`,
-      // but it's a little annoying that screen readers (NVDA)
-      // announce "'Chat' property page" every time
-      // the focus enters this tabpanel, because it's the "default" one,
-      // it's not often that another tab (Gallery) is selected.
-      // So, let's comment this out for now, until we resolve
-      // https://github.com/deltachat/deltachat-desktop/issues/5074.
-      // aria-labelledby='tab-message-list-view'
-
-      // NoChatSelected also has this ID and class.
-      id='message-list-and-composer'
       className='message-list-and-composer'
       style={style}
       ref={conversationRef}

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -401,17 +401,9 @@ function ChatNavButtons({ chat }: { chat: T.FullChat }) {
 
   return (
     <>
-      <span
-        role='tablist'
-        aria-orientation='horizontal'
-        className='views'
-        data-no-drag-region
-      >
+      <span className='views' data-no-drag-region>
         <Button
-          role='tab'
-          id='tab-media-view'
           onClick={openMediaViewDialog}
-          aria-controls='media-view'
           aria-label={tx('apps_and_media')}
           title={tx('apps_and_media')}
           className='navbar-button'
@@ -420,8 +412,6 @@ function ChatNavButtons({ chat }: { chat: T.FullChat }) {
           <Icon coloring='navbar' icon='apps' size={18} />
         </Button>
         {settingsStore?.desktopSettings.enableOnDemandLocationStreaming && (
-          // Yes, this is not marked as `role='tab'`.
-          // I'm not sure if this is alright.
           <Button
             onClick={() => openMapWebxdc(selectedAccountId(), chatId)}
             aria-label={tx('tab_map')}


### PR DESCRIPTION
The issue has been introduced in
3bc21041bfbafea2da9c297adcdffa28528e8480
(https://github.com/deltachat/deltachat-desktop/pull/5149).
That MR was unfinished in this aspect.
This MR finished it, and closes
https://github.com/deltachat/deltachat-desktop/issues/5074.

This reverts 00c7e6939675156e842f45ca9948dfa9b4cce507
(https://github.com/deltachat/deltachat-desktop/pull/4675).
Also see 4073e2a400fc98b22a18d3b760a8f441e4fe42f8
(https://github.com/deltachat/deltachat-desktop/pull/5076).
