### PR TITLE
fix: draft WebXDC name being 'Unknown App' rarely

### DIFF
--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -239,16 +239,21 @@ export function DraftAttachment({
 }) {
   const isViewTypeWebxdc = attachment.viewType === 'Webxdc'
   const [attachmentIdToLoad, setAttachmentIdToLoad] = useState(attachment.id)
-  const hasFileNameChanged = useHasChanged2(attachment.fileName)
-  if (hasFileNameChanged) {
-    // Only reload webxdc info if filename has changed, because
-    // the `id` itself could be changing as often as we update the draft.
-    setAttachmentIdToLoad(attachment.id)
-  }
   const webxdcInfoFetch = useRpcFetch(
     BackendRemote.rpc.getWebxdcInfo,
     isViewTypeWebxdc ? [selectedAccountId(), attachmentIdToLoad] : null
   )
+  const hasFileNameChanged = useHasChanged2(attachment.fileName)
+  if (hasFileNameChanged || webxdcInfoFetch?.result?.ok === false) {
+    // Only reload webxdc info if filename has changed, because
+    // the `id` itself could be changing as often as we update the draft.
+    //
+    // Additionally, since this is a draft message, a draft could get replaced,
+    // i.e. the draft message could get deleted. If that happens,
+    // the fetch will fail. In such a case let's also make sure
+    // that we're fetching the latest draft.
+    setAttachmentIdToLoad(attachment.id)
+  }
 
   if (!attachment) {
     return null


### PR DESCRIPTION
Can happen when adding a WebXDC attachment to the draft.

Currently this bug only happens if for some reason
`MessageListAndComposer` re-renders while a WebXDC is being added.
The fact that the bug doesn't manifest itself every time
is because in `useRef` we mutate the `draftRef`
instead of properly setting the state,
so a re-render with `draftState.file` being a temp file
gets skipped.
This state only lasts until `saveAndRefetchDraft_` finishes.

This bug has been discovered when refactoring `useDraft`
to get rid of the `useRef`:
https://github.com/deltachat/deltachat-desktop/pull/5612.
Thanks @nicodh for writing the tests that caught it!