### PR TITLE
improvement: translate more settings strings

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -11,12 +11,6 @@
   "background_sync_disabled_explaination": {
     "message": "Background sync disabled, profile is only synced when selected"
   },
-  "pref_all_accounts": {
-    "message": "All Profiles"
-  },
-  "pref_current_account": {
-    "message": "Current Profile"
-  },
   "webxdc_beforeunload_dialog_title": {
     "message": "Close app?"
   },
@@ -49,12 +43,6 @@
   },
   "search_result_for_x": {
     "message": "Result for \"%s\""
-  },
-  "reset_encryption": {
-    "message": "Reset Encryption"
-  },
-  "reset_encryption_confirm": {
-    "message": "Forget encryption key for this contact."
   },
   "voice_send": {
     "message": "Record a voice message"

--- a/packages/frontend/src/components/Settings/Notifications.tsx
+++ b/packages/frontend/src/components/Settings/Notifications.tsx
@@ -65,7 +65,7 @@ export default function Notifications({ desktopSettings }: Props) {
 
   return (
     <>
-      <SettingsHeading>{tx('pref_all_accounts')}</SettingsHeading>
+      <SettingsHeading>{tx('all_profiles')}</SettingsHeading>
       <DesktopSettingsSwitch
         settingsKey='notifications'
         label={tx('pref_notifications_explain')}
@@ -82,7 +82,7 @@ export default function Notifications({ desktopSettings }: Props) {
         {tx('pref_in_chat_sounds')}
       </SettingsSelector>
       <SettingsSeparator></SettingsSeparator>
-      <SettingsHeading>{tx('pref_current_account')}</SettingsHeading>
+      <SettingsHeading>{tx('current_profile')}</SettingsHeading>
       <SettingsSwitch
         label={tx('menu_mute')}
         value={isMuted}


### PR DESCRIPTION
And remove strings that are no longer used
from `_untranslated_en.json`.

The "All Profiles" and "Current Profile" strings
have been added in
https://github.com/deltachat/deltachat-android/commit/9caf94d03544e7d085037c0df05a514b69126d29.

The `reset_encryption` strings usages have been removed in
193dfd544893b75bb1f9428373f50f189643b260.

#skip-changelog because this is insignificant.