### PR TITLE
refactor: remove residuals of `enableAVCalls`

### DIFF
--- a/images/videocamera.svg
+++ b/images/videocamera.svg
@@ -1,9 +1,0 @@
-<svg
-    xmlns="http://www.w3.org/2000/svg"
-    viewBox="0 0 24 24"
-    id="vector">
-    <path
-        id="path"
-        d="M 17 10.5 L 17 7 C 17 6.45 16.55 6 16 6 L 4 6 C 3.45 6 3 6.45 3 7 L 3 17 C 3 17.55 3.45 18 4 18 L 16 18 C 16.55 18 17 17.55 17 17 L 17 13.5 L 21 17.5 L 21 6.5 L 17 10.5 Z"
-        fill="#ffffff"/>
-</svg>

--- a/packages/frontend/scss/_icons.scss
+++ b/packages/frontend/scss/_icons.scss
@@ -2,13 +2,6 @@
   display: block;
   width: 48px;
   height: 48px;
-
-  &.videocamera {
-    background-image: url('./images/videocamera.svg');
-    background-repeat: no-repeat;
-    margin: 5px;
-    background-size: 38px;
-  }
 }
 
 span.rotate90 {

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -21,9 +21,10 @@ export interface DesktopSettingsType {
    */
   lastAccount?: number
   /**
-   * @see also {@linkcode enableAVCallsV2}
+   * @deprecated removed in https://github.com/deltachat/deltachat-desktop/pull/3965
+   * @see {@linkcode enableAVCallsV2}
    */
-  enableAVCalls: boolean
+  enableAVCalls?: boolean
   /**
    * The new version of video calls.
    * @see https://github.com/orgs/deltachat/projects/81

--- a/packages/shared/state.ts
+++ b/packages/shared/state.ts
@@ -13,7 +13,6 @@ export function getDefaultState(): DesktopSettingsType {
     locale: null, // if this is null, the system chooses the system language that electron reports
     credentials: undefined,
     lastAccount: undefined,
-    enableAVCalls: false,
     enableAVCallsV2: false,
     enableBroadcastLists: false,
     enableChatAuditLog: false,

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -186,7 +186,6 @@ class TauriRuntime implements Runtime {
     const frontendOnly = {
       showNotificationContent: true,
       enterKeySends: false,
-      enableAVCalls: false,
       enableAVCallsV2: false,
       enableBroadcastLists: false,
       enableChatAuditLog: false,


### PR DESCRIPTION
Follow-up to 9974b17d96cd464ab0978e382cde1932ee65da39
(https://github.com/deltachat/deltachat-desktop/pull/5531).
