### PR TITLE
refactor: remove `useRef` from `useDraft`

### DIFF
--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { T } from '@deltachat/jsonrpc-client'
 
 import { getLogger } from '../../../../shared/logger'
@@ -88,21 +88,6 @@ export function useDraft(
      */
     _setDraftStateButKeepTextareaValue,
   ] = useState<DraftObject>(() => emptyDraft(chatId))
-
-  /**
-   * `draftRef.current` gets set to `draftState` on every render.
-   * That is, when you mutate the value of this ref,
-   * `draftState` also gets mutated.
-   *
-   * Having this `ref` is just a hack to perform direct state mutations
-   * without triggering a re-render or linter's warnings about the missing
-   * `draftState` hook dependency.
-   * @see {@linkcode saveAndRefetchDraft_} docs about the cases
-   * where it's nice to update the draft object, but not re-render
-   * until we have re-fetched it from the backend.
-   */
-  const draftRef = useRef<DraftObject>(draftState)
-  draftRef.current = draftState
 
   /**
    * @see {@link _setDraftStateButKeepTextareaValue}.
@@ -227,10 +212,14 @@ export function useDraft(
    * - Adding an attachment ({@linkcode addFileToDraft}).
    *   Because the file name might get changed
    *   by the backend, and because we don't set the file size locally.
+   *
+   * TODO fix: when adding an attachment, the composer quickly flashes
+   * the new attachment as "file <path>; 0 bytes",
+   * even if it is a media attachment or a contact.
+   * The same flash happens when setting a quote.
    */
   const saveAndRefetchDraft_ = useCallback(
-    async (chatId: number) => {
-      const draft = draftRef.current
+    async (chatId: number, draft: DraftObject) => {
       if (
         (draft.text && draft.text.length > 0) ||
         (draft.file && draft.file != '') ||
@@ -280,45 +269,66 @@ export function useDraft(
   )
   const saveAndRefetchDraft = useMemo(
     () =>
-      chatId != null && canSend ? () => saveAndRefetchDraft_(chatId) : null,
+      chatId != null && canSend
+        ? (newDraftState: DraftObject) =>
+            saveAndRefetchDraft_(chatId, newDraftState)
+        : null,
     [canSend, chatId, saveAndRefetchDraft_]
+  )
+
+  const setAndSaveAndRefetchDraftButKeepTextareaValue = useMemo(
+    () =>
+      saveAndRefetchDraft == null
+        ? null
+        : (newDraftState: DraftObject) => {
+            _setDraftStateButKeepTextareaValue(newDraftState)
+            return saveAndRefetchDraft(newDraftState)
+          },
+    [saveAndRefetchDraft]
   )
 
   const updateDraftText = (text: string, InputChatId: number) => {
     if (chatId !== InputChatId) {
       log.warn("chat Id and InputChatId don't match, do nothing")
     } else {
-      if (draftRef.current) {
-        draftRef.current.text = text // don't need to rerender on text change
-      }
-      saveAndRefetchDraft?.()
+      setAndSaveAndRefetchDraftButKeepTextareaValue?.({
+        ...draftState,
+        text,
+      })
     }
   }
 
   const removeQuote = useCallback(() => {
-    if (draftRef.current) {
-      draftRef.current.quote = null
-    }
-    saveAndRefetchDraft?.()
+    setAndSaveAndRefetchDraftButKeepTextareaValue?.({
+      ...draftState,
+      quote: null,
+    })
     inputRef.current?.focus()
-  }, [inputRef, saveAndRefetchDraft])
+  }, [draftState, inputRef, setAndSaveAndRefetchDraftButKeepTextareaValue])
 
   const removeFile = useCallback(() => {
-    draftRef.current.file = ''
-    draftRef.current.viewType = 'Text'
-    saveAndRefetchDraft?.()
+    setAndSaveAndRefetchDraftButKeepTextareaValue?.({
+      ...draftState,
+      file: '',
+      viewType: 'Text',
+    })
+
     inputRef.current?.focus()
-  }, [inputRef, saveAndRefetchDraft])
+  }, [draftState, inputRef, setAndSaveAndRefetchDraftButKeepTextareaValue])
 
   const addFileToDraft = useCallback(
     async (file: string, fileName: string | null, viewType: T.Viewtype) => {
-      draftRef.current.file = file
-      draftRef.current.fileName = fileName
-      draftRef.current.viewType = viewType
       inputRef.current?.focus()
-      return saveAndRefetchDraft?.()
+      return setAndSaveAndRefetchDraftButKeepTextareaValue?.({
+        ...draftState,
+        file,
+        fileName,
+        viewType,
+        fileBytes: 0,
+        fileMime: null,
+      })
     },
-    [inputRef, saveAndRefetchDraft]
+    [draftState, inputRef, setAndSaveAndRefetchDraftButKeepTextareaValue]
   )
 
   const { jumpToMessage } = useMessage()
