### PR TITLE
improvement: adjust notif settings appearance

### DIFF
--- a/packages/frontend/src/components/Settings/Notifications.tsx
+++ b/packages/frontend/src/components/Settings/Notifications.tsx
@@ -96,6 +96,7 @@ export default function Notifications({ desktopSettings }: Props) {
         label={tx('pref_mention_notifications')}
         description={tx('pref_mention_notifications_explain')}
         disabled={isMuted || !desktopSettings['notifications']}
+        disabledValue={false}
       />
     </>
   )


### PR DESCRIPTION
Add `disabledValue` to "Mentions" toggle, so that when
"Current Profile -> Mute Notifications" is on,
"Mentions" gets automatically toggled off.

It will retain its actual value in settings store,
this only affects appearance.

Before / after:

<img width="389" height="184" alt="image" src="https://github.com/user-attachments/assets/a7eabcac-cec1-4375-b4d0-c705db8cb0e0" /> <img width="392" height="162" alt="image" src="https://github.com/user-attachments/assets/7daef85d-a8dd-49c2-98c0-8bb58a879818" />


#skip-changelog because this is insignificant.