### PR TITLE
Reload main window on language change

### DIFF
--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -420,6 +420,7 @@ class ElectronRuntime implements Runtime {
     )
     ipcBackend.on('chooseLanguage', (_ev, locale) => {
       this.onChooseLanguage?.(locale)
+      ipcBackend.send('reload-main-window')
     })
     ipcBackend.on('theme-update', () => this.onThemeUpdate?.())
     ipcBackend.on('showAboutDialog', () => this.onShowDialog?.('about'))


### PR DESCRIPTION
resolves #5403 

#skip-changelog

We have to reload the main window (not restart the app!) to make sure all caches are reset. Otherwise we would always have to care explicit that caches are reset on language change.

Since we "remember" last open chat and draft etc. there is no impact for the user except a short reload of the window.

FYI Signal has to restart the whole app on each language change

<img width="432" height="208" alt="image" src="https://github.com/user-attachments/assets/f702f7b1-d89b-4b46-8fe6-828a58ffd970" />

@r10s  TBD: do we need to show a confirm dialog before reloading?