### PR TITLE
test: fix E2E tests

### DIFF
--- a/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
@@ -33,7 +33,6 @@ const expectSelectedChats = async (chatNums: number[]) => {
 test.beforeAll(async ({ browser }) => {
   const contextForProfileCreation = await browser.newContext()
   const pageForProfileCreation = await contextForProfileCreation.newPage()
-  const pageForTestsP = browser.newPage()
 
   await reloadPage(pageForProfileCreation)
 
@@ -44,12 +43,11 @@ test.beforeAll(async ({ browser }) => {
     numberOfProfiles,
     existingProfiles,
     pageForProfileCreation,
-    contextForProfileCreation,
     browser.browserType().name()
   )
 
   await contextForProfileCreation.close()
-  page = await pageForTestsP
+  page = await browser.newPage()
   await reloadPage(page)
 
   chatList = page.getByRole('tablist', { name: 'Chats' })
@@ -60,7 +58,7 @@ test.beforeAll(async ({ browser }) => {
 })
 
 test.afterAll(async ({ browser }) => {
-  await page.close()
+  await page?.close()
 
   const context = await browser.newContext()
   const pageForProfileDeletion = await context.newPage()


### PR DESCRIPTION
The `unencrypted-group-tests.spec.ts` was not properly rebased
in one of the recent MRs.

Sorry about that!