### PR TITLE
Handle invalid qr code properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - some strings being untranslated
 - VCard (share contact) avatars not having color (all being gray instead) #5552
 - some emoji avatars displaying incorrect emoji
+- handle invalid qr code properly #5555
 
 ### Changed
 - update `@deltachat/stdio-rpc-server` and `deltachat/jsonrpc-client` to `2.17.0`

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -423,16 +423,26 @@ export default function useProcessQR() {
         return callback?.()
       }
 
-      // Just show the contents of the scanned QR code if it is correct but
+      // Just show the contents of the scanned QR code
+      // so the user can see what it contains,
       // we don't know what to do with it ..
-      openDialog(CopyContentAlertDialog, {
-        message:
-          qr.kind === 'url'
-            ? tx('qrscan_contains_url', url)
-            : tx('qrscan_contains_text', url),
-        content: url,
-        cb: callback,
-      })
+      if (isLoggedIn) {
+        openDialog(CopyContentAlertDialog, {
+          message:
+            qr.kind === 'url'
+              ? tx('qrscan_contains_url', url)
+              : tx('qrscan_contains_text', url),
+          content: url,
+        })
+        // this closes the underlying scan dialog immediately
+        // while the copyContent dialog is still open
+        return callback?.()
+      } else {
+        await openAlertDialog({
+          message: tx('qraccount_qr_code_cannot_be_used'),
+        })
+        return callback?.()
+      }
     },
     [
       openAlertDialog,


### PR DESCRIPTION
resolves #5555

tbd: should we show the copy dialog when a user with configured account scanned an invalid qr code? Or just a simple alert dialog with just a OK button?

The text can't be copied from a simple alert dialog, since we have user-select: false on the content of the Alert dialog

Maybe we should just change that, so allow select the content of Alert dialogs always?