### PR TITLE
fix: skip key arrow up if meta key is pressed

### DIFF
--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -167,6 +167,8 @@ export default class ComposerMessageInput extends React.Component<
       e.key === 'ArrowUp' &&
       !e.ctrlKey &&
       !e.metaKey &&
+      !e.altKey &&
+      !e.shiftKey &&
       this.props.text.trim() === '' &&
       this.props.onArrowUpWhenEmpty
     ) {


### PR DESCRIPTION
resolves #5779