### PR TITLE
fix: some bugs when switching chats

### DIFF
--- a/packages/frontend/src/components/MessageListView.tsx
+++ b/packages/frontend/src/components/MessageListView.tsx
@@ -15,7 +15,21 @@ export default function MessageListView({
   if (chatWithLinger && accountId) {
     return (
       <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
-        <MessageListAndComposer accountId={accountId} chat={chatWithLinger} />
+        <MessageListAndComposer
+          // Note that `key` has not always been here.
+          // Some downstream components still try to support variable `chatId`.
+          // To name a few:
+          // - `useDraft`'s `abortController`.
+          // - `hasChatChanged` in `MessageList`.
+          // - `useHasChanged2(chatId)` in `Composer`.
+          //
+          // However, most of that code is about resetting some state,
+          // so it probably can be removed.
+          // We do not and should actually rely on any kind of cross-chat state.
+          key={`${accountId}_${chatWithLinger.id}`}
+          accountId={accountId}
+          chat={chatWithLinger}
+        />
       </RecoverableCrashScreen>
     )
   }


### PR DESCRIPTION
While working on `useDraft`, I found myself trying to implement
complex logic to manage outdated async functions,
deciding when and when not to set state.

However, `key` is just much simpler and better.

We do not rely on any kind of cross-chat state,
so having `key={chat.id}` makes sense.

The performance for switching chats appears to be about the same.
Without `key` / with `key`, for an empty chat:

<img width="906" height="390" alt="image" src="https://github.com/user-attachments/assets/65e1c0a2-e801-4569-85eb-3e6d9344b86f" />
<img width="899" height="377" alt="image" src="https://github.com/user-attachments/assets/0179b457-9a15-4010-9995-4f3ce63ab2aa" />

<!-- <img width="903" height="373" alt="image" src="https://github.com/user-attachments/assets/c2714dde-4aba-4c78-9eeb-a0819416f5be" /> -->


Removing the code that supports variable `chatId`
can be done in follow-up MRs / commits.

Edit: this appears to also improve message list rendering performance, i.e. now it's less often that we `fetchMoreTop` immediately after switching chats. And this is also less jumpy visually.