### PR TITLE
set title of advanced settings to 'Advanced'

### DIFF
--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -207,7 +207,7 @@ export default function Settings({ onClose }: DialogProps) {
       {settingsMode === 'advanced' && (
         <>
           <DialogHeader
-            title={tx('menu_more_options')}
+            title={tx('menu_advanced')}
             onClickBack={() => setSettingsMode('main')}
             onClose={onClose}
             dataTestid='settings-advanced'


### PR DESCRIPTION
this PR changes the title of the 'Advanced' settings dialog to 'Advanced'.

as a rule of thumb, the opened dialog should read what the clicked item reads. boring. expected.

(i checked some other dialogs, in general, it is like that :)

before / after:

<img width="300" src="https://github.com/user-attachments/assets/9e790c57-791e-41cd-9378-a0beec7109b4" />
<img width="300" src="https://github.com/user-attachments/assets/81fd297b-65ea-4123-9450-04a43e3d5765" />
