### PR TITLE
tauri: fix: a11y: set `color-scheme` on `:root`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - tauri: save zoom level between webxdc app launches #5163
 - tauri: fix "Connectivity" dialog being unreadable on dark theme
 - tauri: prevent moving around of the whole app with the touchpad gestures on windows #5182
+- tauri: accessibility: fix outline being barely visible on Windows, and adjust some other colors
 - fix horizontal scroll in message list #5162
 
 <a id="1_59_1"></a>

--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -8,6 +8,14 @@
 
 html {
   height: 100%;
+
+  // Since we're managing the color scheme (theme) manually,
+  // let's specify that we're only supporting this color scheme (dark or light).
+  // This affects some default styles, such as outline color and
+  // input (radio buttons, etc) colors.
+  // Outline color is important, because if we don't do this,
+  // the outline is barely visible on dark theme on Tauri on Windows.
+  color-scheme: var(--themeDarkOrLight);
 }
 
 body {

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -2,6 +2,7 @@
 
 $hover-contrast-change: 2%;
 // set light theme variables as fallback
+$themeDarkOrLight: light !default;
 $colorPrimary: #42a5f5 !default;
 $colorDanger: #f96856 !default;
 $colorNone: #a0a0a0 !default;
@@ -52,6 +53,8 @@ $scrollbarTransparency: 0.34 !default;
 
 /* Root Variables */
 :root {
+  --themeDarkOrLight: #{$themeDarkOrLight};
+
   --colorPrimary: #{$colorPrimary};
   --colorDanger: #{$colorDanger};
   --colorNone: #{$colorNone};
@@ -256,6 +259,7 @@ $scrollbarTransparency: 0.34 !default;
   );
 
   /** HTML Email Window */
+  --htmlEmail-themeDarkOrLight: #{$themeDarkOrLight};
   --htmlEmail-background: #{$bgPrimary};
   --htmlEmail-color: #{$textPrimary};
   --htmlEmail-border-color: #{changeContrast($bgPrimary, 20%)};

--- a/packages/frontend/themes/dark.scss
+++ b/packages/frontend/themes/dark.scss
@@ -1,5 +1,6 @@
 /* Set theme variables used for theme Generation */
 @use './_themebase' with (
+  $themeDarkOrLight: dark,
   $outlineColor: #505050,
   $accentColor: #2090ea,
   $bgChatView: #19232b,

--- a/packages/frontend/themes/dark_amoled.scss
+++ b/packages/frontend/themes/dark_amoled.scss
@@ -1,5 +1,6 @@
 /* Set theme variables used for theme Generation */
 @use './_themebase' with (
+  $themeDarkOrLight: dark,
   $accentColor: purple,
   $bgChatView: #000,
   $bgImage: none,

--- a/packages/frontend/themes/darkpurple.scss
+++ b/packages/frontend/themes/darkpurple.scss
@@ -1,5 +1,6 @@
 /* Set theme variables used for theme Generation */
 @use './_themebase' with (
+  $themeDarkOrLight: dark,
   $accentColor: #cc12ac,
   $bgChatView: #252540,
   $bgImage: none,

--- a/packages/frontend/themes/dev_minimal.scss
+++ b/packages/frontend/themes/dev_minimal.scss
@@ -1,5 +1,6 @@
 /* Set theme variables used for theme Generation */
 @use './_themebase' with (
+  $themeDarkOrLight: light,
   $outlineColor: #b9b9b9,
   $accentColor: #000000,
   $bgChatView: #e6dcd4,

--- a/packages/frontend/themes/dev_rocket.scss
+++ b/packages/frontend/themes/dev_rocket.scss
@@ -1,5 +1,6 @@
 /* Set theme variables used for theme Generation */
 @use './_themebase' with (
+  $themeDarkOrLight: light,
   $outlineColor: #b9b9b9,
   $accentColor: #000000,
   $bgChatView: #e6dcd4,

--- a/packages/frontend/themes/light.scss
+++ b/packages/frontend/themes/light.scss
@@ -1,5 +1,6 @@
 /* Set theme variables used for theme Generation */
 @use './_themebase' with (
+  $themeDarkOrLight: light,
   $outlineColor: #b9b9b9,
   $accentColor: #2090ea,
   $bgChatView: #e6dcd4,

--- a/packages/target-electron/static/electron_html_email_view/electron_html_email_view.css
+++ b/packages/target-electron/static/electron_html_email_view/electron_html_email_view.css
@@ -3,6 +3,8 @@ body {
   height: 100%;
   width: 100%;
   margin: 0;
+  /* See `--themeDarkOrLight`. */
+  color-scheme: var(--htmlEmail-themeDarkOrLight);
 }
 body {
   display: flex;

--- a/packages/target-tauri/static/tauri_html_email_view/html_email_view.css
+++ b/packages/target-tauri/static/tauri_html_email_view/html_email_view.css
@@ -3,6 +3,8 @@ body {
   height: 100%;
   width: 100%;
   margin: 0;
+  /* See `--themeDarkOrLight`. */
+  color-scheme: var(--htmlEmail-themeDarkOrLight);
 }
 body {
   display: flex;


### PR DESCRIPTION
I have tested this change, both on Tauri and Electron, and it works.
This also affects radio buttons,
e.g. in "Disappearing messages" dialog,
making them match the current theme (dark or light),
and the HTML email viewer header checkbox.
