### PR TITLE
test: fix example `_env` file

### DIFF
--- a/packages/e2e-tests/_env
+++ b/packages/e2e-tests/_env
@@ -4,5 +4,9 @@ NODE_ENV=test
 # URL of chatmail server
 DC_CHATMAIL_SERVER=https://ci-chatmail.testrun.org
 
-# URL of non chatmail server (including token)
-DC_MAIL_SERVER_URL=
+# Base URL of non chatmail server
+# If you don't have one, you may skip non-Chatmail tests with
+# `pnpm -w e2e --project=chatmail`
+DC_MAIL_SERVER=
+# Access token of the non-Chatmail server.
+DC_MAIL_SERVER_TOKEN=


### PR DESCRIPTION
It was referencing a nonexisten var.
See ce82703ab4d43770cdcfa10f3fb3f87551a8e3f2
(https://github.com/deltachat/deltachat-desktop/pull/5342).

Also add a comment about running tests
without a non-Chatmail server.

#skip-changelog