### PR TITLE
fix: remove reference to deprecated `verified_one_on_one_chats`

### DIFF
--- a/packages/frontend/src/components/screens/WelcomeScreen/ImportBackupProgressDialog.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/ImportBackupProgressDialog.tsx
@@ -46,11 +46,6 @@ export default function ImportBackupProgressDialog({
       try {
         log.debug(`Starting backup import of ${backupFile}`)
         await BackendRemote.rpc.importBackup(accountId, backupFile, null)
-        await BackendRemote.rpc.setConfig(
-          accountId,
-          'verified_one_on_one_chats',
-          '1'
-        )
       } catch (err) {
         setError(unknownErrorToString(err))
         return

--- a/packages/target-electron/src/deltachat/controller.ts
+++ b/packages/target-electron/src/deltachat/controller.ts
@@ -210,13 +210,6 @@ export default class DeltaChatController {
       this.jsonrpcRemote.rpc.startIoForAllAccounts()
       log.info('Started accounts io.')
     }
-    for (const account of await this.jsonrpcRemote.rpc.getAllAccountIds()) {
-      this.jsonrpcRemote.rpc.setConfig(
-        account,
-        'verified_one_on_one_chats',
-        '1'
-      )
-    }
   }
 
   readonly webxdc = new DCWebxdc(this)


### PR DESCRIPTION

closes #5568

This change slipped through our radar:
- I mistakenly thought this was not used anymore in desktop while approving https://github.com/chatmail/core/pull/7165
- nico also missed the breaking change in the changelog https://github.com/chatmail/core/blob/main/CHANGELOG.md#api-changes-1 while he updated core to 2.17: https://github.com/deltachat/deltachat-desktop/pull/5516

Thanks to Raiden for catching and reporting the bug.
