### PR TITLE
fix: a11y: delivery status being announced twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - fix "Recent 3 apps" in the chat header showing apps from another chat sometimes #5265
 - accessibility: improve screen-reader accessibility of the general structure of the app by using landmarks #5067
 - accessibility: don't re-announce message input (composer) after sending every message #5049
+- accessibility: don't announce delivery status twice after sending a message #5442
 - accessibility: correct `aria-posinset` for chat list #5044
 - don't close context menues on window resize #5418
 

--- a/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
+++ b/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
@@ -177,7 +177,7 @@ test('send message to unencrypted group', async () => {
   //
   // When this is no longer the case, we might want to reuse the code
   // from regular group tests.
-  await expect(
-    message.getByRole('button', { name: 'Delivery status: Error' })
-  ).toBeVisible()
+  await expect(message.getByText('Delivery status')).toHaveText(
+    'Delivery status: Error'
+  )
 })

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -312,7 +312,7 @@ $info-text-max-width: 400px;
       background-color: var(--messageOutgoingStatusColor);
     }
   }
-  .metadata.with-image-no-caption > .status-icon {
+  .metadata.with-image-no-caption .status-icon {
     background-color: white;
   }
 

--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -37,12 +37,23 @@
     }
   }
 
-  .aria-live-wrapper {
+  .aria-live-wrapper,
+  .delivery-status-wrapper {
     // Basically try to behave the same as if the wrapper just wasn't there.
     display: inline-block;
     line-height: 0;
   }
 
+  .delivery-status-wrapper {
+    position: relative;
+    button.error-button {
+      // Fill the parent.
+      position: absolute;
+      inset: 0;
+      border: none;
+      background: transparent;
+    }
+  }
   .status-icon {
     margin-bottom: 2px;
   }

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -89,41 +89,48 @@ export default function MessageMetaData(props: Props) {
       />
       <span className='spacer' />
       {direction === 'outgoing' && (
-        <button
-          className={classNames('status-icon', status)}
-          // The main point of `aria-live` here is to let the user know
-          // that their message has been sent or delievered
-          // right after they they send it.
-          // We want at least some indication of something happening
-          // after they press "Enter".
-          // But this is also useful to announce when the message has been read.
-          //
-          // Note that this this applies to _all_ loaded messages
-          // and not just the last one.
-          //
-          // TODO fix: NVDA announces the change twice for some reason,
-          // even when you modify just `aria-label` through the dev tools.
-          // We probably ought to keep `aria-label` fixed to "Delivery status",
-          // and only update the content, i.e. "Delivered", "Read".
-          aria-live='polite'
-          aria-label={tx(
-            `a11y_delivery_status_${
-              status as Exclude<
-                typeof status,
-                // '' is not supposed to happen.
-                // The others are not supposed to happen
-                // as long as direction is outgoing.
-                | ''
-                | (typeof direction extends 'outgoing'
-                    ? 'in_fresh' | 'in_seen' | 'in_noticed'
-                    : never)
-              >
-            }`
+        <div className='delivery-status-wrapper'>
+          {/* The main point of `role='status'` here is to let the user know
+          that their message has been sent or delievered
+          right after they they send it.
+          We want at least some indication of something happening
+          after they press "Enter".
+          But this is also useful to announce when the message has been read.
+
+          Note that this this applies to _all_ loaded messages
+          and not just the last one. */}
+          {/* TODO a11y: we should probably apply `aria-label='Delivery status'`
+          and change the contents to `Delivered` (or `Error` or whatever). */}
+          <div role='status' className={classNames('status-icon', status)}>
+            <span className='visually-hidden'>
+              {tx(
+                `a11y_delivery_status_${
+                  status as Exclude<
+                    typeof status,
+                    // '' is not supposed to happen.
+                    // The others are not supposed to happen
+                    // as long as direction is outgoing.
+                    | ''
+                    | (typeof direction extends 'outgoing'
+                        ? 'in_fresh' | 'in_seen' | 'in_noticed'
+                        : never)
+                  >
+                }`
+              )}
+            </span>
+          </div>
+          {status === 'error' && (
+            <button
+              className='error-button'
+              tabIndex={tabindexForInteractiveContents}
+              onClick={onClickError}
+            >
+              <span className='visually-hidden'>
+                {tx('menu_message_details')}
+              </span>
+            </button>
           )}
-          disabled={status !== 'error'}
-          tabIndex={status === 'error' ? tabindexForInteractiveContents : -1}
-          onClick={status === 'error' ? onClickError : undefined}
-        />
+        </div>
       )}
     </div>
   )


### PR DESCRIPTION
The issue was that apparently NVDA first announces the label
(`aria-label`) of the changed element, and then announces
the change itself, which, in this case, is a change to
`aria-label`. This results in it simply announcing the label twice.

Let's mitigate this by removing `aria-label`.
And along the way, let's split the button
into a `role='status'` element and a "Message Info" button.

I have verified that the look of the app is the same, with WebXDC messages, info messages, and videos.

TODO:
- [x] Merge the base, up to the last commit.
  It's easier to test it after the rebase, therefore it's draft.