### PR TITLE
update advanced settings order

### DIFF
--- a/packages/frontend/src/components/Settings/Advanced.tsx
+++ b/packages/frontend/src/components/Settings/Advanced.tsx
@@ -58,24 +58,15 @@ export default function Advanced({ settingsStore }: Props) {
       <SettingsButton onClick={() => runtime.openLogFile()}>
         {tx('pref_view_log')}
       </SettingsButton>
-      <CoreSettingsSwitch
-        label={tx('enable_realtime')}
-        settingsKey='webxdc_realtime_enabled'
-        description={tx('enable_realtime_explain')}
-      />
-
-      {/*
-        don't show it on electron yet, as the message "not available on this runtime/platform"
-        would confuse users as long as tauri is not the default */}
-      {runtime.getRuntimeInfo().target === 'tauri' && <SettingsAutoStart />}
 
       <SettingsSeparator />
-
-      <SettingsHeading>{tx('pref_experimental_features')}</SettingsHeading>
-      <ExperimentalFeatures />
-      <SettingsSeparator />
-
       <SettingsHeading>{tx('pref_server')}</SettingsHeading>
+      <SettingsButton
+        onClick={openTransportSettings}
+        dataTestid='open-transport-settings'
+      >
+        {tx('transports')}
+      </SettingsButton>
       <SettingsButton
         onClick={() => {
           openProxySettings()
@@ -90,18 +81,32 @@ export default function Advanced({ settingsStore }: Props) {
         description={tx('pref_multidevice_explain')}
         beforeChange={confirmDisableMultiDevice}
       />
+
+      <SettingsSeparator />
+
+      <SettingsHeading>{tx('pref_experimental_features')}</SettingsHeading>
+      <ExperimentalFeatures />
+
+      <SettingsSeparator />
+
+      <CoreSettingsSwitch
+        label={tx('enable_realtime')}
+        settingsKey='webxdc_realtime_enabled'
+        description={tx('enable_realtime_explain')}
+      />
+
+      {/*
+        don't show it on electron yet, as the message "not available on this runtime/platform"
+        would confuse users as long as tauri is not the default */}
+      {runtime.getRuntimeInfo().target === 'tauri' && <SettingsAutoStart />}
+
       {settingsStore.settings.is_chatmail === '0' && (
         <>
           <SettingsSeparator />
+          <SettingsHeading>Legacy Options</SettingsHeading>
           <ImapFolderHandling settingsStore={settingsStore} />
         </>
       )}
-      <SettingsButton
-        onClick={openTransportSettings}
-        dataTestid='open-transport-settings'
-      >
-        {tx('transports')}
-      </SettingsButton>
     </>
   )
 }

--- a/packages/frontend/src/components/Settings/ImapFolderHandling.tsx
+++ b/packages/frontend/src/components/Settings/ImapFolderHandling.tsx
@@ -20,14 +20,12 @@ export default function ImapFolderHandling({ settingsStore }: Props) {
       <CoreSettingsSwitch
         label={tx('pref_auto_folder_moves')}
         settingsKey='mvbox_move'
-        description={tx('pref_auto_folder_moves_explain')}
         disabled={disableIfOnlyFetchMvBoxIsTrue}
         disabledValue={false}
       />
       <CoreSettingsSwitch
         label={tx('pref_only_fetch_mvbox_title')}
         settingsKey='only_fetch_mvbox'
-        description={tx('pref_only_fetch_mvbox_explain')}
       />
     </>
   )


### PR DESCRIPTION
this PR syncs the advanced settings options with android/ios and with overall priorities:

-  move "server section" up
- inside server section, move "transports" ([soon:](https://github.com/deltachat/deltachat-android/pull/4095) "relays") up
- introduce "legacy" options; these options do no longer get longer explanations (the strings are already deprecated)
- all other things go below "experimental"

in a subsequent PR, experiments should not get a subtitle, there is just too much text and level of detail in that section. we're at "advanced", if at all, a subsequent dialog can explain things

before/after:

<img width="320" src="https://github.com/user-attachments/assets/8f0c3d42-a506-4238-83ca-5b5dd42822c2" />
<img width="320" src="https://github.com/user-attachments/assets/4479b771-6d20-4dd1-a3bf-41bd2e3be4c8" />

