### PR TITLE
feat: multiple selection in chat list

### DIFF
--- a/.log.convention.ignore
+++ b/.log.convention.ignore
@@ -20,6 +20,9 @@ test/
 *.html
 *.yaml
 
+# We use a console.log in the docstring there.
+packages/frontend/src/hooks/useMultiselect.ts
+
 packages/e2e-tests/
 
 packages/target-electron/migration-tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## [Unreleased][unreleased]
 
+<<<<<<< HEAD
 ### Fixed
 - don't close context menues on window resize #5418
 
+=======
+### Added
+- support multiple selection (multiselect) in the list of chats, activated with Ctrl + Click, Shift + Click #5297
+>>>>>>> b9d383489 (docs: add CHANGELOG entry)
 
 <a id="2_11_1"></a>
 

--- a/packages/frontend/src/components/ThreeDotMenu.tsx
+++ b/packages/frontend/src/components/ThreeDotMenu.tsx
@@ -30,7 +30,7 @@ export function useThreeDotMenu(selectedChat?: T.FullChat) {
   const {
     openBlockFirstContactOfChatDialog,
     openChatAuditDialog,
-    openDeleteChatDialog,
+    openDeleteChatsDialog,
     openLeaveGroupOrChannelDialog,
     openClearChatDialog,
   } = useChatDialog()
@@ -53,7 +53,7 @@ export function useThreeDotMenu(selectedChat?: T.FullChat) {
       openBlockFirstContactOfChatDialog(accountId, selectedChat)
 
     const onDeleteChat = () =>
-      openDeleteChatDialog(accountId, selectedChat, chatId)
+      openDeleteChatsDialog(accountId, [selectedChat], chatId)
 
     const onUnmuteChat = () => unmuteChat(accountId, chatId)
 

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -51,6 +51,11 @@ import { isInviteLink } from '../../../../shared/util'
 import { RovingTabindexProvider } from '../../contexts/RovingTabindex'
 import { useRpcFetch } from '../../hooks/useFetch'
 import { useSettingsStore } from '../../stores/settings'
+import { useMultiselect } from '../../hooks/useMultiselect'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+import { useHasChanged2 } from '../../hooks/useHasChanged'
+
+const useMultiselectLog = getLogger('ChatListMultiselect')
 
 const enum LoadStatus {
   FETCHING = 1,
@@ -198,7 +203,7 @@ export default function ChatList(props: {
     showArchivedChats
   )
 
-  const { openContextMenu, activeContextMenuChatId } = useChatListContextMenu()
+  const { openContextMenu, activeContextMenuChatIds } = useChatListContextMenu()
   const createChatByContactId = useCreateChatByContactId()
   const { selectChat } = useChat()
 
@@ -346,25 +351,33 @@ export default function ChatList(props: {
   //   selectFirstChat()
   // )
 
+  const multiselect = useChatListMultiselect(
+    chatListIds,
+    activeChatId,
+    accountId
+  )
+
   const chatlistData: ChatListItemData = useMemo(() => {
     return {
       // This should be in sync with `olElementAttrs` of `ChatListPart`.
       roleTabs: true,
 
       activeChatId,
+      multiselect,
       chatListIds,
       chatCache,
       onChatClick,
       openContextMenu,
-      activeContextMenuChatId,
+      activeContextMenuChatIds,
     }
   }, [
     activeChatId,
+    multiselect,
     chatListIds,
     chatCache,
     onChatClick,
     openContextMenu,
-    activeContextMenuChatId,
+    activeContextMenuChatIds,
   ])
 
   const contactlistData: ContactChatListItemData = useMemo(() => {
@@ -480,6 +493,7 @@ export default function ChatList(props: {
                     // This should be in sync with `chatlistData.roleTabs`.
                     role: 'tablist',
                     'aria-orientation': 'vertical',
+                    'aria-multiselectable': multiselect != undefined,
 
                     // TODO perhaps `pref_` is not nice,
                     // we might need a separate string.
@@ -818,6 +832,170 @@ function useContactAndMessageLogic(
     messageCache,
     queryStrIsValidEmail,
   }
+}
+
+function useChatListMultiselect(
+  chatListIds: Awaited<ReturnType<typeof BackendRemote.rpc.getChatlistEntries>>,
+  activeChatId: T.BasicChat['id'] | null,
+  accountId: number
+) {
+  /**
+   * Same as `activeChatId`, but a ref to avoid re-renders.
+   */
+  const activeChatIdRef = useRef(activeChatId)
+  activeChatIdRef.current = activeChatId
+
+  const [dummyValueForSelectionReset, _setDummyValueForSelectionReset] =
+    useState(Symbol())
+  const resetSelection = useCallback(
+    () => _setDummyValueForSelectionReset(Symbol()),
+    []
+  )
+  /**
+   * This is used to tell whether a selection is "valid",
+   * otherwise we should use the default, reset state.
+   * When this value changes, the previous selection becomes invalid.
+   */
+  const selectionId_ = useMemo(
+    () => Symbol(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      // When the active chat gets changed, for example, as a result of
+      // executing the Ctrl + PageDown shortcut,
+      // we want to reset selection, invalidate it,
+      // to reduce confusion,
+      // e.g. "is the currently active chat selected or not?"
+      //
+      // `activeChatId` never (or almost never?) gets changed
+      // automatically, it's always a result of a user action,
+      // so resetting selection in this case shouldn't make users angry.
+      activeChatId,
+      dummyValueForSelectionReset,
+      // It's not strictly necessary to watch `accountId` as of now,
+      // because the code above this hook ensures that the component
+      // is re-created when accountId changes.
+      // But let's do it for future-proofing.
+      accountId,
+    ]
+  )
+  // Put behind a ref to avoid re-renders.
+  const selectionId = useRef(selectionId_)
+  selectionId.current = selectionId_
+
+  const [multiselectState_, setMultiselectState_] = useState({
+    selectedChats: new Set<(typeof chatListIds)[number]>(),
+    // Initialize with a new Symbol so that the initial state is "invalid".
+    forSelectionId: Symbol(),
+  })
+  const setSelectedChats = useCallback(
+    (newSelectedChats: Set<(typeof chatListIds)[number]>) => {
+      setMultiselectState_({
+        selectedChats: newSelectedChats,
+        forSelectionId: selectionId.current,
+      })
+    },
+    []
+  )
+  const activeChatSet: Set<(typeof chatListIds)[number]> = useMemo(
+    () => (activeChatId == null ? new Set() : new Set([activeChatId])),
+    [activeChatId]
+  )
+  const multiselectStateIsValid =
+    selectionId.current === multiselectState_.forSelectionId
+  const selectedChats = multiselectStateIsValid
+    ? multiselectState_.selectedChats
+    : // Make sure to have the active chat selected by default,
+      // e.g. for the case when the user wants to Ctrl + Click
+      // another chat.
+      // This is important, because the chat list items
+      // are only styled as "selected" based on `multiselect`,
+      // and not `activeChatId` (see `isSelected` in `ChatListItemRowChat`).
+      //
+      // TODO or should we do this though? Why complicate things?
+      // Just mark "selected" and "active" chat distinctly
+      // and we're good?
+      // Maybe it's better to manage this inside of `useMultiselect`?
+      activeChatSet
+
+  // Remove chats from selection that have been removed from `chatListIds`.
+  //
+  // Why not `useMemo`? Because if the removed chat gets added back to the list,
+  // we _don't_ want it to get added back to selection,
+  // to avoid, let's say, accidentally deleting a chat.
+  //
+  // For example, let's say the user had two chats selected, but then
+  // one of the selected chats got archived (e.g. from another device).
+  // Then they forgot about selecting it and went to delete some other chats:
+  // they selected two other chats for deletion, but then a message arrives
+  // to the archived chat, unarchiving it.
+  // This would suddenly make 4 chats selected, instead of 3,
+  // and they could unintentionally delete the one they archived.
+  //
+  // An alternative would be to simply reset (invalidate) selection
+  // on _any_ change to `chatListIds`,
+  // but that would not be nice, e.g. for example if only the order
+  // of chat list items changed, e.g. when receiving a new message.
+  //
+  // This also handles the more common case of simply resetting selection
+  // after you have deleted / archived selected chats.
+  //
+  // TODO should this be part of `useMultiselect`?
+  // Or at least another, more "advanced" but still generic wrapper for it.
+  if (useHasChanged2(chatListIds)) {
+    // Using `multiselectState_.selectedChats` instead of `selectedChats`
+    // To avoid an infinite loop of `setMultiselectState_`
+    // when `selectedChats === activeChatSet`.
+    const newSelectedChats = new Set(multiselectState_.selectedChats)
+    let foundMissing = false
+    for (const id of multiselectState_.selectedChats) {
+      if (!chatListIds.includes(id)) {
+        foundMissing = true
+        newSelectedChats.delete(id)
+      }
+    }
+    if (foundMissing) {
+      setMultiselectState_(old => ({
+        selectedChats: newSelectedChats,
+        // Keep the ID: in case it's already invalid, don't revalidate it.
+        forSelectionId: old.forSelectionId,
+      }))
+    }
+  }
+
+  const multiselect = useMultiselect(
+    chatListIds,
+    selectedChats,
+    useCallback(
+      newSelectedChats => {
+        // `chatListIds` might include `C.DC_CHAT_ID_ARCHIVED_LINK`.
+        // Let's make sure that only normal chat list items can be selected
+        // with multiselect.
+        // Note that the context menu and regular clicks still work
+        // for these chats.
+        // This is primarily for `C.DC_CHAT_ID_ARCHIVED_LINK`,
+        // but let's be conservative and also exclude
+        // other weird chat list items.
+        for (let i = 0; i <= C.DC_CHAT_ID_LAST_SPECIAL; i++) {
+          newSelectedChats.delete(i)
+        }
+
+        // TODO perf: to avoid re-renders, maybe store this into a ref,
+        // but only update reactive state only if there are 2+ items selected?
+        setSelectedChats(newSelectedChats)
+      },
+      [setSelectedChats]
+    ),
+    useMultiselectLog
+  )
+
+  return useMemo(
+    () => ({
+      ...multiselect,
+      setSelectedChats,
+      resetSelection,
+    }),
+    [multiselect, setSelectedChats, resetSelection]
+  )
 }
 
 function translated_messages_label(count: number) {

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -173,7 +173,7 @@ export default function ChatList(props: {
   const accountId = selectedAccountId()
 
   const {
-    selectedChatId,
+    selectedChatId: activeChatId,
     showArchivedChats,
     onChatClick,
     queryStr,
@@ -275,9 +275,9 @@ export default function ChatList(props: {
     }
   }, [])
 
-  const selectedChatIndex = useMemo(
-    () => (selectedChatId != null ? chatListIds.indexOf(selectedChatId) : -1),
-    [chatListIds, selectedChatId]
+  const activeChatIndex = useMemo(
+    () => (activeChatId != null ? chatListIds.indexOf(activeChatId) : -1),
+    [chatListIds, activeChatId]
   )
   const lastShowArchivedChatsState = useRef(showArchivedChats)
   const lastQuery = useRef(queryStr)
@@ -291,8 +291,8 @@ export default function ChatList(props: {
       return
     }
     // when showArchivedChats changes, select selected chat if it is archived/not-archived otherwise select first item
-    if (selectedChatIndex !== -1) {
-      scrollChatIntoView(selectedChatIndex)
+    if (activeChatIndex !== -1) {
+      scrollChatIntoView(activeChatIndex)
     } else {
       if (lastShowArchivedChatsState.current !== showArchivedChats) {
         scrollChatIntoView(0)
@@ -300,7 +300,7 @@ export default function ChatList(props: {
     }
     lastShowArchivedChatsState.current = showArchivedChats
   }, [
-    selectedChatIndex,
+    activeChatIndex,
     isSearchActive,
     scrollChatIntoView,
     showArchivedChats,
@@ -311,22 +311,22 @@ export default function ChatList(props: {
 
   // KeyboardShortcuts ---------
   useKeyBindingAction(KeybindAction.ChatList_ScrollToSelectedChat, () =>
-    scrollChatIntoView(selectedChatIndex)
+    scrollChatIntoView(activeChatIndex)
   )
 
   useKeyBindingAction(KeybindAction.ChatList_SelectNextChat, () => {
-    if (selectedChatId === null) return selectFirstChat()
-    const selectedChatIndex = chatListIds.indexOf(selectedChatId)
-    const newChatId = chatListIds[selectedChatIndex + 1]
+    if (activeChatId === null) return selectFirstChat()
+    const activeChatIndex = chatListIds.indexOf(activeChatId)
+    const newChatId = chatListIds[activeChatIndex + 1]
     if (newChatId && newChatId !== C.DC_CHAT_ID_ARCHIVED_LINK) {
       selectChat(accountId, newChatId)
     }
   })
 
   useKeyBindingAction(KeybindAction.ChatList_SelectPreviousChat, () => {
-    if (selectedChatId === null) return selectFirstChat()
-    const selectedChatIndex = chatListIds.indexOf(selectedChatId)
-    const newChatId = chatListIds[selectedChatIndex - 1]
+    if (activeChatId === null) return selectFirstChat()
+    const activeChatIndex = chatListIds.indexOf(activeChatId)
+    const newChatId = chatListIds[activeChatIndex - 1]
     if (newChatId && newChatId !== C.DC_CHAT_ID_ARCHIVED_LINK) {
       selectChat(accountId, newChatId)
     }
@@ -351,7 +351,7 @@ export default function ChatList(props: {
       // This should be in sync with `olElementAttrs` of `ChatListPart`.
       roleTabs: true,
 
-      selectedChatId,
+      activeChatId,
       chatListIds,
       chatCache,
       onChatClick,
@@ -359,7 +359,7 @@ export default function ChatList(props: {
       activeContextMenuChatId,
     }
   }, [
-    selectedChatId,
+    activeChatId,
     chatListIds,
     chatCache,
     onChatClick,

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -90,7 +90,7 @@ export function useChatListContextMenu(): {
   const {
     openBlockFirstContactOfChatDialog,
     openEncryptionInfoDialog,
-    openDeleteChatDialog,
+    openDeleteChatsDialog,
     openLeaveGroupOrChannelDialog,
   } = useChatDialog()
   const openViewGroupDialog = useOpenViewGroupDialog()
@@ -107,7 +107,7 @@ export function useChatListContextMenu(): {
     activeContextMenuChatId,
     openContextMenu: async (event, chatListItem, selectedChatId) => {
       const onDeleteChat = () =>
-        openDeleteChatDialog(accountId, chatListItem, selectedChatId)
+        openDeleteChatsDialog(accountId, [chatListItem], selectedChatId)
       const onEncrInfo = () =>
         openEncryptionInfoDialog({
           chatId: chatListItem.id,

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -163,159 +163,157 @@ export function useChatListContextMenu(): {
       const isOutBroadcast =
         chatListItem.chatType === C.DC_CHAT_TYPE_OUT_BROADCAST
 
-      const menu: (ContextMenuItem | false)[] = chatListItem
-        ? [
-            // Pin
-            pin,
-            // Mute
-            !chatListItem.isMuted
-              ? {
-                  label: tx('menu_mute'),
-                  subitems: [
-                    {
-                      label: tx('mute_for_one_hour'),
-                      action: () => {
-                        BackendRemote.rpc.setChatMuteDuration(
-                          accountId,
-                          chatListItem.id,
-                          {
-                            kind: 'Until',
-                            duration: Timespans.ONE_HOUR_IN_SECONDS,
-                          }
-                        )
-                      },
-                    },
-                    {
-                      label: tx('mute_for_eight_hours'),
-                      action: () => {
-                        BackendRemote.rpc.setChatMuteDuration(
-                          accountId,
-                          chatListItem.id,
-                          {
-                            kind: 'Until',
-                            duration: Timespans.ONE_HOUR_IN_SECONDS * 8,
-                          }
-                        )
-                      },
-                    },
-                    {
-                      label: tx('mute_for_one_day'),
-                      action: () => {
-                        BackendRemote.rpc.setChatMuteDuration(
-                          accountId,
-                          chatListItem.id,
-                          {
-                            kind: 'Until',
-                            duration: Timespans.ONE_DAY_IN_SECONDS,
-                          }
-                        )
-                      },
-                    },
-                    {
-                      label: tx('mute_for_seven_days'),
-                      action: () => {
-                        BackendRemote.rpc.setChatMuteDuration(
-                          accountId,
-                          chatListItem.id,
-                          {
-                            kind: 'Until',
-                            duration: Timespans.ONE_WEEK_IN_SECONDS,
-                          }
-                        )
-                      },
-                    },
-                    {
-                      label: tx('mute_forever'),
-                      action: () => {
-                        BackendRemote.rpc.setChatMuteDuration(
-                          accountId,
-                          chatListItem.id,
-                          { kind: 'Forever' }
-                        )
-                      },
-                    },
-                  ],
-                }
-              : {
-                  label: tx('menu_unmute'),
-                  action: onUnmuteChat,
+      const menu: (ContextMenuItem | false)[] = [
+        // Pin
+        pin,
+        // Mute
+        !chatListItem.isMuted
+          ? {
+              label: tx('menu_mute'),
+              subitems: [
+                {
+                  label: tx('mute_for_one_hour'),
+                  action: () => {
+                    BackendRemote.rpc.setChatMuteDuration(
+                      accountId,
+                      chatListItem.id,
+                      {
+                        kind: 'Until',
+                        duration: Timespans.ONE_HOUR_IN_SECONDS,
+                      }
+                    )
+                  },
                 },
-            // Archive
-            archive,
-            { type: 'separator' },
-            // View Profile
-            !isGroup && {
-              label: tx('menu_view_profile'),
-              action: onViewProfile,
+                {
+                  label: tx('mute_for_eight_hours'),
+                  action: () => {
+                    BackendRemote.rpc.setChatMuteDuration(
+                      accountId,
+                      chatListItem.id,
+                      {
+                        kind: 'Until',
+                        duration: Timespans.ONE_HOUR_IN_SECONDS * 8,
+                      }
+                    )
+                  },
+                },
+                {
+                  label: tx('mute_for_one_day'),
+                  action: () => {
+                    BackendRemote.rpc.setChatMuteDuration(
+                      accountId,
+                      chatListItem.id,
+                      {
+                        kind: 'Until',
+                        duration: Timespans.ONE_DAY_IN_SECONDS,
+                      }
+                    )
+                  },
+                },
+                {
+                  label: tx('mute_for_seven_days'),
+                  action: () => {
+                    BackendRemote.rpc.setChatMuteDuration(
+                      accountId,
+                      chatListItem.id,
+                      {
+                        kind: 'Until',
+                        duration: Timespans.ONE_WEEK_IN_SECONDS,
+                      }
+                    )
+                  },
+                },
+                {
+                  label: tx('mute_forever'),
+                  action: () => {
+                    BackendRemote.rpc.setChatMuteDuration(
+                      accountId,
+                      chatListItem.id,
+                      { kind: 'Forever' }
+                    )
+                  },
+                },
+              ],
+            }
+          : {
+              label: tx('menu_unmute'),
+              action: onUnmuteChat,
             },
-            // View Group Profile (for non encrypted groups)
-            isGroup &&
-              !chatListItem.isEncrypted &&
-              chatListItem.isSelfInGroup && {
-                label: tx('menu_view_profile'),
-                action: onViewGroup,
-              },
-            // Edit Group
-            isGroup &&
-              chatListItem.isEncrypted &&
-              chatListItem.isSelfInGroup && {
-                label: tx('menu_edit_group'),
-                dataTestid: 'edit-group',
-                action: onViewGroup,
-              },
-            // Edit Channel
-            isOutBroadcast && {
-              label: tx('edit_channel'),
-              action: onViewGroup,
-            },
-            // Clone Group
-            isGroup && {
-              label: tx('clone_chat'),
-              action: () => {
-                openDialog(CloneChat, {
-                  setViewMode: 'createGroup',
-                  chatTemplateId: chatListItem.id,
-                })
-              },
-            },
+        // Archive
+        archive,
+        { type: 'separator' },
+        // View Profile
+        !isGroup && {
+          label: tx('menu_view_profile'),
+          action: onViewProfile,
+        },
+        // View Group Profile (for non encrypted groups)
+        isGroup &&
+          !chatListItem.isEncrypted &&
+          chatListItem.isSelfInGroup && {
+            label: tx('menu_view_profile'),
+            action: onViewGroup,
+          },
+        // Edit Group
+        isGroup &&
+          chatListItem.isEncrypted &&
+          chatListItem.isSelfInGroup && {
+            label: tx('menu_edit_group'),
+            dataTestid: 'edit-group',
+            action: onViewGroup,
+          },
+        // Edit Channel
+        isOutBroadcast && {
+          label: tx('edit_channel'),
+          action: onViewGroup,
+        },
+        // Clone Group
+        isGroup && {
+          label: tx('clone_chat'),
+          action: () => {
+            openDialog(CloneChat, {
+              setViewMode: 'createGroup',
+              chatTemplateId: chatListItem.id,
+            })
+          },
+        },
 
-            // Encryption Info
-            !chatListItem.isDeviceTalk &&
-              !chatListItem.isSelfTalk && {
-                label: tx('encryption_info_title_desktop'),
-                action: onEncrInfo,
-              },
-            { type: 'separator' },
-            // Leave channel
-            chatListItem.chatType === C.DC_CHAT_TYPE_IN_BROADCAST &&
-              !chatListItem.isContactRequest && {
-                label: tx('menu_leave_channel'),
-                action: onLeaveGroupOrChannel,
-              },
-            // Leave group
-            isGroup &&
-              chatListItem.isEncrypted &&
-              chatListItem.isSelfInGroup && {
-                label: tx('menu_leave_group'),
-                action: onLeaveGroupOrChannel,
-              },
-            // Block contact
-            !isGroup &&
-              !(
-                chatListItem.isSelfTalk ||
-                chatListItem.isDeviceTalk ||
-                isOutBroadcast
-              ) && {
-                label: tx('menu_block_contact'),
-                action: onBlockContact,
-              },
-            // Delete
-            {
-              label: tx('menu_delete_chat'),
-              action: onDeleteChat,
-            },
-          ]
-        : []
+        // Encryption Info
+        !chatListItem.isDeviceTalk &&
+          !chatListItem.isSelfTalk && {
+            label: tx('encryption_info_title_desktop'),
+            action: onEncrInfo,
+          },
+        { type: 'separator' },
+        // Leave channel
+        chatListItem.chatType === C.DC_CHAT_TYPE_IN_BROADCAST &&
+          !chatListItem.isContactRequest && {
+            label: tx('menu_leave_channel'),
+            action: onLeaveGroupOrChannel,
+          },
+        // Leave group
+        isGroup &&
+          chatListItem.isEncrypted &&
+          chatListItem.isSelfInGroup && {
+            label: tx('menu_leave_group'),
+            action: onLeaveGroupOrChannel,
+          },
+        // Block contact
+        !isGroup &&
+          !(
+            chatListItem.isSelfTalk ||
+            chatListItem.isDeviceTalk ||
+            isOutBroadcast
+          ) && {
+            label: tx('menu_block_contact'),
+            action: onBlockContact,
+          },
+        // Delete
+        {
+          label: tx('menu_delete_chat'),
+          action: onDeleteChat,
+        },
+      ]
 
       event.preventDefault() // prevent default runtime context menu from opening
 

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -173,6 +173,51 @@ export function useChatListContextMenu(): {
       const isOutBroadcast =
         chatListItem.chatType === C.DC_CHAT_TYPE_OUT_BROADCAST
 
+      const viewCloneEncInfo = [
+        // View Profile
+        !isGroup && {
+          label: tx('menu_view_profile'),
+          action: onViewProfile,
+        },
+        // View Group Profile (for non encrypted groups)
+        isGroup &&
+          !chatListItem.isEncrypted &&
+          chatListItem.isSelfInGroup && {
+            label: tx('menu_view_profile'),
+            action: onViewGroup,
+          },
+        // Edit Group
+        isGroup &&
+          chatListItem.isEncrypted &&
+          chatListItem.isSelfInGroup && {
+            label: tx('menu_edit_group'),
+            dataTestid: 'edit-group',
+            action: onViewGroup,
+          },
+        // Edit Channel
+        isOutBroadcast && {
+          label: tx('edit_channel'),
+          action: onViewGroup,
+        },
+        // Clone Group
+        isGroup && {
+          label: tx('clone_chat'),
+          action: () => {
+            openDialog(CloneChat, {
+              setViewMode: 'createGroup',
+              chatTemplateId: chatListItem.id,
+            })
+          },
+        },
+
+        // Encryption Info
+        !chatListItem.isDeviceTalk &&
+          !chatListItem.isSelfTalk && {
+            label: tx('encryption_info_title_desktop'),
+            action: onEncrInfo,
+          },
+      ]
+
       const menu: (ContextMenuItem | false)[] = [
         // Pin
         pin,
@@ -220,49 +265,10 @@ export function useChatListContextMenu(): {
             },
         // Archive
         archive,
-        { type: 'separator' },
-        // View Profile
-        !isGroup && {
-          label: tx('menu_view_profile'),
-          action: onViewProfile,
-        },
-        // View Group Profile (for non encrypted groups)
-        isGroup &&
-          !chatListItem.isEncrypted &&
-          chatListItem.isSelfInGroup && {
-            label: tx('menu_view_profile'),
-            action: onViewGroup,
-          },
-        // Edit Group
-        isGroup &&
-          chatListItem.isEncrypted &&
-          chatListItem.isSelfInGroup && {
-            label: tx('menu_edit_group'),
-            dataTestid: 'edit-group',
-            action: onViewGroup,
-          },
-        // Edit Channel
-        isOutBroadcast && {
-          label: tx('edit_channel'),
-          action: onViewGroup,
-        },
-        // Clone Group
-        isGroup && {
-          label: tx('clone_chat'),
-          action: () => {
-            openDialog(CloneChat, {
-              setViewMode: 'createGroup',
-              chatTemplateId: chatListItem.id,
-            })
-          },
-        },
-
-        // Encryption Info
-        !chatListItem.isDeviceTalk &&
-          !chatListItem.isSelfTalk && {
-            label: tx('encryption_info_title_desktop'),
-            action: onEncrInfo,
-          },
+        ...(viewCloneEncInfo.some(item => Boolean(item))
+          ? ([{ type: 'separator' }] as const)
+          : []),
+        ...viewCloneEncInfo,
         { type: 'separator' },
         // Leave channel
         chatListItem.chatType === C.DC_CHAT_TYPE_IN_BROADCAST &&

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -148,6 +148,16 @@ export function useChatListContextMenu(): {
         )
       const onBlockContact = () =>
         openBlockFirstContactOfChatDialog(accountId, chatListItem)
+      const muteUntil = (duration: Timespans) => {
+        return BackendRemote.rpc.setChatMuteDuration(
+          accountId,
+          chatListItem.id,
+          {
+            kind: 'Until',
+            duration,
+          }
+        )
+      }
       const onUnmuteChat = () => unmuteChat(accountId, chatListItem.id)
 
       const { pin, archive } = archiveStateMenu(
@@ -171,58 +181,27 @@ export function useChatListContextMenu(): {
           ? {
               label: tx('menu_mute'),
               subitems: [
-                {
-                  label: tx('mute_for_one_hour'),
-                  action: () => {
-                    BackendRemote.rpc.setChatMuteDuration(
-                      accountId,
-                      chatListItem.id,
-                      {
-                        kind: 'Until',
-                        duration: Timespans.ONE_HOUR_IN_SECONDS,
-                      }
-                    )
+                ...[
+                  {
+                    label: tx('mute_for_one_hour'),
+                    duration: Timespans.ONE_HOUR_IN_SECONDS,
                   },
-                },
-                {
-                  label: tx('mute_for_eight_hours'),
-                  action: () => {
-                    BackendRemote.rpc.setChatMuteDuration(
-                      accountId,
-                      chatListItem.id,
-                      {
-                        kind: 'Until',
-                        duration: Timespans.ONE_HOUR_IN_SECONDS * 8,
-                      }
-                    )
+                  {
+                    label: tx('mute_for_eight_hours'),
+                    duration: Timespans.ONE_HOUR_IN_SECONDS * 8,
                   },
-                },
-                {
-                  label: tx('mute_for_one_day'),
-                  action: () => {
-                    BackendRemote.rpc.setChatMuteDuration(
-                      accountId,
-                      chatListItem.id,
-                      {
-                        kind: 'Until',
-                        duration: Timespans.ONE_DAY_IN_SECONDS,
-                      }
-                    )
+                  {
+                    label: tx('mute_for_one_day'),
+                    duration: Timespans.ONE_DAY_IN_SECONDS,
                   },
-                },
-                {
-                  label: tx('mute_for_seven_days'),
-                  action: () => {
-                    BackendRemote.rpc.setChatMuteDuration(
-                      accountId,
-                      chatListItem.id,
-                      {
-                        kind: 'Until',
-                        duration: Timespans.ONE_WEEK_IN_SECONDS,
-                      }
-                    )
+                  {
+                    label: tx('mute_for_seven_days'),
+                    duration: Timespans.ONE_WEEK_IN_SECONDS,
                   },
-                },
+                ].map(({ label, duration }) => ({
+                  label,
+                  action: () => muteUntil(duration),
+                })),
                 {
                   label: tx('mute_forever'),
                   action: () => {

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -50,7 +50,7 @@ function archiveStateMenu(
     action: () => {
       BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Pinned')
 
-      if (chat.isArchived) {
+      if (isTheSelectedChat && chat.isArchived) {
         unselectChat()
       }
     },

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -7,7 +7,6 @@ import MailingListProfile from '../dialogs/MailingListProfile'
 import { BackendRemote } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { ContextMenuContext } from '../../contexts/ContextMenuContext'
-import { unmuteChat } from '../../backend/chat'
 import useChat from '../../hooks/chat/useChat'
 import { CloneChat } from '../dialogs/CreateChat'
 import useChatDialog from '../../hooks/chat/useChatDialog'
@@ -19,46 +18,59 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 import type { T } from '@deltachat/jsonrpc-client'
 import type { UnselectChat } from '../../contexts/ChatContext'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+
+const log = getLogger('ChatListContextMenu')
 
 function archiveStateMenu(
   unselectChat: UnselectChat,
   accountId: number,
-  chat: T.ChatListItemFetchResult & { kind: 'ChatListItem' },
+  chats: Array<T.ChatListItemFetchResult & { kind: 'ChatListItem' }>,
   tx: ReturnType<typeof useTranslationFunction>,
-  isTheSelectedChat: boolean
+  selectedChatId: number | null
 ): { pin: ContextMenuItem; archive: ContextMenuItem } {
+  // This is copy-pasted.
+  const forAllChatsFn = (
+    fn: (chat: (typeof chats)[number]) => Promise<unknown>
+  ) => {
+    // TODO perf: maybe we need to introduce batch JSON-RPC methods,
+    // instead of simply making one request per each chat?
+    return () => Promise.all(chats.map(chat => fn(chat)))
+  }
+
   const archive: ContextMenuItem = {
     label: tx('menu_archive_chat'),
-    action: () => {
-      BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Archived')
-      if (isTheSelectedChat) {
+    action: forAllChatsFn(async chat => {
+      if (chat.id === selectedChatId) {
         unselectChat()
       }
-    },
+      await BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Archived')
+    }),
   }
   const unArchive: ContextMenuItem = {
     label: tx('menu_unarchive_chat'),
-    action: () => {
-      BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Normal')
-      if (isTheSelectedChat) {
+    action: forAllChatsFn(async chat => {
+      if (chat.id === selectedChatId) {
         unselectChat()
       }
-    },
+      await BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Normal')
+    }),
   }
   const pin: ContextMenuItem = {
     label: tx('pin_chat'),
-    action: () => {
-      BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Pinned')
-
-      if (isTheSelectedChat && chat.isArchived) {
+    action: forAllChatsFn(async chat => {
+      if (chat.id === selectedChatId && chat.isArchived) {
         unselectChat()
       }
-    },
+
+      await BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Pinned')
+    }),
   }
   const unPin: ContextMenuItem = {
     label: tx('unpin_chat'),
-    action: () =>
-      BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Normal'),
+    action: forAllChatsFn(chat =>
+      BackendRemote.rpc.setChatVisibility(accountId, chat.id, 'Normal')
+    ),
   }
 
   /*
@@ -68,9 +80,9 @@ function archiveStateMenu(
   normal	  y	      n       	y	  n
   */
 
-  if (chat.isPinned) {
+  if (chats.every(chat => chat.isPinned)) {
     return { pin: unPin, archive }
-  } else if (chat.isArchived) {
+  } else if (chats.every(chat => chat.isArchived)) {
     return { pin, archive: unArchive }
   } else {
     // normal
@@ -81,10 +93,13 @@ function archiveStateMenu(
 export function useChatListContextMenu(): {
   openContextMenu: (
     event: React.MouseEvent<any, MouseEvent>,
-    chatListItem: T.ChatListItemFetchResult & { kind: 'ChatListItem' },
+    /**
+     * Must be of non-0 length.
+     */
+    chatListItems: Array<T.ChatListItemFetchResult & { kind: 'ChatListItem' }>,
     selectedChatId: number | null
   ) => Promise<void>
-  activeContextMenuChatId: number | null
+  activeContextMenuChatIds: number[]
 } {
   const { openDialog } = useDialog()
   const {
@@ -99,32 +114,44 @@ export function useChatListContextMenu(): {
   const accountId = selectedAccountId()
   const { unselectChat } = useChat()
   const tx = useTranslationFunction()
-  const [activeContextMenuChatId, setActiveContextMenuChatId] = useState<
-    number | null
-  >(null)
+  const [activeContextMenuChatIds, setActiveContextMenuChatIds] = useState<
+    number[]
+  >([])
 
   return {
-    activeContextMenuChatId,
-    openContextMenu: async (event, chatListItem, selectedChatId) => {
-      const onDeleteChat = () =>
-        openDeleteChatsDialog(accountId, [chatListItem], selectedChatId)
-      const onEncrInfo = () =>
+    // TODO can we remove `activeContextMenuChatIds`? It's only used
+    // to style the items, but we now have the multiselect thing.
+    activeContextMenuChatIds,
+
+    openContextMenu: async (event, chatListItems, selectedChatId) => {
+      if (chatListItems.length === 0) {
+        log.error('openContextMenu called with 0 chats')
+        return
+      }
+
+      const onDeleteChats = () =>
+        openDeleteChatsDialog(accountId, chatListItems, selectedChatId)
+      const onEncrInfo = (chat: (typeof chatListItems)[number]) =>
         openEncryptionInfoDialog({
-          chatId: chatListItem.id,
-          dmChatContact: chatListItem.dmChatContact,
+          chatId: chat.id,
+          dmChatContact: chat.dmChatContact,
         })
-      const onViewGroup = async () => {
+      const onViewGroup = async (
+        chatId: (typeof chatListItems)[number]['id']
+      ) => {
         // throws error if chat was not found
         const fullChat = await BackendRemote.rpc.getFullChatById(
           accountId,
-          chatListItem.id
+          chatId
         )
         openViewGroupDialog(fullChat)
       }
-      const onViewProfile = async () => {
+      const onViewProfile = async (
+        chatId: (typeof chatListItems)[number]['id']
+      ) => {
         const fullChat = await BackendRemote.rpc.getFullChatById(
           accountId,
-          chatListItem.id
+          chatId
         )
         if (!fullChat) {
           throw new Error('chat was not found')
@@ -140,81 +167,89 @@ export function useChatListContextMenu(): {
           })
         }
       }
-      const onLeaveGroupOrChannel = () =>
+      const onLeaveGroupOrChannel = (chat: (typeof chatListItems)[number]) =>
         openLeaveGroupOrChannelDialog(
           accountId,
-          chatListItem.id,
-          chatListItem.chatType === C.DC_CHAT_TYPE_GROUP
+          chat.id,
+          chat.chatType === C.DC_CHAT_TYPE_GROUP
         )
-      const onBlockContact = () =>
-        openBlockFirstContactOfChatDialog(accountId, chatListItem)
-      const muteUntil = (duration: Timespans) => {
-        return BackendRemote.rpc.setChatMuteDuration(
-          accountId,
-          chatListItem.id,
-          {
-            kind: 'Until',
-            duration,
-          }
-        )
+      const onBlockContact = (chat: (typeof chatListItems)[number]) =>
+        openBlockFirstContactOfChatDialog(accountId, chat)
+
+      // This is copy-pasted.
+      const forAllChatsFn = (
+        fn: (chat: (typeof chatListItems)[number]) => Promise<unknown>
+      ) => {
+        // TODO perf: maybe we need to introduce batch JSON-RPC methods,
+        // instead of simply making one request per each chat?
+        return () => Promise.all(chatListItems.map(chat => fn(chat)))
       }
-      const onUnmuteChat = () => unmuteChat(accountId, chatListItem.id)
 
       const { pin, archive } = archiveStateMenu(
         unselectChat,
         accountId,
-        chatListItem,
+        chatListItems,
         tx,
-        selectedChatId === chatListItem.id
+        selectedChatId
       )
 
-      const isGroup = chatListItem.chatType === C.DC_CHAT_TYPE_GROUP
+      const singleChat = chatListItems.length === 1 ? chatListItems[0] : false
 
-      const isOutBroadcast =
-        chatListItem.chatType === C.DC_CHAT_TYPE_OUT_BROADCAST
+      const isGroup: boolean =
+        singleChat && singleChat.chatType === C.DC_CHAT_TYPE_GROUP
 
+      const isOutBroadcast: boolean =
+        singleChat && singleChat.chatType === C.DC_CHAT_TYPE_OUT_BROADCAST
+
+      // TODO pluralize strings.
       const viewCloneEncInfo = [
         // View Profile
-        !isGroup && {
-          label: tx('menu_view_profile'),
-          action: onViewProfile,
-        },
-        // View Group Profile (for non encrypted groups)
-        isGroup &&
-          !chatListItem.isEncrypted &&
-          chatListItem.isSelfInGroup && {
+        singleChat &&
+          !isGroup && {
             label: tx('menu_view_profile'),
-            action: onViewGroup,
+            action: () => onViewProfile(singleChat.id),
+          },
+        // View Group Profile (for non encrypted groups)
+        singleChat &&
+          isGroup &&
+          !singleChat.isEncrypted &&
+          singleChat.isSelfInGroup && {
+            label: tx('menu_view_profile'),
+            action: () => onViewGroup(singleChat.id),
           },
         // Edit Group
-        isGroup &&
-          chatListItem.isEncrypted &&
-          chatListItem.isSelfInGroup && {
+        singleChat &&
+          isGroup &&
+          singleChat.isEncrypted &&
+          singleChat.isSelfInGroup && {
             label: tx('menu_edit_group'),
             dataTestid: 'edit-group',
-            action: onViewGroup,
+            action: () => onViewGroup(singleChat.id),
           },
         // Edit Channel
-        isOutBroadcast && {
-          label: tx('edit_channel'),
-          action: onViewGroup,
-        },
-        // Clone Group
-        isGroup && {
-          label: tx('clone_chat'),
-          action: () => {
-            openDialog(CloneChat, {
-              setViewMode: 'createGroup',
-              chatTemplateId: chatListItem.id,
-            })
+        singleChat &&
+          isOutBroadcast && {
+            label: tx('edit_channel'),
+            action: () => onViewGroup(singleChat.id),
           },
-        },
+        // Clone Group
+        singleChat &&
+          isGroup && {
+            label: tx('clone_chat'),
+            action: () => {
+              openDialog(CloneChat, {
+                setViewMode: 'createGroup',
+                chatTemplateId: singleChat.id,
+              })
+            },
+          },
 
         // Encryption Info
-        !chatListItem.isDeviceTalk &&
-          !chatListItem.isSelfTalk && {
+        singleChat &&
+          !singleChat.isDeviceTalk &&
+          !singleChat.isSelfTalk && {
             label: tx('encryption_info_title_desktop'),
-            action: onEncrInfo,
+            action: () => onEncrInfo(singleChat),
           },
       ]
 
@@ -222,7 +257,7 @@ export function useChatListContextMenu(): {
         // Pin
         pin,
         // Mute
-        !chatListItem.isMuted
+        chatListItems.some(item => !item.isMuted)
           ? {
               label: tx('menu_mute'),
               subitems: [
@@ -245,23 +280,30 @@ export function useChatListContextMenu(): {
                   },
                 ].map(({ label, duration }) => ({
                   label,
-                  action: () => muteUntil(duration),
+                  action: forAllChatsFn(chat =>
+                    BackendRemote.rpc.setChatMuteDuration(accountId, chat.id, {
+                      kind: 'Until',
+                      duration,
+                    })
+                  ),
                 })),
                 {
                   label: tx('mute_forever'),
-                  action: () => {
-                    BackendRemote.rpc.setChatMuteDuration(
-                      accountId,
-                      chatListItem.id,
-                      { kind: 'Forever' }
-                    )
-                  },
+                  action: forAllChatsFn(chat =>
+                    BackendRemote.rpc.setChatMuteDuration(accountId, chat.id, {
+                      kind: 'Forever',
+                    })
+                  ),
                 },
               ],
             }
           : {
               label: tx('menu_unmute'),
-              action: onUnmuteChat,
+              action: forAllChatsFn(chat =>
+                BackendRemote.rpc.setChatMuteDuration(accountId, chat.id, {
+                  kind: 'NotMuted',
+                })
+              ),
             },
         // Archive
         archive,
@@ -270,39 +312,45 @@ export function useChatListContextMenu(): {
           : []),
         ...viewCloneEncInfo,
         { type: 'separator' },
+        // TODO support leaving multiple channels
+        // and blocking multiple contacts.
+        //
         // Leave channel
-        chatListItem.chatType === C.DC_CHAT_TYPE_IN_BROADCAST &&
-          !chatListItem.isContactRequest && {
+        singleChat &&
+          singleChat.chatType === C.DC_CHAT_TYPE_IN_BROADCAST &&
+          !singleChat.isContactRequest && {
             label: tx('menu_leave_channel'),
-            action: onLeaveGroupOrChannel,
+            action: () => onLeaveGroupOrChannel(singleChat),
           },
         // Leave group
-        isGroup &&
-          chatListItem.isEncrypted &&
-          chatListItem.isSelfInGroup && {
+        singleChat &&
+          isGroup &&
+          singleChat.isEncrypted &&
+          singleChat.isSelfInGroup && {
             label: tx('menu_leave_group'),
-            action: onLeaveGroupOrChannel,
+            action: () => onLeaveGroupOrChannel(singleChat),
           },
         // Block contact
-        !isGroup &&
+        singleChat &&
+          !isGroup &&
           !(
-            chatListItem.isSelfTalk ||
-            chatListItem.isDeviceTalk ||
+            singleChat.isSelfTalk ||
+            singleChat.isDeviceTalk ||
             isOutBroadcast
           ) && {
             label: tx('menu_block_contact'),
-            action: onBlockContact,
+            action: () => onBlockContact(singleChat),
           },
         // Delete
         {
           label: tx('menu_delete_chat'),
-          action: onDeleteChat,
+          action: onDeleteChats,
         },
       ]
 
       event.preventDefault() // prevent default runtime context menu from opening
 
-      setActiveContextMenuChatId(chatListItem.id)
+      setActiveContextMenuChatIds(chatListItems.map(item => item.id))
       await openContextMenu({
         ...mouseEventToPosition(event),
         items: menu,
@@ -310,7 +358,7 @@ export function useChatListContextMenu(): {
           'aria-label': tx('chat_list_item_menu_label'),
         },
       })
-      setActiveContextMenuChatId(null)
+      setActiveContextMenuChatIds([])
     },
   }
 }

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -160,9 +160,11 @@ export const PlaceholderChatListItem = React.memo(_ => {
 
 function ChatListItemArchiveLink({
   onClick,
+  onFocus,
   chatListItem,
 }: {
-  onClick: () => void
+  onClick: (event: React.MouseEvent) => void
+  onFocus?: (event: React.FocusEvent) => void
   chatListItem: Type.ChatListItemFetchResult & {
     kind: 'ArchiveLink'
   }
@@ -195,7 +197,10 @@ function ChatListItemArchiveLink({
       tabIndex={tabIndex}
       onClick={onClick}
       onKeyDown={tabindexOnKeydown}
-      onFocus={tabindexSetAsActiveElement}
+      onFocus={e => {
+        tabindexSetAsActiveElement()
+        onFocus?.(e)
+      }}
       onContextMenu={onContextMenu}
       aria-haspopup='menu'
       className={`chat-list-item archive-link-item ${tabindexClassName} ${
@@ -217,13 +222,15 @@ function ChatListItemError({
   chatListItem,
   onClick,
   roleTab,
+  onFocus,
   isSelected,
   onContextMenu,
 }: {
   chatListItem: Type.ChatListItemFetchResult & {
     kind: 'Error'
   }
-  onClick: () => void
+  onClick: (event: React.MouseEvent) => void
+  onFocus?: (event: React.FocusEvent) => void
   onContextMenu?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => void
@@ -247,7 +254,10 @@ function ChatListItemError({
       tabIndex={tabIndex}
       onClick={onClick}
       onKeyDown={tabindexOnKeydown}
-      onFocus={tabindexSetAsActiveElement}
+      onFocus={e => {
+        onFocus?.(e)
+        tabindexSetAsActiveElement()
+      }}
       onContextMenu={onContextMenu}
       aria-haspopup={onContextMenu != undefined ? 'menu' : undefined}
       role={roleTab ? 'tab' : undefined}
@@ -283,6 +293,7 @@ function ChatListItemError({
 function ChatListItemNormal({
   chatListItem,
   onClick,
+  onFocus,
   isSelected,
   roleTab,
   onContextMenu,
@@ -291,7 +302,8 @@ function ChatListItemNormal({
   chatListItem: Type.ChatListItemFetchResult & {
     kind: 'ChatListItem'
   }
-  onClick: () => void
+  onClick: (event: React.MouseEvent) => void
+  onFocus?: (event: React.FocusEvent) => void
   onContextMenu?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => void
@@ -321,7 +333,10 @@ function ChatListItemNormal({
       tabIndex={tabIndex}
       onClick={onClick}
       onKeyDown={tabindexOnKeydown}
-      onFocus={tabindexSetAsActiveElement}
+      onFocus={e => {
+        onFocus?.(e)
+        tabindexSetAsActiveElement()
+      }}
       onContextMenu={onContextMenu}
       aria-haspopup={onContextMenu != undefined ? 'menu' : undefined}
       role={roleTab ? 'tab' : undefined}
@@ -373,7 +388,8 @@ function ChatListItemNormal({
 
 type ChatListItemProps = {
   chatListItem: Type.ChatListItemFetchResult | undefined
-  onClick: () => void
+  onClick: (event: React.MouseEvent) => void
+  onFocus?: (event: React.FocusEvent) => void
   onContextMenu?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
   ) => void
@@ -389,7 +405,7 @@ type ChatListItemProps = {
 }
 
 const ChatListItem = React.memo<ChatListItemProps>(props => {
-  const { chatListItem, onClick, roleTab } = props
+  const { chatListItem, onClick, roleTab, onFocus } = props
 
   // if not loaded by virtual list yet
   if (typeof chatListItem === 'undefined') return <PlaceholderChatListItem />
@@ -400,6 +416,7 @@ const ChatListItem = React.memo<ChatListItemProps>(props => {
         chatListItem={chatListItem}
         onClick={onClick}
         roleTab={roleTab}
+        onFocus={onFocus}
         isSelected={props.isSelected}
         onContextMenu={props.onContextMenu}
         isContextMenuActive={props.isContextMenuActive}
@@ -411,13 +428,18 @@ const ChatListItem = React.memo<ChatListItemProps>(props => {
         chatListItem={chatListItem}
         onClick={onClick}
         roleTab={roleTab}
+        onFocus={onFocus}
         isSelected={props.isSelected}
         onContextMenu={props.onContextMenu}
       />
     )
   } else if (chatListItem.kind == 'ArchiveLink') {
     return (
-      <ChatListItemArchiveLink chatListItem={chatListItem} onClick={onClick} />
+      <ChatListItemArchiveLink
+        chatListItem={chatListItem}
+        onClick={onClick}
+        onFocus={onFocus}
+      />
     )
   } else {
     return <PlaceholderChatListItem />

--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -14,7 +14,7 @@ import type { T } from '@deltachat/jsonrpc-client'
 import type { useChatListContextMenu } from './ChatListContextMenu'
 
 export type ChatListItemData = {
-  selectedChatId: number | null
+  activeChatId: number | null
   /**
    * Whether to set `role='tab'` on the items.
    *
@@ -60,7 +60,7 @@ export const ChatListItemRowChat = React.memo<{
   style: React.CSSProperties
 }>(({ index, data, style }) => {
   const {
-    selectedChatId,
+    activeChatId,
     roleTabs,
     chatListIds,
     chatCache,
@@ -80,10 +80,10 @@ export const ChatListItemRowChat = React.memo<{
   const onContextMenu = useCallback(
     (event: React.MouseEvent) => {
       if (chat?.kind === 'ChatListItem') {
-        openContextMenu(event, chat, selectedChatId)
+        openContextMenu(event, chat, activeChatId)
       }
     },
-    [chat, openContextMenu, selectedChatId]
+    [chat, openContextMenu, activeChatId]
   )
   const onContextMenuRef = useRef(onContextMenu)
   onContextMenuRef.current = onContextMenu
@@ -92,7 +92,7 @@ export const ChatListItemRowChat = React.memo<{
     <li style={style}>
       <ChatListItem
         roleTab={roleTabs}
-        isSelected={selectedChatId === chatId}
+        isSelected={activeChatId === chatId}
         chatListItem={chat}
         onClick={useCallback(() => onChatClickRef.current(chatId), [chatId])}
         onContextMenu={useCallback(

--- a/packages/frontend/src/components/dialogs/SelectChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectChat/index.tsx
@@ -79,7 +79,7 @@ export default function SelectChat(props: Props) {
                       chatListIds,
                       onChatClick: props.onChatClick,
 
-                      selectedChatId: null,
+                      activeChatId: null,
                       activeContextMenuChatId: null,
                       openContextMenu: async () => {},
                     }}

--- a/packages/frontend/src/components/dialogs/SelectChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectChat/index.tsx
@@ -80,7 +80,7 @@ export default function SelectChat(props: Props) {
                       onChatClick: props.onChatClick,
 
                       activeChatId: null,
-                      activeContextMenuChatId: null,
+                      activeContextMenuChatIds: [],
                       openContextMenu: async () => {},
                     }}
                   >

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -432,7 +432,7 @@ function ViewGroupInner(
                         chatListIds,
                         onChatClick,
 
-                        selectedChatId: null,
+                        activeChatId: null,
                         activeContextMenuChatId: null,
                         openContextMenu: async () => {},
                       }}

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -433,7 +433,7 @@ function ViewGroupInner(
                         onChatClick,
 
                         activeChatId: null,
-                        activeContextMenuChatId: null,
+                        activeContextMenuChatIds: [],
                         openContextMenu: async () => {},
                       }}
                     >

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -360,7 +360,7 @@ export function ViewProfileInner({
                       chatListIds,
                       onChatClick,
 
-                      selectedChatId: null,
+                      activeChatId: null,
                       activeContextMenuChatId: null,
                       openContextMenu: async () => {},
                     }}

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -361,7 +361,7 @@ export function ViewProfileInner({
                       onChatClick,
 
                       activeChatId: null,
-                      activeContextMenuChatId: null,
+                      activeContextMenuChatIds: [],
                       openContextMenu: async () => {},
                     }}
                   >

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -205,10 +205,12 @@ export function useMultiselect<T>(
   // but not on `FocusEvent`. This is why we need to track them here.
   const shiftPressed = useRef(false)
   const ctrlPressed = useRef(false)
+  const metaPressed = useRef(false)
   useEffect(() => {
     const onEvent = (ev: KeyboardEvent | MouseEvent) => {
       shiftPressed.current = ev.shiftKey
       ctrlPressed.current = ev.ctrlKey
+      metaPressed.current = ev.metaKey
     }
     document.addEventListener('keydown', onEvent, { passive: true })
     document.addEventListener('keyup', onEvent, { passive: true })
@@ -233,7 +235,7 @@ export function useMultiselect<T>(
       // but let's not do that, e.g. in case we later actually need it,
       // and also because `event.ctrlKey` is a more reliable
       // "source of truth" than our custom `ctrlPressed` tracking code.
-      if (event.ctrlKey) {
+      if (event.ctrlKey || event.metaKey) {
         toggleItemSelection(item)
         lastActivatedItem.current = item
         return true // shouldPreventDefault
@@ -258,7 +260,7 @@ export function useMultiselect<T>(
       if (shiftPressed.current) {
         onSelectContiguous(item)
       } else {
-        if (!ctrlPressed.current) {
+        if (!(ctrlPressed.current || metaPressed.current)) {
           // This is to make sure that a sequence
           // ArrowDown
           // ArrowDown

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -1,0 +1,318 @@
+import type React from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
+
+/**
+ * Think of it as `null`, but this ensures that we don't mix it up
+ * with the actual `null`, should one appear in the `availableItems` array.
+ */
+const none = Symbol()
+
+/**
+ * Helps implement keyboard (and mouse) -accessible multiselect behavior
+ * on an existing widget.
+ *
+ * This hook is not concerned with how focus is managed
+ * (be it arrow keys or something else).
+ * But most of the time you want to make sure that focus can be managed
+ * with arrow keys (roving tabindex),
+ * so that the behavior is aligned with the recommended shortcuts
+ * for the [Listbox pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/).
+ *
+ * @example
+ *
+ * ```tsx
+ * const itemIds = [1, 2, 3, 4, 5]
+ * const [selectedItems, setSelectedItems] = useState(new Set<number>())
+ * const multiselect = useMultiselect(itemIds, selectedItems, setSelectedItems)
+ * const myOnClick = useCallback((id: number) => {
+ *   console.log('Clicked item', id)
+ * }, [])
+ * return (
+ *   <ul
+ *     role='listbox' // Or 'tablist' or whatever.
+ *     aria-multiselectable={true}
+ *   >
+ *     {itemIds.map(id => (
+ *       <li>
+ *         <button
+ *           role='option' // Or 'tab' or whatever.
+ *           aria-selected={multiselect.selectedItems.has(id)}
+ *           className={multiselect.selectedItems.has(id) ? 'selected' : ''}
+ *           onClick={event => {
+ *             const shouldPreventDefault = multiselect.onClick(event, id)
+ *             if (shouldPreventDefault) {
+ *               event.preventDefault()
+ *               return
+ *             }
+ *             // The "regular", non-multiselect click action.
+ *             myOnClick(id)
+ *           }}
+ *           onFocus={() => multiselect.onFocus(id)}
+ *         >
+ *           Item {id}
+ *         </button>
+ *       </li>
+ *     ))}
+ *   </ul>
+ * )
+ * ```
+ *
+ * This does not provide the most advanced selection behavior,
+ * for example, Shift + Click will reset previous selection,
+ * which is annoying.
+ * But it will work for 95% of user needs.
+ *
+ * If you are looking for a more thorough library, consider
+ * https://react-spectrum.adobe.com/react-aria/selection.html.
+ * In particular, see
+ * [`useSelectableCollection`](https://github.com/adobe/react-spectrum/blob/e6772602376d9726f2347ff0eb2d379b4cd256a9/packages/%40react-aria/selection/src/useSelectableCollection.ts#L107C17-L323).
+ *
+ * The items in DOM must be focusable and interactive (e.g. `<button>`s).
+ * Interactivity is required because we listen on `click` events
+ * as opposed to `keydown` events with `.code === "Space"`,
+ * because we support both keyboard and mouse selection.
+ *
+ * If items are removed from {@link availableItems},
+ * they will not be automatically removed from {@link selectedItems}.
+ * Make sure to handle this yourself, to avoid confusing behavior
+ * where items are selected, but are not visible on the screen.
+ *
+ * It is also possible to provide {@link selectedItems} Set
+ * that includes items which are not a part of {@link availableItems}.
+ */
+export function useMultiselect<T>(
+  /**
+   * The ordered list of available options.
+   * They must be in the focus order, so that Shift + Click
+   * knows the in-between items that need to be marked as selected.
+   *
+   * It goes without saying that all options must be unique
+   * (no option is === to the other), otherwise Shift selection
+   * behavior is not defined.
+   *
+   * This is only used for contiguous selection (Shift + Click).
+   */
+  availableItems: T[],
+
+  selectedItems: Set<T>,
+  /**
+   * This is guaranteed to only be invoked synchronously
+   * inside the returned `onClick` and `onFocus` functions.
+   */
+  onSelectionChange: (newSelectedItems: Set<T>) => void,
+  logger?: {
+    error: (...args: any) => void
+  }
+) {
+  // TODO feat: a way to set initially active item?
+  // And to programmatically change it later.
+  /**
+   * "Activated" is not necessarily "selected",
+   * because it could actually have gotten unselected instead,
+   * e.g. with Ctrl + Click.
+   */
+  const lastActivatedItem = useRef<T | typeof none>(none)
+
+  // Put this behind a ref, so that `onFocus` and `onClick`
+  // don't have to be recalculated, just for performance.
+  const availableItemsRef = useRef(availableItems)
+  availableItemsRef.current = availableItems
+
+  const selectedItemsRef = useRef(selectedItems)
+  selectedItemsRef.current = selectedItems
+
+  const loggerRef = useRef(logger)
+  loggerRef.current = logger
+
+  const toggleItemSelection = useCallback(
+    (itemToToggle: T) => {
+      const curr = selectedItemsRef.current
+      const next = new Set(curr)
+      if (curr.has(itemToToggle)) {
+        next.delete(itemToToggle)
+      } else {
+        next.add(itemToToggle)
+      }
+      onSelectionChange(next)
+    },
+    [onSelectionChange]
+  )
+  /**
+   * Besides changing selection, this reads and writes `lastActivatedItem`.
+   */
+  const onSelectContiguous = useCallback(
+    (toItem: T) => {
+      if (lastActivatedItem.current === none) {
+        // Note that in this case Shift + ArrowDown will only select
+        // one item, and not 2, as one might expect.
+        lastActivatedItem.current = toItem
+      }
+      const prevLastActivatedItem = lastActivatedItem.current
+
+      // Keep in mind that these can be the same item.
+      const from = prevLastActivatedItem
+      const to = toItem
+
+      let fromInd = availableItemsRef.current.indexOf(from)
+      if (fromInd === -1) {
+        // This could happen if `availableItems` got updated
+        // such that `prevLastActivatedItem` is no longer a member of it.
+        // Maybe there is a more graceful way to handle this.
+        onSelectionChange(new Set([from]))
+        return
+      }
+      // `lastIndexOf` is functionally equivalent to `indexOf`
+      // given that all items are unique,
+      // but this has higher performance when selecting down,
+      // which is the most usual case.
+      let toInd = availableItemsRef.current.lastIndexOf(to)
+      if (toInd === -1) {
+        loggerRef.current?.error(
+          'useMultiselect: could not make contiguous selection: target item',
+          to,
+          'is not a member of availableItems',
+          availableItemsRef.current
+        )
+        onSelectionChange(new Set([from]))
+      }
+
+      ;[fromInd, toInd] = [Math.min(fromInd, toInd), Math.max(fromInd, toInd)]
+
+      // Yes, we replace the entire selection. Not good.
+      // But otherwise it requires a lot more logic, namely
+      // contiguous selection should never _un_select items,
+      // _except_ when executing sequence
+      // Shift + ArrowDown
+      // Shift + ArrowUp
+      // or
+      // Shift + End
+      // Shift + Home
+      onSelectionChange(
+        new Set(
+          availableItemsRef.current.slice(
+            fromInd,
+            // `end` is exclusive, so + 1 to make it inclusive.
+            // Yes, this could be out of range, but `Array.slice()` handles it.
+            toInd + 1
+          )
+        )
+      )
+    },
+    [onSelectionChange]
+  )
+
+  // Note that these are also present on `MouseEvent` (click),
+  // but not on `FocusEvent`. This is why we need to track them here.
+  const shiftPressed = useRef(false)
+  const ctrlPressed = useRef(false)
+  useEffect(() => {
+    const onEvent = (ev: KeyboardEvent | MouseEvent) => {
+      shiftPressed.current = ev.shiftKey
+      ctrlPressed.current = ev.ctrlKey
+    }
+    document.addEventListener('keydown', onEvent, { passive: true })
+    document.addEventListener('keyup', onEvent, { passive: true })
+    // Also listen on clicks, in case e.g. the user
+    // Alt + Tabbed from the window while holding Ctrl or Shift,
+    // which would result in us not catching the `keyup` event,
+    // resulting in the variable getting stuck on `true`
+    // even if the key isn't actually pressed.
+    document.addEventListener('click', onEvent, { passive: true })
+    return () => {
+      document.removeEventListener('keydown', onEvent)
+      document.removeEventListener('keyup', onEvent)
+      document.removeEventListener('click', onEvent)
+    }
+  }, [])
+
+  // This handles the "Space" keydown event, as well as clicks.
+  const onClick = useCallback(
+    (event: React.MouseEvent, item: T): boolean => {
+      // Note that we use `event.ctrlKey` and not `ctrlPressed.current`.
+      // We could get rid of the `event` argument,
+      // but let's not do that, e.g. in case we later actually need it,
+      // and also because `event.ctrlKey` is a more reliable
+      // "source of truth" than our custom `ctrlPressed` tracking code.
+      if (event.ctrlKey) {
+        toggleItemSelection(item)
+        lastActivatedItem.current = item
+        return true // shouldPreventDefault
+      }
+      if (event.shiftKey) {
+        // TODO perf: when using mouse clicks, we do this twice:
+        // once on focus, and once on click.
+        onSelectContiguous(item)
+        return true // shouldPreventDefault
+      }
+
+      onSelectionChange(new Set([item]))
+      lastActivatedItem.current = item
+      return false
+    },
+    [onSelectContiguous, onSelectionChange, toggleItemSelection]
+  )
+
+  // Handle Shift + ArrowDown, Shift + End.
+  const onFocus = useCallback(
+    (item: T) => {
+      if (shiftPressed.current) {
+        onSelectContiguous(item)
+      } else {
+        if (!ctrlPressed.current) {
+          // This is to make sure that a sequence
+          // ArrowDown
+          // ArrowDown
+          // Shift + ArrowDown
+          // selects only two items: the previously focused on
+          // and the newly focused one.
+          //
+          // While this feels better (for me personally),
+          // this might be in contradiction with recommendations from
+          // https://www.w3.org/WAI/ARIA/apg/patterns/listbox/,
+          // thus might be unintuitive for some users.
+          // Namely, the fact that ArrowDown (without Shift pressed)
+          // changes focus, but does not change selection.
+          //
+          // So let's comment this out for now, until we implement
+          // the "focus changes selection" mode, in which this line
+          // will come in handy.
+          //
+          // lastActivatedItem.current = item
+        }
+      }
+    },
+    [onSelectContiguous]
+  )
+
+  // `useMemo` to avoid re-renders. Is this a common pattern??
+  return useMemo(
+    () => ({
+      /**
+       * It's the {@link selectedItems} argument, unchanged,
+       * provided for convenience.
+       */
+      selectedItems,
+      /**
+       * This must be invoked when an item is clicked,
+       * i.e. on `click` events.
+       *
+       * It does not matter whether the provided `item` is a member of
+       * {@link availableItems}.
+       *
+       * @returns whether the caller should `preventDefault()`
+       * the original event and not execute the regular click action.
+       */
+      onClick,
+      /**
+       * This must be invoked when an item is focused,
+       * i.e. on `focus` events.
+       *
+       * It is OK to invoke this with an `item` that is not
+       * a member of {@link availableItems}, however, contiguous selection
+       * (Shift + ArrowDown) will not work properly then.
+       */
+      onFocus,
+    }),
+    [onClick, onFocus, selectedItems]
+  )
+}


### PR DESCRIPTION
<img width="334" height="397" alt="image" src="https://github.com/user-attachments/assets/f30b876a-9627-4bf2-aeaa-e4574ad2e907" />

To use it, simply hold Shift or Ctrl and click on the chat list items.
Keyboard is also supported.
Accessibility is taken into account
(`aria-selected`, `aria-multiselectable`).

This has minimal effect on non-multiselect behavior,
i.e. if you don't hold Shift or Ctrl, you won't see a big difference.
The most significant change in this regard is that
if you right-click a chat that is not the active chat,
it will get highlighted, and the active chat will get un-highlighted,
until the context menu gets closed.

Note that the active chat and the selected chats have the same look
(i.e. darker background).
I have tried to minimize confusion between them.
But in the end we might need to style them differently.
Although at the current state it also works quite well IMO.

Summary of the changes:
- Make `ChatListContextMenu` support multiple items
  (without changing behavior for single selection).
  The behavior if things such as "pin / unpin", "mute / unmute"
  is the same as in Android.
  The "Delete Chat" dialog also supports multiple items,
  and displays the to be deleted chat names.
- Rename `selectedChatId` to `activeChatId` in `ChatList.tsx`
- Introduce the `useMultiselect` hook. It basically takes `click`
  and `focus` events, and outputs the set of selected items.
  It basically depends on the existing `useRovingTabindex` hook
  for arrow key focus management.
  I have tried searching for existing such libraries,
  but didn't find one that's sufficiently generic and simple.
- Introduce `useChatListMultiselect` hook that wraps
  `useMultiselect`, and more concretely implements multiselect
  specifically for chat list. For example,
  resets selection when the active chat changes.
- Pass down `onClick` and `onFocus` handlers
  to chat list item components.
- Adjust `onContextMenu` to handle multiselect.

The more useful feature would be to multiselect messages,
but I decided to start with a simpler case,
as I once did with `useRovingTabindex`.

TODO:
- [x] Address TODOs in the code, clean up comments.
- [x] Get feedback.
- [x] Consider putting this behind a feature flag.
  Edit: We have decided that this is not needed.
- [x] Consider adding more UI, namely a "n chats selected" indicator.
  Edit: we have decided that this can be done later.
- [x] Add E2E tests, maybe a lot of them. But probably after getting feedback.
  https://github.com/deltachat/deltachat-desktop/pull/5431 - not a lot of them, but covers the basic stuff.
- [x] Write better MR description
  - [x] Maybe something about existing libraries.
  - [x] Summary of the changes: context menu to support multiple items, but otherwise unchanged; introduced the generic `useMultiselect` hook that basically relies on `useRovingTabindex`.
- [x] Merge the MR that this is based on: https://github.com/deltachat/deltachat-desktop/pull/5283
- [x] Add CHANGELOG entry.
- [x] Apparently it's planned to make a release with just https://github.com/deltachat/deltachat-desktop/pull/5423. If so, let's merge this MR after that release.

Otherwise this works quite well IMO.

#public-preview