### PR TITLE
don't show ... in subtitle on most left groups

### DIFF
--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -399,7 +399,7 @@ function ViewGroupInner(
               />
               <div className='group-profile-subtitle'>
                 {!isBroadcast
-                  ? group.selfInGroup
+                  ? group.contactIds.length > 1 || group.selfInGroup
                     ? tx('n_members', group.contactIds.length.toString(), {
                         quantity: group.contactIds.length,
                       })

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -340,7 +340,7 @@ function chatSubtitle(chat: Type.FullChat) {
   const tx = window.static_translate
   if (chat.id && chat.id > C.DC_CHAT_ID_LAST_SPECIAL) {
     if (chat.chatType === 'Group') {
-      if (chat.selfInGroup) {
+      if (chat.contactIds.length > 1 || chat.selfInGroup) {
         return tx('n_members', [String(chat.contactIds.length)], {
           quantity: chat.contactIds.length,
         })


### PR DESCRIPTION
checking for self-in-group was introduced at #5704 to avoid showing misleading "1 member" during securejoin, when the member list is not known.

this has the disadvantage that the ... subtitle is also shown for left groups.

at https://github.com/deltachat/deltachat-android/pull/4017 we improved the condition for showing member count slightly to "member-count > 1 || self-in-group",
see there for more reasoning and discussion

this is still a bit hacky,
but that's it :)

~~ftr, there is also the subtitle in the profile, but for adapting that, #5738 should be merged before~~ EDIT: after #5738  is merged, i rebase and applied the same condition to the profile