### PR TITLE
fix: "recent apps" section showing least recent

### DIFF
--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -161,15 +161,17 @@ export default function MainScreen({ accountId }: Props) {
       null,
       null
     )
+    // mediaIds holds the ids of the last updated apps,
+    // in reverse order
+    mediaIds.reverse()
+    const firstFew = mediaIds.slice(0, maxIcons)
+
     const mediaLoadResult = await BackendRemote.rpc.getMessages(
       accountId,
-      mediaIds.slice(0, maxIcons)
+      firstFew
     )
-    const lastUpdatedApps = mediaIds
-      .reverse()
+    const lastUpdatedApps = firstFew
       .map((id: number) => {
-        // mediaIds holds the ids of the last updated apps,
-        // in reverse order
         if (mediaLoadResult[id]?.kind === 'message') {
           return mediaLoadResult[id]
         }


### PR DESCRIPTION
Looks like https://github.com/deltachat/deltachat-desktop/pull/5260
didn't work out as intended, I should have tested.

I have verified that this works, it shows the most recent app first.
Make sure to `pnpm install` before testing yourself.

#skip-changelog