### PR TITLE
fix: only fetch system info one time on startup not every time you switch accounts

### DIFF
--- a/packages/frontend/src/ScreenController.tsx
+++ b/packages/frontend/src/ScreenController.tsx
@@ -84,6 +84,9 @@ export default class ScreenController extends Component {
   }
 
   private async startup() {
+    BackendRemote.rpc.getSystemInfo().then(info => {
+      log.info('system_info', info)
+    })
     const lastLoggedInAccountId = await this._getLastUsedAccount()
     if (lastLoggedInAccountId) {
       await this.selectAccount(lastLoggedInAccountId)
@@ -159,9 +162,6 @@ export default class ScreenController extends Component {
 
     BackendRemote.rpc.getInfo(accountId).then(info => {
       log.info('account_info', info)
-    })
-    BackendRemote.rpc.getSystemInfo().then(info => {
-      log.info('system_info', info)
     })
 
     await BackendRemote.rpc.selectAccount(accountId)


### PR DESCRIPTION
only fetch and log system info on startup, its content does not change anyway.
It is still useful to have, so that log contains core and sqlite version atleast once.
