### PR TITLE
Remove e2ee_enabled key

### DIFF
--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -13,7 +13,6 @@ export interface SettingsStoreState {
     [P in (typeof settingsKeys)[number]]: {
       sentbox_watch: string
       mvbox_move: string
-      e2ee_enabled: string
       addr: string
       displayname: string
       selfstatus: string
@@ -37,7 +36,6 @@ export interface SettingsStoreState {
 const settingsKeys = [
   'sentbox_watch',
   'mvbox_move',
-  'e2ee_enabled',
   'addr',
   'displayname',
   'selfstatus',


### PR DESCRIPTION
e2ee_enabled is removed in core 2.13

The existing key in desktop settings cause a failure with core >= 2.13

#skip-changelog