### PR TITLE
fix: app hang on attach contact sometimes

### DIFF
--- a/packages/frontend/src/components/dialogs/SelectContact/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectContact/index.tsx
@@ -28,10 +28,8 @@ export default function SelectContactDialog({
   onOk: (contact: T.Contact) => void
 } & DialogProps) {
   const [queryStr, setQueryStr] = useState('')
-  const { contactIds, contactCache, loadContacts } = useLazyLoadedContacts(
-    C.DC_GCL_ADD_SELF,
-    queryStr
-  )
+  const { contactIds, contactCache, loadContacts, isContactLoaded } =
+    useLazyLoadedContacts(C.DC_GCL_ADD_SELF, queryStr)
   const tx = useTranslationFunction()
 
   const selectContactListRef = useRef<HTMLDivElement>(null)
@@ -71,12 +69,7 @@ export default function SelectContactDialog({
                 ref={infiniteLoaderRef}
                 itemCount={contactIds.length}
                 loadMoreItems={loadContacts}
-                // perf: consider using `isContactLoaded` from `useLazyLoadedContacts`
-                // otherwise sometimes we might load the same contact twice (performance thing)
-                // See https://github.com/bvaughn/react-window/issues/765
-                isItemLoaded={index =>
-                  contactCache[contactIds[index]] != undefined
-                }
+                isItemLoaded={isContactLoaded}
                 // minimumBatchSize={100}
               >
                 {({ onItemsRendered, ref }) => (


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5723.

It seems that sometimes this causes front-end to basically
infinitely spam the backend with `get_contacts_by_ids`.

`isContactLoaded` also starts returning `true`
as soon as we have started loading a contact,
and not only when we have loaded it.

This might not completely fix such a potential bug,
but this should at least make it not happen in practice.

TODO:
- [ ] Verify that the bug no longer happens. This can be done after merging the MR,
  in which case the issue should only be closed when it is confirmed that the bug is fixed.