### PR TITLE
refactor: simplify `selectChat`

### DIFF
--- a/packages/frontend/src/components/RuntimeAdapter.tsx
+++ b/packages/frontend/src/components/RuntimeAdapter.tsx
@@ -53,7 +53,7 @@ export default function RuntimeAdapter({
           await saveLastChatId(notificationAccountId, chatId)
           await window.__selectAccount(notificationAccountId)
         } else if (chatId !== 0) {
-          await selectChat(accountId, chatId)
+          selectChat(accountId, chatId)
           clearNotificationsForChat(notificationAccountId, chatId)
         }
         if (msgId) {

--- a/packages/frontend/src/components/message/VCard.tsx
+++ b/packages/frontend/src/components/message/VCard.tsx
@@ -46,7 +46,7 @@ export default function VCardComponent({
     const chatId = await createChatByContactId(accountId, contactIds[0])
     if (chatId) {
       await BackendRemote.rpc.createContact(accountId, addr, displayName)
-      await selectChat(selectedAccountId(), chatId)
+      selectChat(selectedAccountId(), chatId)
     }
   }
   return (

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -101,7 +101,7 @@ export default function useMessage() {
       }
 
       // Workaround to actual jump to message in regarding mounted component view
-      // We must set this before the potential `await selectChat()`,
+      // We must set this before the potential `selectChat()`,
       // i.e. before the render of the message list
       // so that it shows the target message right away.
       window.__internal_jump_to_message_asap = {
@@ -123,7 +123,7 @@ export default function useMessage() {
 
       // Check if target message is in same chat, if not switch first
       if (msgChatId !== chatId) {
-        await selectChat(accountId, msgChatId)
+        selectChat(accountId, msgChatId)
       }
 
       window.__closeAllDialogs?.()

--- a/packages/frontend/src/hooks/chat/useSelectLastChat.ts
+++ b/packages/frontend/src/hooks/chat/useSelectLastChat.ts
@@ -28,7 +28,7 @@ export default function useSelectLastChat(accountId?: number) {
     if (account.kind === 'Configured') {
       const lastChatId = await getLastChatId(accountId)
       if (lastChatId && !smallScreenMode) {
-        await selectChat(accountId, lastChatId)
+        selectChat(accountId, lastChatId)
       }
     }
   }, [accountId, selectChat, smallScreenMode])


### PR DESCRIPTION
- **refactor: move "switch to archive on selectChat"**
- **refactor: simplify `selectChat`**

Let's stop providing this unused async API and be more React'ive.

This fixes a bunch of React linter warnings
(access to refs during render)
(see https://github.com/deltachat/deltachat-desktop/pull/5770#issuecomment-3574735021).

Moving the `Switch to "archived" view` code was a requirement for the last, i.e. main, commit.
I have tested that that still works.