### PR TITLE
refactor: remove dead `|| ''` in `useDraft`

### DIFF
--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -178,7 +178,7 @@ export function useDraft(
           _setDraftStateButKeepTextareaValue(_old => ({
             chatId,
             id: newDraft.id,
-            text: newDraft.text || '',
+            text: newDraft.text,
             file: newDraft.file,
             fileBytes: newDraft.fileBytes,
             fileMime: newDraft.fileMime,


### PR DESCRIPTION
`newDraft.text` is always of type `string`, so this piece of code
is of no use.
