### PR TITLE
fix copying of links into richtext editors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - improve performance in "Edit Group" a little #5237
 - tauri: accessibility: fix outline being barely visible on Windows, and adjust some other colors #5217
 - improve performance a little in some other places #5225
+- fix copying of links into richtext editors
 
 <a id="1_60_0"></a>
 

--- a/packages/frontend/src/components/message/Link.tsx
+++ b/packages/frontend/src/components/message/Link.tsx
@@ -86,7 +86,7 @@ export const LabeledLink = ({
   }
   return (
     <a
-      href={'#' + target}
+      href={target}
       x-target-url={target}
       title={realUrl}
       onClick={onClick}
@@ -210,7 +210,7 @@ export const Link = ({
 
   return (
     <a
-      href='#'
+      href={asciiUrl}
       x-target-url={asciiUrl}
       title={asciiUrl}
       onClick={onClick}

--- a/packages/frontend/src/components/message/MessageMarkdown.tsx
+++ b/packages/frontend/src/components/message/MessageMarkdown.tsx
@@ -224,7 +224,7 @@ function EmailLink({
 
   return (
     <a
-      href={'#'}
+      href={`mailto:${email}`}
       x-not-a-link='email'
       x-target-email={email}
       onClick={handleClick}


### PR DESCRIPTION
we set it to empty anchor/fragment as a theoretical security precaution, but it harms usability and seems to serve no purpose in practice