### PR TITLE
Change copy dialog button order

### DIFF
--- a/packages/frontend/src/components/dialogs/QrCodeCopyConfirmationDialog.tsx
+++ b/packages/frontend/src/components/dialogs/QrCodeCopyConfirmationDialog.tsx
@@ -41,7 +41,11 @@ export default function QrCodeCopyConfirmationDialog({
   }
 
   return (
-    <Dialog onClose={onClose}>
+    <Dialog
+      onClose={onClose}
+      canEscapeKeyClose={true}
+      canOutsideClickClose={true}
+    >
       <DialogBody>
         <DialogContent paddingTop>
           <p>{message}</p>
@@ -50,11 +54,15 @@ export default function QrCodeCopyConfirmationDialog({
       </DialogBody>
       <DialogFooter>
         <FooterActions>
-          <FooterActionButton onClick={onCopy} data-testid='confirm-qr-code'>
-            {tx('global_menu_edit_copy_desktop')}
-          </FooterActionButton>
           <FooterActionButton onClick={onCancel}>
             {tx('cancel')}
+          </FooterActionButton>
+          <FooterActionButton
+            onClick={onCopy}
+            data-testid='confirm-qr-code'
+            styling='primary'
+          >
+            {tx('global_menu_edit_copy_desktop')}
           </FooterActionButton>
         </FooterActions>
       </DialogFooter>


### PR DESCRIPTION
resolves #5792 

The dialog now is also affected by #5696 

With the wrong button order it worked to copy with "enter" since the copy button was the first focusable element. Now "enter" just cancels...