### PR TITLE
fix: dropping files on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - fix notifications not working sometimes, introduced in 1.59.1
+- fix dropping files from outside not working on Windows, introduced in 1.59.1
 - fix "Copy Selected Text" item never appearing in message context menu
 - fix `runtime.isDroppedFileFromOutside` is not working as indended #5165
 - accessibility: fix incorrect "Gallery" button "tab" role, introduced in 1.59.0


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5167.
Closes https://github.com/deltachat/deltachat-desktop/issues/5193.

This is a follow-up to
- https://github.com/deltachat/deltachat-desktop/pull/4951.
- https://github.com/deltachat/deltachat-desktop/pull/5109.
- https://github.com/deltachat/deltachat-desktop/pull/5094.

This also fixed drag and drop to inside Delta Chat on Tauri, both in and out.

I have verified that this fixes dropping multiple files,
and a single file from outside.
But the code is still very problematic.
