### PR TITLE
refactor: simplify `video-calls.ts` (chatId)

### DIFF
--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -140,7 +140,7 @@ const enum CallDirection {
   Outgoing,
 }
 
-function openVideoCallWindow<T extends CallDirection>(
+function openVideoCallWindow<D extends CallDirection>(
   accountId: number,
   /**
    * Depending on the call direction we only know
@@ -155,10 +155,10 @@ function openVideoCallWindow<T extends CallDirection>(
         chatId?: undefined
         callMessageId: number
       },
-  callDirection: T,
+  callDirection: D,
   {
     callerWebrtcOffer,
-  }: T extends CallDirection.Incoming
+  }: D extends CallDirection.Incoming
     ? {
         callerWebrtcOffer: string
       }
@@ -168,7 +168,7 @@ function openVideoCallWindow<T extends CallDirection>(
 ): {
   closeWindow: () => void
   windowClosed: Promise<void>
-} & (T extends CallDirection.Incoming
+} & (D extends CallDirection.Incoming
   ? {
       /**
        * Resolves to `null` if the page port got closed,


### PR DESCRIPTION
We can now get the `chatId` directly, instead of asynchronously
determening it from `messageId`.
This allows us to simplify the host name
and remove the `getChatInfo` helper function.

Note that now all calls in the same chat have the same origin.
Which is OK.

This also renames a type `T` which was conflicting. This became evident to me just after these changes.

TODO:
- [x] Updgrade core, this MR depends on that. Then rebase and test.