### PR TITLE
Add missing tasks

### DIFF
--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -245,8 +245,16 @@ export function useChatListContextMenu(): {
               label: tx('menu_view_profile'),
               action: onViewProfile,
             },
+            // View Group Profile (for non encrypted groups)
+            isGroup &&
+              !chatListItem.isEncrypted &&
+              chatListItem.isSelfInGroup && {
+                label: tx('menu_view_profile'),
+                action: onViewGroup,
+              },
             // Edit Group
             isGroup &&
+              chatListItem.isEncrypted &&
               chatListItem.isSelfInGroup && {
                 label: tx('menu_edit_group'),
                 dataTestid: 'edit-group',
@@ -283,6 +291,7 @@ export function useChatListContextMenu(): {
               },
             // Leave group
             isGroup &&
+              chatListItem.isEncrypted &&
               chatListItem.isSelfInGroup && {
                 label: tx('menu_leave_group'),
                 action: onLeaveGroupOrChannel,

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -431,7 +431,7 @@ function ViewGroupInner(
               <RovingTabindexProvider
                 wrapperElementRef={groupMemberContactListWrapperRef}
               >
-                {!chatDisabled && (
+                {!chatDisabled && group.isEncrypted && (
                   <>
                     <PseudoListItemAddMember
                       onClick={() => showAddMemberDialog()}

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -318,6 +318,10 @@ function ViewGroupInner(
   // See https://github.com/deltachat/deltachat-desktop/issues/5294
   // > the chat itself picks up "group wording"
   const membersOrRecipients = isBroadcast ? 'recipients' : 'members'
+
+  // We don't allow editing of non encryped groups (email groups)
+  const allowEdit = !chatDisabled && group.isEncrypted
+
   const showAddMemberDialog = () => {
     openDialog(AddMemberDialog, {
       listFlags,
@@ -355,12 +359,21 @@ function ViewGroupInner(
     <>
       {!profileContact && (
         <>
-          <DialogHeader
-            title={!isBroadcast ? tx('tab_group') : tx('channel')}
-            onClickEdit={onClickEdit}
-            onClose={onClose}
-            dataTestid='view-group-dialog-header'
-          />
+          {allowEdit && (
+            <DialogHeader
+              title={!isBroadcast ? tx('tab_group') : tx('channel')}
+              onClickEdit={onClickEdit}
+              onClose={onClose}
+              dataTestid='view-group-dialog-header'
+            />
+          )}
+          {!allowEdit && (
+            <DialogHeader
+              title={tx('tab_group')}
+              onClose={onClose}
+              dataTestid='view-group-dialog-header'
+            />
+          )}
           <DialogBody>
             <DialogContent paddingBottom>
               <ProfileInfoHeader
@@ -446,7 +459,7 @@ function ViewGroupInner(
                 )}
                 <ContactList
                   contacts={group.contacts}
-                  showRemove={!chatDisabled}
+                  showRemove={!chatDisabled && group.isEncrypted}
                   onClick={contact => {
                     if (contact.id === C.DC_CONTACT_ID_SELF) {
                       return


### PR DESCRIPTION
resolves #5294

- [ ] hide "add member" and "show QR invite" buttons for non-pgp group chats and disable/hidde option/button to remove members (available API: `FullChat.is_encrypted`)
- [ ] hide "leave" for for unencryted group chats, EDIT: "clone" can stay as we get  "New E-Mail" (thanks @Hocuri )
- [ ] do not allow to edit unencryted group chats names and avatars
- [ ] open "e2ee explained" dialog also on info message DC_INFO_CHAT_E2EE (in addition to DC_INFO_PROTECTION_ENABLED, cmp [android/#3822](https://github.com/deltachat/deltachat-android/pull/3822) ) - otherwise, DC_INFO_CHAT_E2EE does not require any special rendering or icon 