### PR TITLE
improvement: use account label initial as avatar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - some strings being untranslated
 
 ### Changed
+- Use profile label first letter (or emoji) as its avatar when no avatar set, instead of the profile public name
 - update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `2.17.0`
 - update translations (7-10-2025)
 

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -304,7 +304,7 @@ export default function AccountItem({
                 style={{ backgroundColor: account.color }}
               >
                 {avatarInitial(
-                  account.displayName || '',
+                  account.privateTag || account.displayName || '',
                   account.addr || undefined
                 )}
               </div>

--- a/packages/frontend/src/components/screens/AccountDeletionScreen/AccountDeletionScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountDeletionScreen/AccountDeletionScreen.tsx
@@ -80,7 +80,9 @@ export default function AccountDeletionScreen({
                         style={{ backgroundColor: accountInfo.color }}
                       >
                         {avatarInitial(
-                          accountInfo.displayName || '',
+                          accountInfo.privateTag ||
+                            accountInfo.displayName ||
+                            '',
                           accountInfo.addr || undefined
                         )}
                       </div>


### PR DESCRIPTION
This makes the profile tags (labels) more usefult,
because otherwise these labels are only ever displayed
in the profile hover "tooltip".

<img width="68" height="75" alt="image" src="https://github.com/user-attachments/assets/8305394d-f4d0-42b4-8638-96c194f4404b" />

TODO:
- [ ] sync with Android and iOS DC clients. Although the "accounts" display there is a little different, so maybe the "be consistent" requirements here are not that strict.