### PR TITLE
fix: WebXDC apps only opening on one account

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -112,7 +112,7 @@ export default class DCWebxdc {
     let dummyProxy_: { server: Server; url: string } | undefined
     const getDummyProxyUrl = async () => {
       if (dummyProxy_) {
-        if (dummyProxy_.server.listening) {
+        if (!dummyProxy_.server.listening) {
           // TODO maybe also close all WebXDC instances
           // as soon as we encounter any error?
           // This would be more important when/if we get rid of `host-rules`.


### PR DESCRIPTION
The symptoms are:
- After launching Delta Chat, WebXDC apps open OK.
- After switching to another account and clicking a WebXDC app,
  nothing happens.
- On second click, the app window opens, but it's blank.

The bug has been introduced in
b3f66a5a11a60ccb61ae4381d41abb729a1a235d
(https://github.com/deltachat/deltachat-desktop/pull/5451).

I have tested that this MR fixes the bug.

I would say that this is quite an important bug,
for which it would be worth creating another release.
Thankfully, we haven't published 2.25.0 yet.

Sorry about the mess 😟