### PR TITLE
fix: closeHandler should not prevent dialog from closing

### DIFF
--- a/packages/frontend/src/contexts/DialogContext.tsx
+++ b/packages/frontend/src/contexts/DialogContext.tsx
@@ -58,15 +58,23 @@ export const DialogContextProvider = ({ children }: PropsWithChildren<{}>) => {
     (dialogElement, additionalProps) => {
       const newDialogId = generateRandomUUID()
 
+      // Extract custom onClose handler if provided
+      const customOnClose = additionalProps?.onClose
+
       const newDialog = createElement(
         // From this point on we are only interested in the `DialogProps`
         dialogElement as DialogElementConstructor<DialogProps>,
         {
           key: `dialog-${newDialogId}`,
-          onClose: () => {
+          ...additionalProps,
+          onClose: (result?: any) => {
+            // Call custom onClose handler first if provided
+            if (customOnClose) {
+              customOnClose(result)
+            }
+            // Always close the dialog
             closeDialog(newDialogId)
           },
-          ...additionalProps,
         }
       )
 


### PR DESCRIPTION
This fixes an imo unexpected behaviour, though no existing bug or error:

if an onClose handler is passed as prop to a Dialog component it overrides the internal onClose handler instead just being invoked when the dialog is closed. So the dialog is not closed at all.

We could extend the behaviour to await a result of the custom onClose handler (if provided) so we could keep the dialog open iw wanted, but that kight be another discussion (and PR)