@@ -333,8 +343,9 @@ export function useDraft(
       | KeybindAction.Composer_SelectReplyToDown
   ) => {
     if (
-      saveAndRefetchDraft == null ||
-      // These are implied by `saveAndRefetchDraft == null`,
+      setAndSaveAndRefetchDraftButKeepTextareaValue == null ||
+      // These are implied by
+      // `setAndSaveAndRefetchDraftButKeepTextareaValue == null`,
       // but TypeScript doesn't know
       chatId == undefined ||
       !canSend
@@ -342,11 +353,13 @@ export function useDraft(
       return
     }
     const quoteMessage = (messageId: number) => {
-      draftRef.current.quote = {
-        kind: 'WithMessage',
-        messageId,
-      }
-      saveAndRefetchDraft()
+      setAndSaveAndRefetchDraftButKeepTextareaValue({
+        ...draftState,
+        quote: {
+          kind: 'WithMessage',
+          messageId,
+        },
+      })
 
       jumpToMessage({
         accountId,
@@ -372,7 +385,7 @@ export function useDraft(
           messageListState.messageCache[id]?.kind === 'message' &&
           messageListState.messageCache[id]?.isInfo === false
       )
-    const currQuote = draftRef.current.quote
+    const currQuote = draftState.quote
     if (!currQuote) {
       if (upOrDown === KeybindAction.Composer_SelectReplyToUp) {
         quoteMessage(messageIds[messageIds.length - 1])
@@ -430,17 +443,19 @@ export function useDraft(
 
   useEffect(() => {
     window.__setQuoteInDraft = (messageId: number) => {
-      draftRef.current.quote = {
-        kind: 'WithMessage',
-        messageId,
-      }
-      saveAndRefetchDraft?.()
+      setAndSaveAndRefetchDraftButKeepTextareaValue?.({
+        ...draftState,
+        quote: {
+          kind: 'WithMessage',
+          messageId,
+        },
+      })
       inputRef.current?.focus()
     }
     return () => {
       window.__setQuoteInDraft = null
     }
-  }, [draftRef, inputRef, saveAndRefetchDraft])
+  }, [draftState, inputRef, setAndSaveAndRefetchDraftButKeepTextareaValue])
 
   return {
     draftState,


### PR DESCRIPTION
This change has a negative side-effect,
see the new TODO comment.

It was paralyzing to have this `useRef`
because of how hard it was to understand
all these state mutations, and the purpose of them.

Performance-wise this commit should not have much of an impact,
because even before this commit we have still been re-rendering
after each update to the draft state. The re-render would happen
after `getDraft` inside of `saveAndRefetchDraft_`.
With this commit we now re-render twice:
immediately upon setting the draft, and then after `getDraft`.

This MR is mainly a preparation for https://github.com/deltachat/deltachat-desktop/pull/5643.
However, it's valuable on its own, to make changing `useDraft` easier.

## History

`draftRef = useRef` was introduced 5 years ago, in
4bbdbe390b03e15eb059ca6af15a44156413ee44
(https://github.com/deltachat/deltachat-desktop/pull/1951),
as a workaround for our misunderstanding
of how React (or rather JavaScript?) works
(also see cfb2acd744c4b0e795cd17cc08c754102c83b39d,
which says "not sure why the state change does not work...").
Namely, the fact that `setState` (`setDraft`)
does not synchronously update the state returned from `useState`.

Later we embraced the usage of `useRef` to avoid unwanted re-renders.
Namely, see the new TODO comment again.
We also relied on this not re-rendering for setting the quote,
i.e. see how we used to incorrectly type cast `as Type.MessageQuote`
before e0a90c9f383e3a18acd72442fb320f730d7c9dfe.
This approach also caused issues later, but has been worked around:
- https://github.com/deltachat/deltachat-desktop/issues/4337
- d0b1ddd37e6bfe7f6be36ecb7fd283f6af880653
    (https://github.com/deltachat/deltachat-desktop/pull/4395).
