### PR TITLE
fix: dont exec Ctrl + Up if composer not focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - tauri: fix fullscreen avatar for selfavatar #5240
 - fix: showing 0 instead ? as size for empty files #5253
 - show avatar for deleted saved messages #5221
+- don't execute Ctrl + Up shortcut if the message input is not focused
 
 <a id="1_59_2"></a>
 

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -226,17 +226,17 @@ export default function ChatList(props: {
         ? CHATLISTITEM_MESSAGE_HEIGHT
         : 0))
 
-  // scroll to selected chat ---
   const chatListRef = useRef<List<any>>(null)
-  const selectedChatIndex =
-    selectedChatId != null ? chatListIds.indexOf(selectedChatId) : -1
-
   const scrollChatIntoView = useCallback((index: number) => {
     if (index !== -1) {
       chatListRef.current?.scrollToItem(index)
     }
   }, [])
 
+  const selectedChatIndex = useMemo(
+    () => (selectedChatId != null ? chatListIds.indexOf(selectedChatId) : -1),
+    [chatListIds, selectedChatId]
+  )
   const lastShowArchivedChatsState = useRef(showArchivedChats)
   const lastQuery = useRef(queryStr)
   // on select chat - scroll to selected chat - chatView

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -228,9 +228,8 @@ export default function ChatList(props: {
 
   // scroll to selected chat ---
   const listRefRef = useRef<List<any>>(null)
-  const selectedChatIndex = chatListIds.findIndex(
-    chatId => chatId === selectedChatId
-  )
+  const selectedChatIndex =
+    selectedChatId != null ? chatListIds.indexOf(selectedChatId) : -1
 
   const scrollSelectedChatIntoView = useCallback((index: number) => {
     if (index !== -1) {
@@ -275,9 +274,7 @@ export default function ChatList(props: {
 
   useKeyBindingAction(KeybindAction.ChatList_SelectNextChat, () => {
     if (selectedChatId === null) return selectFirstChat()
-    const selectedChatIndex = chatListIds.findIndex(
-      chatId => chatId === selectedChatId
-    )
+    const selectedChatIndex = chatListIds.indexOf(selectedChatId)
     const newChatId = chatListIds[selectedChatIndex + 1]
     if (newChatId && newChatId !== C.DC_CHAT_ID_ARCHIVED_LINK) {
       selectChat(accountId, newChatId)
@@ -286,9 +283,7 @@ export default function ChatList(props: {
 
   useKeyBindingAction(KeybindAction.ChatList_SelectPreviousChat, () => {
     if (selectedChatId === null) return selectFirstChat()
-    const selectedChatIndex = chatListIds.findIndex(
-      chatId => chatId === selectedChatId
-    )
+    const selectedChatIndex = chatListIds.indexOf(selectedChatId)
     const newChatId = chatListIds[selectedChatIndex - 1]
     if (newChatId && newChatId !== C.DC_CHAT_ID_ARCHIVED_LINK) {
       selectChat(accountId, newChatId)

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -231,7 +231,7 @@ export default function ChatList(props: {
   const selectedChatIndex =
     selectedChatId != null ? chatListIds.indexOf(selectedChatId) : -1
 
-  const scrollSelectedChatIntoView = useCallback((index: number) => {
+  const scrollChatIntoView = useCallback((index: number) => {
     if (index !== -1) {
       chatListRef.current?.scrollToItem(index)
     }
@@ -243,24 +243,24 @@ export default function ChatList(props: {
   // follow chat after loading or when it's position in the chatlist changes
   useEffect(() => {
     if (isSearchActive && lastQuery.current !== queryStr) {
-      scrollSelectedChatIntoView(0)
+      scrollChatIntoView(0)
       // search is active, don't scroll to selected chat, scroll up instead when queryStr changes
       lastQuery.current = queryStr
       return
     }
     // when showArchivedChats changes, select selected chat if it is archived/not-archived otherwise select first item
     if (selectedChatIndex !== -1) {
-      scrollSelectedChatIntoView(selectedChatIndex)
+      scrollChatIntoView(selectedChatIndex)
     } else {
       if (lastShowArchivedChatsState.current !== showArchivedChats) {
-        scrollSelectedChatIntoView(0)
+        scrollChatIntoView(0)
       }
     }
     lastShowArchivedChatsState.current = showArchivedChats
   }, [
     selectedChatIndex,
     isSearchActive,
-    scrollSelectedChatIntoView,
+    scrollChatIntoView,
     showArchivedChats,
     queryStr,
   ])
@@ -269,7 +269,7 @@ export default function ChatList(props: {
 
   // KeyboardShortcuts ---------
   useKeyBindingAction(KeybindAction.ChatList_ScrollToSelectedChat, () =>
-    scrollSelectedChatIntoView(selectedChatIndex)
+    scrollChatIntoView(selectedChatIndex)
   )
 
   useKeyBindingAction(KeybindAction.ChatList_SelectNextChat, () => {

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -227,13 +227,13 @@ export default function ChatList(props: {
         : 0))
 
   // scroll to selected chat ---
-  const listRefRef = useRef<List<any>>(null)
+  const chatListRef = useRef<List<any>>(null)
   const selectedChatIndex =
     selectedChatId != null ? chatListIds.indexOf(selectedChatId) : -1
 
   const scrollSelectedChatIntoView = useCallback((index: number) => {
     if (index !== -1) {
-      listRefRef.current?.scrollToItem(index)
+      chatListRef.current?.scrollToItem(index)
     }
   }, [])
 
@@ -420,7 +420,7 @@ export default function ChatList(props: {
                   width={'100%'}
                   height={chatsHeight(height)}
                   setListRef={(ref: List<any> | null) =>
-                    ((listRefRef.current as any) = ref)
+                    ((chatListRef.current as any) = ref)
                   }
                   itemKey={index => 'key' + chatListIds[index]}
                   itemData={chatlistData}

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -116,13 +116,15 @@ export function keyDownEvent2Action(
       // Also consider adding this to `ev.repeat` when it stops being so sluggish
       ev.code === 'ArrowUp' &&
       (ev.ctrlKey || ev.metaKey) &&
-      !(ev.ctrlKey && ev.metaKey) // Both at the same time
+      !(ev.ctrlKey && ev.metaKey) && // Both at the same time
+      (ev.target as HTMLElement)?.id === 'composer-textarea'
     ) {
       return KeybindAction.Composer_SelectReplyToUp
     } else if (
       ev.code === 'ArrowDown' &&
       (ev.ctrlKey || ev.metaKey) &&
-      !(ev.ctrlKey && ev.metaKey) // Both at the same time
+      !(ev.ctrlKey && ev.metaKey) && // Both at the same time
+      (ev.target as HTMLElement)?.id === 'composer-textarea'
     ) {
       return KeybindAction.Composer_SelectReplyToDown
     } else if (


### PR DESCRIPTION
This is important for the upcoming multiselect feature
(https://github.com/deltachat/deltachat-desktop/issues/2892),
but also makes sense otherwise.

Only look at the last commit, this is based on another branch.

TODO:
- [ ] Merge the MR that this is based on