### PR TITLE
fix: calls: show initial letter img if no avatar

### DIFF
--- a/packages/frontend/scss/misc/_avatar.scss
+++ b/packages/frontend/scss/misc/_avatar.scss
@@ -1,3 +1,5 @@
+// When changing these, consider also updating the avatar SVG
+// in `video-calls.ts`.
 .avatar {
   --local-avatar-size: 48px;
   --local-avatar-vertical-margin: 8px;

--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -58,6 +58,7 @@
     "@deltachat/jsonrpc-client": "catalog:",
     "@deltachat/stdio-rpc-server": "catalog:",
     "@deltachat/calls-webapp": "catalog:",
+    "escape-html": "^1.0.3",
     "mime-types": "catalog:",
     "sass": "catalog:",
     "ws": "7.5.10"
@@ -69,6 +70,7 @@
     "@types/adm-zip": "^0.5.5",
     "@types/chai": "^4.3.17",
     "@types/debounce": "^1.2.4",
+    "@types/escape-html": "^1.0.4",
     "@types/mime-types": "catalog:",
     "@types/mocha": "^10.0.7",
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,9 @@ importers:
       '@deltachat/stdio-rpc-server':
         specifier: 'catalog:'
         version: 2.22.0(@deltachat/jsonrpc-client@2.22.0(ws@7.5.10))
+      escape-html:
+        specifier: ^1.0.3
+        version: 1.0.3
       mime-types:
         specifier: 'catalog:'
         version: 2.1.35
@@ -378,6 +381,9 @@ importers:
       '@types/debounce':
         specifier: ^1.2.4
         version: 1.2.4
+      '@types/escape-html':
+        specifier: ^1.0.4
+        version: 1.0.4
       '@types/mime-types':
         specifier: 'catalog:'
         version: 2.1.4
@@ -1328,6 +1334,9 @@ packages:
 
   '@types/emoji-mart@3.0.14':
     resolution: {integrity: sha512-/vMkVnet466bK37ugf2jry9ldCZklFPXYMB2m+qNo3vkP2I7L0cvtNFPKAjfcHgPg9Z8pbYqVqZn7AgsC0qf+g==}
+
+  '@types/escape-html@1.0.4':
+    resolution: {integrity: sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -4737,6 +4746,8 @@ snapshots:
   '@types/emoji-mart@3.0.14':
     dependencies:
       '@types/react': 19.2.2
+
+  '@types/escape-html@1.0.4': {}
 
   '@types/estree@1.0.8': {}
 


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5529.

The SVG approach works nicely.

<img width="300" height="578" alt="image" src="https://github.com/user-attachments/assets/4a8a31d6-f10f-479f-a559-1d9133198353" />  <img width="300" height="473" alt="image" src="https://github.com/user-attachments/assets/a6c33e56-7749-44ad-90f3-e80236542e3b" /> <img width="300" height="466" alt="image" src="https://github.com/user-attachments/assets/3577d0db-e43a-410f-8a4d-4cc7ff35d812" />


TODO:
- [x] Address TODO comments.

#skip-changelog because this is experimental.