### PR TITLE
refactor: fix potential `newProxyUrl` bug

### DIFF
--- a/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
+++ b/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { DialogProps } from '../../../contexts/DialogContext'
 import Dialog, {
   DialogBody,
@@ -54,6 +54,9 @@ export default function ProxyConfiguration(
   props: DialogProps & {
     accountId: number
     configured: boolean
+    /**
+     * Changing this value after initial render has no effect.
+     */
     newProxyUrl?: string
   }
 ) {
@@ -200,12 +203,11 @@ export default function ProxyConfiguration(
   )
 
   // Handle new proxy URL from props
-  useEffect(() => {
-    if (props.newProxyUrl) {
-      addProxy(props.newProxyUrl)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.newProxyUrl]) // skip addProxy in deps since it has too many deps itself
+  const addedProxyFromProps = useRef(false)
+  if (props.newProxyUrl && !addedProxyFromProps.current) {
+    addedProxyFromProps.current = true
+    addProxy(props.newProxyUrl)
+  }
 
   const openQrScanner = useCallback(() => {
     openDialog(ProxyQrScanner, {


### PR DESCRIPTION
This unfortunately appears to trigger an existing bug. A race condition where `batchGetConfig` resolves _after_ the initial `addProxy`.
The result is that the proxy just doesn't get added in the end.

https://github.com/deltachat/deltachat-desktop/blob/9298502b681059c1b60b2098c8f98b9adfa82b00/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx#L112-L147

That bug needs to get fixed, then this MR can be merged.