### PR TITLE
do not recommended to enter email address, even on non-chatmail

### DIFF
--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -346,9 +346,7 @@ function CreateChatMain(props: CreateChatMainProps) {
           className='search-input'
           onChange={e => setQueryStr(e.target.value)}
           value={queryStr}
-          placeholder={
-            isChatmail ? tx('search') : tx('contacts_enter_name_or_email')
-          }
+          placeholder={tx('search')}
           onKeyDown={onKeyDown}
           autoFocus
           spellCheck={false}


### PR DESCRIPTION
this PR changes the search placeholder to a neutral "Search" instead of "Enter name or email address" - even on chatmail, the latter one is often a bad advice, even more if you mimic that behaviour on your other accounts. 

using email that way is advanced, it should in no way worsen experience with the recommended

ftr, this is also what android/ios are doing, and also desktop inside "new email" when adding recipients