### PR TITLE
fix: remove some key codes from keyhandler

### DIFF
--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -78,6 +78,7 @@ export function keyDownEvent2Action(
   // When modifying this, don't forget to also update the corresponding
   // `aria-keyshortcuts` properties, and the "Keybindings" help window.
   if (!ev.repeat) {
+    // check if key is latin, if not we have to use ev.code instead of ev.key
     const isLatin = ev.key && /^\p{Script=Latin}$/u.test(ev.key)
     // fire only on first press
     if (ev.altKey && ev.code === 'ArrowDown') {
@@ -159,7 +160,7 @@ export function keyDownEvent2Action(
       }
     } else if (
       ((ev.metaKey || ev.ctrlKey) && ev.key === '/') ||
-      (!isLatin && ev.code === 'KeySlash')
+      (!isLatin && ev.code === 'Slash')
     ) {
       return KeybindAction.KeybindingCheatSheet_Open
     }


### PR DESCRIPTION
resolves #5595

This is just a workaround to solve the issue that copy & paste shortcuts (and others) might not be working on different keyboard layouts.

Since copy & paste usage has a much higher priority than maybe having no shortcut to open the settings. And any keyCode can collide with some generic shortcut depending on the keyboard layout on the current machine.

The current approach with only checking the event.key is not a final solution since it might not be possible to use non latin keyboards for shortcuts.

A more proper solution would be to use a library (maybe like https://github.com/mckravchyk/shocut which supports non-latin keyboards it seems) or implement a similar approach ourself

edit: added a simple isLatin check to provide a fallback for non latin keyboards