### PR TITLE
reword 'Save As' to 'Export Attachment'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Changed
 - tauri: macOS: webxdc: Remove the nowhere-proxy to support pre-14 macOS. #5202
+- reword 'Save As' to 'Export Attachment' to have a clearer cut to 'Save' #5245
 
 ### Fixed
 - tauri: remember webxdc app windows' position and size between app re-launches

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -64,7 +64,7 @@ const contextMenuFactory = (
       action: openWebxdc.bind(null, message),
     },
     {
-      label: tx('save_as'),
+      label: tx('menu_export_attachment'),
       action: onDownload.bind(null, message),
     },
     showCopyImage && {

--- a/packages/frontend/src/components/dialogs/FullscreenAvatar.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenAvatar.tsx
@@ -32,7 +32,7 @@ export default function FullscreenAvatar(
       },
     },
     {
-      label: tx('save_as'),
+      label: tx('menu_export_attachment'),
       action: saveAs,
     },
   ])

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -109,7 +109,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
       },
     },
     {
-      label: tx('save_as'),
+      label: tx('menu_export_attachment'),
       action: onDownload.bind(null, msg),
     },
     {

--- a/packages/frontend/src/components/dialogs/WebxdcSendToChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/WebxdcSendToChat/index.tsx
@@ -68,7 +68,7 @@ export default function WebxdcSaveToChatDialog(props: Props) {
           <FooterActions align='start'>
             {file && (
               <FooterActionButton onClick={onSaveClick}>
-                {tx('save_as')}
+                {tx('menu_export_attachment')}
               </FooterActionButton>
             )}
           </FooterActions>

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -347,7 +347,7 @@ function buildContextMenu(
     },
     // Save attachment as
     showAttachmentOptions && {
-      label: tx('save_as'),
+      label: tx('menu_export_attachment'),
       action: onDownload.bind(null, message),
     },
     // copy link


### PR DESCRIPTION
in fact, it is 'Export Attachment' on android since forever, and it was changed on desktop to 'Save As' for forgotten or today minor reasons at https://github.com/deltachat/deltachat-desktop/pull/2546

now, that we have 'Save' used for 'Saving Messages' on all platforms, it makes sense to go back to 'Export Attachment' - we've seen that coming, that 'Save' and 'Save As' is a too close wording for different things, but now we get real user feedback and it is time to iterate :)

that way, we use the same term again for the same functionality.

ftr, 'Download Attachment' was bad as well, see
https://github.com/deltachat/deltachat-desktop/pull/2160

<img width=540 src=https://github.com/user-attachments/assets/989fd49f-385c-420c-92e0-a5eae98d30e5>

ftr, could be shortened to just "Export", but that is another consideration