### PR TITLE
refactor: apply `type="button"` to all buttons

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ export default defineConfig(
       },
       rules: {
         'react/prop-types': 'off',
+        'react/button-has-type': 'warn',
       },
     },
     {

--- a/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountItem.tsx
@@ -257,6 +257,7 @@ export default function AccountItem({
       })}
     >
       <button
+        type='button'
         className={classNames(styles.account, rovingTabindex.className, {
           [styles.active]: isSelected,
           [styles['context-menu-active']]: isContextMenuActive,

--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -173,6 +173,7 @@ export default function AccountListSidebar({
           <RovingTabindexProvider wrapperElementRef={accountsListRef}>
             {accountsFetch.lingeringResult?.ok === false ? (
               <button
+                type='button'
                 onClick={() => {
                   if (
                     !accountsFetch.lingeringResult ||
@@ -241,6 +242,7 @@ export default function AccountListSidebar({
           inside a landmark / section.
           But which? It doesn't really belong to "Profiles". */}
           <button
+            type='button'
             aria-label={tx('menu_settings')}
             className={styles.settingsButton}
             onClick={openSettings}
@@ -277,6 +279,7 @@ function AddAccountButton(props: { onClick: () => void }) {
 
   return (
     <button
+      type='button'
       ref={ref}
       aria-label={tx('add_account')}
       className={classNames(styles.addButton, rovingTabindex.className)}

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -268,6 +268,7 @@ export function AppPicker({ onAppSelected }: Props) {
           <p>{app.short_description}</p>
           {setSearchQuery && app.author && (
             <button
+              type='button'
               onClick={() => {
                 if (setSearchQuery && app.author) {
                   setSearchQuery(app.author)
@@ -339,6 +340,7 @@ export function AppPicker({ onAppSelected }: Props) {
               this is not null. */}
               {filteredApps!.map(app => (
                 <button
+                  type='button'
                   key={app.app_id}
                   className={styles.appListItem}
                   onClick={() => setSelectedAppInfo(app)}
@@ -352,6 +354,7 @@ export function AppPicker({ onAppSelected }: Props) {
         <div className={styles.tabBar}>
           {categories.map(category => (
             <button
+              type='button'
               key={category}
               className={classNames(styles.tab, {
                 [styles.activeTab]: selectedCategory === category,

--- a/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
@@ -181,6 +181,7 @@ export const AudioRecorder = ({
   if (!recording) {
     return (
       <button
+        type='button'
         aria-label={tx('voice_send')}
         className={styles.microphoneButton}
         onClick={() => onRecordingStart()}
@@ -192,6 +193,7 @@ export const AudioRecorder = ({
     return (
       <div className={styles.audioRecorder}>
         <button
+          type='button'
           className={styles.microphoneButton}
           onClick={() => onRecordingStop()}
           aria-label={tx('stop_recording')}
@@ -200,10 +202,15 @@ export const AudioRecorder = ({
         </button>
         <Timer />
         <VolumeMeter volume={volume} />
-        <button className={styles.cancel} onClick={() => onRecordingCancel()}>
+        <button
+          type='button'
+          className={styles.cancel}
+          onClick={() => onRecordingCancel()}
+        >
           {tx('cancel')}
         </button>
         <button
+          type='button'
           className={styles.stopRecording}
           onClick={() => onRecordingStop()}
           aria-description={tx('stop_recording')}

--- a/packages/frontend/src/components/Avatar/index.tsx
+++ b/packages/frontend/src/components/Avatar/index.tsx
@@ -131,6 +131,7 @@ export function ClickForFullscreenAvatarWrapper(
 
   return filename && !disableFullscreen ? (
     <button
+      type='button'
       className={styles.avatarButton}
       onClick={() => {
         openDialog(FullscreenAvatar, {

--- a/packages/frontend/src/components/Button/index.tsx
+++ b/packages/frontend/src/components/Button/index.tsx
@@ -19,6 +19,7 @@ export default function Button({
 }: ButtonProps) {
   return (
     <button
+      type='button'
       className={classNames(
         styles.button,
         active && styles.active,

--- a/packages/frontend/src/components/ConnectivityToast.tsx
+++ b/packages/frontend/src/components/ConnectivityToast.tsx
@@ -163,6 +163,7 @@ export default function ConnectivityToast() {
       Ensure to set `position: relative` on all interactive elements
       so that they are clickable */}
       <button
+        type='button'
         onClick={onInfoTextClick}
         className='showInfoButton'
         aria-label={tx('connectivity')}
@@ -172,6 +173,7 @@ export default function ConnectivityToast() {
         <>
           <a title={networkState[1]}>{tx('connectivity_not_connected')}</a>
           <button
+            type='button'
             className='tryNowButton'
             onClick={onTryReconnectClick}
             disabled={!tryConnectCooldown}

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -406,6 +406,7 @@ export function ContextMenu(props: {
             const isExpanded = index === openSublevels[levelIdx]
             return (
               <button
+                type='button'
                 className={classNames({
                   item: true,
                   selected: isExpanded,

--- a/packages/frontend/src/components/Dialog/HeaderButton.tsx
+++ b/packages/frontend/src/components/Dialog/HeaderButton.tsx
@@ -22,6 +22,7 @@ export default function HeaderButton({
 }: Props) {
   return (
     <button
+      type='button'
       data-no-drag-region
       className={classNames(styles.headerButton, className)}
       {...props}

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -634,6 +634,7 @@ function GalleryTab(props: {
 
   return (
     <button
+      type='button'
       ref={ref}
       className={`tab-item ${isSelected ? 'selected' : ''} ${
         rovingTabindex.className

--- a/packages/frontend/src/components/GroupImage.tsx
+++ b/packages/frontend/src/components/GroupImage.tsx
@@ -59,6 +59,7 @@ export default function GroupImage(props: Props) {
         />
       </AvatarTag>
       <button
+        type='button'
         className='group-image-edit-button'
         data-testid='group-image-edit-button'
         onClick={openContextMenu}

--- a/packages/frontend/src/components/Icon/index.tsx
+++ b/packages/frontend/src/components/Icon/index.tsx
@@ -90,7 +90,7 @@ export default function Icon({
 
 export function IconButton({ coloring, size, icon, ...rest }: IconButtonProps) {
   return (
-    <button {...rest} className={classNames(styles.iconButton)}>
+    <button type='button' {...rest} className={classNames(styles.iconButton)}>
       <Icon coloring={coloring} size={size} icon={icon} />
     </button>
   )

--- a/packages/frontend/src/components/ImageCropper/index.tsx
+++ b/packages/frontend/src/components/ImageCropper/index.tsx
@@ -418,6 +418,7 @@ export default function ImageCropper({
           </div>
           <div className={styles.imageCropperControls}>
             <button
+              type='button'
               className={styles.imageCropperControlsButton}
               onClick={onZoomIn}
               aria-label={tx('menu_zoom_in')}
@@ -425,6 +426,7 @@ export default function ImageCropper({
               <Icon coloring='navbar' icon='plus' size={18} />
             </button>
             <button
+              type='button'
               className={styles.imageCropperControlsButton}
               onClick={onZoomOut}
               aria-label={tx('menu_zoom_out')}
@@ -432,6 +434,7 @@ export default function ImageCropper({
               <Icon coloring='navbar' icon='minus' size={18} />
             </button>
             <button
+              type='button'
               className={styles.imageCropperControlsButton}
               onClick={onRotateImages}
               aria-label={tx('ImageEditorHud_rotate')}
@@ -439,6 +442,7 @@ export default function ImageCropper({
               <Icon coloring='navbar' icon='rotate-right' size={24} />
             </button>
             <button
+              type='button'
               className={styles.imageCropperControlsButton}
               onClick={onFlipX}
               aria-label={tx('ImageEditorHud_flip')}

--- a/packages/frontend/src/components/ImageSelector/index.tsx
+++ b/packages/frontend/src/components/ImageSelector/index.tsx
@@ -67,6 +67,7 @@ export default function ImageSelector({
         />
         {!filePath && (
           <button
+            type='button'
             title={selectLabel ? selectLabel : tx('profile_image_select')}
             aria-label={selectLabel ? selectLabel : tx('profile_image_select')}
             className={styles.imageSelectorButton}
@@ -77,6 +78,7 @@ export default function ImageSelector({
         )}
         {filePath && (
           <button
+            type='button'
             title={removeLabel ? removeLabel : tx('profile_image_delete')}
             aria-label={removeLabel ? removeLabel : tx('profile_image_delete')}
             className={styles.imageSelectorButton}

--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -147,6 +147,7 @@ export default function LoginForm({ credentials, setCredentials }: LoginProps) {
 
           <p className='text'>{tx('login_advanced_hint')}</p>
           <button
+            type='button'
             className='advanced'
             aria-controls='advanced-collapse'
             onClick={() => setUiShowAdvanced(!uiShowAdvanced)}

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -529,6 +529,7 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
         )}
         {!processingFile && (
           <button
+            type='button'
             className={styles.qrReaderButton}
             onClick={handleSelectInput}
             aria-label={tx('menu_settings')}

--- a/packages/frontend/src/components/Reactions/index.tsx
+++ b/packages/frontend/src/components/Reactions/index.tsx
@@ -80,6 +80,7 @@ export default function Reactions(props: Props) {
         </span>
       )}
       <button
+        type='button'
         className={styles.openReactionsListDialogButton}
         aria-label={tx('more_info_desktop')}
         onClick={handleClick}

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -85,6 +85,7 @@ export default function ReactionsBar({
         >
           {myReaction && !isMyReactionDefault && (
             <button
+              type='button'
               role='menuitemradio'
               aria-checked={true}
               onClick={() => toggleReaction(myReaction!)}
@@ -100,6 +101,7 @@ export default function ReactionsBar({
             const isChecked = myReaction === emoji
             return (
               <button
+                type='button'
                 role='menuitemradio'
                 aria-checked={isChecked}
                 key={`emoji-${index}`}
@@ -113,6 +115,7 @@ export default function ReactionsBar({
             )
           })}
           <button
+            type='button'
             role='menuitem'
             aria-haspopup='dialog'
             aria-label={tx('react_more_emojis')}

--- a/packages/frontend/src/components/SearchInput/SearchInputButton.tsx
+++ b/packages/frontend/src/components/SearchInput/SearchInputButton.tsx
@@ -25,6 +25,7 @@ export default function SearchInputButton({
 }: Props) {
   return (
     <button
+      type='button'
       aria-label={props['aria-label']}
       data-testid={props['dataTestid']}
       className={classNames(styles.searchInputButton, className)}

--- a/packages/frontend/src/components/Settings/Appearance.tsx
+++ b/packages/frontend/src/components/Settings/Appearance.tsx
@@ -256,6 +256,7 @@ function BackgroundSelector({
         />
         <div className={'background-options'}>
           <button
+            type='button'
             onClick={onButton.bind(null, SetBackgroundAction.default)}
             style={{
               backgroundImage: 'var(--chatViewBgImgPath)',
@@ -265,11 +266,13 @@ function BackgroundSelector({
             aria-label={tx('pref_background_default')}
           />
           <button
+            type='button'
             onClick={onButton.bind(null, SetBackgroundAction.defaultColor)}
             style={{ backgroundColor: 'var(--chatViewBg)' }}
             aria-label={tx('pref_background_default_color')}
           />
           <button
+            type='button'
             onClick={onButton.bind(null, SetBackgroundAction.customImage)}
             className='custom-image'
             aria-label={tx('pref_background_custom_image')}
@@ -281,6 +284,7 @@ function BackgroundSelector({
             />
           </button>
           <button
+            type='button'
             onClick={onButton.bind(null, SetBackgroundAction.customColor)}
             className='custom-color'
             aria-label={tx('pref_background_custom_color')}
@@ -301,6 +305,7 @@ function BackgroundSelector({
           'petito-moreno.webp',
         ].map(elem => (
           <button
+            type='button'
             onClick={onButton.bind(null, SetBackgroundAction.presetImage)}
             style={{
               backgroundImage: `url(./images/backgrounds/thumb/${elem})`,

--- a/packages/frontend/src/components/Settings/Profile.tsx
+++ b/packages/frontend/src/components/Settings/Profile.tsx
@@ -30,6 +30,7 @@ export default function Profile({ settingsStore, onStatusClick }: Props) {
 
   return (
     <button
+      type='button'
       className={styles.profile}
       onClick={onStatusClick}
       data-testid='edit-profile-button'

--- a/packages/frontend/src/components/Settings/SettingsButton.tsx
+++ b/packages/frontend/src/components/Settings/SettingsButton.tsx
@@ -19,6 +19,7 @@ export default function SettingsButton({
 }: Props) {
   return (
     <button
+      type='button'
       className={classNames(styles.settingsButton, {
         [styles.highlight]: highlight,
       })}

--- a/packages/frontend/src/components/Settings/SettingsIconButton.tsx
+++ b/packages/frontend/src/components/Settings/SettingsIconButton.tsx
@@ -23,6 +23,7 @@ export default function SettingsIconButton({
 }: Props) {
   return (
     <button
+      type='button'
       className={styles.settingsIconButton}
       onClick={onClick}
       data-testid={dataTestid}

--- a/packages/frontend/src/components/Settings/SettingsSelector.tsx
+++ b/packages/frontend/src/components/Settings/SettingsSelector.tsx
@@ -15,7 +15,7 @@ export default function SettingsSelector(props: Props) {
   return (
     // TODO a11y: this component implements `<select>` functionality,
     // but there are no `aria` attributes that make it clear.
-    <button className={styles.settingsSelector} onClick={onClick}>
+    <button type='button' className={styles.settingsSelector} onClick={onClick}>
       <div className={styles.settingsSelectorLabel}>{children}</div>
       {currentValue && (
         <div className={styles.settingsSelectorValue}>{currentValue}</div>

--- a/packages/frontend/src/components/ShortcutMenu/index.tsx
+++ b/packages/frontend/src/components/ShortcutMenu/index.tsx
@@ -53,6 +53,7 @@ export default function ShortcutMenu(props: Props) {
       />
       {props.message.originalMsgId !== null && (
         <button
+          type='button'
           className={classNames(styles.originalMessageButton)}
           aria-label={tx('show_in_chat')}
           onClick={onClick}
@@ -93,6 +94,7 @@ function ReactButton(props: {
 
   return (
     <button
+      type='button'
       aria-label={tx('react')}
       className={styles.shortcutMenuButton}
       onClick={onClick}
@@ -111,6 +113,7 @@ function ContextMenuButton(props: {
 
   return (
     <button
+      type='button'
       aria-label={tx('a11y_message_context_menu_btn_label')}
       className={styles.shortcutMenuButton}
       onClick={props.onClick}

--- a/packages/frontend/src/components/attachment/mediaAttachment.tsx
+++ b/packages/frontend/src/components/attachment/mediaAttachment.tsx
@@ -237,6 +237,7 @@ export function ImageAttachment({
 
     return (
       <button
+        type='button'
         ref={interactiveElRef}
         className={`media-attachment-media${isBroken ? ` broken` : ''} ${
           rovingTabindex.className
@@ -320,6 +321,7 @@ export function VideoAttachment({
     const isBroken = !file || !hasSupportedFormat
     return (
       <button
+        type='button'
         ref={interactiveElRef}
         className={`media-attachment-media${isBroken ? ` broken` : ''} ${
           rovingTabindex.className
@@ -537,6 +539,7 @@ export function FileAttachmentRow({
     const extension = getExtension(message)
     return (
       <button
+        type='button'
         ref={interactiveElRef}
         className={'media-attachment-generic ' + rovingTabindex.className}
         onClick={ev => {
@@ -700,6 +703,7 @@ export function WebxdcAttachment({
     const { summary, name, document } = webxdcInfo
     return (
       <button
+        type='button'
         ref={interactiveElRef}
         className={'media-attachment-webxdc ' + rovingTabindex.className}
         onContextMenu={openContextMenu}

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -134,6 +134,7 @@ export default function Attachment({
     }
     return (
       <button
+        type='button'
         onClick={onClickAttachment}
         tabIndex={tabindexForInteractiveContents}
         className={classNames(
@@ -156,6 +157,7 @@ export default function Attachment({
     if (!message.file) {
       return (
         <button
+          type='button'
           onClick={onClickAttachment}
           tabIndex={tabindexForInteractiveContents}
           style={{ cursor: 'pointer' }}
@@ -204,6 +206,7 @@ export default function Attachment({
     const extension = getExtension(message)
     return (
       <button
+        type='button'
         className={classNames(
           'message-attachment-generic',
           withContentBelow ? 'content-below' : null

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -439,6 +439,7 @@ export default function ChatList(props: {
               )}
             </RovingTabindexProvider>
             <button
+              type='button'
               className='floating-action-button'
               onClick={onCreateChat}
               id='new-chat-button'

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -200,6 +200,7 @@ function ChatListItemArchiveLink({
 
   return (
     <button
+      type='button'
       ref={ref}
       {...rest}
       tabIndex={tabIndex}
@@ -261,6 +262,7 @@ function ChatListItemError({
 
   return (
     <button
+      type='button'
       ref={ref}
       {...rest}
       tabIndex={tabIndex}
@@ -351,6 +353,7 @@ function RegularChatListItem({
 
   return (
     <button
+      type='button'
       ref={ref}
       {...rest}
       tabIndex={tabIndex}
@@ -505,6 +508,7 @@ export const ChatListItemMessageResult = React.memo<
 
   return (
     <button
+      type='button'
       ref={ref}
       {...rest}
       tabIndex={tabIndex}

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -490,6 +490,7 @@ const Composer = forwardRef<
     return (
       <section ref={ref} className='composer contact-request'>
         <button
+          type='button'
           className='contact-request-button delete'
           onClick={async () => {
             if (selectedChat.chatType !== 'Single') {
@@ -512,6 +513,7 @@ const Composer = forwardRef<
           {selectedChat.chatType === 'Single' ? tx('block') : tx('delete')}
         </button>
         <button
+          type='button'
           className='contact-request-button accept'
           onClick={() => {
             EffectfulBackendActions.acceptChat(selectedAccountId(), chatId)
@@ -699,6 +701,7 @@ const Composer = forwardRef<
             )}
           {showSendButton && (
             <button
+              type='button'
               // This ensures that the button loses focus as we switch between
               // the editing mode and the regular mode,
               // so that it's harder to accidentally send a normal message

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -85,6 +85,7 @@ function StickersListItem(props: { filePath: string; onClick: () => void }) {
   const rovingTabindex = useRovingTabindex(ref)
   return (
     <button
+      type='button'
       ref={ref}
       className={'sticker ' + rovingTabindex.className}
       onClick={onClick}
@@ -169,6 +170,7 @@ const EmojiOrStickerSelectorButton = (
   const { isSelected, onClick, children, ...rest } = props
   return (
     <button
+      type='button'
       {...rest}
       role='tab'
       aria-selected={isSelected}

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -195,6 +195,7 @@ export default function MenuAttachment({
 
   return (
     <button
+      type='button'
       aria-label={tx('menu_add_attachment')}
       id='attachment-menu-button'
       data-testid='open-attachment-menu'

--- a/packages/frontend/src/components/contact/ContactListItem.tsx
+++ b/packages/frontend/src/components/contact/ContactListItem.tsx
@@ -106,6 +106,7 @@ export function ContactListItem(
       aria-posinset={props['aria-posinset']}
     >
       <button
+        type='button'
         ref={refMain}
         className={classNames(
           'contact-list-item-button',
@@ -148,6 +149,7 @@ export function ContactListItem(
       )}
       {showRemove && contact.id !== 1 && (
         <button
+          type='button'
           className='btn-remove'
           onClick={onRemoveClick}
           disabled={disabled}

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
@@ -91,6 +91,7 @@ export const AddMemberChip = (props: {
         <div>{contact.displayName}</div>
       </div>
       <button
+        type='button'
         className={styles.removeMember}
         onClick={() => onRemoveClick(contact)}
         aria-label='Remove'

--- a/packages/frontend/src/components/dialogs/QrCode.tsx
+++ b/packages/frontend/src/components/dialogs/QrCode.tsx
@@ -69,6 +69,7 @@ export default function QrCode({
     <Dialog onClose={onClose} dataTestid='qr-dialog'>
       <div className='qr-code-switch'>
         <button
+          type='button'
           className={classNames({ active: showQrCode })}
           onClick={() => setShowQrCode(true)}
           data-testid='qr-show'
@@ -76,6 +77,7 @@ export default function QrCode({
           {tx('qrshow_title')}
         </button>
         <button
+          type='button'
           className={classNames({ active: !showQrCode })}
           onClick={() => setShowQrCode(false)}
           data-testid='show-qr-scan'

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
@@ -113,6 +113,7 @@ function ReactionsDialogListItem(props: {
 
   return (
     <button
+      type='button'
       ref={ref}
       onClick={() => {
         if (notFromSelf) {

--- a/packages/frontend/src/components/helpers/PseudoListItem.tsx
+++ b/packages/frontend/src/components/helpers/PseudoListItem.tsx
@@ -30,6 +30,7 @@ export function PseudoListItem(
   return (
     <div className='contact-list-item' id={id} key={id}>
       <button
+        type='button'
         ref={buttonRef}
         className={'contact-list-item-button ' + rovingTabindex.className}
         onClick={onClick}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -81,7 +81,12 @@ const Avatar = ({
 
   if (profileImage) {
     return (
-      <button className='author-avatar' onClick={onClick} tabIndex={tabIndex}>
+      <button
+        type='button'
+        className='author-avatar'
+        onClick={onClick}
+        tabIndex={tabIndex}
+      >
         <img alt={displayName} src={runtime.transformBlobURL(profileImage)} />
       </button>
     )
@@ -89,6 +94,7 @@ const Avatar = ({
     const initial = avatarInitial(displayName, address)
     return (
       <button
+        type='button'
         className='author-avatar default'
         aria-label={displayName}
         onClick={onClick}
@@ -136,6 +142,7 @@ const AuthorName = ({
 
   return (
     <button
+      type='button'
       key='author'
       className='author'
       style={{ color }}
@@ -174,6 +181,7 @@ const ForwardedTitle = ({
           '$$forwarder$$',
           () => (
             <button
+              type='button'
               className='forwarded-indicator-button'
               onClick={() => onContactClick(contact)}
               tabIndex={tabIndex}
@@ -186,6 +194,7 @@ const ForwardedTitle = ({
         )
       ) : (
         <button
+          type='button'
           onClick={() => onContactClick(contact)}
           className='forwarded-indicator-button'
           tabIndex={tabIndex}
@@ -729,6 +738,7 @@ export default function Message(props: {
         )}
         {(downloadState == 'Failure' || downloadState === 'Available') && (
           <button
+            type='button'
             onClick={downloadFullMessage.bind(null, message.id)}
             tabIndex={tabindexForInteractiveContents}
           >
@@ -853,6 +863,7 @@ export default function Message(props: {
           {content}
           {hasHtml && (
             <button
+              type='button'
               onClick={openMessageHTML.bind(null, message.id)}
               className='show-html'
               tabIndex={tabindexForInteractiveContents}

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -1038,6 +1038,7 @@ function JumpDownButton({
           {countToShow}
         </div>
         <button
+          type='button'
           className='button'
           onClick={() => {
             jumpToMessage({

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -128,6 +128,7 @@ export default function MessageMetaData(props: Props) {
           </div>
           {error !== null && (
             <button
+              type='button'
               className='error-button'
               tabIndex={tabindexForInteractiveContents}
               onClick={onClickError}

--- a/packages/frontend/src/components/screens/CrashScreen.tsx
+++ b/packages/frontend/src/components/screens/CrashScreen.tsx
@@ -62,8 +62,12 @@ export class CrashScreen extends React.Component<
             )
           </h2>
           <p>
-            <button onClick={_ => runtime.reloadWebContent()}>Reload</button>
-            <button onClick={_ => runtime.openLogFile()}>Open Logfile</button>
+            <button type='button' onClick={_ => runtime.reloadWebContent()}>
+              Reload
+            </button>
+            <button type='button' onClick={_ => runtime.openLogFile()}>
+              Open Logfile
+            </button>
           </p>
           <p>
             <pre className='error-details'>{this.state.error}</pre>

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -470,6 +470,7 @@ function ChatHeading({ chat }: { chat: T.FullChat }) {
         )}
       </div>
       <button
+        type='button'
         onClick={onTitleClick}
         aria-label={buttonLabel}
         data-testid='chat-info-button'

--- a/packages/frontend/src/components/screens/RecoverableCrashScreen.tsx
+++ b/packages/frontend/src/components/screens/RecoverableCrashScreen.tsx
@@ -80,8 +80,12 @@ export class RecoverableCrashScreen extends React.Component<
             )
           </h2>
           <p>
-            <button onClick={_ => runtime.reloadWebContent()}>Reload</button>
-            <button onClick={_ => runtime.openLogFile()}>Open Logfile</button>
+            <button type='button' onClick={_ => runtime.reloadWebContent()}>
+              Reload
+            </button>
+            <button type='button' onClick={_ => runtime.openLogFile()}>
+              Open Logfile
+            </button>
           </p>
           <p>
             <pre className='error-details'>{this.state.error}</pre>


### PR DESCRIPTION
We do not utilize `<form>`s at all currently (well, just once),
so this is basically a no-brainer change.

This allows us to introduce `<form>` elements fearlessly,
ensuring that no button will act as a "submit" button
without our intent, see e.g. this recent MR:
https://github.com/deltachat/deltachat-desktop/pull/5805.

I have checked that prior to all the changes `pnpm check:lint`
returned 84 `react/button-has-type` errors and after my changes
`git diff | grep "type='button'" | wc -l` returned also 84.
I have also skimmed through all the changes in ~2 minutes to see that they look sane-ish.

Edit: I will rebase https://github.com/deltachat/deltachat-desktop/pull/5805 on top of main when this MR is merged if needed.