### PR TITLE
test: bump test timeout from 30s to 5m

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -19,12 +19,15 @@ export default defineConfig({
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: [['list'], ['html']],
-  // timeout: 30 * 60 * 1000,
+
+  // Our tests involve network interaction, so we want a higher timeout
+  // for assertions, such as receiving an invitation to a group,
+  // as well as whole tests.
+  timeout: 5 * 60 * 1000,
   expect: {
-    // Our tests involve network interaction, so we want a higher timeout
-    // for assertions, such as receiving an invitation to a group.
     timeout: 60_000,
   },
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
"Invite new user to group" keeps failing.

Related:
- https://github.com/deltachat/deltachat-desktop/pull/5236.
- https://github.com/deltachat/deltachat-desktop/pull/4791.

#skip-changelog