### PR TITLE
fix: avatar initials not being always uppercase

### DIFF
--- a/packages/shared/avatarInitial.ts
+++ b/packages/shared/avatarInitial.ts
@@ -8,8 +8,6 @@ const userPerceivedCharacterSegmenter = new Intl.Segmenter(undefined, {
  */
 export function avatarInitial(name: string, addr?: string): string {
   const str = name || addr || ''
-  return (
-    userPerceivedCharacterSegmenter.segment(str)[Symbol.iterator]().next().value
-      ?.segment ?? ''
-  )
+  const segments = userPerceivedCharacterSegmenter.segment(str)
+  return segments[Symbol.iterator]().next().value?.segment.toUpperCase() ?? ''
 }


### PR DESCRIPTION
The issue has been introduced in
18c4250ad55f52f91073c84724549dfa13c5322d
(https://github.com/deltachat/deltachat-desktop/pull/5652).
