### PR TITLE
test: increase E2E `expect` timeout

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
   expect: {
     // Our tests involve network interaction, so we want a higher timeout
     // for assertions, such as receiving an invitation to a group.
-    timeout: 20_000,
+    timeout: 60_000,
   },
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {


### PR DESCRIPTION
It keeps failing for group tests,
for some reason those are taking very long.
Let's see if a minute will do.

#skip-changelog