### PR TITLE
fix: potential race in WebXDC attachment info

### DIFF
--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -239,7 +239,8 @@ export function DraftAttachment({
 }) {
   const isViewTypeWebxdc = attachment.viewType === 'Webxdc'
   const [attachmentIdToLoad, setAttachmentIdToLoad] = useState(attachment.id)
-  if (useHasChanged2(attachment.fileName)) {
+  const hasFileNameChanged = useHasChanged2(attachment.fileName)
+  if (hasFileNameChanged) {
     // Only reload webxdc info if filename has changed, because
     // the `id` itself could be changing as often as we update the draft.
     setAttachmentIdToLoad(attachment.id)


### PR DESCRIPTION
Plus simplify the code, and improve the comment a little.

This is a follow-up to b352801fb8d2e816e364aadced44235299a6baa0
(https://github.com/deltachat/deltachat-desktop/pull/5227).

Partially addresses https://github.com/deltachat/deltachat-desktop/pull/5576.

#skip-changelog because this is insignificant.