### PR TITLE
fix: notifications not working sometimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 
 ### Fixed
+- fix notifications not working sometimes, introduced in 1.59.1
 - fix "Copy Selected Text" item never appearing in message context menu
 - fix `runtime.isDroppedFileFromOutside` is not working as indended #5165
 - accessibility: fix incorrect "Gallery" button "tab" role, introduced in 1.59.0

--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -103,7 +103,11 @@ function incomingMessageHandler(
     return
   }
 
-  if (chatId === window.__selectedChatId && document.hasFocus()) {
+  if (
+    accountId === window.__selectedAccountId &&
+    chatId === window.__selectedChatId &&
+    document.hasFocus()
+  ) {
     // window has focus don't send notification for the selected chat
     //
     // It is important for accessibility to notify the user of all new messages,


### PR DESCRIPTION
To be precise, when the chat ID of the currently selected chat
mathches the chat ID of the chat on another account
in which a message gets received.

The bug has been introduced in
928d73a70ec991266e8b0ff274ce8194c9b18b03
(https://github.com/deltachat/deltachat-desktop/pull/5146).

I have verified that this fixes the bug.