### PR TITLE
Fix: Reduce image footer width in media only messages

### DIFF
--- a/packages/frontend/src/components/message/styles.module.scss
+++ b/packages/frontend/src/components/message/styles.module.scss
@@ -26,7 +26,7 @@
     bottom: 5px;
     margin-inline-start: 10px;
     position: absolute;
-    right: 5px;
+    inset-inline-end: 5px;
   }
 
   // &.withReactionsNoText {


### PR DESCRIPTION
Reduce the width of the footer so it doesn't cover the image.

Closes https://github.com/deltachat/deltachat-desktop/issues/5744