### PR TITLE
fix: openAlertDialog never resolving if Esc closed

### DIFF
--- a/packages/frontend/src/components/CopyContentAlertDialog.tsx
+++ b/packages/frontend/src/components/CopyContentAlertDialog.tsx
@@ -33,7 +33,13 @@ export default function CopyContentAlertDialog({
   }
 
   return (
-    <Dialog onClose={onClose} dataTestid='copy-content-alert-dialog'>
+    <Dialog
+      onClose={() => {
+        cb && cb()
+        onClose()
+      }}
+      dataTestid='copy-content-alert-dialog'
+    >
       <DialogBody>
         <DialogContent paddingTop>
           <p>{message}</p>

--- a/packages/frontend/src/components/dialogs/AlertDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AlertDialog.tsx
@@ -33,7 +33,14 @@ export default function AlertDialog({
   }
 
   return (
-    <Dialog width={350} onClose={onClose} dataTestid={dataTestid}>
+    <Dialog
+      width={350}
+      onClose={() => {
+        cb && cb()
+        onClose()
+      }}
+      dataTestid={dataTestid}
+    >
       <DialogBody>
         <DialogContent paddingTop>
           <p className='whitespace'>{message}</p>


### PR DESCRIPTION
And also do the same for `CopyContentAlertDialog`.

According to the search for `(?<!  )openAlertDialog\(`,
there are no places where this bug affects behavior
in a significant way.
This is mostly just about whether the dialog one layer below
(QR scanner) will get closed or will stay open.

Apart from `openAlertDialog`, there is another place
which relies on the `cb` argument, and that is `AccountSetupScreen`,
but there the behavior also seems unaffected.
