### PR TITLE
fix: hide "Reply" and "Save" for info and call msgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Added
 -flip electron fuses to avoid security debates #5423
 
+### Fixed
+- don't show "Reply" and "Save" for info messages (e.g. "user A removed user B") and video call invitations #5337
+
 <a id="2_11_0"></a>
 
 ## [2.11.0] - 2025-08-18

--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -151,6 +151,47 @@ test('send message', async ({ page }) => {
   await expect(receivedMessageText).toHaveText(messageText)
 })
 
+test('message menu items presence', async ({ page }) => {
+  const userA = existingProfiles[0]
+  const userB = existingProfiles[1]
+  await switchToProfile(page, userA.id)
+  await page
+    .locator('.chat-list .chat-list-item')
+    .filter({ hasText: userB.name })
+    .click()
+
+  const someRegularOutgoingMessage = page
+    .getByLabel('Messages')
+    .getByText('Hello')
+    .first()
+  await someRegularOutgoingMessage.click({ button: 'right' })
+  await expect(page.getByRole('menu').getByRole('menuitem')).toHaveText([
+    'Reply',
+    'Forward',
+    'React',
+    'Edit',
+    'Save',
+    'Copy Text',
+    'Resend',
+    'Info',
+    'Delete Message',
+  ])
+  await page.keyboard.press('Escape')
+
+  const someInfoMessage = page
+    .getByLabel('Messages')
+    .getByText('Messages are end-to-end encrypted')
+    .first()
+  await someInfoMessage.click({ button: 'right' })
+  await expect(page.getByRole('menu').getByRole('menuitem')).toHaveText([
+    'Forward',
+    'Copy Text',
+    'Info',
+    'Delete Message',
+  ])
+  await page.keyboard.press('Escape')
+})
+
 /**
  * user A deletes one message for himself
  */

--- a/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ChatAuditLogDialog.tsx
@@ -39,6 +39,8 @@ function buildContextMenu(
   closeDialogCallback: DialogProps['onClose']
 ) {
   const tx = window.static_translate // don't use the i18n context here for now as this component is inefficient (rendered one menu for every message)
+  const isInfoOrCallInvitation =
+    message.isInfo || message.viewType === 'VideochatInvitation'
   return [
     // Show in Chat
     {
@@ -78,7 +80,9 @@ function buildContextMenu(
       },
     },
     // Reply
-    {
+    // TODO also check `chat.canSend`, as with `showReply` in `Message.tsx`,
+    // and double-check other items.
+    !isInfoOrCallInvitation && {
       label: tx('reply_noun'),
       action: () => {
         setQuoteInDraft(message.id)
@@ -87,6 +91,7 @@ function buildContextMenu(
     },
     // Reply privately -> only show in groups, don't show on info messages or outgoing messages
     isGroup &&
+      !isInfoOrCallInvitation &&
       message.fromId > C.DC_CONTACT_ID_LAST_SPECIAL && {
         label: tx('reply_privately'),
         action: () => {


### PR DESCRIPTION
Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/5337.

It is still possible to reply to info messages
with the Ctrl + ArrowUp shortcut.
