### PR TITLE
fix: tauri: log core events in debug mode also to the logfile/console

### DIFF
--- a/packages/target-tauri/src-tauri/src/state/deltachat.rs
+++ b/packages/target-tauri/src-tauri/src/state/deltachat.rs
@@ -68,10 +68,9 @@ impl DeltaChatAppState {
                 }) = &message
                 {
                     if let Some(response) = response.as_object() {
-                        if let (Some(event_object), Some(context_id)) = (
-                            response.get("event").and_then(|e| e.as_object()),
-                            response.get("contextId").and_then(|e| e.as_u64()),
-                        ) {
+                        if let Some(event_object) =
+                            response.get("event").and_then(|e| e.as_object())
+                        {
                             let kind = event_object.get("kind").and_then(|v| v.as_str());
                             let msg = event_object.get("msg").and_then(|v| v.as_str());
                             if let (Some(kind), Some(msg)) = (kind, msg) {


### PR DESCRIPTION
intercept jsonrpc responses to log core events in debug mode. To fix that log file was not logging the core events.

Made this in context of trying to debug https://github.com/chatmail/core/issues/7270.

Also made https://github.com/chatmail/core/pull/7459 for the cases where core was not using tracing simultaneously with emitting logging events (info, warn, info).
Those logging events look better than logging the events, because they don't spam the log with the exact file path and integrate better in the rust logging ecosystem that we also use in tauri.
