### PR TITLE
refactor: move `loadingDraft` state to `useDraft`

### DIFF
--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -10,6 +10,13 @@ const log = getLogger('renderer/composer/ComposerMessageInput')
 
 type ComposerMessageInputProps = {
   /**
+   * Whether the initial loading of the draft is being performed,
+   * e.g. after switching the chat, or after a
+   * {@linkcode BackendRemote.rpc.miscSetDraft} from outside of
+   * {@linkcode useDraft}.
+   */
+  loadingDraft: boolean
+  /**
    * Whether to render the HTML or to return `null`.
    */
   hidden?: boolean
@@ -27,7 +34,6 @@ type ComposerMessageInputState = {
   text: string
   chatId: number
   // error?:boolean|Error
-  loadingDraft: boolean
 }
 
 export default class ComposerMessageInput extends React.Component<
@@ -46,7 +52,6 @@ export default class ComposerMessageInput extends React.Component<
     this.state = {
       text: '',
       chatId: props.chatId,
-      loadingDraft: false,
     }
 
     this.composerSize = 48
@@ -98,7 +103,7 @@ export default class ComposerMessageInput extends React.Component<
    * e.g. after sending the message or opening a chat with an existing draft.
    */
   setText(text: string | null) {
-    this.setState({ text: text || '', loadingDraft: false })
+    this.setState({ text: text || '' })
     this.throttledSaveDraft.cancel()
     this.props.onChange(text || '')
   }
@@ -283,7 +288,7 @@ export default class ComposerMessageInput extends React.Component<
                 ? window.static_translate('edit_message')
                 : window.static_translate('write_message_desktop')
             }
-            disabled={this.state.loadingDraft}
+            disabled={this.props.loadingDraft}
             dir={
               writingDirection === 'rtl'
                 ? 'rtl'

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -112,6 +112,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
 
   const {
     draftState,
+    draftIsLoading,
     updateDraftText,
     onSelectReplyToShortcut,
     removeQuote,
@@ -320,6 +321,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
         regularMessageInputRef={regularMessageInputRef}
         editMessageInputRef={editMessageInputRef}
         draftState={draftState}
+        draftIsLoading={draftIsLoading}
         updateDraftText={updateDraftText}
         onSelectReplyToShortcut={onSelectReplyToShortcut}
         removeQuote={removeQuote}


### PR DESCRIPTION
To make things less imperative.
Maybe now the value of the variable is not the same in all cases,
but the behavior should be pretty much the same,
or maybe even better.
