### PR TITLE
Display message error even for messages that are not OutFailed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - do not create a group if the sender includes self in the To field
 
 ### Fixed
+- Display message error even for messages that are not OutFailed #5498
 - fix app picker sometimes incorrectly showing "Offline"
 - allow using the app picker even when offline, as long as the app store data is cached
 - if adding an app from the app picker fails, show an error dialog

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -763,6 +763,7 @@ export default function Message(props: {
             fileMime={message.fileMime || null}
             direction={direction}
             status={status}
+            error={message.error || null}
             downloadState={message.downloadState}
             isEdited={message.isEdited}
             hasText={text !== null && text !== ''}
@@ -947,6 +948,7 @@ export default function Message(props: {
               fileMime={fileMime}
               direction={direction}
               status={status}
+              error={message.error || null}
               downloadState={downloadState}
               isEdited={message.isEdited}
               hasText={hasText}

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -12,6 +12,7 @@ type Props = {
   fileMime: string | null
   direction?: 'incoming' | 'outgoing'
   status: msgStatus
+  error: string | null
   downloadState: T.DownloadState
   isEdited: boolean
   hasText: boolean
@@ -31,6 +32,7 @@ export default function MessageMetaData(props: Props) {
     fileMime,
     direction,
     status,
+    error,
     downloadState,
     isEdited,
     hasText,
@@ -88,7 +90,7 @@ export default function MessageMetaData(props: Props) {
         module='date'
       />
       <span className='spacer' />
-      {direction === 'outgoing' && (
+      {(direction === 'outgoing' || error !== null) && (
         <div className='delivery-status-wrapper'>
           {/* The main point of `role='status'` here is to let the user know
           that their message has been sent or delievered
@@ -101,7 +103,13 @@ export default function MessageMetaData(props: Props) {
           and not just the last one. */}
           {/* TODO a11y: we should probably apply `aria-label='Delivery status'`
           and change the contents to `Delivered` (or `Error` or whatever). */}
-          <div role='status' className={classNames('status-icon', status)}>
+          <div
+            role='status'
+            className={classNames(
+              'status-icon',
+              error !== null ? 'error' : status
+            )}
+          >
             <span className='visually-hidden'>
               {tx(
                 `a11y_delivery_status_${
@@ -119,7 +127,7 @@ export default function MessageMetaData(props: Props) {
               )}
             </span>
           </div>
-          {status === 'error' && (
+          {error !== null && (
             <button
               className='error-button'
               tabIndex={tabindexForInteractiveContents}


### PR DESCRIPTION
Message may have an error not only whet it is in OutFailed state. Since change <https://github.com/chatmail/core/pull/7222> incoming messages may have an error if they fail to download.

With this change the error is displayed when there is an error regardless of the message status.