### PR TITLE
use new 'Edit Transport' wording instead of deprecated 'Password and Account'

### DIFF
--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -39,9 +39,7 @@ export default function EditAccountAndPasswordDialog({
     <Dialog canOutsideClickClose={false} onClose={onClose}>
       <DialogHeader
         title={
-          isChatmail
-            ? tx('edit_transport')
-            : tx('manual_account_setup_option')
+          isChatmail ? tx('edit_transport') : tx('manual_account_setup_option')
         }
       />
       {EditAccountInner(onClose, addr)}


### PR DESCRIPTION
this works in practise - on creating new profile "Use Classic Email as Transport" is shown - otherwise "Edit Transport".

however, the `isChatmail` condition seems wrong - it should instead be a `isEditingProfile` or so, but not sure how to change it, anyone, please feel free to commit to this PR :)