### PR TITLE
Update truncated text width on resize

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -124,6 +124,10 @@
       div.name {
         font-size: medium;
         font-weight: 300;
+        white-space: nowrap;
+      }
+      div.summary {
+        white-space: nowrap;
       }
       div.experimental {
         color: var(--colorDanger);


### PR DESCRIPTION
Since webxdcInfo is loaded after message is loaded we have to care about height changes (i.e. avoid them to avoid wrong height calculation in message list)

followup for #5227

#skip-changelog