### PR TITLE
refactor: remove unused `ChatView`

### DIFF
--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -11,13 +11,6 @@ import { getLogger } from '@deltachat-desktop/shared/logger'
 
 const log = getLogger('ChatContext')
 
-export enum ChatView {
-  Media,
-  MessageList,
-}
-
-export type SetView = (nextView: ChatView) => void
-
 export type SelectChat = (
   nextAccountId: number,
   chatId: number
@@ -26,7 +19,6 @@ export type SelectChat = (
 export type UnselectChat = () => void
 
 export type ChatContextValue = {
-  activeView: ChatView
   /**
    * `withLinger` means that after `selectChat()` the value of `chatWithLinger`
    * does not change immediately (unlike `chatId`),
@@ -53,7 +45,6 @@ export type ChatContextValue = {
    * @throws if `nextAccountId` is not the currently selected account.
    */
   selectChat: SelectChat
-  setChatView: SetView
   unselectChat: UnselectChat
 }
 
@@ -73,16 +64,10 @@ export const ChatProvider = ({
   accountId,
   unselectChatRef,
 }: PropsWithChildren<Props>) => {
-  const [activeView, setActiveView] = useState(ChatView.MessageList)
-
   const [chatId, setChatId] = useState<number | undefined>()
   useEffect(() => {
     window.__selectedChatId = chatId
   }, [chatId])
-
-  const setChatView = useCallback<SetView>((nextView: ChatView) => {
-    setActiveView(nextView)
-  }, [])
 
   const chatFetch = useRpcFetch(
     BackendRemote.rpc.getFullChatById,
@@ -149,7 +134,6 @@ export const ChatProvider = ({
       }
 
       // Already set known state
-      setActiveView(ChatView.MessageList)
       setChatId(nextChatId)
 
       // Clear system notifications and mark chat as seen in backend
@@ -182,7 +166,6 @@ export const ChatProvider = ({
   )
 
   const unselectChat = useCallback<UnselectChat>(() => {
-    setActiveView(ChatView.MessageList)
     setChatId(undefined)
   }, [])
 
@@ -249,13 +232,11 @@ export const ChatProvider = ({
   }, [accountId, chatWithLinger, chatId, refreshChat])
 
   const value: ChatContextValue = {
-    activeView,
     chatWithLinger,
     chatNoLinger,
     loadingChat: chatFetch?.loading ?? false,
     chatId,
     selectChat,
-    setChatView,
     unselectChat,
   }
 

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 
 import useChat from './useChat'
 import { BackendRemote } from '../../backend-com'
-import { ChatView } from '../../contexts/ChatContext'
 import { getLogger } from '../../../../shared/logger'
 import { notifyWebxdcMessageSent } from '../useWebxdcMessageSent'
 
@@ -82,7 +81,7 @@ const MESSAGE_DEFAULT: T.MessageData = {
 }
 
 export default function useMessage() {
-  const { chatId, setChatView, selectChat } = useChat()
+  const { chatId, selectChat } = useChat()
 
   const jumpToMessage = useCallback<JumpToMessage>(
     async ({
@@ -126,11 +125,10 @@ export default function useMessage() {
       if (msgChatId !== chatId) {
         await selectChat(accountId, msgChatId)
       }
-      setChatView(ChatView.MessageList)
 
       window.__closeAllDialogs?.()
     },
-    [chatId, selectChat, setChatView]
+    [chatId, selectChat]
   )
 
   const sendMessage = useCallback<SendMessage>(


### PR DESCRIPTION
Apparently it's unused ever since we moved "Gallery" to a dialog:
3bc21041bfbafea2da9c297adcdffa28528e8480
(https://github.com/deltachat/deltachat-desktop/pull/5149).
Since then the `activeView` value is never read (and is only set),
and the `ChatView.Media` enum variant is never used.
