### PR TITLE
improvement: change new "Calls" setting title

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -91,5 +91,8 @@
   },
   "accounts_list_item_menu_label": {
     "message": "Actions with Profile"
+  },
+  "calls": {
+    "message": "Calls"
   }
 }

--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -65,7 +65,7 @@ export function ExperimentalFeatures({ settingsStore }: Props) {
       {/* {runtime.getRuntimeInfo().target === 'electron' && (
         <DesktopSettingsSwitch
           settingsKey='enableAVCallsV2'
-          label={tx('videochat') + ' v2'}
+          label={tx('calls')}
           description='Work in progress…'
         />
       )} */}


### PR DESCRIPTION
From "Video calls V2" to just "Calls".
The string is supposed to get pulled from Android
after https://github.com/deltachat/deltachat-android/pull/3785
has been merged.
FYI it will automatically use the new translations,
without the need to remove the string from `_untranslated_en.json`.

#skip-changelog because this is an experimental option.