### PR TITLE
tauri: fix: "Connectivity" dialog style CSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - translate "Emoji" and "Sticker" in emoji & sticker picker
 - tauri: fix webxdc apps not receiving `visibilitychange`, `beforeunload` and `pagehide` when the window gets closed (except on macOS) #5065
 - tauri: save zoom level between webxdc app launches #5163
+- tauri: fix "Connectivity" dialog being unreadable on dark theme
 - tauri: prevent moving around of the whole app with the touchpad gestures on windows #5182
 - fix horizontal scroll in message list #5162
 

--- a/packages/target-tauri/src-tauri/tauri.conf.json5
+++ b/packages/target-tauri/src-tauri/tauri.conf.json5
@@ -18,12 +18,14 @@
         // The sha-256 values are for
         // - `emoji-mart`.
         // - `react-zoom-pan-pinch`'s TransformComponent (2nd and 3rd entries).
+        // - "Connectivity" iframe styles (`rpc.getConnectivityHtml()`)
+        //   (4th entry)
         // We can't use 'unsafe-inline',
         // because Tauri injects nonce values,
         // (see https://tauri.app/security/csp/), and the browser complains:
         // > Note that 'unsafe-inline' is ignored if either a hash
         // > or nonce value is present in the source list.
-        "style-src": "'self' 'sha256-+A14ONesVdzkn6nr37Osn+rUqNz4oFGZFDbLXrlae04=' 'sha256-HV3Dam0GcDz1w0B+b1RFgSxPeS9mwy/UvkSnZ/Bh/Cc=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",
+        "style-src": "'self' 'sha256-+A14ONesVdzkn6nr37Osn+rUqNz4oFGZFDbLXrlae04=' 'sha256-HV3Dam0GcDz1w0B+b1RFgSxPeS9mwy/UvkSnZ/Bh/Cc=' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-Zh4jUM9OY2WmO7yf9x6EN6kOIMV+Qs5XBO/aKendd1M='",
         "font-src": "'self'",
         "script-src": "'self' 'wasm-unsafe-eval'",
         "worker-src": "blob:",


### PR DESCRIPTION
This fixes the dialog content having dark text on dark background.

Add a hash for the core's style,
and don't try to inject styles dynamically,
instead always fall back to light theme.

This does not affect the Electron version.

This is ugly, but better than nothing:

![image](https://github.com/user-attachments/assets/4d485819-781d-433a-a74f-eb67186f91cc)

![image](https://github.com/user-attachments/assets/64a5bc58-f71d-4666-83df-8f79998b2864)
