### PR TITLE
test: fix Playwright VSCode extension not working

### DIFF
--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -1,8 +1,13 @@
 /* eslint-disable no-console */
+import path from 'node:path'
 import { expect, test as base, Page } from '@playwright/test'
 
 const { config } = await import('dotenv')
-config()
+config({
+  // Need to specify path in order to make the Playwright VSCode extension work.
+  // Otherwise it complains that `DC_CHATMAIL_SERVER` is not defined.
+  path: path.join(import.meta.dirname, '.env'),
+})
 
 export const chatmailServerUrl = process.env.DC_CHATMAIL_SERVER
 


### PR DESCRIPTION
The issue has apparently been introduced in
ce82703ab4d43770cdcfa10f3fb3f87551a8e3f2.

TODO:
- [ ] Consider checking if this breaks your personal testing workflow.
  Mine is working. Both the extension and `pnpm e2e`. And they also work in CI.