### PR TITLE
refactor: remove unsafe type cast in `useDraft`

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -542,7 +542,11 @@ const Composer = forwardRef<
                   className='attachment-quote-section is-quote'
                   aria-label={tx('menu_reply')}
                 >
-                  <Quote quote={draftState.quote} tabIndex={0} />
+                  {/* Check that this is a "full" quote.
+                  TODO it would be nice to show a placeholder otherwise. */}
+                  {'text' in draftState.quote && (
+                    <Quote quote={draftState.quote} tabIndex={0} />
+                  )}
                   <CloseButton onClick={removeQuote} />
                 </section>
               )}

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -15,7 +15,7 @@ const log = getLogger('renderer/composer')
 
 export type DraftObject = { chatId: number } & Pick<
   Type.Message,
-  'id' | 'file' | 'quote' | 'viewType' | 'vcardContact'
+  'id' | 'file' | 'viewType' | 'vcardContact'
 > &
   MessageTypeAttachmentSubset & {
     /**
@@ -23,6 +23,13 @@ export type DraftObject = { chatId: number } & Pick<
      * of the composer <textarea>. It's basically duplicated state.
      */
     text: Type.Message['text']
+    quote:
+      | Type.Message['quote']
+      /**
+       * This is for when we've set the quote by `messageId`,
+       * but havent loaded the full quote yet.
+       */
+      | { kind: 'WithMessage'; messageId: number }
   }
 
 function emptyDraft(chatId: number | null): DraftObject {
@@ -326,7 +333,7 @@ export function useDraft(
       draftRef.current.quote = {
         kind: 'WithMessage',
         messageId,
-      } as Type.MessageQuote
+      }
       saveAndRefetchDraft()
 
       jumpToMessage({
@@ -414,7 +421,7 @@ export function useDraft(
       draftRef.current.quote = {
         kind: 'WithMessage',
         messageId,
-      } as Partial<Type.MessageQuote> as any as Type.MessageQuote
+      }
       saveAndRefetchDraft?.()
       inputRef.current?.focus()
     }


### PR DESCRIPTION
This has already caused problems, see
https://github.com/deltachat/deltachat-desktop/issues/4337.
Let's make sure that doesn't happen anymore.

This does not affect behavior significantly.
It's only that the quote is not rendered at all
while it's being loaded,
so you cannot click it to jump to the message.
