### PR TITLE
test: disable flaky non-Chatmail tests again

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -55,13 +55,14 @@ export default defineConfig<TestOptions>({
         isChatmail: true, // create profiles on a dedicated chatmail server
       },
     },
-    {
-      name: 'non-chatmail',
-      use: {
-        ...devices['Desktop Chrome'],
-        isChatmail: false, // create profiles on a dedicated non-chatmail server
-      },
-    },
+    // Our non chatmail server is too unreliable right now to be used in CI
+    // {
+    //   name: 'non-chatmail',
+    //   use: {
+    //     ...devices['Desktop Chrome'],
+    //     isChatmail: false, // create profiles on a dedicated non-chatmail server
+    //   },
+    // },
   ],
 
   /* Run your local dev server before starting the tests */


### PR DESCRIPTION
They keep failing for a lot of recent MRs.

#skip-changelog