### PR TITLE
refactor: `startOutgoingVideoCall`: return Promise

### DIFF
--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -197,8 +197,8 @@ class ElectronRuntime implements Runtime {
   notifyWebxdcInstanceDeleted(accountId: number, instanceId: number): void {
     ipcBackend.invoke('webxdc:instance-deleted', accountId, instanceId)
   }
-  startOutgoingVideoCall(accountId: number, chatId: number): void {
-    ipcBackend.invoke('startOutgoingVideoCall', accountId, chatId)
+  startOutgoingVideoCall(accountId: number, chatId: number): Promise<void> {
+    return ipcBackend.invoke('startOutgoingVideoCall', accountId, chatId)
   }
   openMapsWebxdc(accountId: number, chatId?: number | undefined): void {
     ipcBackend.invoke('open-maps-webxdc', accountId, chatId)

--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -27,7 +27,7 @@ export function startOutgoingVideoCall(accountId: number, chatId: number) {
 
   const jsonrpcRemote = getDCJsonrpcRemote()
 
-  ;(async () => {
+  const callHandledPromise = (async () => {
     const { offer, onAnswer } = await offerPromise
     if (offer == null) {
       log.info("calls-webapp didn't return an offer, aborting outgoing call")
@@ -61,7 +61,11 @@ export function startOutgoingVideoCall(accountId: number, chatId: number) {
     }
     log.info('Received answer from callee')
     onAnswer(answer)
+
+    return await done
   })()
+
+  return callHandledPromise
 }
 
 /**


### PR DESCRIPTION
This should make the front-end console print an error
if `startOutgoingVideoCall` throws an error.
This does not affect functionality.
