### PR TITLE
feat: do not log account and system info on profile selection

### DIFF
--- a/packages/frontend/src/ScreenController.tsx
+++ b/packages/frontend/src/ScreenController.tsx
@@ -157,13 +157,6 @@ export default class ScreenController extends Component {
       await BackendRemote.rpc.startIo(accountId)
     }
 
-    BackendRemote.rpc.getInfo(accountId).then(info => {
-      log.info('account_info', info)
-    })
-    BackendRemote.rpc.getSystemInfo().then(info => {
-      log.info('system_info', info)
-    })
-
     await BackendRemote.rpc.selectAccount(accountId)
   }
 


### PR DESCRIPTION
Account information is anyway available in the about window and otherwise this info just slows down app startup and profile selection and clutters the log
as it is written on every account switch
and this happens a lot if user actually has multiple profiles in use.