### PR TITLE
New condition for preview builds

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -115,8 +115,8 @@ jobs:
        PR_ID: ${{ steps.prepare.outputs.prid }}
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload result to artifacts
+      if: contains(github.event.pull_request.body, '#public-preview') == false
       id: upload-github
-      if: steps.upload.outcome == 'failure'
       uses: actions/upload-artifact@main
       with:
         name: ${{ matrix.os }} output

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -98,9 +98,6 @@ jobs:
         move Delta*Chat*.exe preview/deltachat-desktop-${{ steps.prepare.outputs.prid }}.portable.exe
         dir preview
         cd ..
-    # Debugging
-    - name: Debug PR body
-      run: echo "${{ github.event.pull_request.body }}"
     # Upload Step
     - name: upload folder
       id: upload

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -97,6 +97,9 @@ jobs:
         move Delta*Chat*.exe preview/deltachat-desktop-${{ steps.prepare.outputs.prid }}.portable.exe
         dir preview
         cd ..
+    # Debugging
+    - name: Debug PR body
+      run: echo "${{ github.event.pull_request.body }}"
     # Upload Step
     - name: upload folder
       id: upload

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -101,6 +101,7 @@ jobs:
     - name: upload folder
       id: upload
       shell: bash
+      if: contains(github.event.pull_request.body, '#public-preview')
       run: |
         echo -e "${{ secrets.KEY }}" >__TEMP_INPUT_KEY_FILE
         chmod 600 __TEMP_INPUT_KEY_FILE

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -115,7 +115,7 @@ jobs:
        PR_ID: ${{ steps.prepare.outputs.prid }}
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Upload result to artifacts
-      if: contains(github.event.pull_request.body, '#public-preview') == false
+      if: contains(github.event.pull_request.body, '#public-preview') == false || steps.upload.outcome == 'failure'
       id: upload-github
       uses: actions/upload-artifact@main
       with:

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -3,6 +3,7 @@ name: Preview Builds
 
 on: 
   pull_request:
+    types: [opened, synchronize, reopened, edited]
     paths-ignore:
       - 'docs/**'  # only trigger build if a file outside of /docs was changed
       - 'README_ASSETS/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - upgrade `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `1.160.0`
 - upgrade electron from 34 to 37 #5229
 - update translations (07-07-2025)
+- development: introduce new condition to publish build previews
 
 ### Fixed
 - always set "unread" count to 0 when "jump to bottom" is clicked #5204

--- a/bin/github-actions/postLinksToDetails.js
+++ b/bin/github-actions/postLinksToDetails.js
@@ -34,7 +34,7 @@ if (process.platform === 'darwin') {
     FULL_ARTIFACT_URL ||
     base_url + prId + '.AppImage'
 } else {
-  throw new Error('Unsuported platform: ' + process.platform)
+  throw new Error('Unsupported platform: ' + process.platform)
 }
 
 const STATUS_DATA = {

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -108,7 +108,7 @@ If you're unsure it's always safe to run `pnpm -w fix` to fix everything. If you
 ### CI github actions
 
 We have several [github actions](../.github/workflows/) configured to be executed for each PR. These include code validation, tests and preview builds which are downloadable from the artifacts.
-Previews can be uploaded to https://download.delta.chat/desktop/preview/ by adding a line #public-preview to the PR description. This also works if the line is added later, since the upload step is triggered on "edit" also.
+Previews can be uploaded to https://download.delta.chat/desktop/preview/ by adding a line "#public-preview" to the PR description. This also works if the line is added later, since the upload step is triggered on "edit" also.
 
 The code validation includes a check if the Changelog has a new entry for the PR. That can be skipped (if reasonable) by adding the keyword "#skip-changelog" in the description, ideally followed by a reason for skipping
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -107,9 +107,10 @@ If you're unsure it's always safe to run `pnpm -w fix` to fix everything. If you
 
 ### CI github actions
 
-We have several [github actions](../.github/workflows/) configured to be executed for each PR. These include code validation, tests and preview builds which are downloadable from the artifacts and from https://download.delta.chat/desktop/preview/
+We have several [github actions](../.github/workflows/) configured to be executed for each PR. These include code validation, tests and preview builds which are downloadable from the artifacts.
+Previews can be uploaded to https://download.delta.chat/desktop/preview/ by adding a line #public-preview to the PR description. This also works if the line is added later, since the upload step is triggered on "edit" also.
 
-The code validation includes a check if the Changelog has a new entry for the PR. That can be skipped (if reasonable) by adding the keyword "skip changelog check" in the description, ideally followed by a reason for skipping
+The code validation includes a check if the Changelog has a new entry for the PR. That can be skipped (if reasonable) by adding the keyword "#skip-changelog" in the description, ideally followed by a reason for skipping
 
 ### Tests <a id="tests"></a>
 


### PR DESCRIPTION
To reduce the size of Downloads on https://download.delta.chat, till we have a better solution

Now a line 
#public-preview
is needed in the PR description to trigger the upload of a preview on download.delta.chat
