### PR TITLE
refactor: remove pointless magic condition

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -154,7 +154,6 @@ const Composer = forwardRef<
       if (
         message &&
         message.kind === 'message' &&
-        message.state >= 10 &&
         isMessageEditable(message, selectedChat)
       ) {
         // Enter edit mode only for editable messages


### PR DESCRIPTION
It seems to be only relevant when `state === C.DC_STATE_UNDEFINED`,
which is not something that we expect.
Anyways all the logic we need
should be inside of `isMessageEditable`.

The condition has been introduced in one of the earlier versions
of the MR https://github.com/deltachat/deltachat-desktop/pull/5713,
and its purpose has not been discussed.
