### PR TITLE
improvement: calls: use in-app "Answer?" prompt

### DIFF
--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -315,7 +315,13 @@ function openVideoCallWindow<T extends CallDirection>(
     })
   }
 
-  if (callerWebrtcOffer != undefined) {
+  /**
+   * Whether to utilize the "Accept call?" prompt
+   * that is provided inside the `calls-webapp` itself,
+   * or use a native dialog instead.
+   */
+  const useBuiltinAcceptCallPrompt = true
+  if (callerWebrtcOffer != undefined && !useBuiltinAcceptCallPrompt) {
     // const _assert: CallDirection.Incoming = callDirection
     ;(async () => {
       let chatInfo: null | T.BasicChat = null
@@ -379,8 +385,10 @@ function openVideoCallWindow<T extends CallDirection>(
   const hash =
     callDirection === CallDirection.Outgoing
       ? '#startCall'
-      : // Otherwise we'll set the hash later, when the call gets accepted.
-        ''
+      : useBuiltinAcceptCallPrompt
+        ? `#offerIncomingCall=${btoa(callerWebrtcOffer!)}`
+        : // Otherwise we'll set the hash later, when the call gets accepted.
+          ''
   win.webContents.loadURL(`${SCHEME_NAME}://${host}${hash}`, {
     extraHeaders: 'Content-Security-Policy: ' + CSP,
   })

--- a/packages/target-electron/static/calls-webapp-preload.js
+++ b/packages/target-electron/static/calls-webapp-preload.js
@@ -22,6 +22,10 @@ portP.then(port => {
         location.hash = `onAnswer=${btoa(e.data.answer)}`
         break
       }
+      /**
+       * Note that this is unused when
+       * {@linkcode useBuiltinAcceptCallPrompt} === true
+       */
       case 'offer': {
         location.hash = `acceptCall=${btoa(e.data.offer)}`
         break

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -346,7 +346,7 @@ importers:
         version: 2.15.0(@deltachat/jsonrpc-client@2.15.0(ws@7.5.10))
       calls-webapp#build-for-deltachat-desktop:
         specifier: 'catalog:'
-        version: https://codeload.github.com/deltachat/calls-webapp/tar.gz/02a5b0651b3c4451c32d12d25fdcc62284721b7e
+        version: https://codeload.github.com/deltachat/calls-webapp/tar.gz/fb751a65713840857ddde4633ad0a89e1bcc2988
       mime-types:
         specifier: 'catalog:'
         version: 2.1.35
@@ -1666,8 +1666,8 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  calls-webapp#build-for-deltachat-desktop@https://codeload.github.com/deltachat/calls-webapp/tar.gz/02a5b0651b3c4451c32d12d25fdcc62284721b7e:
-    resolution: {tarball: https://codeload.github.com/deltachat/calls-webapp/tar.gz/02a5b0651b3c4451c32d12d25fdcc62284721b7e}
+  calls-webapp#build-for-deltachat-desktop@https://codeload.github.com/deltachat/calls-webapp/tar.gz/fb751a65713840857ddde4633ad0a89e1bcc2988:
+    resolution: {tarball: https://codeload.github.com/deltachat/calls-webapp/tar.gz/fb751a65713840857ddde4633ad0a89e1bcc2988}
     version: 0.0.0
 
   callsites@3.1.0:
@@ -5040,7 +5040,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  calls-webapp#build-for-deltachat-desktop@https://codeload.github.com/deltachat/calls-webapp/tar.gz/02a5b0651b3c4451c32d12d25fdcc62284721b7e: {}
+  calls-webapp#build-for-deltachat-desktop@https://codeload.github.com/deltachat/calls-webapp/tar.gz/fb751a65713840857ddde4633ad0a89e1bcc2988: {}
 
   callsites@3.1.0: {}
 


### PR DESCRIPTION
- It looks nicer.
- Allows you to toggle video and mute mic before you accept the call.

<img width="476" height="446" alt="image" src="https://github.com/user-attachments/assets/d4a709c4-43fd-4959-b14b-95f6b41941ad" />

See https://github.com/deltachat/calls-webapp/pull/37.

Security-wise, not that it's critical, but note that now
we pass the offer to the app immediately, so hypothetically
the app could auto-accept the call without waiting
for user interaction, if it wanted to.

Let's not remove the old prompt code for now.

The updated calls-webapp has been built from ~~<https://github.com/deltachat/calls-webapp/commit/63fd46ee132029635e838b81e6f61d84019688d1>~~ https://github.com/deltachat/calls-webapp/commit/0fa0c9dd616183070ed9b58e4ada6b1c0382349e (latest main).

#skip-changelog because this is an experimental feature.