### PR TITLE
fix: hide "Disappearing Messages" and "Edit" for unencrypted chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Fixed
-- don't show "Edit Message" in classic E-Mail chats #5365
+- don't show "Edit Message" and "Disappearing Messages" in classic E-Mail chats #5365
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Fixed
+- don't show "Edit Message" in classic E-Mail chats #5365
 
 ### Changed
 

--- a/packages/frontend/src/components/ThreeDotMenu.tsx
+++ b/packages/frontend/src/components/ThreeDotMenu.tsx
@@ -79,9 +79,11 @@ export function useThreeDotMenu(selectedChat?: T.FullChat) {
           )
         },
       },
+      // See https://github.com/deltachat/deltachat-android/blob/fd4a377752cc6778f161590fde2f9ab29c5d3011/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java#L445-L447.
       canSend &&
         selectedChat.chatType !== C.DC_CHAT_TYPE_IN_BROADCAST &&
-        selectedChat.chatType !== C.DC_CHAT_TYPE_MAILINGLIST && {
+        selectedChat.chatType !== C.DC_CHAT_TYPE_MAILINGLIST &&
+        selectedChat.isEncrypted && {
           label: tx('ephemeral_messages'),
           action: onDisappearingMessages,
         },

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -280,9 +280,13 @@ function buildContextMenu(
   // Do not show "reply" in read-only chats
   const showReply = chat.canSend
 
-  // See https://github.com/deltachat/deltachat-desktop/issues/4695.
+  // See
+  // - https://github.com/deltachat/deltachat-desktop/issues/4695.
+  // - https://github.com/deltachat/deltachat-desktop/issues/5365.
+  // - https://github.com/deltachat/deltachat-android/blob/fd4a377752cc6778f161590fde2f9ab29c5d3011/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java#L334
   const showEdit =
     message.fromId === C.DC_CONTACT_ID_SELF &&
+    chat.isEncrypted &&
     message.text !== '' &&
     chat.canSend &&
     !message.isInfo &&


### PR DESCRIPTION
- **fix: hide "Edit Message" for unencrypted chats**
- **fix: hide "Disappearing Messages" for unencrypted**

Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/5365.

What's left is avatars.
