### PR TITLE
simplify reviving QR code cases

### DIFF
--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -78,8 +78,7 @@ const WITHDRAW_OR_REVIVE_CONFIGS: WithdrawOrReviveConfigs = {
     dataTestid: 'withdraw-verify-group',
   },
   reviveVerifyGroup: {
-    messageKey: 'revive_verifygroup_explain',
-    getMessageArgs: qr => [qr.grpname],
+    messageKey: 'revive_verifycontact_explain',
   },
   withdrawJoinBroadcast: {
     messageKey: 'withdraw_joinbroadcast_explain',
@@ -87,8 +86,7 @@ const WITHDRAW_OR_REVIVE_CONFIGS: WithdrawOrReviveConfigs = {
     dataTestid: 'withdraw-verify-channel',
   },
   reviveJoinBroadcast: {
-    messageKey: 'revive_joinbroadcast_explain',
-    getMessageArgs: qr => [qr.name],
+    messageKey: 'revive_verifycontact_explain',
   },
 } satisfies WithdrawOrReviveConfigs_
 


### PR DESCRIPTION
after discussion with @Hocuri we decided that it is not worth to maintain strings for the very special and advanced _different_ cases of reviving QR codes.

instead, just always the same message is shown. in fact, it is like that on android/iOS/ubuntu-touch since forever. and if your really scan your own, just before accidentally deactivated QR code, you know what that is about

<img width="523" height="548" alt="Screenshot 2025-12-08 at 15 26 28" src="https://github.com/user-attachments/assets/5b0cbbd2-2a7a-4fa9-8048-f687c03836a8" />

cmp. https://github.com/deltachat/deltachat-android/pull/4097