### PR TITLE
fix: allow offline usage of app picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `2.12.0`
 
 ### Fixed
+- if adding an app from the app picker fails, show an error dialog
 - fix "Recent 3 apps" in the chat header showing apps from another chat sometimes #5265
 - accessibility: improve screen-reader accessibility of the general structure of the app by using landmarks #5067
 - accessibility: don't re-announce message input (composer) after sending every message #5049

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `2.12.0`
 
 ### Fixed
+- fix app picker sometimes incorrectly showing "Offline"
+- allow using the app picker even when offline, as long as the app store data is cached
 - if adding an app from the app picker fails, show an error dialog
 - fix "Recent 3 apps" in the chat header showing apps from another chat sometimes #5265
 - accessibility: improve screen-reader accessibility of the general structure of the app by using landmarks #5067

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -122,9 +122,6 @@ export function AppPicker({ onAppSelected }: Props) {
         }
       }
       const newIcons: { [key: string]: string } = {}
-      for (const app of apps) {
-        newIcons[app.app_id] = `./images/icons/image_outline.svg`
-      }
       setIcons(newIcons)
       let count = 0
       for (const app of apps) {
@@ -250,7 +247,7 @@ export function AppPicker({ onAppSelected }: Props) {
     return (
       <div className={styles.appItem}>
         <img
-          src={icons[app.app_id] ?? ''}
+          src={icons[app.app_id] ?? './images/icons/image_outline.svg'}
           alt={`${app.name} icon`}
           className={styles.appIcon}
         />
@@ -305,7 +302,7 @@ export function AppPicker({ onAppSelected }: Props) {
           />
         )}
         <div className={styles.appPickerList}>
-          {!isOffline && Object.keys(icons).length > 0 ? (
+          {!isOffline && Object.keys(apps).length > 0 ? (
             <>
               {selectedAppInfo && (
                 <AppInfoOverlay


### PR DESCRIPTION
Don't show the list of apps only if we failed to fetch it,
and not whenever we're offline.

This also fixes an annoying bug where the app picker
would show "offline" if you opened it
during "updating" network status,
which notably also happens when you just focused the window
(due to a `rpc.maybeNetwork()` call).
And this has been causing E2E test failures recently.

`getHttpResponse` is able to cache data since not so long ago,
so let's utilize that.

Note that the fact that we have cached the list of apps
doesn't mean that all the apps themselved are cached,
so users might still encounter an error.

However, if the list of apps and the app file is cached,
this allows you, even when offline,
to send an app to the chat and open it.

This change also makes sense even if `getHttpResponse`
didn't do any caching. We do not rely on this.

https://github.com/user-attachments/assets/73bd9fcc-49a6-4a19-874f-a51fa6042134

TODO:
- [ ] Merge the base, https://github.com/deltachat/deltachat-desktop/pull/5444. We pretty much depend on that MR.