### PR TITLE
Dont close menues on resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- don't close context menues on window resize #5418
+
+
 <a id="2_11_1"></a>
 
 ## [2.11.1] - 2025-09-01

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -374,13 +374,9 @@ export function ContextMenu(props: {
       }
     }
 
-    const onResize = () => closeCallback()
-
     document.addEventListener('keydown', onKeyDown)
-    window.addEventListener('resize', onResize)
     return () => {
       document.removeEventListener('keydown', onKeyDown)
-      window.removeEventListener('resize', onResize)
     }
   }, [openSublevels, closeCallback, expandMenu])
 


### PR DESCRIPTION
resolves #5418 

While this PR solves the related issue it will introduce other maybe unexpected behaviours, when context menues are open and the window is resized. But since resizing is mostly triggered by the user (except in the use case the issue describes) there is no high urgency to fix or adapt the positioning.