### PR TITLE
perf: `field-sizing` for composer height, not JS

### DIFF
--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -70,6 +70,9 @@
     .microphone-button {
       background: none;
       border: none;
+
+      // So that the composer doesn't make them shrink as you type text.
+      flex-shrink: 0;
     }
 
     .attachment-button {
@@ -148,12 +151,20 @@
       padding: 0px;
       border: 0;
       height: auto;
-      line-height: 24px;
+      $line-height: 24px;
+      line-height: $line-height;
       margin-top: 8px;
       margin-bottom: 8px;
       overflow-y: hidden;
       background-color: var(--composerBg);
       color: var(--composerText);
+
+      &.use-field-sizing-css-prop {
+        field-sizing: content;
+        max-height: calc(var(--maxLines) * $line-height);
+
+        overflow-y: auto;
+      }
 
       &::placeholder {
         color: var(--composerPlaceholderText);

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -8,6 +8,9 @@ import { I18nContext } from '../../contexts/I18nContext'
 
 const log = getLogger('renderer/composer/ComposerMessageInput')
 
+const browserSupportsCSSFieldSizing = CSS.supports('field-sizing', 'content')
+const maxLines = 9
+
 type ComposerMessageInputProps = {
   /**
    * Whether the initial loading of the draft is being performed,
@@ -163,7 +166,10 @@ export default class ComposerMessageInput extends React.Component<
         this.moveCursorToTheEnd()
       }
     }
-    if (prevState.chatId === this.state.chatId) {
+    if (
+      !browserSupportsCSSFieldSizing &&
+      prevState.chatId === this.state.chatId
+    ) {
       this.resizeTextareaAndComposer()
     }
   }
@@ -211,7 +217,7 @@ export default class ComposerMessageInput extends React.Component<
   }
 
   resizeTextareaAndComposer() {
-    const maxScrollHeight = 9 * 24
+    const maxScrollHeight = maxLines * 24
 
     const el = this.textareaRef.current
 
@@ -273,7 +279,13 @@ export default class ComposerMessageInput extends React.Component<
       <I18nContext.Consumer>
         {({ writingDirection }) => (
           <textarea
-            className='message-input-area'
+            className={
+              'message-input-area' +
+              (browserSupportsCSSFieldSizing
+                ? ' use-field-sizing-css-prop'
+                : '')
+            }
+            style={{ '--maxLines': maxLines } as React.CSSProperties}
             id='composer-textarea'
             ref={this.textareaRef}
             rows={1}


### PR DESCRIPTION
Before / after:

<img width="1537" height="356" alt="image" src="https://github.com/user-attachments/assets/506f1372-8e0d-40f9-a081-793dabc802a2" />
<img width="1116" height="368" alt="image" src="https://github.com/user-attachments/assets/d4e80bf7-60d3-41dd-8e9d-b08ea3057a3d" />

As you can see, the single key processing time went down from ~7ms to ~4ms.