### PR TITLE
refactor: remove `useRef` from `useDraft`

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -155,12 +155,7 @@ const Composer = forwardRef<
       // random filename
       const filename = Math.random().toString(36).substring(2, 10) + '.mp3'
       const path = await runtime.writeTempFileFromBase64(filename, b64)
-      addFileToDraft(path, filename, 'Voice').catch((reason: any) => {
-        log.error('Cannot send message:', reason)
-        openDialog(AlertDialog, {
-          message: `${tx('error')}: ${reason}`,
-        })
-      })
+      addFileToDraft(path, filename, 'Voice')
     }
   }
 


### PR DESCRIPTION
This change has a negative side-effect,
see the new TODO comment.

It was paralyzing to have this `useRef`
because of how hard it was to understand
all these state mutations, and the purpose of them.

Note that the behavior of the `Promise` returned from
`addFileToDraft()` did not change much,
at least in the "happy path".
But it is now more generic.

This also removes the `.catch` on `addFileToDraft()`
for voice messages.
We don't really expect an error there,
plus it's probably better to handle
all such "could not add file" cases in a single place.

Performance-wise this commit should not have much of an impact,
because even before this commit we have still been re-rendering
after each update to the draft state. The re-render would happen
after `getDraft` inside of `saveAndRefetchDraft_`.
With this commit we now re-render twice:
immediately upon setting the draft, and then after `getDraft`.

--- History ---

`draftRef = useRef` was introduced 5 years ago, in
4bbdbe390b03e15eb059ca6af15a44156413ee44
(https://github.com/deltachat/deltachat-desktop/pull/1951),
as a workaround for our misunderstanding
of how React (or rather JavaScript?) works
(also see cfb2acd744c4b0e795cd17cc08c754102c83b39d,
which says "not sure why the state change does not work...").
Namely, the fact that `setState` (`setDraft`)
does not synchronously update the state returned from `useState`.

Later we embraced the usage of `useRef` to avoid unwanted re-renders.
Namely, see the new TODO comment again.
We also relied on this not re-rendering for setting the quote,
i.e. see how we incorrectly type cast `as Type.MessageQuote`.
This approach also caused issues later, but has been worked around:
- https://github.com/deltachat/deltachat-desktop/issues/4337
- d0b1ddd37e6bfe7f6be36ecb7fd283f6af880653
    (https://github.com/deltachat/deltachat-desktop/pull/4395).

TODO:
- [x] Merge the base, such that only 1 commit remains.
- [x] Merge https://github.com/deltachat/deltachat-desktop/pull/5613.