### PR TITLE
fix: not marking last info message as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update last used app icons immediately after sending a new app
 
 ### Changed
+- adjust distance between info messages to match Delta Chat for Android #5244
 - tauri: macOS: webxdc: Remove the nowhere-proxy to support pre-14 macOS. #5202
 - reword 'Save As' to 'Export Attachment' to have a clearer cut to 'Save' #5245
 - use rpc.getWebxdcInfo instead of message.webxdcInfo #5227
@@ -14,6 +15,7 @@
 
 ### Fixed
 - always set "unread" count to 0 when "jump to bottom" is clicked #5204
+- fix the last info message not getting marked as read when you scroll to it #5244
 - tauri: remember webxdc app windows' position and size between app re-launches
 - tauri: remember HTML email viewer window position / size for all HTML messages together, instead of separately for each individual message #5171
 - tauri: fix fullscreen media view zoom, pan, pinch not working quite right #5200

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -399,7 +399,6 @@
 .info-message {
   width: 100%;
   text-align: center;
-  margin: 26px 0px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
This also reduces the margin between info messages
to (somewhat) match Android.

Note that there are many kinds of `info-message`s, including daymarkers, webxdc info messages, "no chat selected" message. This affects all of them.

Reproduction steps:
1. Create a group.
2. Open the group chat.
   Do not unfocus the window for the rest of the steps.
3. From another device, trigger an info message in this group,
   for example, by setting "disappearing messages".
4. Make sure to scroll to the bottom of the messsage list.

You will notice that the "unread" counters for this chat remain at 1.

This had to do with the `.info-message` margin pushing
the `.message-observer-bottom` to the very bottom
of the message list, such that when you scroll to the bottom,
it doesn't register as `isIntersecting` in
`unreadMessageInViewIntersectionObserver`.
The `.info-message` margin is greater than the common margin
of `.message-list-and-composer__message-list` items,
so they two collapse, thus `.message-observer-bottom`
is pushed to the bottom.
Regular message bubbles do not have such margin, so this bug
does not apply to them.

![image](https://github.com/user-attachments/assets/04717532-5fe0-4e04-94a3-a1ecd23d4305)
![image](https://github.com/user-attachments/assets/4199d9de-5085-4fa6-aae8-87eb3ebf7088)


The look, before / after:

 ![image](https://github.com/user-attachments/assets/924ecb36-c9c6-430e-a474-02940b02a6c3) ![image](https://github.com/user-attachments/assets/1e47ad37-24db-4785-b1f2-fb4594392084)