### PR TITLE
fix: use `avatarInitial` fn on all avatars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 - refactor proxy dialog styles to fix #5507
 - some strings being untranslated
+- some emoji avatars displaying incorrect emoji
 
 ### Changed
 - update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `2.17.0`

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -56,6 +56,7 @@ import type { PrivateReply } from '../../hooks/chat/usePrivateReply'
 import type { JumpToMessage } from '../../hooks/chat/useMessage'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 import { useRovingTabindex } from '../../contexts/RovingTabindex'
+import { avatarInitial } from '../Avatar'
 
 interface CssWithAvatarColor extends CSSProperties {
   '--local-avatar-color': string
@@ -70,7 +71,7 @@ const Avatar = ({
   onContactClick: (contact: T.Contact) => void
   tabIndex: -1 | 0
 }) => {
-  const { profileImage, color, displayName } = contact
+  const { profileImage, color, displayName, address } = contact
 
   const onClick = () => onContactClick(contact)
 
@@ -81,10 +82,7 @@ const Avatar = ({
       </button>
     )
   } else {
-    const codepoint = displayName && displayName.codePointAt(0)
-    const initial = codepoint
-      ? String.fromCodePoint(codepoint).toUpperCase()
-      : '#'
+    const initial = avatarInitial(displayName, address)
     return (
       <button
         className='author-avatar default'

--- a/packages/frontend/src/components/message/VCard.tsx
+++ b/packages/frontend/src/components/message/VCard.tsx
@@ -8,6 +8,7 @@ import { createChatByContactId } from '../../backend/chat'
 import useChat from '../../hooks/chat/useChat'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useConfirmationDialog from '../../hooks/dialog/useConfirmationDialog'
+import { avatarInitial } from '../Avatar'
 
 /**
  * displays a VCard attachement with avatar, mail & name
@@ -66,10 +67,7 @@ export function VisualVCardComponent({
   tabindexForInteractiveContents?: -1 | 0
 }) {
   const { profileImage, color, displayName, addr } = vcardContact
-  const codepoint = displayName && displayName.codePointAt(0)
-  const initial = codepoint
-    ? String.fromCodePoint(codepoint).toUpperCase()
-    : '#'
+  const initial = avatarInitial(displayName, addr)
 
   const Tag = onClick ? 'button' : 'div'
   return (


### PR DESCRIPTION
Some of our numerious avatar components
were still using the buggy `displayName.codePointAt(0)`
approach, which doesn't work for composite emojis,
such as "woman programmer". See
656542c0d9c588c255477b7aee27d0507a72c695
(https://github.com/deltachat/deltachat-desktop/pull/4038).

<img width="219" height="147" alt="image" src="https://github.com/user-attachments/assets/4724b602-45b0-43b4-b35d-1aba4ee37b85" />

<img width="333" height="114" alt="image" src="https://github.com/user-attachments/assets/10ffee5c-a10e-409d-ba7c-b7a1ab1fc73c" />
