### PR TITLE
Improve outline visibility (a bit)

### DIFF
--- a/packages/frontend/scss/chat/_chat-list-item.scss
+++ b/packages/frontend/scss/chat/_chat-list-item.scss
@@ -16,6 +16,7 @@
   flex-direction: row;
   padding: 0px 10px;
   align-items: center;
+  outline-offset: -1px;
 
   .status-icon {
     flex-shrink: 0;
@@ -360,4 +361,9 @@
 #new-chat-button {
   right: 15px;
   position: absolute;
+  outline-offset: 2px;
+  &:focus {
+    height: 52px;
+    width: 52px;
+  }
 }

--- a/packages/frontend/scss/chat/_chat-list-item.scss
+++ b/packages/frontend/scss/chat/_chat-list-item.scss
@@ -361,9 +361,8 @@
 #new-chat-button {
   right: 15px;
   position: absolute;
-  outline-offset: 2px;
-  &:focus {
-    height: 52px;
-    width: 52px;
+  &:focus-visible {
+    outline-offset: 2px;
+    scale: 1.1;
   }
 }

--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -56,6 +56,7 @@
     display: flex;
     align-items: flex-end;
     background-color: var(--composerBg);
+    padding: 2px 0;
 
     .attachment-button,
     .emoji-button,
@@ -72,6 +73,7 @@
 
       box-shadow: none;
       border: none;
+      outline-offset: -1px;
 
       &:hover {
         background: none;
@@ -110,6 +112,9 @@
 
       &:focus:not(:focus-visible) {
         outline: none;
+      }
+      &:focus-visible {
+        outline-offset: 2px;
       }
 
       .paper-plane {

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -467,6 +467,7 @@ $info-text-max-width: 400px;
     border-radius: 20px;
     opacity: 0.9;
     color: var(--infoMessageBubbleText);
+    outline-offset: 4px;
 
     .status-icon.sending {
       background-color: var(--infoMessageBubbleText);

--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -95,6 +95,7 @@
     :global(.views) {
       display: flex;
       height: 100%;
+      padding: 4px 0;
     }
 
     :global(.navbar-button) {


### PR DESCRIPTION
When navigating with the keyboard in light mode it seems sometimes the focus is "lost" since the contrast of the outline is too small. This PR improves that for:
- selected chat item
- create chat button
- Info messages

Before:

https://github.com/user-attachments/assets/04054f97-8465-48dc-b12f-2188ad3305c3

After:

https://github.com/user-attachments/assets/d9eefe8a-83ad-44fa-b8d0-180a3151d59f



#skip-changelog