### PR TITLE
prevent navigation when clicking on email addresses

### DIFF
--- a/packages/frontend/src/components/message/MessageMarkdown.tsx
+++ b/packages/frontend/src/components/message/MessageMarkdown.tsx
@@ -215,7 +215,9 @@ function EmailLink({
   const createChatByEmail = useCreateChatByEmail()
   const { selectChat } = useChat()
 
-  const handleClick = async () => {
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement> = async ev => {
+    ev.preventDefault()
+    ev.stopPropagation()
     const chatId = await createChatByEmail(accountId, email)
     if (chatId) {
       selectChat(accountId, chatId)


### PR DESCRIPTION
(affects mainly browser and tauri edition, not so much electron, because there we block all navigation in the main window)

fixes regression introduced by #5286

for more info see
https://github.com/deltachat/deltachat-desktop/pull/5286/files/d3262d2a74d4a7d14759b89f43ea6100521f4825#r2207270975

#skip-changelog
