### PR TITLE
fix: don't ask "Replace Draft?" unnecessarily

### DIFF
--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -457,11 +457,22 @@ export async function createDummyChat(page: Page, chatName: string) {
   await page.getByRole('textbox', { name: 'Group Name' }).fill(chatName)
   await page.getByTestId('group-create-button').click()
 }
-export async function deleteChat(page: Page, chatName: string | RegExp) {
-  await page
+/**
+ * This RegExp ensures that we don't select by draft or last message text.
+ * `\w` is for the avatar initial.
+ */
+export const makeChatNameRegex = (chatName: string) =>
+  new RegExp(`^\\w?${chatName}`)
+export function getChat(page: Page, chatName: string | RegExp) {
+  return page
     .getByLabel('Chats')
-    .getByRole('tab', { name: chatName })
-    .click({ button: 'right' })
+    .getByRole('tablist')
+    .getByRole('tab', {
+      name: chatName instanceof RegExp ? chatName : makeChatNameRegex(chatName),
+    })
+}
+export async function deleteChat(page: Page, chatName: string | RegExp) {
+  await getChat(page, chatName).click({ button: 'right' })
   await page.getByRole('menuitem', { name: /.*(Delete|Leave).*/ }).click()
   await page.getByRole('button', { name: 'Delete' }).click()
 }
@@ -490,7 +501,7 @@ export async function selectChat(
   options?: { dontWaitForLoaded?: boolean }
 ) {
   const chatList = page.getByLabel('Chats').getByRole('tablist')
-  await chatList.getByRole('tab', { name: chatName }).click()
+  await getChat(page, chatName).click()
 
   if (options?.dontWaitForLoaded) {
     return

--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -11,6 +11,7 @@ import {
   makeDummyContactInviteLink,
   selectChat as selectChatByName,
   sendMessage,
+  getChat,
 } from '../playwright-helper'
 
 test.describe.configure({
@@ -468,7 +469,7 @@ test.describe('draft', () => {
       .click()
 
     const shareProfile = async () => {
-      await chatList.getByText(dummyContactName).click({ button: 'right' })
+      await getChat(page, dummyContactName).click({ button: 'right' })
       await page.getByRole('menuitem', { name: 'View Profile' }).click()
       await page
         .getByRole('dialog')

--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -416,34 +416,34 @@ test.describe('draft', () => {
       await replaceDraftDialog.getByRole('button', { name: 'Cancel' }).click()
     }
 
+    // If there is a file but no text, it's safe to set the text.
+    await expect(textarea).toBeFocused()
+    await textarea.clear()
+    await testDraftIsEmpty()
+    await attachFile()
+    await commandSuggestion.click()
+    await testDraftHasFile()
+    await expect(textarea).toHaveText('/someBotCommand')
+
     const somePriorDraftText =
       'Draft text before bot command has been clicked' + Math.random()
-    await expect(textarea).toBeFocused()
     await textarea.fill(somePriorDraftText)
     await clickCommandAndCancel()
     await expect(textarea).toHaveText(somePriorDraftText)
-
-    await textarea.clear()
-    await testDraftIsEmpty()
-    // It probably doesn't make senese to warn when there is no text
-    // but only a file, but let's test for this.
-    await attachFile()
-    await clickCommandAndCancel()
-    await testDraftHasFile()
-    await expect(textarea).toBeEmpty()
 
     await selectChat(2)
     await expect(textarea).toBeEmpty()
     await selectChat(1)
     await clickCommandAndCancel()
     await testDraftHasFile()
-    await expect(textarea).toBeEmpty()
+    await expect(textarea).toHaveText(somePriorDraftText)
 
     await commandSuggestion.click()
     await replaceDraftDialog
       .getByRole('button', { name: 'Replace Draft' })
       .click()
     await expect(textarea).toHaveText('/someBotCommand')
+    await getRemoveQuoteOrFileButton(composerSection).click()
     await textarea.clear()
     await testDraftIsEmpty()
   })
@@ -493,10 +493,18 @@ test.describe('draft', () => {
     }
 
     await selectChat(1)
-    await attachFile()
     const somePriorDraftText = 'Some prior draft text' + Math.random()
     await expect(textarea).toBeFocused()
     await textarea.fill(somePriorDraftText)
+    // Can add a file to draft if already have text but no file.
+    await shareProfile()
+    await expect(
+      composerSection.getByRole('region', { name: 'Attachment' })
+    ).toContainText(dummyContactName)
+    await expect(textarea).toHaveText(somePriorDraftText)
+
+    await getRemoveQuoteOrFileButton(composerSection).click()
+    await attachFile()
     await tryShareProfileAndCancel()
     const myName = 'Alice'
     await expect(
@@ -505,16 +513,14 @@ test.describe('draft', () => {
     await expect(composerSection).not.toContainText(dummyContactName)
     await expect(textarea).toHaveText(somePriorDraftText)
 
-    await getRemoveQuoteOrFileButton(composerSection).click()
-    // Again, it probably doesn't make sense to replace the whole draft
-    // if we only need to attach a file (contact), but let's test.
-    await tryShareProfileAndCancel()
-    await expect(textarea).toHaveText(somePriorDraftText)
-
     await selectChat(2)
     await expect(textarea).toBeEmpty()
     await selectChat(1)
     await tryShareProfileAndCancel()
+    await expect(
+      composerSection.getByRole('region', { name: 'Attachment' })
+    ).toContainText(myName)
+    await expect(composerSection).not.toContainText(dummyContactName)
     await expect(textarea).toHaveText(somePriorDraftText)
 
     await shareProfile()
@@ -525,9 +531,10 @@ test.describe('draft', () => {
       composerSection.getByRole('region', { name: 'Attachment' })
     ).not.toContainText(myName)
     await expect(composerSection).toContainText(dummyContactName)
-    await expect(textarea).not.toHaveText(somePriorDraftText)
+    await expect(textarea).toHaveText(somePriorDraftText)
 
     await getRemoveQuoteOrFileButton(composerSection).click()
+    await textarea.clear()
     await testDraftIsEmpty()
   })
 })

--- a/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
@@ -225,12 +225,17 @@ function ShareProfileDialog(
 
       const filePath = await runtime.writeTempFile('contact.vcard', vcard)
 
-      await createDraftMessage(targetAccountId, chatId, '', {
-        name: `${contact.displayName}.vcard`,
-        path: filePath,
-        viewType: 'Vcard',
-        deleteTempFileWhenDone: true,
-      })
+      await createDraftMessage(
+        targetAccountId,
+        chatId,
+        null, // text
+        {
+          name: `${contact.displayName}.vcard`,
+          path: filePath,
+          viewType: 'Vcard',
+          deleteTempFileWhenDone: true,
+        }
+      )
     } else {
       await createDraftMessage(targetAccountId, chatId, contact.address)
     }

--- a/packages/frontend/src/components/dialogs/WebxdcSendToChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/WebxdcSendToChat/index.tsx
@@ -40,7 +40,7 @@ export default function WebxdcSaveToChatDialog(props: Props) {
       : undefined
     // Close dialog before createDraftMessage because it may switch accounts
     onClose()
-    await createDraftMessage(targetAccountId, chatId, messageText ?? '', file2)
+    await createDraftMessage(targetAccountId, chatId, messageText, file2)
   }
 
   const onSaveClick = async () => {

--- a/packages/frontend/src/hooks/chat/useCreateDraftMesssage.ts
+++ b/packages/frontend/src/hooks/chat/useCreateDraftMesssage.ts
@@ -12,7 +12,7 @@ const log = getLogger('useCreateDraftMessage')
 export type CreateDraftMessage = (
   accountId: number,
   chatId: number,
-  messageText: string,
+  messageText: string | null,
   file?: {
     path: string
     name?: string
@@ -67,7 +67,7 @@ export default function useCreateDraftMessage() {
               viewType: file.viewType ?? 'File',
             }
           : undefined,
-        text: messageText,
+        text: messageText ?? undefined,
       }
       window.__checkSetDraftRequest?.()
     },

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -514,14 +514,37 @@ export function useDraft(
     }
 
     ;(async () => {
-      // TODO fix: consider checking _only_ whether either file or text
-      // is going to get overridden in the current draft.
-      // If there is no file, just add the file to draft,
-      // no need to ask for confirmation.
-      //
-      // Also if the file and the text are the same as in the current draft,
-      // no need to do anything.
-      if (!isDraftEmpty(draftState)) {
+      const newDraftState = { ...draftState }
+
+      let askConfirm = false
+      if (setDraftRequest.text !== undefined) {
+        if (
+          draftState.text.length > 0 &&
+          draftState.text !== (setDraftRequest.text satisfies string)
+        ) {
+          askConfirm = true
+        }
+
+        newDraftState.text = setDraftRequest.text
+      }
+      if (setDraftRequest.file !== undefined) {
+        if (
+          draftState.file != null &&
+          draftState.file?.length > 0 &&
+          draftState.file !== (setDraftRequest.file.path satisfies string)
+        ) {
+          askConfirm = true
+        }
+
+        // Same as in `addFileToDraft`.
+        newDraftState.file = setDraftRequest.file.path
+        newDraftState.fileName = setDraftRequest.file.name ?? null
+        newDraftState.viewType = setDraftRequest.file.viewType
+        newDraftState.fileMime = null
+        newDraftState.fileBytes = 0
+      }
+
+      if (askConfirm) {
         // perf: we could add `chat` argument to `useDraft`,
         // but let's not change API for such a minor thing
         const chatName: string = await BackendRemote.rpc
@@ -538,19 +561,6 @@ export function useDraft(
         }
       }
 
-      const newDraftState = emptyDraft()
-
-      if (setDraftRequest.text !== undefined) {
-        newDraftState.text = setDraftRequest.text
-      }
-      if (setDraftRequest.file !== undefined) {
-        // Same as in `addFileToDraft`.
-        newDraftState.file = setDraftRequest.file.path
-        newDraftState.fileName = setDraftRequest.file.name ?? null
-        newDraftState.viewType = setDraftRequest.file.viewType
-        newDraftState.fileMime = null
-        newDraftState.fileBytes = 0
-      }
       // Cannot use `setAndDebouncedSaveAndRefetchDraft`
       // because it doesn't return the Promise. See also `addFileToDraft`.
       //


### PR DESCRIPTION
Don't ask if nothing is actually going to get lost.

Edit: I had to change up the tests, because it started selecting chats by the name of the contact in draft.

TODO:
- [x] Adjust tests for the new behavior