### PR TITLE
fix: WebXDC apps having `isSecureContext == false`

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -32,6 +32,7 @@ if (rc['help'] === true || rc['h'] === true) {
   process.exit()
 }
 
+import { callsWebappElectronScheme } from './windows/video-call.js'
 protocol.registerSchemesAsPrivileged([
   {
     scheme: 'webxdc',
@@ -64,9 +65,8 @@ protocol.registerSchemesAsPrivileged([
       stream: true, // needed for audio playback
     },
   },
+  callsWebappElectronScheme,
 ])
-import { registerCallsWebappSchemeAsPrivileged } from './windows/video-call.js'
-registerCallsWebappSchemeAsPrivileged()
 
 const app = rawApp as ExtendedAppMainProcess
 app.rc = rc

--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -4,8 +4,10 @@ import {
   Menu,
   MessageChannelMain,
   net,
-  protocol,
   session,
+  // This is actually used in a JSDoc.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type protocol,
 } from 'electron/main'
 import { join } from 'path'
 import { appIcon, htmlDistDir } from '../application-constants'
@@ -773,18 +775,17 @@ async function getChatInfo(
   return await jsonrpcRemote.rpc.getBasicChatInfo(accountId, chatId)
 }
 
-export function registerCallsWebappSchemeAsPrivileged() {
-  protocol.registerSchemesAsPrivileged([
-    {
-      scheme: SCHEME_NAME,
-      privileges: {
-        // Needed for `getUserMedia`.
-        secure: true,
+/**
+ * To be passed to {@linkcode protocol.registerSchemesAsPrivileged}.
+ */
+export const callsWebappElectronScheme = {
+  scheme: SCHEME_NAME,
+  privileges: {
+    // Needed for `getUserMedia`.
+    secure: true,
 
-        // Needed for videos to work.
-        stream: true,
-        standard: true,
-      },
-    },
-  ])
+    // Needed for videos to work.
+    stream: true,
+    standard: true,
+  },
 }


### PR DESCRIPTION
This has probably been introduced in
a570afac0f9396307feaeb63ed394dba3c15108f.
Apparently we shouldn't call `protocol.registerSchemesAsPrivileged`
twice, because the previous one gets overridden.

Thanks to @hpk42 and @ralphtheninja for discovering this, and apologies for carelessness.

#skip-changelog because the bug has not been released.

I have verified that this fixes it, by running the Webxdc Test app.