### PR TITLE
fix:  "Send Autocrypt msg" dialog button label

### DIFF
--- a/packages/frontend/src/components/Settings/Encryption.tsx
+++ b/packages/frontend/src/components/Settings/Encryption.tsx
@@ -68,7 +68,13 @@ export function KeyViewPanel({
   )
 }
 
-function InitiatePanel({ onClick }: { onClick: todo }) {
+function InitiatePanel({
+  onClick,
+  onClose,
+}: {
+  onClick: todo
+  onClose: () => void
+}) {
   const tx = useTranslationFunction()
 
   return (
@@ -77,8 +83,13 @@ function InitiatePanel({ onClick }: { onClick: todo }) {
         <Callout>{tx('autocrypt_send_asm_explain_before')}</Callout>
       </DialogBody>
       <DialogFooter>
-        <FooterActions align='center'>
-          <FooterActionButton onClick={onClick}>{tx('ok')}</FooterActionButton>
+        <FooterActions>
+          <FooterActionButton onClick={onClose}>
+            {tx('cancel')}
+          </FooterActionButton>
+          <FooterActionButton onClick={onClick} styling='primary'>
+            {tx('autocrypt_send_asm_button')}
+          </FooterActionButton>
         </FooterActions>
       </DialogFooter>
     </>
@@ -104,7 +115,7 @@ export function SendAutocryptSetupMessage({ onClose: _onClose }: DialogProps) {
   if (key) {
     body = <KeyViewPanel autocryptKey={key} onClose={onClose} />
   } else {
-    body = <InitiatePanel onClick={initiateKeyTransfer} />
+    body = <InitiatePanel onClick={initiateKeyTransfer} onClose={onClose} />
   }
 
   return (


### PR DESCRIPTION
It was just "OK", but it performs an action.

This also brings it in line with Delta Chat Android.

Before / after:
<img width="432" height="210" alt="image" src="https://github.com/user-attachments/assets/2090f699-ca6b-4f39-b2d3-93fbd10f5fa5" /> <img width="428" height="212" alt="image" src="https://github.com/user-attachments/assets/f55cb3a2-2cfc-4392-ba3f-b24f4ec561b6" />
