### PR TITLE
Add SKIP_FUSES env var

### DIFF
--- a/packages/target-electron/build/afterPackHook.mjs
+++ b/packages/target-electron/build/afterPackHook.mjs
@@ -104,7 +104,9 @@ export default async context => {
   // asar is electrons archive format, flatpak doesn't use it. read more about what asar is on https://www.electronjs.org/docs/latest/glossary#asar
   const asar = env['NO_ASAR'] ? false : true
   await copyMapXdc(resources_dir, source_dir, asar)
-  await setFuses(context)
+  if (!env['SKIP_FUSES']) {
+    await setFuses(context)
+  }
 }
 
 async function packageMSVCRedist(context) {


### PR DESCRIPTION
If SKIP_FUSES = true we skip the flip fuses script.

This helps building nixOS packages. See comments in #5423 

#skip-changelog