### PR TITLE
improvement: a11y: add `aria-label` for some menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - don't show "Edit Message", "Disappearing Messages" and fullscreen avatar view in classic E-Mail chats #5365
 - accessibility: improve keyboard and screen reader accessibility of the "Add Reaction" menu #5376
+- accessibility: add labels to some menus (e.g. message context menu, chat list item context menu) #5347
 
 ### Changed
 

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -85,5 +85,11 @@
   },
   "edit_channel": {
     "message": "Edit Channel"
+  },
+  "chat_list_item_menu_label": {
+    "message": "Actions with Chat"
+  },
+  "accounts_list_item_menu_label": {
+    "message": "Actions with Profile"
   }
 }

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -98,78 +98,81 @@ export default function AccountItem({
 
   const bgSyncDisabled = syncAllAccounts === false && !isSelected
 
-  const { onContextMenu, isContextMenuActive } = useContextMenuWithActiveState([
-    muted
-      ? {
-          label: tx('menu_unmute'),
-          action: () => {
-            AccountNotificationStoreInstance.effect.setMuted(accountId, false)
+  const { onContextMenu, isContextMenuActive } = useContextMenuWithActiveState(
+    [
+      muted
+        ? {
+            label: tx('menu_unmute'),
+            action: () => {
+              AccountNotificationStoreInstance.effect.setMuted(accountId, false)
+            },
+          }
+        : {
+            label: tx('menu_mute'),
+            action: () => {
+              AccountNotificationStoreInstance.effect.setMuted(accountId, true)
+            },
           },
-        }
-      : {
-          label: tx('menu_mute'),
-          action: () => {
-            AccountNotificationStoreInstance.effect.setMuted(accountId, true)
-          },
+      {
+        label: tx('mark_all_as_read'),
+        action: () => {
+          markAccountAsRead(accountId)
         },
-    {
-      label: tx('mark_all_as_read'),
-      action: () => {
-        markAccountAsRead(accountId)
       },
-    },
-    {
-      label: tx('menu_all_media'),
-      action: async () => {
-        await onSelectAccount(accountId)
-        // set Timeout forces it to be run after react update
-        setTimeout(() => {
-          ActionEmitter.emitAction(KeybindAction.GlobalGallery_Open)
-          // NOTE(maxph): Gallery.tsx gets unmounted before receiving media data
-          // and only partially updates chat header without changing chat view to Gallery,
-          // so here 50ms is a temprorary workaround for that
-        }, 50)
-      },
-    },
-    {
-      label: tx('menu_show_global_map'),
-      action: async () => {
-        await onSelectAccount(accountId)
-        openMapWebxdc(accountId)
-      },
-    },
-    { type: 'separator' },
-    {
-      label: tx('menu_settings'),
-      action: async () => {
-        await onSelectAccount(accountId)
-        setTimeout(() => {
+      {
+        label: tx('menu_all_media'),
+        action: async () => {
+          await onSelectAccount(accountId)
           // set Timeout forces it to be run after react update
-          // without the small delay the app crashed randomly in the e2e tests
-          ActionEmitter.emitAction(KeybindAction.Settings_Open)
-        }, 100)
+          setTimeout(() => {
+            ActionEmitter.emitAction(KeybindAction.GlobalGallery_Open)
+            // NOTE(maxph): Gallery.tsx gets unmounted before receiving media data
+            // and only partially updates chat header without changing chat view to Gallery,
+            // so here 50ms is a temprorary workaround for that
+          }, 50)
+        },
       },
-      dataTestid: 'open-settings-menu-item',
-    },
-    {
-      label: tx('profile_tag'),
-      action: async () => {
-        openDialog(EditPrivateTagDialog, {
-          accountId,
-          currentTag: await BackendRemote.rpc.getConfig(
+      {
+        label: tx('menu_show_global_map'),
+        action: async () => {
+          await onSelectAccount(accountId)
+          openMapWebxdc(accountId)
+        },
+      },
+      { type: 'separator' },
+      {
+        label: tx('menu_settings'),
+        action: async () => {
+          await onSelectAccount(accountId)
+          setTimeout(() => {
+            // set Timeout forces it to be run after react update
+            // without the small delay the app crashed randomly in the e2e tests
+            ActionEmitter.emitAction(KeybindAction.Settings_Open)
+          }, 100)
+        },
+        dataTestid: 'open-settings-menu-item',
+      },
+      {
+        label: tx('profile_tag'),
+        action: async () => {
+          openDialog(EditPrivateTagDialog, {
             accountId,
-            'private_tag'
-          ),
-        })
+            currentTag: await BackendRemote.rpc.getConfig(
+              accountId,
+              'private_tag'
+            ),
+          })
+        },
       },
-    },
-    { type: 'separator' },
-    {
-      label: tx('delete_account'),
-      action: openAccountDeletionScreen.bind(null, accountId),
-      dataTestid: 'delete-account-menu-item',
-    },
-  ])
+      { type: 'separator' },
+      {
+        label: tx('delete_account'),
+        action: openAccountDeletionScreen.bind(null, accountId),
+        dataTestid: 'delete-account-menu-item',
+      },
+    ],
+    { 'aria-label': tx('accounts_list_item_menu_label') }
+  )
 
   let badgeContent
   if (bgSyncDisabled) {

--- a/packages/frontend/src/components/ThreeDotMenu.tsx
+++ b/packages/frontend/src/components/ThreeDotMenu.tsx
@@ -220,6 +220,7 @@ export function useThreeDotMenu(selectedChat?: T.FullChat) {
       x,
       y,
       items: menu,
+      ariaAttrs: { 'aria-labelledby': 'three-dot-menu-button' },
     })
   }
 }

--- a/packages/frontend/src/components/chat/ChatListContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatListContextMenu.tsx
@@ -323,6 +323,9 @@ export function useChatListContextMenu(): {
       await openContextMenu({
         ...mouseEventToPosition(event),
         items: menu,
+        ariaAttrs: {
+          'aria-label': tx('chat_list_item_menu_label'),
+        },
       })
       setActiveContextMenuChatId(null)
     },

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -221,6 +221,9 @@ export default function MenuAttachment({
       x,
       y,
       items: menu,
+      ariaAttrs: {
+        'aria-labelledby': 'attachment-menu-button',
+      },
     })
   }
 

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -520,6 +520,9 @@ export default function Message(props: {
       openContextMenu({
         ...showContextMenuEventPos,
         items,
+        ariaAttrs: {
+          'aria-label': tx('a11y_message_context_menu_btn_label'),
+        },
       })
     },
     [
@@ -533,6 +536,7 @@ export default function Message(props: {
       showReactionsBar,
       text,
       jumpToMessage,
+      tx,
     ]
   )
   const ref = useRef<any>(null)

--- a/packages/frontend/src/hooks/useContextMenu.ts
+++ b/packages/frontend/src/hooks/useContextMenu.ts
@@ -9,8 +9,9 @@ import type {
 } from '../components/ContextMenu'
 
 export default function useContextMenu(
-  itemsOrItemsFactoryFn: ContextMenuItems | ContextMenuItemsFactoryFn
+  itemsOrItemsFactoryFn: ContextMenuItems | ContextMenuItemsFactoryFn,
+  ariaAttrs?: Parameters<typeof makeContextMenu>[2]
 ) {
   const { openContextMenu } = useContext(ContextMenuContext)
-  return makeContextMenu(itemsOrItemsFactoryFn, openContextMenu)
+  return makeContextMenu(itemsOrItemsFactoryFn, openContextMenu, ariaAttrs)
 }


### PR DESCRIPTION
https://www.w3.org/WAI/ARIA/apg/patterns/menubar/ :
> An element with role menu either has:
> - aria-labelledby set to a value that refers to the menuitem
>   or button that controls its display.
> - A label provided by aria-label.
