### PR TITLE
test: fix qrcode test not deleting all profiles

### DIFF
--- a/packages/e2e-tests/tests/qrcode-tests.spec.ts
+++ b/packages/e2e-tests/tests/qrcode-tests.spec.ts
@@ -47,6 +47,11 @@ test.beforeAll(async ({ browser }) => {
 test.beforeEach(async ({ page }) => {
   await reloadPage(page)
 })
+test.afterEach(async ({ page }) => {
+  // These tests might add or delete profiles, so let's make sure
+  // that `existingProfiles` is always up to date.
+  existingProfiles = await loadExistingProfiles(page)
+})
 
 test.afterAll(async ({ browser }) => {
   const context = await browser.newContext()


### PR DESCRIPTION
This is a problem for adding future tests which run after it,
because they'll refuse to proceed if there are existing profiles,
which was the case in
https://github.com/deltachat/deltachat-desktop/pull/5311.

#skip-changelog

I have verified that this fixes the issue.
