### PR TITLE
Remove "Watch Sent folder" preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - show appropriate messages when scanning wrong qr codes #5563
 - fix: remove the option to select info messages with Ctrl + Up/Down #5337
 
+### Changed
+
+- Removed "Watch Sent Folder" preference. #5611
+
 <a id="2_22_0"></a>
 
 ## [2.22.0] - 2025-10-17

--- a/packages/frontend/src/components/Settings/ImapFolderHandling.tsx
+++ b/packages/frontend/src/components/Settings/ImapFolderHandling.tsx
@@ -18,12 +18,6 @@ export default function ImapFolderHandling({ settingsStore }: Props) {
     <>
       <ShowClassicEmail settingsStore={settingsStore} />
       <CoreSettingsSwitch
-        label={tx('pref_watch_sent_folder')}
-        settingsKey='sentbox_watch'
-        disabled={disableIfOnlyFetchMvBoxIsTrue}
-        disabledValue={false}
-      />
-      <CoreSettingsSwitch
         label={tx('pref_send_copy_to_self')}
         settingsKey='bcc_self'
         description={tx('pref_send_copy_to_self_explain')}

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -11,7 +11,6 @@ export interface SettingsStoreState {
   selfContact: Type.Contact
   settings: {
     [P in (typeof settingsKeys)[number]]: {
-      sentbox_watch: string
       mvbox_move: string
       addr: string
       displayname: string
@@ -33,7 +32,6 @@ export interface SettingsStoreState {
 }
 
 const settingsKeys = [
-  'sentbox_watch',
   'mvbox_move',
   'addr',
   'displayname',


### PR DESCRIPTION
It is going to be removed in the next core release: <https://github.com/chatmail/core/pull/7189>