### PR TITLE
fix: overriding draft on bot command click

### DIFF
--- a/packages/frontend/src/components/message/MessageMarkdown.tsx
+++ b/packages/frontend/src/components/message/MessageMarkdown.tsx
@@ -316,7 +316,7 @@ function BotCommandSuggestion({
 
     if (draft) {
       // Ask if the draft should be replaced
-      const confirmed = openConfirmationDialog({
+      const confirmed: boolean = await openConfirmationDialog({
         message: window.static_translate('confirm_replace_draft', name),
         confirmLabel: window.static_translate('replace_draft'),
       })


### PR DESCRIPTION
The prompt dialog simply didn't do anything,
the draft would get overridden immediately.
