### PR TITLE
refactor: fix potential ChatListItem `memo()` bugs

### DIFF
--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -385,53 +385,41 @@ type ChatListItemProps = {
   isSelected?: boolean
 }
 
-const ChatListItem = React.memo<ChatListItemProps>(
-  props => {
-    const { chatListItem, onClick, roleTab } = props
+const ChatListItem = React.memo<ChatListItemProps>(props => {
+  const { chatListItem, onClick, roleTab } = props
 
-    // if not loaded by virtual list yet
-    if (typeof chatListItem === 'undefined') return <PlaceholderChatListItem />
+  // if not loaded by virtual list yet
+  if (typeof chatListItem === 'undefined') return <PlaceholderChatListItem />
 
-    if (chatListItem.kind == 'ChatListItem') {
-      return (
-        <ChatListItemNormal
-          chatListItem={chatListItem}
-          onClick={onClick}
-          roleTab={roleTab}
-          isSelected={props.isSelected}
-          onContextMenu={props.onContextMenu}
-          isContextMenuActive={props.isContextMenuActive}
-        />
-      )
-    } else if (chatListItem.kind == 'Error') {
-      return (
-        <ChatListItemError
-          chatListItem={chatListItem}
-          onClick={onClick}
-          roleTab={roleTab}
-          isSelected={props.isSelected}
-          onContextMenu={props.onContextMenu}
-        />
-      )
-    } else if (chatListItem.kind == 'ArchiveLink') {
-      return (
-        <ChatListItemArchiveLink
-          chatListItem={chatListItem}
-          onClick={onClick}
-        />
-      )
-    } else {
-      return <PlaceholderChatListItem />
-    }
-  },
-  (prevProps, nextProps) => {
-    const shouldRerender =
-      prevProps.chatListItem !== nextProps.chatListItem ||
-      prevProps.isSelected !== nextProps.isSelected ||
-      prevProps.isContextMenuActive !== nextProps.isContextMenuActive
-    return !shouldRerender
+  if (chatListItem.kind == 'ChatListItem') {
+    return (
+      <ChatListItemNormal
+        chatListItem={chatListItem}
+        onClick={onClick}
+        roleTab={roleTab}
+        isSelected={props.isSelected}
+        onContextMenu={props.onContextMenu}
+        isContextMenuActive={props.isContextMenuActive}
+      />
+    )
+  } else if (chatListItem.kind == 'Error') {
+    return (
+      <ChatListItemError
+        chatListItem={chatListItem}
+        onClick={onClick}
+        roleTab={roleTab}
+        isSelected={props.isSelected}
+        onContextMenu={props.onContextMenu}
+      />
+    )
+  } else if (chatListItem.kind == 'ArchiveLink') {
+    return (
+      <ChatListItemArchiveLink chatListItem={chatListItem} onClick={onClick} />
+    )
+  } else {
+    return <PlaceholderChatListItem />
   }
-)
+})
 
 export default ChatListItem
 

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -73,14 +73,17 @@ export default function MainScreen({ accountId }: Props) {
     unselectChat()
   }
 
-  const onChatClick = (chatId: number) => {
-    if (chatId === C.DC_CHAT_ID_ARCHIVED_LINK) {
-      setArchivedChatsSelected(true)
-      return
-    }
+  const onChatClick = useCallback(
+    (chatId: number) => {
+      if (chatId === C.DC_CHAT_ID_ARCHIVED_LINK) {
+        setArchivedChatsSelected(true)
+        return
+      }
 
-    accountId && selectChat(accountId, chatId)
-  }
+      accountId && selectChat(accountId, chatId)
+    },
+    [accountId, selectChat]
+  )
 
   const searchChats = useCallback(
     (queryStr: string, chatId: number | null = null) => {


### PR DESCRIPTION
We do not re-render `ChatListItem`
even when `onContextMenu` prop changes,
due to the fact that we don't check if this prop changed
in our `areEqual` function.

This commit makes it harder to introduce a bug
when introducing new props for `ChatListItem`,
and potentially fixes some existing bugs.

I have verified that the component still doesn't re-render unnecessarily,
e.g. when switching to another chat.

TODO:
- [x] merge the base branch #5275