### PR TITLE
fix: hide fullscreen avatar view for unencrypted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased][unreleased]
 
 ### Fixed
-- don't show "Edit Message" and "Disappearing Messages" in classic E-Mail chats #5365
+- don't show "Edit Message", "Disappearing Messages" and fullscreen avatar view in classic E-Mail chats #5365
 
 ### Changed
 

--- a/packages/frontend/src/components/Avatar/index.tsx
+++ b/packages/frontend/src/components/Avatar/index.tsx
@@ -138,8 +138,7 @@ export function ClickForFullscreenAvatarWrapper(
 ) {
   const { openDialog } = useDialog()
 
-  const { children, filename, disableFullscreen, ...buttonProps } =
-    props
+  const { children, filename, disableFullscreen, ...buttonProps } = props
 
   return filename && !disableFullscreen ? (
     <button
@@ -175,14 +174,12 @@ export function shouldDisableClickForFullscreen<
   } else {
     const _assert: ChatSubset = chatOrContact
   }
-  const [contact, chat] = isContact
-    ? [chatOrContact, undefined]
-    : [undefined, chatOrContact]
 
   // It's just an "envelope" icon, there is no need to view it in full screen.
   // See https://github.com/deltachat/deltachat-desktop/issues/5365.
-  const isAvatarADummyImage =
-    chat != undefined ? !chat.isEncrypted : !contact.isKeyContact
+  const isAvatarADummyImage = isContact
+    ? !chatOrContact.isKeyContact
+    : !chatOrContact.isEncrypted
 
   return isAvatarADummyImage
 }

