### PR TITLE
perf: open message context menu instantly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 - Update last used app icons immediately after sending a new app
 
+### Fixed
+- improve performance: remove message context menu open delay
+
 <a id="1_59_2"></a>
 
 ## [1.59.2] - 2025-06-25

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -459,17 +459,13 @@ export default function Message(props: {
   const [messageWidth, setMessageWidth] = useState(0)
 
   const showContextMenu = useCallback(
-    async (
+    (
       event: React.MouseEvent<
         HTMLButtonElement | HTMLAnchorElement | HTMLDivElement,
         MouseEvent
       >
     ) => {
       event.preventDefault() // prevent default runtime context menu from opening
-      const chat = await BackendRemote.rpc.getFullChatById(
-        accountId,
-        message.chatId
-      )
 
       const showContextMenuEventPos = mouseEventToPosition(event)
 
@@ -510,7 +506,7 @@ export default function Message(props: {
           openDialog,
           privateReply,
           handleReactClick,
-          chat,
+          chat: props.chat,
           jumpToMessage,
         },
         target
@@ -523,6 +519,7 @@ export default function Message(props: {
     },
     [
       accountId,
+      props.chat,
       conversationType,
       message,
       openContextMenu,


### PR DESCRIPTION
By removing an unnecessary call to `rpc.getFullChatById()`:
a `T.FullChat` object is already provided in props.
