### PR TITLE
fix: remove `:emoji:` replacement on incoming msgs

### DIFF
--- a/packages/frontend/src/components/message/MessageBody.tsx
+++ b/packages/frontend/src/components/message/MessageBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import classNames from 'classnames'
-import { getSizeClass, replaceColons } from '../conversations/emoji'
+import { getSizeClass } from '../conversations/emoji'
 import { parseAndRenderMessage } from './MessageParser'
 
 /** limit where message parser will not parse the message, limit of core is lower, this is just a failsafe */
@@ -27,20 +27,20 @@ function MessageBody({
   if (text.length >= UPPER_LIMIT_FOR_PARSED_MESSAGES) {
     return <>{text}</>
   }
+  const textTrimmed = trim(text)
   // if text is only emojis and Jumbomoji is enabled
-  const emojifiedText = trim(text.replace(/:[\w\d_\-+]*:/g, replaceColons))
   if (!disableJumbomoji) {
-    const sizeClass = getSizeClass(emojifiedText)
+    const sizeClass = getSizeClass(textTrimmed)
     if (sizeClass !== undefined) {
       return (
         <span className={classNames('emoji-container', sizeClass)}>
-          {emojifiedText}
+          {textTrimmed}
         </span>
       )
     }
   }
   return parseAndRenderMessage(
-    emojifiedText,
+    textTrimmed,
     nonInteractiveContent,
     tabindexForInteractiveContents ?? 0
   )


### PR DESCRIPTION
Technically this can be considered a breaking change which might make some users angry.

Prior to this, we would render a message saying
`Foo :smile: bar` as `Foo 😄 bar`.
While this might be still needed for older messages
that use this format, it's hard to imagine
that anyone is actually using this format nowadays,
so let's render incoming messages as is in this regard.

Before / after:
<img width="159" height="84" alt="image" src="https://github.com/user-attachments/assets/8f2cb081-e3c8-4338-a3d2-03fbe398d19b" /> <img width="154" height="82" alt="image" src="https://github.com/user-attachments/assets/0cb1aeeb-3886-46c6-9c7a-ddb434983edc" />

We still do this replacement when sending messages,
ever since 20ea65d29847459e9179f1f57a8048447cdadbea
(https://github.com/deltachat/deltachat-desktop/pull/1781),
and it's probably enough (given that we need to do that at all).

https://github.com/deltachat/deltachat-desktop/blob/2b2ab0bd399478c36d41f6e8e69e1da963bd05b2/packages/frontend/src/components/composer/Composer.tsx#L220-L221

This should improve performance a little, and simplify the code.