### PR TITLE
perf: reduce debouncing in `useContactIds`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - accessibility: add accessible labels for lists (messages list, chat list, profiles list) #5030
 - improve performance: remove message context menu open delay
+- improve performace in contact search #5230
 - improve performance: don't mark messages as seen unnecessarily when focusing window #5243
 - improve performance in "Edit Group" a little #5237
 - tauri: accessibility: fix outline being barely visible on Windows, and adjust some other colors #5217

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -28,6 +28,7 @@
     "@deltachat/message_parser_wasm": "^0.14.1",
     "@emoji-mart/data": "^1.2.1",
     "@emoji-mart/react": "^1.1.1",
+    "@jcoreio/async-throttle": "^1.6.1",
     "classnames": "^2.5.1",
     "debounce": "^1.2.1",
     "emoji-js-clean": "^4.0.0",

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
@@ -29,7 +29,7 @@ export function AddMemberDialog({
     contactCache,
     loadContacts,
     queryStrIsValidEmail,
-    refresh: refreshContacts,
+    refreshContacts,
   } = useLazyLoadedContacts(listFlags, queryStr)
   return (
     <Dialog

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -136,7 +136,7 @@ function CreateChatMain(props: CreateChatMainProps) {
     contactCache,
     loadContacts,
     queryStrIsValidEmail,
-    refresh: refreshContacts,
+    refreshContacts,
   } = useLazyLoadedContacts(C.DC_GCL_ADD_SELF, queryStr)
 
   const chooseContact = async ({ id }: Type.Contact) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       '@emoji-mart/react':
         specifier: ^1.1.1
         version: 1.1.1(emoji-mart@5.6.0)(react@19.1.0)
+      '@jcoreio/async-throttle':
+        specifier: ^1.6.1
+        version: 1.6.1
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -1082,6 +1085,10 @@ packages:
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@jcoreio/async-throttle@1.6.1':
+    resolution: {integrity: sha512-9c9SH93yYEX6zK7N8GThr7twbRtJdKX59CuIKd3qtF0SH4ZDAgeMuQPlWnWMLmWy/RdGKgHJaiciOoOHnFlmUA==}
+    engines: {node: '>=16'}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -4355,6 +4362,10 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@jcoreio/async-throttle@1.6.1':
+    dependencies:
+      '@babel/runtime': 7.19.0
 
   '@jridgewell/resolve-uri@3.1.2':
     optional: true


### PR DESCRIPTION
Note that this affects many places:
- Chat list search.
- "New Chat" dialog search.
- "Attach Contact" dialog search.

***
- replace `debounce` with `asyncThrottle`,
  which allows for much lower delay thanks to the fact
  that it awaits the previous call.
- fix potential race conditions, utilize `useFetch`.
  This partially addresses
  https://github.com/deltachat/deltachat-desktop/issues/4501.

Also note that this adds a new NPM dependency.

The esbuild upgrade has been automatically performed by PNPM.

I have tested the change.

TODO:
- [ ] Merge https://github.com/deltachat/deltachat-desktop/pull/5222.