### PR TITLE
fix: no error log if .env not found

### DIFF
--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -6,8 +6,8 @@ const envPath = path.join(import.meta.dirname, '.env')
 
 try {
   process.loadEnvFile?.(envPath)
-} catch (error) {
-  console.error(`Failed to load ${envPath}`, error)
+} catch (_error) {
+  console.log(`No .env file to load ${envPath}`)
 }
 
 export const chatmailServerDomain = process.env.DC_CHATMAIL_DOMAIN


### PR DESCRIPTION
Avoid misleading error logs in e2e tests. In CI context there is no .env file which is not an error.