### PR TITLE
adapt help layout to layout used elsewhere

### DIFF
--- a/static/help/help.css
+++ b/static/help/help.css
@@ -18,7 +18,7 @@ html {
   opacity: 0.9;
   border: 0;
   border-radius: 10px;
-  padding: 3px 8px;
+  padding: 4px 12px;
   cursor: pointer;
 }
 


### PR DESCRIPTION
the layout of the help was a bit outdated; this PR adapts paddings, and link colors.

moreover, it marks external links as such (as on iOS), making it far easier to navigate through the help.

(the vast majority of external links are in the "discuss" sections behind "advanced", btw)

before:
----
<img width="808" height="635" alt="Screenshot 2025-11-24 at 18 14 35" src="https://github.com/user-attachments/assets/84a95182-ea72-44f6-aead-4c7bd1094916" />
<img width="808" height="635" alt="Screenshot 2025-11-24 at 18 14 23" src="https://github.com/user-attachments/assets/430204af-fbeb-497a-b263-57b7a9f30a0b" />

after - search aright, more spacing, external links marked, updated "blue"
----

<img width="808" height="635" alt="Screenshot 2025-11-24 at 18 15 06" src="https://github.com/user-attachments/assets/46856965-bb7d-4309-ad4b-f870beafe9fe" />
<img width="808" height="635" alt="Screenshot 2025-11-24 at 18 15 11" src="https://github.com/user-attachments/assets/b01b3ff8-a83a-48c5-a791-ba0c694b80a7" />

