### PR TITLE
Fetch webxdc info seperately with `rpc.getWebxdcInfo`, because new core will no longer provide it in the MessageObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed
 - tauri: macOS: webxdc: Remove the nowhere-proxy to support pre-14 macOS. #5202
 - reword 'Save As' to 'Export Attachment' to have a clearer cut to 'Save' #5245
+- use rpc.getWebxdcInfo instead of message.webxdcInfo #5227
 
 ### Fixed
 - tauri: remember webxdc app windows' position and size between app re-launches

--- a/packages/frontend/src/components/attachment/Attachment.tsx
+++ b/packages/frontend/src/components/attachment/Attachment.tsx
@@ -83,5 +83,5 @@ export function dragAttachmentOut(
 
 export type MessageTypeAttachmentSubset = Pick<
   Type.Message,
-  'id' | 'file' | 'fileMime' | 'fileBytes' | 'fileName' | 'webxdcInfo'
+  'id' | 'file' | 'fileMime' | 'fileBytes' | 'fileName' | 'viewType'
 >

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -625,29 +625,6 @@ export function WebxdcAttachment({
     ? webxdcInfoFetch.result.value
     : null
 
-  // If the message is not yet loaded by GridGallery, show loading state
-  if (!loadResult || loadResult.kind !== 'message') {
-    return (
-      <div
-        ref={interactiveElRef}
-        className={'media-attachment-webxdc ' + rovingTabindex.className}
-        {...rovingTabindexProps}
-      >
-        <img
-          className='icon'
-          src={runtime.getWebxdcIconURL(selectedAccountId(), messageId)}
-        />
-        <div className='text-part'>
-          <div className='name'>Loading...</div>
-          <div className='summary'></div>
-        </div>
-      </div>
-    )
-  }
-
-  // At this point, loadResult.kind is guaranteed to be 'message'
-  const message = loadResult
-
   if (webxdcInfoFetch?.loading) {
     const onContextMenu = getBrokenMediaContextMenu(
       contextMenu.openContextMenu,
@@ -673,7 +650,7 @@ export function WebxdcAttachment({
         </div>
       </div>
     )
-  } else if (webxdcInfo == null) {
+  } else if (webxdcInfo == null || loadResult.kind !== 'message') {
     const onContextMenu = getBrokenMediaContextMenu(
       contextMenu.openContextMenu,
       openDialog,
@@ -707,7 +684,7 @@ export function WebxdcAttachment({
       contextMenu.openContextMenu,
       openDialog,
       jumpToMessage,
-      message,
+      loadResult,
       accountId
     )
     const { summary, name, document } = webxdcInfo
@@ -716,12 +693,12 @@ export function WebxdcAttachment({
         ref={interactiveElRef}
         className={'media-attachment-webxdc ' + rovingTabindex.className}
         onContextMenu={openContextMenu}
-        onClick={openWebxdc.bind(null, message, webxdcInfo ?? undefined)}
+        onClick={openWebxdc.bind(null, loadResult, webxdcInfo ?? undefined)}
         {...rovingTabindexProps}
       >
         <img
           className='icon'
-          src={runtime.getWebxdcIconURL(selectedAccountId(), message.id)}
+          src={runtime.getWebxdcIconURL(selectedAccountId(), loadResult.id)}
         />
         <div className='text-part'>
           <div

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -613,7 +613,8 @@ export function WebxdcAttachment({
   useEffect(() => {
     if (loadResult.kind === 'message') {
       setIsLoadingWebxdcInfo(true)
-      BackendRemote.rpc.getWebxdcInfo(accountId, messageId)
+      BackendRemote.rpc
+        .getWebxdcInfo(accountId, messageId)
         .then(info => {
           if (info) {
             setWebxdcInfo(info)
@@ -622,7 +623,14 @@ export function WebxdcAttachment({
           }
         })
         .catch(error => {
-          log.error('Failed to load webxdc info for message:', messageId, 'accountId:', accountId, 'error:', error)
+          log.error(
+            'Failed to load webxdc info for message:',
+            messageId,
+            'accountId:',
+            accountId,
+            'error:',
+            error
+          )
           setWebxdcInfo(null)
         })
         .finally(() => {

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -242,19 +242,24 @@ export function DraftAttachment({
   useEffect(() => {
     if (attachment && attachment.viewType === 'Webxdc') {
       setIsLoadingWebxdcInfo(true)
-      BackendRemote.rpc.getWebxdcInfo(accountId, attachment.id)
+      BackendRemote.rpc
+        .getWebxdcInfo(accountId, attachment.id)
         .then((info: T.WebxdcMessageInfo) => {
           setWebxdcInfo(info)
         })
         .catch((error: any) => {
-          console.error('Failed to load webxdc info for draft:', attachment.id, error)
+          console.error(
+            'Failed to load webxdc info for draft:',
+            attachment.id,
+            error
+          )
           setWebxdcInfo(null)
         })
         .finally(() => {
           setIsLoadingWebxdcInfo(false)
         })
     }
-  }, [accountId, attachment?.id, attachment?.viewType])
+  }, [accountId, attachment, attachment.id, attachment.viewType])
 
   if (!attachment) {
     return null
@@ -287,7 +292,9 @@ export function DraftAttachment({
         <img className='icon' src={iconUrl} alt='app icon' />
         <div className='text-part'>
           <div className='name'>
-            {isLoadingWebxdcInfo ? 'Loading...' : webxdcInfo?.name || 'Unknown App'}
+            {isLoadingWebxdcInfo
+              ? 'Loading...'
+              : webxdcInfo?.name || 'Unknown App'}
           </div>
           <div className='size'>
             {attachment.fileBytes ? filesize(attachment.fileBytes) : '?'}

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -706,7 +706,7 @@ export default Composer
 
 export type DraftObject = { chatId: number } & Pick<
   Type.Message,
-  'id' | 'text' | 'file' | 'quote' | 'viewType' | 'vcardContact' | 'webxdcInfo'
+  'id' | 'text' | 'file' | 'quote' | 'viewType' | 'vcardContact'
 > &
   MessageTypeAttachmentSubset
 
@@ -722,7 +722,6 @@ function emptyDraft(chatId: number | null): DraftObject {
     quote: null,
     viewType: 'Text',
     vcardContact: null,
-    webxdcInfo: null,
   }
 }
 
@@ -807,7 +806,6 @@ export function useDraft(
             viewType: newDraft.viewType,
             quote: newDraft.quote,
             vcardContact: newDraft.vcardContact,
-            webxdcInfo: newDraft.webxdcInfo,
           }))
           inputRef.current?.setText(newDraft.text)
         }
@@ -881,7 +879,6 @@ export function useDraft(
         viewType: newDraft.viewType,
         quote: newDraft.quote,
         vcardContact: newDraft.vcardContact,
-        webxdcInfo: newDraft.webxdcInfo,
       }))
       // don't load text to prevent bugging back
     } else {

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1114,13 +1114,35 @@ function WebxdcMessageContent({
   tabindexForInteractiveContents: -1 | 0
 }) {
   const tx = useTranslationFunction()
+  const [webxdcInfo, setWebxdcInfo] = useState<T.WebxdcMessageInfo | null>(null)
+  const [isLoadingWebxdcInfo, setIsLoadingWebxdcInfo] = useState(false)
+  const accountId = selectedAccountId()
+
+  useEffect(() => {
+    if (message.viewType === 'Webxdc') {
+      setIsLoadingWebxdcInfo(true)
+      BackendRemote.rpc.getWebxdcInfo(accountId, message.id)
+        .then((info: T.WebxdcMessageInfo) => {
+          setWebxdcInfo(info)
+        })
+        .catch((error: any) => {
+          console.error('Failed to load webxdc info for message:', message.id, error)
+          setWebxdcInfo(null)
+        })
+        .finally(() => {
+          setIsLoadingWebxdcInfo(false)
+        })
+    }
+  }, [accountId, message.id, message.viewType])
+
   if (message.viewType !== 'Webxdc') {
     return null
   }
-  const info = message.webxdcInfo || {
-    name: 'INFO MISSING!',
+
+  const info = webxdcInfo || {
+    name: isLoadingWebxdcInfo ? 'Loading...' : 'INFO MISSING!',
     document: undefined,
-    summary: 'INFO MISSING!',
+    summary: isLoadingWebxdcInfo ? '' : 'INFO MISSING!',
   }
 
   return (

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1121,12 +1121,17 @@ function WebxdcMessageContent({
   useEffect(() => {
     if (message.viewType === 'Webxdc') {
       setIsLoadingWebxdcInfo(true)
-      BackendRemote.rpc.getWebxdcInfo(accountId, message.id)
+      BackendRemote.rpc
+        .getWebxdcInfo(accountId, message.id)
         .then((info: T.WebxdcMessageInfo) => {
           setWebxdcInfo(info)
         })
         .catch((error: any) => {
-          console.error('Failed to load webxdc info for message:', message.id, error)
+          console.error(
+            'Failed to load webxdc info for message:',
+            message.id,
+            error
+          )
           setWebxdcInfo(null)
         })
         .finally(() => {

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1157,7 +1157,7 @@ function WebxdcMessageContent({
         alt={`icon of ${info.name}`}
         // No need to turn this element into a `<button>` for a11y,
         // because there is a button below that does the same.
-        onClick={() => openWebxdc(message)}
+        onClick={() => openWebxdc(message, webxdcInfo ?? undefined)}
         // Not setting `tabIndex={tabindexForInteractiveContents}` here
         // because there is a button below that does the same
       />
@@ -1172,7 +1172,7 @@ function WebxdcMessageContent({
       <Button
         className={styles.startWebxdcButton}
         styling='primary'
-        onClick={() => openWebxdc(message)}
+        onClick={() => openWebxdc(message, webxdcInfo ?? undefined)}
         tabIndex={tabindexForInteractiveContents}
       >
         {tx('start_app')}

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -152,7 +152,10 @@ export async function downloadFullMessage(messageId: number) {
   await BackendRemote.rpc.downloadFullMessage(selectedAccountId(), messageId)
 }
 
-export async function openWebxdc(message: Type.Message) {
+export async function openWebxdc(
+  message: Type.Message,
+  webxdcInfo?: T.WebxdcMessageInfo
+) {
   const accountId = selectedAccountId()
-  internalOpenWebxdc(accountId, message)
+  internalOpenWebxdc(accountId, message, webxdcInfo)
 }

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -469,7 +469,7 @@ function AppIcon({ accountId, app }: { accountId: number; app: T.Message }) {
       title={appName}
       aria-label={appName}
       onClick={() => {
-        openWebxdc(app)
+        openWebxdc(app, webxdcInfo ?? undefined)
       }}
     >
       <img

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -436,20 +436,15 @@ function ChatNavButtons({ chat }: { chat: T.FullChat }) {
   )
 }
 
-function AppIcon({
-  accountId,
-  app,
-}: {
-  accountId: number
-  app: T.Message
-}) {
+function AppIcon({ accountId, app }: { accountId: number; app: T.Message }) {
   const [webxdcInfo, setWebxdcInfo] = useState<T.WebxdcMessageInfo | null>(null)
   const [isLoadingWebxdcInfo, setIsLoadingWebxdcInfo] = useState(false)
 
   useEffect(() => {
     if (app.viewType === 'Webxdc') {
       setIsLoadingWebxdcInfo(true)
-      BackendRemote.rpc.getWebxdcInfo(accountId, app.id)
+      BackendRemote.rpc
+        .getWebxdcInfo(accountId, app.id)
         .then((info: T.WebxdcMessageInfo) => {
           setWebxdcInfo(info)
         })
@@ -463,7 +458,8 @@ function AppIcon({
     }
   }, [accountId, app.id, app.viewType])
 
-  const appName = webxdcInfo?.name || (isLoadingWebxdcInfo ? 'Loading...' : 'Unknown App')
+  const appName =
+    webxdcInfo?.name || (isLoadingWebxdcInfo ? 'Loading...' : 'Unknown App')
 
   return (
     <Button

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -436,6 +436,56 @@ function ChatNavButtons({ chat }: { chat: T.FullChat }) {
   )
 }
 
+function AppIcon({
+  accountId,
+  app,
+}: {
+  accountId: number
+  app: T.Message
+}) {
+  const [webxdcInfo, setWebxdcInfo] = useState<T.WebxdcMessageInfo | null>(null)
+  const [isLoadingWebxdcInfo, setIsLoadingWebxdcInfo] = useState(false)
+
+  useEffect(() => {
+    if (app.viewType === 'Webxdc') {
+      setIsLoadingWebxdcInfo(true)
+      BackendRemote.rpc.getWebxdcInfo(accountId, app.id)
+        .then((info: T.WebxdcMessageInfo) => {
+          setWebxdcInfo(info)
+        })
+        .catch((error: any) => {
+          console.error('Failed to load webxdc info for app:', app.id, error)
+          setWebxdcInfo(null)
+        })
+        .finally(() => {
+          setIsLoadingWebxdcInfo(false)
+        })
+    }
+  }, [accountId, app.id, app.viewType])
+
+  const appName = webxdcInfo?.name || (isLoadingWebxdcInfo ? 'Loading...' : 'Unknown App')
+
+  return (
+    <Button
+      styling='borderless'
+      key={app.id}
+      className={styles.webxdcIconButton}
+      title={appName}
+      aria-label={appName}
+      onClick={() => {
+        openWebxdc(app)
+      }}
+    >
+      <img
+        className={styles.webxdcIcon}
+        src={runtime.getWebxdcIconURL(accountId, app.id)}
+        alt={appName}
+        onContextMenu={(e: React.MouseEvent) => e.preventDefault()}
+      />
+    </Button>
+  )
+}
+
 function AppIcons({
   accountId,
   apps,
@@ -453,23 +503,7 @@ function AppIcons({
       data-no-drag-region='true'
     >
       {apps.map(app => (
-        <Button
-          styling='borderless'
-          key={app.id}
-          className={styles.webxdcIconButton}
-          title={app.webxdcInfo?.name}
-          aria-label={app.webxdcInfo?.name}
-          onClick={() => {
-            openWebxdc(app)
-          }}
-        >
-          <img
-            className={styles.webxdcIcon}
-            src={runtime.getWebxdcIconURL(accountId, app.id)}
-            alt={app.webxdcInfo?.name}
-            onContextMenu={(e: React.MouseEvent) => e.preventDefault()}
-          />
-        </Button>
+        <AppIcon key={app.id} accountId={accountId} app={app} />
       ))}
     </div>
   )

--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -191,7 +191,10 @@ async function showNotification(
             message.parentId
           )
         }
-        const webxdcInfo = await BackendRemote.rpc.getWebxdcInfo(accountId, message.id)
+        const webxdcInfo = await BackendRemote.rpc.getWebxdcInfo(
+          accountId,
+          message.id
+        )
         if (webxdcInfo) {
           summaryText = eventText
           summaryPrefix = `${webxdcInfo.name}`

--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -191,11 +191,12 @@ async function showNotification(
             message.parentId
           )
         }
-        if (message.webxdcInfo) {
+        const webxdcInfo = await BackendRemote.rpc.getWebxdcInfo(accountId, message.id)
+        if (webxdcInfo) {
           summaryText = eventText
-          summaryPrefix = `${message.webxdcInfo.name}`
-          if (message.webxdcInfo.icon) {
-            const iconName = message.webxdcInfo.icon
+          summaryPrefix = `${webxdcInfo.name}`
+          if (webxdcInfo.icon) {
+            const iconName = webxdcInfo.icon
             const iconBlob = await BackendRemote.rpc.getWebxdcBlob(
               accountId,
               message.id,

--- a/packages/frontend/src/system-integration/webxdc.ts
+++ b/packages/frontend/src/system-integration/webxdc.ts
@@ -4,6 +4,7 @@
 
 import { BackendRemote, Type } from '../backend-com'
 import { runtime } from '@deltachat-desktop/runtime-interface'
+import { T } from '@deltachat/jsonrpc-client'
 
 export function initWebxdc() {
   BackendRemote.on('WebxdcStatusUpdate', (accountId, { msgId }) => {
@@ -27,7 +28,8 @@ export function initWebxdc() {
  */
 export async function internalOpenWebxdc(
   accountId: number,
-  message: Type.Message
+  message: Type.Message,
+  webxdcInfo?: T.WebxdcMessageInfo
 ) {
   let href = ''
   let messageId = message.id
@@ -37,7 +39,9 @@ export async function internalOpenWebxdc(
     messageId = message.parentId
     message = await BackendRemote.rpc.getMessage(accountId, messageId)
   }
-  const webxdcInfo = await BackendRemote.rpc.getWebxdcInfo(accountId, messageId)
+  if (!webxdcInfo) {
+    webxdcInfo = await BackendRemote.rpc.getWebxdcInfo(accountId, messageId)
+  }
   if (!webxdcInfo) {
     // we can open only messages with webxdc info
     throw new Error('no webxdc info for message ' + message)

--- a/packages/frontend/src/system-integration/webxdc.ts
+++ b/packages/frontend/src/system-integration/webxdc.ts
@@ -37,7 +37,8 @@ export async function internalOpenWebxdc(
     messageId = message.parentId
     message = await BackendRemote.rpc.getMessage(accountId, messageId)
   }
-  if (!message.webxdcInfo) {
+  const webxdcInfo = await BackendRemote.rpc.getWebxdcInfo(accountId, messageId)
+  if (!webxdcInfo) {
     // we can open only messages with webxdc info
     throw new Error('no webxdc info for message ' + message)
   }
@@ -53,7 +54,7 @@ export async function internalOpenWebxdc(
     accountId,
     displayname,
     chatName,
-    webxdcInfo: message.webxdcInfo,
+    webxdcInfo,
     href,
   })
 }

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -687,7 +687,8 @@ export default class DCWebxdc {
       async (_ev, accountId: number, instanceId: number) => {
         const instance = open_apps[`${accountId}.${instanceId}`]
         if (instance) {
-          const { chatId, webxdcInfo } = await this.rpc.getMessage(
+          const webxdcInfo = await this.rpc.getWebxdcInfo(accountId, instanceId)
+          const { chatId } = await this.rpc.getMessage(
             accountId,
             instanceId
           )
@@ -761,8 +762,8 @@ export default class DCWebxdc {
             open_apps[key].win.loadURL('about:blank')
             open_apps[key].win.close()
           }
-          const messageWithMap = await this.rpc.getMessage(accountId, msgId)
-          if (messageWithMap && messageWithMap.webxdcInfo) {
+          const webxdcInfo = await this.rpc.getWebxdcInfo(accountId, msgId)
+          if (webxdcInfo) {
             openWebxdc(
               evt,
               msgId,
@@ -770,7 +771,7 @@ export default class DCWebxdc {
                 accountId,
                 displayname: '',
                 chatName,
-                webxdcInfo: messageWithMap.webxdcInfo,
+                webxdcInfo,
                 href: '',
               },
               // special behaviour for the map dc integration,

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -688,10 +688,7 @@ export default class DCWebxdc {
         const instance = open_apps[`${accountId}.${instanceId}`]
         if (instance) {
           const webxdcInfo = await this.rpc.getWebxdcInfo(accountId, instanceId)
-          const { chatId } = await this.rpc.getMessage(
-            accountId,
-            instanceId
-          )
+          const { chatId } = await this.rpc.getMessage(accountId, instanceId)
           const { name } = await this.rpc.getBasicChatInfo(accountId, chatId)
           if (instance.win && webxdcInfo) {
             instance.win.title = makeTitle(webxdcInfo, name)


### PR DESCRIPTION
Resolves #5218 

I already tested various stuff, only thing I'm not really sure about is if broken media handling in Gallery is still the same as before, as I didn't had the various use cases