### PR TITLE
feat: show info dialog in useProcessQr

### DIFF
--- a/packages/frontend/src/components/dialogs/Transports/index.tsx
+++ b/packages/frontend/src/components/dialogs/Transports/index.tsx
@@ -17,15 +17,14 @@ import classNames from 'classnames'
 import useDialog from '../../../hooks/dialog/useDialog'
 import { processQr } from '../../../backend/qr'
 import Icon from '../../Icon'
-import { TranslationKey } from '@deltachat-desktop/shared/translationKeyType'
 
 export const addTransportConfirmationDialog = async (
   domain: string,
   multiDeviceMode: boolean,
   openConfirmationDialog: (options: { message: string }) => Promise<boolean>,
-  tx: (key: TranslationKey, ...args: any[]) => string
+  confirmLabel: string
 ): Promise<boolean> => {
-  let message = `${tx('confirm_add_transport')}\n ${domain}`
+  let message = `${confirmLabel}\n ${domain}`
   if (multiDeviceMode) {
     message +=
       '\n\nNote if using multi-device:\nbefore changing or adding transports make sure all other devices have at least version 2.33.0 installed. Otherwise they will run out of sync.'
@@ -102,7 +101,7 @@ export default function TransportsDialog(
             qr.domain,
             multiDeviceMode === '1',
             openConfirmationDialog,
-            tx
+            tx('confirm_add_transport')
           )
           if (!confirmed) {
             return

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -302,7 +302,7 @@ export default function useProcessQR() {
             qr.domain,
             multiDeviceMode,
             openConfirmationDialog,
-            tx
+            tx('confirm_add_transport')
           )
           if (!confirmed) {
             return


### PR DESCRIPTION
To have the same confirmation dialog when scanning a DC ACCOUNT qr code from main scanner