--- a/packages/frontend/src/components/Avatar/index.tsx
+++ b/packages/frontend/src/components/Avatar/index.tsx
@@ -133,15 +133,15 @@ export function AvatarFromContact(
 export function ClickForFullscreenAvatarWrapper(
   props: React.ButtonHTMLAttributes<HTMLButtonElement> & {
     filename?: string
-    disableClickForFullscreen: boolean
+    disableFullscreen: boolean
   }
 ) {
   const { openDialog } = useDialog()
 
-  const { children, filename, disableClickForFullscreen, ...buttonProps } =
+  const { children, filename, disableFullscreen, ...buttonProps } =
     props
 
-  return filename && !disableClickForFullscreen ? (
+  return filename && !disableFullscreen ? (
     <button
       className={styles.avatarButton}
       onClick={() => {

--- a/packages/frontend/src/components/ImageSelector/index.tsx
+++ b/packages/frontend/src/components/ImageSelector/index.tsx
@@ -63,6 +63,7 @@ export default function ImageSelector({
           color={color}
           imagePath={filePath || undefined}
           initials={initials}
+          disableClickForFullscreen={false}
         />
         {!filePath && (
           <button

--- a/packages/frontend/src/components/ImageSelector/index.tsx
+++ b/packages/frontend/src/components/ImageSelector/index.tsx
@@ -63,7 +63,7 @@ export default function ImageSelector({
           color={color}
           imagePath={filePath || undefined}
           initials={initials}
-          disableClickForFullscreen={false}
+          disableFullscreen={false}
         />
         {!filePath && (
           <button

--- a/packages/frontend/src/components/LargeProfileImage/index.tsx
+++ b/packages/frontend/src/components/LargeProfileImage/index.tsx
@@ -11,7 +11,10 @@ type Props = {
   color?: string
   imagePath?: string
   initials: string
-}
+} & Pick<
+  Parameters<typeof ClickForFullscreenAvatarWrapper>[0],
+  'disableClickForFullscreen'
+>
 
 interface CssWithAvatarColor extends CSSProperties {
   '--local-avatar-color': string
@@ -21,13 +24,17 @@ export default function LargeProfileImage({
   color,
   imagePath,
   initials,
+  disableClickForFullscreen,
 }: Props) {
   const tx = useTranslationFunction()
 
   return (
     <div className={styles.largeProfileImage}>
       {imagePath ? (
-        <ClickForFullscreenAvatarWrapper filename={imagePath}>
+        <ClickForFullscreenAvatarWrapper
+          filename={imagePath}
+          disableClickForFullscreen={disableClickForFullscreen}
+        >
           <img
             className={styles.largeProfileImageArea}
             src={runtime.transformBlobURL(imagePath)}

--- a/packages/frontend/src/components/LargeProfileImage/index.tsx
+++ b/packages/frontend/src/components/LargeProfileImage/index.tsx
@@ -13,7 +13,7 @@ type Props = {
   initials: string
 } & Pick<
   Parameters<typeof ClickForFullscreenAvatarWrapper>[0],
-  'disableClickForFullscreen'
+  'disableFullscreen'
 >
 
 interface CssWithAvatarColor extends CSSProperties {
@@ -24,7 +24,7 @@ export default function LargeProfileImage({
   color,
   imagePath,
   initials,
-  disableClickForFullscreen,
+  disableFullscreen,
 }: Props) {
   const tx = useTranslationFunction()
 
@@ -33,7 +33,7 @@ export default function LargeProfileImage({
       {imagePath ? (
         <ClickForFullscreenAvatarWrapper
           filename={imagePath}
-          disableClickForFullscreen={disableClickForFullscreen}
+          disableFullscreen={disableFullscreen}
         >
           <img
             className={styles.largeProfileImageArea}

--- a/packages/frontend/src/components/ProfileInfoHeader/index.tsx
+++ b/packages/frontend/src/components/ProfileInfoHeader/index.tsx
@@ -12,7 +12,7 @@ type Props = {
   wasSeenRecently?: boolean
 } & Pick<
   Parameters<typeof ClickForFullscreenAvatarWrapper>[0],
-  'disableClickForFullscreen'
+  'disableFullscreen'
 >
 
 export default function ProfileInfoHeader({
@@ -20,13 +20,13 @@ export default function ProfileInfoHeader({
   color,
   displayName,
   wasSeenRecently = false,
-  disableClickForFullscreen,
+  disableFullscreen,
 }: Props) {
   return (
     <div className={styles.profileInfoHeader}>
       <ClickForFullscreenAvatarWrapper
         filename={avatarPath}
-        disableClickForFullscreen={disableClickForFullscreen}
+        disableFullscreen={disableFullscreen}
       >
         <Avatar
           displayName={displayName}

--- a/packages/frontend/src/components/ProfileInfoHeader/index.tsx
+++ b/packages/frontend/src/components/ProfileInfoHeader/index.tsx
@@ -10,17 +10,24 @@ type Props = {
   color?: string
   displayName: string
   wasSeenRecently?: boolean
-}
+} & Pick<
+  Parameters<typeof ClickForFullscreenAvatarWrapper>[0],
+  'disableClickForFullscreen'
+>
 
 export default function ProfileInfoHeader({
   avatarPath,
   color,
   displayName,
   wasSeenRecently = false,
+  disableClickForFullscreen,
 }: Props) {
   return (
     <div className={styles.profileInfoHeader}>
-      <ClickForFullscreenAvatarWrapper filename={avatarPath}>
+      <ClickForFullscreenAvatarWrapper
+        filename={avatarPath}
+        disableClickForFullscreen={disableClickForFullscreen}
+      >
         <Avatar
           displayName={displayName}
           avatarPath={avatarPath}

--- a/packages/frontend/src/components/Settings/Profile.tsx
+++ b/packages/frontend/src/components/Settings/Profile.tsx
@@ -33,7 +33,7 @@ export default function Profile({ settingsStore }: Props) {
         initials={initials}
         color={settingsStore.selfContact.color}
         imagePath={profileImagePath}
-        disableClickForFullscreen={false}
+        disableFullscreen={false}
       />
       <div className={styles.profileDetails}>
         <div className={styles.profileDisplayName}>{profileName}</div>

--- a/packages/frontend/src/components/Settings/Profile.tsx
+++ b/packages/frontend/src/components/Settings/Profile.tsx
@@ -33,6 +33,7 @@ export default function Profile({ settingsStore }: Props) {
         initials={initials}
         color={settingsStore.selfContact.color}
         imagePath={profileImagePath}
+        disableClickForFullscreen={false}
       />
       <div className={styles.profileDetails}>
         <div className={styles.profileDisplayName}>{profileName}</div>

--- a/packages/frontend/src/components/dialogs/MailingListProfile.tsx
+++ b/packages/frontend/src/components/dialogs/MailingListProfile.tsx
@@ -46,7 +46,7 @@ export default function MailingListProfile(
             avatarPath={chat.profileImage ? chat.profileImage : undefined}
             color={chat.color}
             displayName={chat.name}
-            disableClickForFullscreen={shouldDisableClickForFullscreen(chat)}
+            disableFullscreen={shouldDisableClickForFullscreen(chat)}
           />
         </DialogContent>
       </DialogBody>

--- a/packages/frontend/src/components/dialogs/MailingListProfile.tsx
+++ b/packages/frontend/src/components/dialogs/MailingListProfile.tsx
@@ -11,6 +11,7 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { C, type T } from '@deltachat/jsonrpc-client'
 import { DialogProps } from '../../contexts/DialogContext'
 import ProfileInfoHeader from '../ProfileInfoHeader'
+import { shouldDisableClickForFullscreen } from '../Avatar'
 
 /**
  * This dialog is used to display the profile of a mailing list
@@ -45,6 +46,7 @@ export default function MailingListProfile(
             avatarPath={chat.profileImage ? chat.profileImage : undefined}
             color={chat.color}
             displayName={chat.name}
+            disableClickForFullscreen={shouldDisableClickForFullscreen(chat)}
           />
         </DialogContent>
       </DialogBody>

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -11,7 +11,7 @@ import {
   PseudoListItemAddMember,
 } from '../helpers/PseudoListItem'
 import ViewProfile from './ViewProfile'
-import { avatarInitial } from '../Avatar'
+import { avatarInitial, shouldDisableClickForFullscreen } from '../Avatar'
 import { DeltaInput } from '../Login-Styles'
 import { BackendRemote, onDCEvent } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
@@ -395,6 +395,9 @@ function ViewGroupInner(
                 avatarPath={groupImage ? groupImage : undefined}
                 color={chat.color}
                 displayName={groupName}
+                disableClickForFullscreen={shouldDisableClickForFullscreen(
+                  chat
+                )}
               />
             </DialogContent>
             {isRelatedChatsEnabled && chatListIds.length > 0 && (

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -11,7 +11,10 @@ import {
   PseudoListItemAddMember,
 } from '../helpers/PseudoListItem'
 import ViewProfile from './ViewProfile'
-import { avatarInitial, shouldDisableClickForFullscreen } from '../Avatar'
+import {
+  avatarInitial,
+  shouldDisableClickForFullscreen as shouldDisableFullscreenAvatar,
+} from '../Avatar'
 import { DeltaInput } from '../Login-Styles'
 import { BackendRemote, onDCEvent } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
@@ -395,9 +398,7 @@ function ViewGroupInner(
                 avatarPath={groupImage ? groupImage : undefined}
                 color={chat.color}
                 displayName={groupName}
-                disableClickForFullscreen={shouldDisableClickForFullscreen(
-                  chat
-                )}
+                disableFullscreen={shouldDisableFullscreenAvatar(chat)}
               />
             </DialogContent>
             {isRelatedChatsEnabled && chatListIds.length > 0 && (

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -30,6 +30,7 @@ import type { DialogProps } from '../../../contexts/DialogContext'
 import type { T } from '@deltachat/jsonrpc-client'
 import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
 import { ChatListItemRowChat } from '../../chat/ChatListItemRow'
+import { shouldDisableClickForFullscreen } from '../../Avatar'
 
 const log = getLogger('renderer/dialogs/ViewProfile')
 
@@ -260,6 +261,7 @@ export function ViewProfileInner({
           color={contact.color}
           displayName={displayName}
           wasSeenRecently={contact.wasSeenRecently}
+          disableClickForFullscreen={shouldDisableClickForFullscreen(contact)}
         />
         {statusText !== '' && (
           <>

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -261,7 +261,7 @@ export function ViewProfileInner({
           color={contact.color}
           displayName={displayName}
           wasSeenRecently={contact.wasSeenRecently}
-          disableClickForFullscreen={shouldDisableClickForFullscreen(contact)}
+          disableFullscreen={shouldDisableClickForFullscreen(contact)}
         />
         {statusText !== '' && (
           <>


### PR DESCRIPTION
A side effect is that one can't enlarge the "Device Messages"
chat avatar. Which is probably good.

Closes https://github.com/deltachat/deltachat-desktop/issues/5365,
together with
https://github.com/deltachat/deltachat-desktop/pull/5371.
