### PR TITLE
fix: change confirm label

### DIFF
--- a/packages/frontend/src/components/Settings/Advanced.tsx
+++ b/packages/frontend/src/components/Settings/Advanced.tsx
@@ -39,7 +39,8 @@ export default function Advanced({ settingsStore }: Props) {
       const confirmed = await confirmDialog(
         openDialog,
         tx('pref_multidevice_change_warn'),
-        tx('ok')
+        tx('perm_continue'),
+        true
       )
       // If user didn't confirm, return false to prevent the change
       return confirmed === true


### PR DESCRIPTION
Dialog should say **_continue_** instead _**ok**_ and show a danger button as in https://github.com/deltachat/deltachat-ios/pull/2922