### PR TITLE
Improvements to Dialog Bottom Margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - accessibility: correct `aria-posinset` for chat list #5044
 - don't close context menues on window resize #5418
 - tauri: accessibility: fix focus always being locked on the message input #5125
+- fix: remove weird bottom margins in some scrollable dialogs #5494
 
 <a id="2_11_1"></a>
 
@@ -42,7 +43,7 @@
 ### Added
 - support RTL layout if locale.dir = rtf #4168
 - added estonian language
-- add more rtl configurations to languages that use it 
+- add more rtl configurations to languages that use it
 
 ### Changed
 - update translations (15-08-2025)

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -94,11 +94,6 @@ $paddingVertical: 20px;
   }
 }
 
-// if there is no footer we need a bottom margin
-.dialogBody:last-child {
-  margin-bottom: 20px;
-}
-
 .dialogFooter {
   width: 100%;
   background-color: var(--bp4DialogBgPrimary);

--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -14,7 +14,7 @@ import Advanced from './Advanced'
 import Profile from './Profile'
 import Dialog, { DialogBody, DialogHeader } from '../Dialog'
 import EditProfileDialog from '../dialogs/EditProfileDialog'
-import SettingsSeparator from './SettingsSeparator'
+import SettingsSeparator, { SettingsEndSeparator } from './SettingsSeparator'
 import useDialog from '../../hooks/dialog/useDialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
@@ -145,6 +145,7 @@ export default function Settings({ onClose }: DialogProps) {
             <SettingsIconButton icon='info' onClick={() => openDialog(About)}>
               {tx('global_menu_help_about_desktop')}
             </SettingsIconButton>
+            <SettingsEndSeparator />
           </DialogBody>
         </>
       )}
@@ -160,6 +161,7 @@ export default function Settings({ onClose }: DialogProps) {
               settingsStore={settingsStore}
               desktopSettings={settingsStore.desktopSettings}
             />
+            <SettingsEndSeparator />
           </DialogBody>
         </>
       )}
@@ -172,6 +174,7 @@ export default function Settings({ onClose }: DialogProps) {
           />
           <DialogBody>
             <Notifications desktopSettings={settingsStore.desktopSettings} />
+            <SettingsEndSeparator />
           </DialogBody>
         </>
       )}
@@ -188,6 +191,7 @@ export default function Settings({ onClose }: DialogProps) {
               desktopSettings={settingsStore.desktopSettings}
               settingsStore={settingsStore}
             />
+            <SettingsEndSeparator />
           </DialogBody>
         </>
       )}
@@ -201,6 +205,7 @@ export default function Settings({ onClose }: DialogProps) {
           />
           <DialogBody>
             <Advanced settingsStore={settingsStore} />
+            <SettingsEndSeparator />
           </DialogBody>
         </>
       )}

--- a/packages/frontend/src/components/Settings/SettingsSeparator.tsx
+++ b/packages/frontend/src/components/Settings/SettingsSeparator.tsx
@@ -5,3 +5,7 @@ import styles from './styles.module.scss'
 export default function SettingsSeparator() {
   return <hr className={styles.settingsSeparator} />
 }
+
+export function SettingsEndSeparator() {
+  return <hr className={styles.settingsEndSeparator} />
+}

--- a/packages/frontend/src/components/Settings/styles.module.scss
+++ b/packages/frontend/src/components/Settings/styles.module.scss
@@ -23,6 +23,16 @@ $settingsHeight: 40px;
   margin-top: 15px;
 }
 
+.settingsEndSeparator {
+  background-color: transparent;
+  border: 0;
+  height: 0;
+  margin-bottom: 20px;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
+  margin-top: 0;
+}
+
 .settingsButton {
   background-color: transparent;
   border: 0;

--- a/packages/frontend/src/components/dialogs/About.tsx
+++ b/packages/frontend/src/components/dialogs/About.tsx
@@ -196,6 +196,7 @@ export default function About({ onClose }: DialogProps) {
               )}
             </tbody>
           </table>
+          <br /> {/* some space at the bottom of the dialog */}
         </DialogContent>
       </DialogBody>
     </DialogWithHeader>

--- a/packages/frontend/src/components/dialogs/MediaView/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/MediaView/styles.module.scss
@@ -9,5 +9,10 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  margin-bottom: 10px !important;
+  // apply margin as part of scroll content
+  // so that scroll area can go to the end of dialog
+  // while still spreserving the bottom margin when user srolled to the end
+  div:has(> :global(.item)) {
+    margin-bottom: 10px;
+  }
 }

--- a/packages/frontend/src/components/screens/WelcomeScreen/AlternativeSetupsDialog.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/AlternativeSetupsDialog.tsx
@@ -86,6 +86,7 @@ export default function AlternativeSetupsDialog({
           >
             {tx('import_backup_title')}
           </Button>
+          <br /> {/* space after buttons */}
         </DialogContent>
       </DialogBody>
     </Dialog>

--- a/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/OnboardingScreen.tsx
@@ -70,6 +70,7 @@ export default function OnboardingScreen(props: Props) {
               {tx('onboarding_alternative_logins')}
             </Button>
           </div>
+          <br /> {/* space after buttons */}
         </DialogContent>
       </DialogBody>
     </>

--- a/packages/frontend/src/components/screens/WelcomeScreen/UseOtherServerDialog.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/UseOtherServerDialog.tsx
@@ -51,7 +51,6 @@ export default function UseOtherServerDialog({ onClose }: DialogProps) {
             {tx('instant_onboarding_other_server')}{' '}
             <Icon icon='open_in_new' className={styles.openExternalIcon} />
           </Button>
-
           <Button
             className={styles.welcomeScreenButton}
             onClick={onClickLogin}
@@ -66,6 +65,7 @@ export default function UseOtherServerDialog({ onClose }: DialogProps) {
           >
             {tx('scan_invitation_code')}
           </Button>
+          <br /> {/* space after buttons */}
         </DialogContent>
       </DialogBody>
     </Dialog>


### PR DESCRIPTION
- **remove dialog margin**
- **re-add dialog margin to settings. It is a seperate element, because that way it is inside of the scroll area, not taking away from it, only visible when you scrolled to the end.**
- **reintroduce bottom space for gallery, again by adding the margin to the scroll content and not the container**
- **add spacing to remaining dialogs. using br line break beacuse it works just fine and is easy to do and understand. again, idea here is to add it to the content and not outside of it for the case that the dialog is scrollable.**

Before this pr scroll-able content vanishes at an invisible line:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/32b6cdb5-7b50-4293-81ad-dc62c4dd2dd0" />
After this pr the content is visible until the edge of the dialog:
<img width="550"  alt="image" src="https://github.com/user-attachments/assets/6e5903e8-b2e2-40cf-8938-cc6c0f769a95" />
