### PR TITLE
chore: add FreeBSD to distribution platforms

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,7 +59,7 @@
   - [ ] [arch](https://archlinux.org/packages/extra/any/deltachat-desktop/)
   - [ ] [nix](https://search.nixos.org/packages?channel=unstable&show=deltachat-desktop&from=0&type=packages&query=deltachat)
   - [ ] [snap](https://snapcraft.io/deltachat-desktop) (community)
-  - [ ] [FreeBSD](https://github.com/pfsense/FreeBSD-ports/tree/devel/net-im/deltachat-desktop)
+  - [ ] [FreeBSD](https://www.freshports.org/net-im/deltachat-desktop)
   ```
   See [example](https://github.com/deltachat/deltachat-desktop/issues/3582)
 


### PR DESCRIPTION
Add FreeBSD to the list of distribution channels in "Release status issue"