### PR TITLE
refactor: rename `isWindowsStorePackage`

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -4,7 +4,7 @@ import { mkdirSync, Stats, watchFile } from 'fs'
 import { app as rawApp, dialog, ipcMain, protocol } from 'electron'
 import rc from './rc.js'
 import contextMenu from './electron-context-menu.js'
-import { isWindowsStorePackage } from './isAppx.js'
+import { initIsWindowsStorePackageVar } from './isAppx.js'
 import { getHelpMenu } from './help_menu.js'
 import { initialisePowerMonitor } from './resume_from_sleep.js'
 
@@ -144,7 +144,7 @@ app.isQuitting = false
 Promise.all([
   new Promise((resolve, _reject) => app.on('ready', resolve)),
   DesktopSettings.load(),
-  isWindowsStorePackage(),
+  initIsWindowsStorePackageVar(),
   webxdcStartUpCleanup(),
 ])
   .then(onReady)

--- a/packages/target-electron/src/isAppx.ts
+++ b/packages/target-electron/src/isAppx.ts
@@ -6,7 +6,7 @@ import { existsSync } from 'fs'
 
 export let appx = false
 
-export async function isWindowsStorePackage() {
+export async function initIsWindowsStorePackageVar() {
   if (platform() === 'win32') {
     const app_path = app.getAppPath()
     try {


### PR DESCRIPTION
The name implies that it returns a value, but it doesn't.

This (almost) reverts the rename made in
5a7d82f734d661e8a8b37cdaba2a43a94a916379
(https://github.com/deltachat/deltachat-desktop/pull/4067).
