### PR TITLE
New chat button color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - do not open self chat on info message click #5361
 - fix Connectivity colors in dark mode #5397
 - Not fully downloaded messages display an ✉️ icon #5399
+- fix new chat button bg in dark modes #5183
 
 <a id="2_10_0"></a>
 

--- a/packages/frontend/scss/chat/_chat-list-item.scss
+++ b/packages/frontend/scss/chat/_chat-list-item.scss
@@ -349,7 +349,7 @@
   padding: calc((var(--size) - var(--iconSize)) / 2);
 
   border: none;
-  background-color: var(--floatingActionButtonBg);
+  background-color: var(--newChatButtonBg);
   border-radius: 100%;
 
   .Icon {

--- a/packages/frontend/src/components/ShortcutMenu/styles.module.scss
+++ b/packages/frontend/src/components/ShortcutMenu/styles.module.scss
@@ -58,7 +58,7 @@ $transitionDuration: 50ms;
 }
 
 .originalMessageButton {
-  background-color: var(--iconBackground);
+  background-color: var(--showInChatButtonBg);
   border-radius: 100%;
   height: 40px;
   width: 40px;

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -73,8 +73,8 @@ $scrollbarTransparency: 0.34 !default;
   --buttonDangerHover: #{changeContrast($btnDangerBackground, 10%)};
   --buttonDisabledBackground: #{changeContrast($bgSecondary, 10%)};
   --buttonDisabledText: #{changeContrast($textSecondary, 25%)};
-  /* Icons */
-  --iconBackground: #757575; /* color from emoji.png */
+  /* Icons in context menu */
+  --iconBackground: #{$colorNone};
   /* NavBar */
   --navBarBackground: #{$bgNavBar};
   --navBarHeight: 50px;
@@ -158,6 +158,7 @@ $scrollbarTransparency: 0.34 !default;
   --messageAttachmentIconBg: transparent;
   /* Manual value: This will not get generated in the future */
   --messageAttachmentFileInfo: #{$textPrimary};
+  --showInChatButtonBg: #{$colorNone};
   /* Login Screen */
   --loginInputFocusColor: #{$colorPrimary};
   --loginButtonText: #{$colorPrimary};

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -32,7 +32,7 @@ $keybindingKeyBackground: lightgray !default;
 $keybindingKeyBorder: gray !default;
 $keybindingKeyShadow: rgba(0, 0, 0, 0.35) !default;
 
-$floatingActionButtonBg: #42a5f5 !default;
+$newChatButtonBg: #42a5f5 !default;
 $chatListItemSelectedBg: #e3f2fd !default;
 $scrollbarTransparency: 0.34 !default;
 
@@ -127,7 +127,7 @@ $scrollbarTransparency: 0.34 !default;
   --keybindingKeyShadow: #{$keybindingKeyShadow};
   --keybindingActionBackground: #{$keybindingActionBackground};
   /* Floating Action Button */
-  --floatingActionButtonBg: #{$floatingActionButtonBg};
+  --newChatButtonBg: #{$newChatButtonBg};
   /* Message Bubble */
   --messageText: #{$textPrimary};
   --messageTextLink: #{$textPrimary};

--- a/packages/frontend/themes/dark.scss
+++ b/packages/frontend/themes/dark.scss
@@ -14,7 +14,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #42a5f5,
-  $newChatButtonBg: #333,
+  $newChatButtonBg: #a0a0a0,
   $keybindingHintsBoxBackground: #333,
   $keybindingActionBackground: #454545,
   $keybindingKeyBackground: lightgray,

--- a/packages/frontend/themes/dark.scss
+++ b/packages/frontend/themes/dark.scss
@@ -14,7 +14,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #42a5f5,
-  $floatingActionButtonBg: #333,
+  $newChatButtonBg: #333,
   $keybindingHintsBoxBackground: #333,
   $keybindingActionBackground: #454545,
   $keybindingKeyBackground: lightgray,

--- a/packages/frontend/themes/dark_amoled.scss
+++ b/packages/frontend/themes/dark_amoled.scss
@@ -13,7 +13,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #42a5f5,
-  $newChatButtonBg: #222,
+  $newChatButtonBg: #a0a0a0,
   $keybindingHintsBoxBackground: #222,
   $keybindingActionBackground: #353535,
   $keybindingKeyBackground: lightgray,

--- a/packages/frontend/themes/dark_amoled.scss
+++ b/packages/frontend/themes/dark_amoled.scss
@@ -13,7 +13,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #42a5f5,
-  $floatingActionButtonBg: #222,
+  $newChatButtonBg: #222,
   $keybindingHintsBoxBackground: #222,
   $keybindingActionBackground: #353535,
   $keybindingKeyBackground: lightgray,

--- a/packages/frontend/themes/darkpurple.scss
+++ b/packages/frontend/themes/darkpurple.scss
@@ -13,7 +13,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #42a5f5,
-  $floatingActionButtonBg: #4e1479,
+  $newChatButtonBg: #4e1479,
   $keybindingHintsBoxBackground: rgba(0, 0, 0, 0.2),
   $keybindingActionBackground: #333444,
   $keybindingKeyBackground: lightgray,

--- a/packages/frontend/themes/dev_minimal.scss
+++ b/packages/frontend/themes/dev_minimal.scss
@@ -14,7 +14,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #000000,
-  $floatingActionButtonBg: gray,
+  $newChatButtonBg: gray,
   $keybindingHintsBoxBackground: rgba(0, 0, 0, 0.05),
   $keybindingActionBackground: rgba(0, 0, 0, 0.05),
   $keybindingKeyBackground: lightgray,

--- a/packages/frontend/themes/dev_rocket.scss
+++ b/packages/frontend/themes/dev_rocket.scss
@@ -14,7 +14,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #000000,
-  $floatingActionButtonBg: gray,
+  $newChatButtonBg: gray,
   $keybindingHintsBoxBackground: rgba(0, 0, 0, 0.05),
   $keybindingActionBackground: rgba(0, 0, 0, 0.05),
   $keybindingKeyBackground: lightgray,

--- a/packages/frontend/themes/light.scss
+++ b/packages/frontend/themes/light.scss
@@ -14,7 +14,7 @@
   $colorDanger: #f96856,
   $colorNone: #a0a0a0,
   $colorPrimary: #42a5f5,
-  $floatingActionButtonBg: #415e6b,
+  $newChatButtonBg: #415e6b,
   $keybindingHintsBoxBackground: rgba(0, 0, 0, 0.05),
   $keybindingActionBackground: rgba(0, 0, 0, 0.05),
   $keybindingKeyBackground: lightgray,


### PR DESCRIPTION
This PR renames floatingActionButtonBg to newChatButtonBg since the color is only used for that button

 It also introduces a new css variable "showInChatButtonBg"  since the color was assigned from variable iconBackground which doesn't make sense.


resolves #5183

<img width="479" height="217" alt="image" src="https://github.com/user-attachments/assets/9510504d-6fea-49f8-901f-a643c3824c67" />

