### PR TITLE
refactor: remove unnecessary `__reloadDraft`

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -19,12 +19,7 @@ import { replaceColonsSafe } from '../conversations/emoji'
 import { Quote } from '../message/Message'
 import { DraftAttachment } from '../attachment/messageAttachment'
 import { useSettingsStore } from '../../stores/settings'
-import {
-  BackendRemote,
-  EffectfulBackendActions,
-  onDCEvent,
-  Type,
-} from '../../backend-com'
+import { BackendRemote, EffectfulBackendActions, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { confirmDialog } from '../message/messageFunctions'
@@ -178,27 +173,7 @@ const Composer = forwardRef<
     })
   }
 
-  const hasSecureJoinEnded = useRef<boolean>(false)
-  useEffect(() => {
-    if (hasSecureJoinEnded) {
-      // after can send was updated
-      window.__reloadDraft && window.__reloadDraft()
-      hasSecureJoinEnded.current = false
-    }
-  }, [selectedChat.canSend])
-
   const showSendButton = currentEditText !== '' || !!draftState.file
-
-  useEffect(() => {
-    return onDCEvent(accountId, 'SecurejoinJoinerProgress', ({ progress }) => {
-      // fix bug where composer was locked after joining a group via qr code
-      if (progress === 1000) {
-        // if already updated can send, currently this is not the case
-        window.__reloadDraft && window.__reloadDraft()
-        hasSecureJoinEnded.current = true
-      }
-    })
-  }, [accountId])
 
   const composerSendMessage =
     messageEditing.isEditingModeActive || draftIsLoading


### PR DESCRIPTION
This is apparently no longer necessary after
2b3cc19c50f4b0d7910de6777fc04d15fc5ce4b8
(https://github.com/deltachat/deltachat-desktop/pull/4394)
Apparently the issue was about the fact that
the composer will not get un-disabled unless we explicitly call
`setText()` or `setState({ loadingDraft: false })`.

This basically reverts
- fdf080dacdc1874deb65491bd64d416939271eb9
  (https://github.com/deltachat/deltachat-desktop/pull/4085).
- 2265667639c76ca14cf46858746562e1a39612d5
  (https://github.com/deltachat/deltachat-desktop/pull/3547).

Now the `disabled` state is controlled
with the reactive `draftIsLoading`, and the chat state
is reloaded on `ChatModified` events,
so such issues should no longer be happening,
and this imperative code can be removed

I added a test for those bugs: https://github.com/deltachat/deltachat-desktop/pull/5656. I also ran the test on this code, and it passed.

Together with https://github.com/deltachat/deltachat-desktop/pull/5663, this will allow us to remove `__reloadDraft`.