### PR TITLE
refactor: fix error log message in `useFetch`

### DIFF
--- a/packages/frontend/src/hooks/useFetch.ts
+++ b/packages/frontend/src/hooks/useFetch.ts
@@ -144,11 +144,7 @@ export function useFetchGeneric<F extends AsyncFNoArgs>(
               result: { ok: false, err },
               fetchId,
             })
-            log.errorWithoutStackTrace(
-              'error while executing fetch',
-              err,
-              fetchId
-            )
+            log.errorWithoutStackTrace('error while executing fetch', err)
           }
         })
 


### PR DESCRIPTION
Currently this just always prints
`Error: An object could not be cloned.`,
when trying to `IpcRenderer.send` inside of `errorWithoutStackTrace`.
