### PR TITLE
fix: do not minimize the window before hiding it

### DIFF
--- a/packages/target-electron/src/tray.ts
+++ b/packages/target-electron/src/tray.ts
@@ -55,12 +55,9 @@ function mainWindowIsVisible() {
   return mainWindow.window.isVisible() && mainWindow.window.isFocused()
 }
 
-export function hideDeltaChat(minimize?: boolean) {
+export function hideDeltaChat() {
   if (!mainWindow.window) {
     throw new Error('window does not exist, this should never happen')
-  }
-  if (minimize === true) {
-    mainWindow.window.minimize()
   }
   mainWindow.window.hide()
   if (process.platform === 'linux') tray?.setContextMenu(getTrayMenu() as Menu)
@@ -74,7 +71,7 @@ export function showDeltaChat() {
 }
 
 function hideOrShowDeltaChat() {
-  mainWindowIsVisible() ? hideDeltaChat(true) : showDeltaChat()
+  mainWindowIsVisible() ? hideDeltaChat() : showDeltaChat()
 }
 
 export function quitDeltaChat() {


### PR DESCRIPTION
Minimizing the window with mainWindow.window.minimize() before hiding it with mainWindow.window.hide()
results in a crash when mainWindow.window.show()
is called later when running on Wayland:
`[3179:0628/212044.664566:FATAL:wayland_toplevel_window.cc(1123)] Should not be called with kMinimized state`

I have tested the fix in `labwc` by clicking the icon to hide and show the window multiple times,
as well as hiding the window manually by clicking
on the window name in the taskbar (wlr/taskbar module of waybar) and then restoring it via the tray icon.
This also fixed the problem when running `niri`,
I cannot reproduce the crash with it as well.

Closes <https://github.com/deltachat/deltachat-desktop/issues/3989>