### PR TITLE
improvement: add more margin for daymarker msgs

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -475,6 +475,12 @@ $info-text-max-width: 400px;
   }
 
   &.daymarker {
+    // Be careful with overriding margins on messages, see
+    // commit c56a78595df073bada81e1f769407990e37d8d57
+    // (https://github.com/deltachat/deltachat-desktop/pull/5244).
+    // `margin-top` should be fine, unlike margin-bottom.
+    margin-top: 1.5rem;
+
     .bubble {
       font-weight: bold;
     }


### PR DESCRIPTION
Such that days are more visually separated.

Closes https://github.com/deltachat/deltachat-desktop/issues/5338.

Related: https://github.com/deltachat/deltachat-desktop/pull/5244.

#skip-changelog because this is minor.

Before / After:

<img width="277" height="110" alt="image" src="https://github.com/user-attachments/assets/e7edc322-c358-4aa9-9064-99d397b39d79" /> <img width="326" height="116" alt="image" src="https://github.com/user-attachments/assets/33c2b657-96fd-463e-9b79-fecd36ee2994" />
