### PR TITLE
fix: hide "fullscreen avatar" for Saved Messages

### DIFF
--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -261,7 +261,11 @@ export function ViewProfileInner({
           color={contact.color}
           displayName={displayName}
           wasSeenRecently={contact.wasSeenRecently}
-          disableFullscreen={shouldDisableClickForFullscreen(contact)}
+          disableFullscreen={
+            isSelfChat ||
+            isDeviceChat ||
+            shouldDisableClickForFullscreen(contact)
+          }
         />
         {statusText !== '' && (
           <>


### PR DESCRIPTION
See https://github.com/deltachat/deltachat-android/issues/3855.

TODO:
- [x] Merge https://github.com/deltachat/deltachat-desktop/pull/5373.

Note that for Device Messages it's already hidden,
thanks to https://github.com/deltachat/deltachat-desktop/pull/5373.

#skip-changelog because this is insignificant.
