### PR TITLE
test: add default `DC_CHATMAIL_SERVER` to example

### DIFF
--- a/packages/e2e-tests/_env
+++ b/packages/e2e-tests/_env
@@ -2,7 +2,7 @@ DC_ACCOUNTS_DIR=../../e2e-tests/data/accounts
 NODE_ENV=test
 
 # URL of chatmail user
-DC_CHATMAIL_SERVER=
+DC_CHATMAIL_SERVER=https://ci-chatmail.testrun.org
 
 # URL of non chatmail server (including token)
 DC_MAIL_SERVER_URL=


### PR DESCRIPTION
This should make it easier for people to run the tests.
They won't need to search for a working tests server.

This partially reverts ce82703ab4d43770cdcfa10f3fb3f87551a8e3f2.

#skip-changelog