### PR TITLE
perf: clean up unread message observing, improve perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- improve performance: don't mark messages as seen unnecessarily when focusing window #5243
+
 <a id="1_60_0"></a>
 
 ## [1.60.0] - 2025-07-10

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -43,7 +43,7 @@ type ChatTypes =
 
 const onWindowFocus = (accountId: number) => {
   log.debug('window focused')
-  const messageElements = Array.prototype.slice.call(
+  const messageElements: HTMLElement[] = Array.prototype.slice.call(
     document.querySelectorAll('#message-list .message-observer-bottom')
   )
 

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -58,9 +58,11 @@ const onWindowFocus = (accountId: number) => {
     )
   })
 
-  const messageIdsToMarkAsRead = visibleElements.map(el =>
-    Number.parseInt(el.getAttribute('id').split('-')[1])
-  )
+  const messageIdsToMarkAsRead = visibleElements
+    .map(el =>
+      el.dataset.messageid ? Number.parseInt(el.dataset.messageid) : undefined
+    )
+    .filter(id => id != undefined)
 
   if (messageIdsToMarkAsRead.length !== 0) {
     log.debug(
@@ -173,9 +175,23 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
       const messageIdsToMarkAsRead = []
       for (const entry of entries) {
         if (!entry.isIntersecting) continue
-        const messageKey = entry.target.getAttribute('id')
-        if (messageKey === null) continue
-        const messageId = messageKey.split('-')[1]
+        if (!(entry.target instanceof HTMLElement)) {
+          log.error(
+            'onUnreadMessageInView: entry.target is not HTMLElement:',
+            entry.target
+          )
+          continue
+        }
+        const messageId = entry.target.dataset.messageid
+          ? Number.parseInt(entry.target.dataset.messageid)
+          : undefined
+        if (messageId == undefined || !Number.isSafeInteger(messageId)) {
+          log.error(
+            'onUnreadMessageInView: failed to get message id from element',
+            entry.target
+          )
+          continue
+        }
         const messageHeight = entry.target.clientHeight
 
         log.debug(
@@ -185,7 +201,7 @@ export default function MessageList({ accountId, chat, refComposer }: Props) {
           `onUnreadMessageInView: messageId ${messageId} marking as read`
         )
 
-        messageIdsToMarkAsRead.push(Number.parseInt(messageId))
+        messageIdsToMarkAsRead.push(messageId)
         if (unreadMessageInViewIntersectionObserver.current === null) continue
         unreadMessageInViewIntersectionObserver.current.unobserve(entry.target)
       }

--- a/packages/frontend/src/components/message/MessageWrapper.tsx
+++ b/packages/frontend/src/components/message/MessageWrapper.tsx
@@ -63,11 +63,19 @@ export function MessageWrapper(props: RenderMessageProps) {
   return (
     <li id={props.key2} className='message-wrapper'>
       <Message {...props} />
-      <div
-        ref={observerRef}
-        className='message-observer-bottom'
-        data-messageid={props.key2}
-      />
+      {/* TODO perf: `shouldInViewObserve` does not become `false`
+      when we do mark a message as read, because the messagelist.ts
+      does not update its state on such events.
+      Maybe we could listen for such events in this component,
+      or somehow manually remove the observer when we do perform the
+      `rpc.markseenMsgs` request. */}
+      {shouldInViewObserve && (
+        <div
+          ref={observerRef}
+          className='message-observer-bottom'
+          data-messageid={props.key2}
+        />
+      )}
     </li>
   )
 }

--- a/packages/frontend/src/components/message/MessageWrapper.tsx
+++ b/packages/frontend/src/components/message/MessageWrapper.tsx
@@ -66,7 +66,7 @@ export function MessageWrapper(props: RenderMessageProps) {
       <div
         ref={observerRef}
         className='message-observer-bottom'
-        id={'bottom-' + props.key2}
+        data-messageid={props.key2}
       />
     </li>
   )

--- a/packages/frontend/src/components/message/MessageWrapper.tsx
+++ b/packages/frontend/src/components/message/MessageWrapper.tsx
@@ -1,4 +1,4 @@
-import React, { useLayoutEffect } from 'react'
+import React, { useLayoutEffect, useRef } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import Message from './Message'
@@ -18,6 +18,7 @@ type RenderMessageProps = {
 const log = getLogger('renderer/message/MessageWrapper')
 
 export function MessageWrapper(props: RenderMessageProps) {
+  const observerRef = useRef<HTMLDivElement>(null)
   const state = props.message.state
   const shouldInViewObserve =
     state === C.DC_STATE_IN_FRESH || state === C.DC_STATE_IN_NOTICED
@@ -27,14 +28,10 @@ export function MessageWrapper(props: RenderMessageProps) {
   useLayoutEffect(() => {
     if (!shouldInViewObserve) return
 
-    log.debug(
-      `MessageWrapper: key: ${props.key2} We should observe this message if in view`
-    )
-
-    const messageBottomElement = document.querySelector('#bottom-' + props.key2)
+    const messageBottomElement = observerRef.current
     if (!messageBottomElement) {
       log.error(
-        `MessageWrapper: key: ${props.key2} couldn't find dom element. Returning`
+        `MessageWrapper: expected messageBottomElement for message ${props.key2} to be present, but it's not?`
       )
       return
     }
@@ -66,7 +63,11 @@ export function MessageWrapper(props: RenderMessageProps) {
   return (
     <li id={props.key2} className='message-wrapper'>
       <Message {...props} />
-      <div className='message-observer-bottom' id={'bottom-' + props.key2} />
+      <div
+        ref={observerRef}
+        className='message-observer-bottom'
+        id={'bottom-' + props.key2}
+      />
     </li>
   )
 }


### PR DESCRIPTION
Do some refactoring, and reduce the amount of unnecessary RPC calls.

Prior to this, when the window gets focused,
we'd try to mark _all_ visible messages as seen,
even if they're already seen or outgoing.
This would cause an unnecessary `debouncedUpdateBadgeCounter`,
which is quite expensive.

See individual commits for better understanding.