### PR TITLE
Improve display of call messages

### DIFF
--- a/images/icons/phone.svg
+++ b/images/icons/phone.svg
@@ -1,1 +1,39 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368"><path d="M798-120q-125 0-247-54.5T329-329Q229-429 174.5-551T120-798q0-18 12-30t30-12h162q14 0 25 9.5t13 22.5l26 140q2 16-1 27t-11 19l-97 98q20 37 47.5 71.5T387-386q31 31 65 57.5t72 48.5l94-94q9-9 23.5-13.5T670-390l138 28q14 4 23 14.5t9 23.5v162q0 18-12 30t-30 12ZM241-600l66-66-17-94h-89q5 41 14 81t26 79Zm358 358q39 17 79.5 27t81.5 13v-88l-94-19-67 67ZM241-600Zm358 358Z"/></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24px"
+   viewBox="0 -960 960 960"
+   width="24px"
+   fill="#5f6368"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="phone_filled.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="35.75"
+     inkscape:cx="11.986014"
+     inkscape:cy="12"
+     inkscape:window-width="1920"
+     inkscape:window-height="1048"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="m 798,-120 c -83.33333,0 -165.66667,-18.16667 -247,-54.5 C 469.66667,-210.83333 395.66667,-262.33333 329,-329 262.33333,-395.66667 210.83333,-469.66667 174.5,-551 138.16667,-632.33333 120,-714.66667 120,-798 c 0,-12 4,-22 12,-30 8,-8 18,-12 30,-12 h 162 c 9.33333,0 17.66667,3.16667 25,9.5 7.33333,6.33333 11.66667,13.83333 13,22.5 l 26,140 c 1.33333,10.66667 1,19.66667 -1,27 -2,7.33333 -5.66667,13.66667 -11,19 l -97,98 c 13.33333,24.66667 29.16667,48.5 47.5,71.5 18.33333,23 38.5,45.16667 60.5,66.5 20.66667,20.66667 42.33333,39.83333 65,57.5 22.66667,17.66667 46.66667,33.83333 72,48.5 l 94,-94 c 6,-6 13.83333,-10.5 23.5,-13.5 9.66667,-3 19.16667,-3.83333 28.5,-2.5 l 138,28 c 9.33333,2.66667 17,7.5 23,14.5 6,7 9,14.83333 9,23.5 v 162 c 0,12 -4,22 -12,30 -8,8 -18,12 -30,12 z"
+     id="path2"
+     sodipodi:nodetypes="sssssssssccsccscscssccsssss" />
+</svg>

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -100,7 +100,8 @@ $info-text-max-width: 400px;
       }
       &.call {
         > .text {
-          margin-inline-end: 24px;
+          --call-icon-size: 24px;
+          margin-inline-end: var(--call-icon-size);
           white-space: nowrap;
           font-weight: bold;
           span:last-child {
@@ -111,8 +112,8 @@ $info-text-max-width: 400px;
             position: absolute;
             top: 18px;
             transform: translateY(-50%);
-            width: 24px;
-            height: 24px;
+            width: var(--call-icon-size);
+            height: var(--call-icon-size);
             @include mixins.color-svg(
               './images/icons/phone_filled.svg',
               var(--messageOutgoingStatusColor),

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -104,13 +104,11 @@ $info-text-max-width: 400px;
           margin-inline-end: var(--call-icon-size);
           white-space: nowrap;
           font-weight: bold;
-          span:last-child {
-            margin-inline-end: 6px;
-          }
           &::after {
             content: '';
             position: absolute;
             top: 18px;
+            inset-inline-end: 8px;
             transform: translateY(-50%);
             width: var(--call-icon-size);
             height: var(--call-icon-size);

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -98,6 +98,29 @@ $info-text-max-width: 400px;
           cursor: pointer;
         }
       }
+      &.call {
+        > .text {
+          margin-inline-end: 24px;
+          white-space: nowrap;
+          font-weight: bold;
+          span:last-child {
+            margin-inline-end: 6px;
+          }
+          &::after {
+            content: '';
+            position: absolute;
+            top: 18px;
+            transform: translateY(-50%);
+            width: 24px;
+            height: 24px;
+            @include mixins.color-svg(
+              './images/icons/phone_filled.svg',
+              var(--messageOutgoingStatusColor),
+              100%
+            );
+          }
+        }
+      }
 
       & > .text {
         color: var(--messageText);
@@ -229,6 +252,14 @@ $info-text-max-width: 400px;
 
 .message.incoming {
   margin-inline-start: 0;
+
+  .msg-body.call > .text::after {
+    @include mixins.color-svg(
+      './images/icons/phone_filled.svg',
+      var(--messagePhoneIconColorIncoming),
+      100%
+    );
+  }
 
   .metadata:not(.with-image-no-caption) {
     .email-icon {

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -115,7 +115,7 @@ $info-text-max-width: 400px;
             width: var(--call-icon-size);
             height: var(--call-icon-size);
             @include mixins.color-svg(
-              './images/icons/phone_filled.svg',
+              './images/icons/phone.svg',
               var(--messageOutgoingStatusColor),
               100%
             );
@@ -256,7 +256,7 @@ $info-text-max-width: 400px;
 
   .msg-body.call > .text::after {
     @include mixins.color-svg(
-      './images/icons/phone_filled.svg',
+      './images/icons/phone.svg',
       var(--messagePhoneIconColorIncoming),
       100%
     );

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -892,6 +892,7 @@ export default function Message(props: {
         <div
           className={classNames('msg-body', {
             'msg-body--clickable': onClickMessageBody,
+            call: message.viewType === 'Call',
           })}
           onClick={onClickMessageBody}
           tabIndex={onClickMessageBody ? tabindexForInteractiveContents : -1}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -272,7 +272,8 @@ function buildContextMenu(
 
   const showAttachmentOptions = !!message.file
   const showCopyImage = !!message.file && message.viewType === 'Image'
-  const showResend = message.sender.id === C.DC_CONTACT_ID_SELF
+  const showResend =
+    message.sender.id === C.DC_CONTACT_ID_SELF && message.viewType !== 'Call'
 
   const isInfoOrCallInvitation =
     message.isInfo || message.viewType === 'VideochatInvitation'
@@ -292,7 +293,8 @@ function buildContextMenu(
     message.text !== '' &&
     chat.canSend &&
     !isInfoOrCallInvitation &&
-    !message.hasHtml
+    !message.hasHtml &&
+    message.viewType !== 'Call'
 
   // Do not show "react" for system messages
   const showSendReaction = showReactionsUi(message, chat)

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -17,6 +17,7 @@ $bgSecondary: #f5f5f5 !default;
 $bgImage: url('./images/background_light.svg') !default;
 $bgMessageBubbleIncoming: #fff !default;
 $bgMessageBubbleOutgoing: #efffde !default;
+$messageOutgoingStatusColor: #4caf50 !default;
 $bgNavBar: #f8f9fa !default;
 $bgChatView: #e6dcd4 !default;
 $textNavBar: #fff !default;
@@ -135,7 +136,7 @@ $scrollbarTransparency: 0.34 !default;
   --infoMessageBubbleText: white;
   --messageIncomingBg: #{$bgMessageBubbleIncoming};
   --messageOutgoingBg: #{$bgMessageBubbleOutgoing};
-  --messageOutgoingStatusColor: #4caf50; // Message Bubble - Buttons
+  --messageOutgoingStatusColor: #{$messageOutgoingStatusColor}; // Message Bubble - Buttons
   /* Message Bubble - Metadata */
   --messageStatusIcon: #4caf50;
   --messageStatusIconSending: #62656a;

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -142,6 +142,7 @@ $scrollbarTransparency: 0.34 !default;
   --messageStatusIconSending: #62656a;
   --messageMetadataIconColorOutgoing: #4caf50;
   --messageMetadataIconColorIncoming: #a4a6a9;
+  --messagePhoneIconColorIncoming: #2090ea;
   --messageMetadataDate: #62656a;
   --messageMetadataIncoming: rgba(#ffffff, 0.7);
   /* Message Bubble - Attachments */

--- a/packages/frontend/themes/dark.scss
+++ b/packages/frontend/themes/dark.scss
@@ -6,6 +6,7 @@
   $bgImage: url('./images/background_dark.svg'),
   $bgMessageBubbleIncoming: #303030,
   $bgMessageBubbleOutgoing: #354535,
+  $messageOutgoingStatusColor: #cdb7b5,
   $bgNavBar: #272727,
   $bgPrimary: #222,
   $bgSecondary: #333,

--- a/packages/frontend/themes/dark.scss
+++ b/packages/frontend/themes/dark.scss
@@ -6,7 +6,7 @@
   $bgImage: url('./images/background_dark.svg'),
   $bgMessageBubbleIncoming: #303030,
   $bgMessageBubbleOutgoing: #354535,
-  $messageOutgoingStatusColor: #cdb7b5,
+  $messageOutgoingStatusColor: #e4d4d3,
   $bgNavBar: #272727,
   $bgPrimary: #222,
   $bgSecondary: #333,

--- a/packages/frontend/themes/dark_amoled.scss
+++ b/packages/frontend/themes/dark_amoled.scss
@@ -6,6 +6,7 @@
   $bgImage: none,
   $bgMessageBubbleIncoming: #222,
   $bgMessageBubbleOutgoing: #343,
+  $messageOutgoingStatusColor: #e4d4d3,
   $bgNavBar: #000,
   $bgPrimary: #000,
   $bgSecondary: #222,

--- a/packages/frontend/themes/darkpurple.scss
+++ b/packages/frontend/themes/darkpurple.scss
@@ -6,7 +6,7 @@
   $bgImage: none,
   $bgMessageBubbleIncoming: #303030,
   $bgMessageBubbleOutgoing: #354535,
-  $messageOutgoingStatusColor: #cdb7b5,
+  $messageOutgoingStatusColor: #e4d4d3,
   $bgNavBar: #4e1479,
   $bgPrimary: #222333,
   $bgSecondary: #333444,

--- a/packages/frontend/themes/darkpurple.scss
+++ b/packages/frontend/themes/darkpurple.scss
@@ -6,6 +6,7 @@
   $bgImage: none,
   $bgMessageBubbleIncoming: #303030,
   $bgMessageBubbleOutgoing: #354535,
+  $messageOutgoingStatusColor: #cdb7b5,
   $bgNavBar: #4e1479,
   $bgPrimary: #222333,
   $bgSecondary: #333444,


### PR DESCRIPTION
Changes:

1. adds phone icons to messages
2. changes outgoing meta data color in dark mode
3. disable edit & forward for call messages

Reasons:
1. Similar to https://github.com/deltachat/deltachat-android/pull/3920 although the UI might still change
2. we had the same color (green) for dark & light mode, but the green has very low contrast to a dark background, the change is more similar to the color in Android
3. call messages should not be forwardable & editable - could be confusing since call messages are more some kind of log

TBD: I used a "filled" phone icon since it seemed to me more visible. Maybe we replace the icon in the navbar also?

<img width="556" height="448" alt="image" src="https://github.com/user-attachments/assets/920d33be-5793-4029-8080-f84d0ccd6d6f" />


Dark mode:
<img width="562" height="450" alt="image" src="https://github.com/user-attachments/assets/b62cb6e1-837b-4a3e-a072-68aed33e5134" />


#skip-changelog as this is part of an experimental WIP feature

