### PR TITLE
fix: focus primary action button

### DIFF
--- a/packages/frontend/src/components/Button/index.tsx
+++ b/packages/frontend/src/components/Button/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import classNames from 'classnames'
 
 import styles from './style.module.scss'
@@ -8,6 +8,8 @@ export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   // borderless means button element has no border and transparent background
   // and is of type button for accessibility reasons
   styling?: 'primary' | 'danger' | 'borderless'
+  // automatically focus this button when it mounts
+  setAutoFocus?: boolean
 }
 
 export default function Button({
@@ -15,10 +17,30 @@ export default function Button({
   active = false,
   styling,
   className,
+  setAutoFocus = false,
   ...props
 }: ButtonProps) {
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    if (setAutoFocus && buttonRef.current) {
+      // Use requestAnimationFrame to ensure the button is fully rendered
+      let cancelled = false
+      requestAnimationFrame(() => {
+        if (!cancelled) {
+          buttonRef.current?.focus()
+        }
+      })
+      return () => {
+        cancelled = true
+      }
+    }
+  }, [setAutoFocus])
+
   return (
     <button
+      ref={buttonRef}
+      type='button'
       className={classNames(
         styles.button,
         active && styles.active,

--- a/packages/frontend/src/components/Dialog/FooterActionButton.tsx
+++ b/packages/frontend/src/components/Dialog/FooterActionButton.tsx
@@ -6,13 +6,12 @@ import type { ButtonProps } from '../Button'
 
 import styles from './styles.module.scss'
 
-export default function FooterActionButton({
-  children,
-  ...props
-}: ButtonProps) {
+const FooterActionButton = ({ children, ...props }: ButtonProps) => {
   return (
     <Button className={styles.footerActionButton} {...props}>
       {children}
     </Button>
   )
 }
+
+export default FooterActionButton

--- a/packages/frontend/src/components/dialogs/ConfirmationDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfirmationDialog.tsx
@@ -61,6 +61,7 @@ export default function ConfirmationDialog({
             {cancelLabel || tx('cancel')}
           </FooterActionButton>
           <FooterActionButton
+            setAutoFocus
             styling={isConfirmDanger ? 'danger' : 'primary'}
             onClick={() => handleClick(true)}
             data-testid='confirm'

--- a/packages/frontend/src/components/dialogs/QrCodeCopyConfirmationDialog.tsx
+++ b/packages/frontend/src/components/dialogs/QrCodeCopyConfirmationDialog.tsx
@@ -61,6 +61,7 @@ export default function QrCodeCopyConfirmationDialog({
             onClick={onCopy}
             data-testid='confirm-qr-code'
             styling='primary'
+            setAutoFocus
           >
             {tx('global_menu_edit_copy_desktop')}
           </FooterActionButton>


### PR DESCRIPTION
resolves #5696

By adding a setAutoFocus prop to FooterActionButton we can control which button  should be focused after rendering.

By setting type="button" we enable the on enter => click behaviour for that button.

In general using form directive and submit button would be more comprehensive but is more relevant for dialogs with multiple form elements on it.

requestAnimationFrame should put the focus event to the end of the rendering process although it is not guaranteed that it works in all scenarios