### PR TITLE
fix: crash when clicking settings when loading

### DIFF
--- a/packages/frontend/src/components/Settings/CoreSettingsSwitch.tsx
+++ b/packages/frontend/src/components/Settings/CoreSettingsSwitch.tsx
@@ -28,12 +28,13 @@ export default function CoreSettingsSwitch({
   disabled,
   disabledValue,
 }: Props) {
-  const settingsStore = useSettingsStore()[0]!
+  const settingsStore = useSettingsStore()[0]
 
+  const disabledFinal: boolean = disabled || settingsStore == null
   const value =
-    disabled === true && typeof disabledValue !== 'undefined'
+    disabledFinal === true && typeof disabledValue !== 'undefined'
       ? disabledValue
-      : settingsStore.settings[settingsKey] === '1'
+      : settingsStore?.settings[settingsKey] === '1'
 
   return (
     <SettingsSwitch
@@ -41,12 +42,15 @@ export default function CoreSettingsSwitch({
       value={value}
       description={description}
       onChange={() => {
+        if (settingsStore == null) {
+          return
+        }
         SettingsStoreInstance.effect.setCoreSetting(
           settingsKey,
           flipDeltaBoolean(settingsStore.settings[settingsKey])
         )
       }}
-      disabled={disabled}
+      disabled={disabledFinal}
     />
   )
 }

--- a/packages/frontend/src/components/Settings/DesktopSettingsSwitch.tsx
+++ b/packages/frontend/src/components/Settings/DesktopSettingsSwitch.tsx
@@ -24,12 +24,13 @@ export default function DesktopSettingsSwitch({
   disabledValue,
   callback,
 }: Props) {
-  const settingsStore = useSettingsStore()[0]!
+  const settingsStore = useSettingsStore()[0]
 
+  const disabledFinal: boolean = disabled || settingsStore == null
   const value =
-    disabled === true && typeof disabledValue !== 'undefined'
+    disabledFinal === true && typeof disabledValue !== 'undefined'
       ? disabledValue
-      : settingsStore.desktopSettings[settingsKey] === true
+      : settingsStore?.desktopSettings[settingsKey] === true
 
   return (
     <SettingsSwitch
@@ -37,6 +38,9 @@ export default function DesktopSettingsSwitch({
       description={description}
       value={value}
       onChange={async () => {
+        if (settingsStore == null) {
+          return
+        }
         const newValue = !settingsStore.desktopSettings[settingsKey]
         await SettingsStoreInstance.effect.setDesktopSetting(
           settingsKey,
@@ -44,7 +48,7 @@ export default function DesktopSettingsSwitch({
         )
         callback?.(newValue)
       }}
-      disabled={disabled}
+      disabled={disabledFinal}
     />
   )
 }

--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -125,14 +125,18 @@ export function ExperimentalFeatures() {
 
 export default function SyncAllAccountsSwitch() {
   const tx = useTranslationFunction()
-  const settingsStore = useSettingsStore()[0]!
+  const settingsStore = useSettingsStore()[0]
 
   return (
     <SettingsSwitch
       label={tx('pref_background_sync_disabled')}
       description={tx('explain_background_sync_disabled')}
-      value={settingsStore.desktopSettings.syncAllAccounts !== true}
+      value={settingsStore?.desktopSettings.syncAllAccounts !== true}
+      disabled={settingsStore == null}
       onChange={() => {
+        if (settingsStore == null) {
+          return
+        }
         SettingsStoreInstance.effect.setDesktopSetting(
           'syncAllAccounts',
           !settingsStore.desktopSettings.syncAllAccounts

--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -30,7 +30,7 @@ type SettingsView =
 export default function Settings({ onClose }: DialogProps) {
   const { openDialog, closeDialog, openDialogIds } = useDialog()
 
-  const settingsStore = useSettingsStore()[0]!
+  const settingsStore = useSettingsStore()[0]
   const tx = useTranslationFunction()
   const [settingsMode, setSettingsMode] = useState<SettingsView>('main')
 
@@ -78,11 +78,14 @@ export default function Settings({ onClose }: DialogProps) {
             dataTestid='settings'
           />
           <DialogBody>
-            <Profile settingsStore={settingsStore} />
+            {settingsStore != null && <Profile settingsStore={settingsStore} />}
             <SettingsIconButton
               icon='person'
               dataTestid='edit-profile-button'
               onClick={() => {
+                if (settingsStore == null) {
+                  return
+                }
                 openDialog(EditProfileDialog, {
                   settingsStore,
                 })
@@ -157,10 +160,12 @@ export default function Settings({ onClose }: DialogProps) {
             onClose={onClose}
           />
           <DialogBody>
-            <ChatsAndMedia
-              settingsStore={settingsStore}
-              desktopSettings={settingsStore.desktopSettings}
-            />
+            {settingsStore != null && (
+              <ChatsAndMedia
+                settingsStore={settingsStore}
+                desktopSettings={settingsStore.desktopSettings}
+              />
+            )}
             <SettingsEndSeparator />
           </DialogBody>
         </>
@@ -173,7 +178,9 @@ export default function Settings({ onClose }: DialogProps) {
             onClose={onClose}
           />
           <DialogBody>
-            <Notifications desktopSettings={settingsStore.desktopSettings} />
+            {settingsStore != null && (
+              <Notifications desktopSettings={settingsStore.desktopSettings} />
+            )}
             <SettingsEndSeparator />
           </DialogBody>
         </>
@@ -186,11 +193,13 @@ export default function Settings({ onClose }: DialogProps) {
             onClose={onClose}
           />
           <DialogBody>
-            <Appearance
-              rc={settingsStore.rc}
-              desktopSettings={settingsStore.desktopSettings}
-              settingsStore={settingsStore}
-            />
+            {settingsStore != null && (
+              <Appearance
+                rc={settingsStore.rc}
+                desktopSettings={settingsStore.desktopSettings}
+                settingsStore={settingsStore}
+              />
+            )}
             <SettingsEndSeparator />
           </DialogBody>
         </>
@@ -204,7 +213,9 @@ export default function Settings({ onClose }: DialogProps) {
             dataTestid='settings-advanced'
           />
           <DialogBody>
-            <Advanced settingsStore={settingsStore} />
+            {settingsStore != null && (
+              <Advanced settingsStore={settingsStore} />
+            )}
             <SettingsEndSeparator />
           </DialogBody>
         </>


### PR DESCRIPTION
It happens e.g. when you click "Settings"
before the settings have loaded.
The non-null assertion was incorrect.

The crash usually happens when running Playwright tests.
