### PR TITLE
fix: use debug build of calls-webapp

### DIFF
--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -34,7 +34,7 @@
     "build": "pnpm build:locales && pnpm build:backend && pnpm --filter=@deltachat-desktop/frontend build && pnpm build:compose-frontend && pnpm build:calls-webapp",
     "build:locales": "pnpm -w translations:convert",
     "build:backend": "node ./bin/build.js",
-    "build:calls-webapp": "node ../../bin/copy.js ./node_modules/calls-webapp#build-for-deltachat-desktop ./html-dist/calls-webapp",
+    "build:calls-webapp": "node ../../bin/copy.js ./node_modules/calls-webapp#debug-build ./html-dist/calls-webapp",
     "build:runtime-impl": "pnpm esbuild --format=esm --bundle --minify --keep-names --sourcemap --outdir=./html-dist runtime-electron/runtime.ts",
     "build:compose-frontend": "node ../../bin/copy.js ../frontend/html-dist ./html-dist && node ../../bin/copy.js ./static ./html-dist && pnpm build:runtime-impl",
     "watch:compose-frontend": "node ../../bin/copy.js ../frontend/html-dist ./html-dist -w & node ../../bin/copy.js ./static ./html-dist -w & pnpm build:runtime-impl --watch",
@@ -57,7 +57,7 @@
   "dependencies": {
     "@deltachat/jsonrpc-client": "catalog:",
     "@deltachat/stdio-rpc-server": "catalog:",
-    "calls-webapp#build-for-deltachat-desktop": "catalog:",
+    "calls-webapp#debug-build": "catalog:",
     "mime-types": "catalog:",
     "sass": "catalog:",
     "ws": "7.5.10"

--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -589,11 +589,15 @@ function handleCallEnd(
 }
 
 // See https://github.com/deltachat/calls-webapp/pull/20.
+// font-src is needed for Eruda (debug) build and should be removed
+// when the "calls" feature goes to production. See
+// https://github.com/deltachat/deltachat-desktop/issues/5547.
 const CSP =
   "default-src 'none';\
 style-src 'self' 'unsafe-inline';\
 script-src 'self' 'unsafe-inline';\
 img-src 'self';\
+font-src data:;\
 media-src 'self'"
 
 async function returnIndexHtmlOrAvatar(request: GlobalRequest) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ catalogs:
     '@webxdc/types':
       specifier: ^2.1.2
       version: 2.1.2
-    calls-webapp#build-for-deltachat-desktop:
-      specifier: github:deltachat/calls-webapp#build-for-deltachat-desktop
+    calls-webapp#debug-build:
+      specifier: github:deltachat/calls-webapp#debug-build
       version: 0.0.0
     mime-types:
       specifier: ^2.1.35
@@ -344,9 +344,9 @@ importers:
       '@deltachat/stdio-rpc-server':
         specifier: 'catalog:'
         version: 2.17.0(@deltachat/jsonrpc-client@2.17.0(ws@7.5.10))
-      calls-webapp#build-for-deltachat-desktop:
+      calls-webapp#debug-build:
         specifier: 'catalog:'
-        version: https://codeload.github.com/deltachat/calls-webapp/tar.gz/c4297b399f7e2d321bd50d2c3a4f5407532b905c
+        version: https://codeload.github.com/deltachat/calls-webapp/tar.gz/a36acf6825226421c236dfcd428eeef895791dc4
       mime-types:
         specifier: 'catalog:'
         version: 2.1.35
@@ -1666,8 +1666,8 @@ packages:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
 
-  calls-webapp#build-for-deltachat-desktop@https://codeload.github.com/deltachat/calls-webapp/tar.gz/c4297b399f7e2d321bd50d2c3a4f5407532b905c:
-    resolution: {tarball: https://codeload.github.com/deltachat/calls-webapp/tar.gz/c4297b399f7e2d321bd50d2c3a4f5407532b905c}
+  calls-webapp#debug-build@https://codeload.github.com/deltachat/calls-webapp/tar.gz/a36acf6825226421c236dfcd428eeef895791dc4:
+    resolution: {tarball: https://codeload.github.com/deltachat/calls-webapp/tar.gz/a36acf6825226421c236dfcd428eeef895791dc4}
     version: 0.0.0
 
   callsites@3.1.0:
@@ -5040,7 +5040,7 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
 
-  calls-webapp#build-for-deltachat-desktop@https://codeload.github.com/deltachat/calls-webapp/tar.gz/c4297b399f7e2d321bd50d2c3a4f5407532b905c: {}
+  calls-webapp#debug-build@https://codeload.github.com/deltachat/calls-webapp/tar.gz/a36acf6825226421c236dfcd428eeef895791dc4: {}
 
   callsites@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ catalog:
   '@deltachat/jsonrpc-client': 2.17.0
   '@deltachat/stdio-rpc-server': 2.17.0
   '@webxdc/types': ^2.1.2
-  'calls-webapp#build-for-deltachat-desktop': "github:deltachat/calls-webapp#build-for-deltachat-desktop"
+  'calls-webapp#debug-build': "github:deltachat/calls-webapp#debug-build"
 
   # dependencies
   '@types/mime-types': ^2.1.4


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5547.
Apparently Chromium developer tools are not good enough.

~~Note that the Eruda icon is not displayed properly because our CSP won't let Eruda load its fonts:~~

<img width="572" height="540" alt="image" src="https://github.com/user-attachments/assets/c072502d-267d-48a6-80d7-4271c076e1b6" />

#skip-changelog because the feature is experimental