### PR TITLE
refactor: don't use basename for file name

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -65,7 +65,7 @@ const Composer = forwardRef<
     updateDraftText: (text: string, InputChatId: number) => void
     addFileToDraft: (
       file: string,
-      fileName: string,
+      fileName: string | null,
       viewType: T.Viewtype
     ) => Promise<void>
     removeFile: () => void

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -23,7 +23,11 @@ import ConfirmSendingFiles from '../dialogs/ConfirmSendingFiles'
 import useMessage from '../../hooks/chat/useMessage'
 
 type Props = {
-  addFileToDraft: (file: string, fileName: string, viewType: T.Viewtype) => void
+  addFileToDraft: (
+    file: string,
+    fileName: string | null,
+    viewType: T.Viewtype
+  ) => void
   focusMessageInput: () => void
   showAppPicker: (show: boolean) => void
   selectedChat: Pick<T.BasicChat, 'name' | 'id' | 'chatType'> | null
@@ -106,7 +110,7 @@ export default function MenuAttachment({
       } else if (files[0].toLowerCase().endsWith('.vcf')) {
         viewType = 'Vcard'
       }
-      addFileToDraft(files[0], basename(files[0]), viewType)
+      addFileToDraft(files[0], null, viewType)
       focusMessageInput()
     } else if (files.length > 1) {
       confirmSendMultipleFiles(files, 'File')
@@ -131,7 +135,7 @@ export default function MenuAttachment({
 
     if (files.length === 1) {
       setLastPath(dirname(files[0]))
-      addFileToDraft(files[0], basename(files[0]), 'Image')
+      addFileToDraft(files[0], null, 'Image')
       focusMessageInput()
     } else if (files.length > 1) {
       confirmSendMultipleFiles(files, 'Image')

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -85,7 +85,7 @@ export function useDraft(
   updateDraftText: (text: string, InputChatId: number) => void
   addFileToDraft: (
     file: string,
-    fileName: string,
+    fileName: string | null,
     viewType: T.Viewtype
   ) => Promise<void>
   removeFile: () => void

--- a/packages/frontend/src/hooks/chat/usePrivateReply.ts
+++ b/packages/frontend/src/hooks/chat/usePrivateReply.ts
@@ -5,7 +5,6 @@ import { BackendRemote } from '../../backend-com'
 import { createChatByContactId } from '../../backend/chat'
 
 import type { T } from '@deltachat/jsonrpc-client'
-import { basename } from 'path'
 
 export type PrivateReply = (
   accountId: number,
@@ -23,14 +22,12 @@ export default function usePrivateReply() {
 
       // retrieve existing draft to append the quotedMessageId
       const oldDraft = await BackendRemote.rpc.getDraft(accountId, chatId)
-      const fileName =
-        oldDraft?.fileName ?? (oldDraft?.file ? basename(oldDraft?.file) : null)
       await BackendRemote.rpc.miscSetDraft(
         accountId,
         chatId,
         oldDraft?.text || null,
         oldDraft?.file || null,
-        fileName,
+        oldDraft?.fileName || null,
         quotedMessageId,
         'Text'
       )


### PR DESCRIPTION
Using `basename()` in the browser environment is not correct,
because it's just a polyfill, and e.g. it doesn't work properly
on Windows, i.e. `basename()` returns the whole path unchanged.

Note that now the file name will be momentarily _not_ shown,
until draft has been re-fetched (see `DraftAttachment`).
But that's probably better than showing the entire path on Windows.

TODO:
- ~~[ ] Also remove the `parse(path)`.~~
  That's a separate topic, can do later.
- ~~[ ]~~ Consider writing our own `basename` which we'll be using only for displaying the file name when `filename == null && path != null`, e.g. here:
  https://github.com/deltachat/deltachat-desktop/blob/dc11bbc7f9de67bda59782fdd226378306928c52/packages/frontend/src/components/attachment/messageAttachment.tsx#L315
  
  Also can be done later.
- [x] When done, see if this comment can be removed:
  https://github.com/deltachat/deltachat-desktop/blob/6b3a03e401d1317e541ce23b9f639f5afca4e332/packages/frontend/src/hooks/chat/useDraft.ts#L212-L215

  Edit: already removed on current main