### PR TITLE
Hide add contact manually if on chatmail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Changed
+- removed "Add contact manually" when on chatmail account #5358
 
 ### Added
 

--- a/packages/frontend/src/components/helpers/PseudoListItem.tsx
+++ b/packages/frontend/src/components/helpers/PseudoListItem.tsx
@@ -117,13 +117,13 @@ export const PseudoListItemAddContact = ({
   const settingsStore = useSettingsStore()[0]
   const isChatmail = settingsStore?.settings.is_chatmail === '1'
 
+  if (isChatmail) return null
+
   return (
     <PseudoListItem
       id='newcontact'
       cutoff='+'
-      text={
-        isChatmail ? tx('menu_new_classic_contact') : tx('menu_new_contact')
-      }
+      text={tx('menu_new_contact')}
       subText={
         queryStrIsEmail ? queryStr + ' ...' : tx('contacts_type_email_above')
       }


### PR DESCRIPTION
This is the first step to resolve _"remove "Add Contact Manually"_ in #5294

"Add contact manually" should never be shown when on a Chatmail account since it is not possible to add a contact just by email.

It does only partial resolve #5336 though, since on non chatmail accounts it is still possible to add contacts manually to Groups. That willl be addressed in another PR