### PR TITLE
fix: `draftIsLoading` always being `false`

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -86,13 +86,13 @@ const Composer = forwardRef<
     regularMessageInputRef,
     editMessageInputRef,
     draftState,
+    draftIsLoading,
     onSelectReplyToShortcut,
     removeQuote,
     updateDraftText,
     addFileToDraft,
     removeFile,
   } = props
-  const draftIsLoading = draftState == null
 
   const chatId = selectedChat.id
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)


### PR DESCRIPTION
The new approach was introduced in
64c4c88d22700565caaf7e05fa7c814dc4d65c95.
