### PR TITLE
refactor: remove unnecessary wrapper closure

### DIFF
--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -36,15 +36,11 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
   const [initialSettings, setInitialAccountSettings] =
     useState<Credentials>(defaultCredentials())
 
-  const [accountSettings, _setAccountSettings] =
+  const [accountSettings, setAccountSettings] =
     useState<Credentials>(defaultCredentials())
 
   const { openDialog } = useDialog()
   const tx = useTranslationFunction()
-
-  const setAccountSettings = (value: Credentials) => {
-    _setAccountSettings(value)
-  }
 
   const loadSettings = async () => {
     if (window.__selectedAccountId === undefined) {
@@ -58,7 +54,7 @@ function EditAccountInner(onClose: DialogProps['onClose']) {
     const accountSettings: T.EnteredLoginParam = transports[0]
 
     setInitialAccountSettings(accountSettings)
-    _setAccountSettings(accountSettings)
+    setAccountSettings(accountSettings)
   }
 
   useEffect(() => {


### PR DESCRIPTION
`setAccountSettings`, in `EditAccountInner`.
It's not needed since 9fac4f9e11a5b303cfe400eb71b1e26c34e01530
(https://github.com/deltachat/deltachat-desktop/pull/4080).
