### PR TITLE
fix: inconsistent `ChatNavButtons` `chatId`

### DIFF
--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -504,15 +504,15 @@ function ChatHeading({ chat }: { chat: T.FullChat }) {
 
 function ChatNavButtons({ chat }: { chat: T.FullChat }) {
   const tx = useTranslationFunction()
-  const { chatId } = useChat()
+  const chatId = chat.id
   const settingsStore = useSettingsStore()[0]
   const { openDialog } = useDialog()
 
   const openMediaViewDialog = useCallback(() => {
     openDialog(MediaView, {
-      chatId: chat.id,
+      chatId,
     })
-  }, [openDialog, chat])
+  }, [openDialog, chatId])
 
   return (
     <>


### PR DESCRIPTION
When switching chats, `chat.id` could be different from `chatId`,
i.e. when the new chat has not loaded yet (see `chatWithLinger`).

This makes sure that the buttons do the actions for the same chat
whose `<ChatHeading>` is displayed.

#skip-changelog because this is not that significant. And maybe hard to explain.

TODO:
- [x] Merge the base into main, so that only one commit remains.