### PR TITLE
refactor: don't require file name to set draft

### DIFF
--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -55,7 +55,7 @@ export default function MenuAttachment({
         for (const filePath of filePaths) {
           await sendMessage(accountId, selectedChat.id, {
             file: filePath,
-            filename: basename(filePath),
+            // filename
             viewtype: msgViewType,
           })
           // start sending other files, don't wait until last file is sent

--- a/packages/frontend/src/hooks/chat/useCreateDraftMesssage.ts
+++ b/packages/frontend/src/hooks/chat/useCreateDraftMesssage.ts
@@ -9,7 +9,7 @@ export type CreateDraftMessage = (
   accountId: number,
   chatId: number,
   messageText: string,
-  file?: { path: string; name: string }
+  file?: { path: string; name?: string }
 ) => Promise<void>
 
 /**

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -1,6 +1,5 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { T } from '@deltachat/jsonrpc-client'
-import { basename } from 'path'
 
 import { getLogger } from '../../../../shared/logger'
 import { BackendRemote, Type } from '../../backend-com'
@@ -216,14 +215,12 @@ export function useDraft(
         (draft.file && draft.file != '') ||
         !!draft.quote
       ) {
-        const fileName =
-          draft.fileName ?? (draft.file ? basename(draft.file) : null)
         await BackendRemote.rpc.miscSetDraft(
           accountId,
           chatId,
           draft.text,
           draft.file !== '' ? draft.file : null,
-          fileName ?? null,
+          draft.fileName,
           draft.quote?.kind === 'WithMessage' ? draft.quote.messageId : null,
           draft.viewType
         )
@@ -292,7 +289,7 @@ export function useDraft(
   }, [inputRef, saveAndRefetchDraft])
 
   const addFileToDraft = useCallback(
-    async (file: string, fileName: string, viewType: T.Viewtype) => {
+    async (file: string, fileName: string | null, viewType: T.Viewtype) => {
       draftRef.current.file = file
       draftRef.current.fileName = fileName
       draftRef.current.viewType = viewType


### PR DESCRIPTION
The Core is able to figure out the file name itself.
