### PR TITLE
refactor: composer: remove dead code

### DIFF
--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -90,7 +90,7 @@ export default class ComposerMessageInput extends React.Component<
     currentState: ComposerMessageInputState
   ) {
     if (currentState.chatId !== props.chatId) {
-      return { chatId: props.chatId, text: '', loadingDraft: true }
+      return { chatId: props.chatId, text: '' }
     }
     return null
   }


### PR DESCRIPTION
Turns out 64c4c88d22700565caaf7e05fa7c814dc4d65c95
did not completely clean up `ComposerMessageInput`
of `loadingDraft`.
