### PR TITLE
Reuse MessageStore in useDraft hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased][unreleased]
 
+### Fixed
+- fix: remove the option to select info messages with Ctrl + Up/Down #5337
+
 <a id="2_22_0"></a>
 
 ## [2.22.0] - 2025-10-17

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -739,7 +739,6 @@ const Composer = forwardRef<
 
 export default Composer
 
-
 function useMessageEditing(
   accountId: number,
   chatId: T.BasicChat['id'],

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -15,7 +15,7 @@ import { debounce } from 'debounce'
 import { MessageWrapper } from './MessageWrapper'
 import { getLogger } from '../../../../shared/logger'
 import { KeybindAction } from '../../keybindings'
-import { useMessageList } from '../../stores/messagelist'
+import { useMessageList, type MessageListStore } from '../../stores/messagelist'
 import { BackendRemote, onDCEvent } from '../../backend-com'
 import { throttledUpdateBadgeCounter } from '../../system-integration/badge-counter'
 import { MessagesDisplayContext } from '../../contexts/MessagesDisplayContext'
@@ -127,28 +127,36 @@ type Props = {
   accountId: number
   chat: T.FullChat
   refComposer: any
+  messageListStore: MessageListStore
+  messageListState: ReturnType<MessageListStore['getState']>
+  fetchMoreBottom: () => void
+  fetchMoreTop: () => void
 }
 
-export default function MessageList({ accountId, chat, refComposer }: Props) {
+export default function MessageList({
+  accountId,
+  chat,
+  refComposer,
+  messageListStore,
+  messageListState,
+  fetchMoreBottom,
+  fetchMoreTop,
+}: Props) {
   const {
-    store: {
-      scheduler,
-      effect: { jumpToMessage, loadMissingMessages },
-      reducer: { unlockScroll, clearJumpStack },
-      activeView,
-    },
-    state: {
-      oldestFetchedMessageListItemIndex,
-      newestFetchedMessageListItemIndex,
-      messageCache,
-      messageListItems,
-      viewState,
-      jumpToMessageStack,
-      loaded,
-    },
-    fetchMoreBottom,
-    fetchMoreTop,
-  } = useMessageList(accountId, chat.id)
+    scheduler,
+    effect: { jumpToMessage, loadMissingMessages },
+    reducer: { unlockScroll, clearJumpStack },
+    activeView,
+  } = messageListStore
+  const {
+    oldestFetchedMessageListItemIndex,
+    newestFetchedMessageListItemIndex,
+    messageCache,
+    messageListItems,
+    viewState,
+    jumpToMessageStack,
+    loaded,
+  } = messageListState
   const { hideReactionsBar, isReactionsBarShown } = useReactionsBar()
 
   const messageListRef = useRef<HTMLDivElement | null>(null)

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -16,6 +16,7 @@ import { ReactionsBarProvider } from '../ReactionsBar'
 import useDialog from '../../hooks/dialog/useDialog'
 import useMessage from '../../hooks/chat/useMessage'
 import { Viewtype } from '@deltachat/jsonrpc-client/dist/generated/types'
+import { useMessageList } from '../../stores/messagelist'
 
 const log = getLogger('renderer/MessageListAndComposer')
 
@@ -101,6 +102,14 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   const regularMessageInputRef = useRef<ComposerMessageInput>(null)
   const editMessageInputRef = useRef<ComposerMessageInput>(null)
+
+  const {
+    store: messageListStore,
+    state: messageListState,
+    fetchMoreBottom,
+    fetchMoreTop,
+  } = useMessageList(accountId, chat.id)
+
   const {
     draftState,
     updateDraftText,
@@ -112,6 +121,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     clearDraftStateAndUpdateTextareaValue,
     setDraftStateAndUpdateTextareaValue,
   } = useDraft(
+    messageListState,
     accountId,
     chat.id,
     chat.isContactRequest,
@@ -295,6 +305,10 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
               accountId={accountId}
               chat={chat}
               refComposer={refComposer}
+              messageListStore={messageListStore}
+              messageListState={messageListState}
+              fetchMoreBottom={fetchMoreBottom}
+              fetchMoreTop={fetchMoreTop}
             />
           </ReactionsBarProvider>
         </RecoverableCrashScreen>

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -10,7 +10,7 @@ import {
   defaultChatViewState,
 } from './chat/chat_view_reducer'
 import { ChatStoreScheduler } from './chat/chat_scheduler'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useMemo, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { debounce } from 'debounce'
 import { getLogger } from '@deltachat-desktop/shared/logger'
@@ -180,7 +180,7 @@ function getView<T>(items: T[], start: number, end: number): T[] {
   return items.slice(start, end + 1)
 }
 
-class MessageListStore extends Store<MessageListState> {
+export class MessageListStore extends Store<MessageListState> {
   scheduler = new ChatStoreScheduler()
 
   emitter = BackendRemote.getContextEvents(this.accountId)


### PR DESCRIPTION
- Extract useDraft from composer
- Include message store
- MessageStore as Singleton

As discussed here https://github.com/deltachat/deltachat-desktop/issues/5337#issuecomment-3127461812 "make the message list available to the shortcut handling code"
To avoid loading messages when navigation up or down when selecting messages for replyTo reuse the MessageStore which already holds the visible messages in messageCache

Special case: if there is already a quoted message in a draft, and the quoted message is not in messageCache (i.e. not visible) - we jump to that message on first shortcut event and only the next up or down will navigate to the next message.
