### PR TITLE
refactor: remove dead code (IPC `webxdc.exit`)

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -682,14 +682,6 @@ export default class DCWebxdc {
       }
     })
 
-    ipcMain.handle('webxdc.exit', async event => {
-      const app = lookupAppFromEvent(event)
-      if (app) {
-        app.win.loadURL('about:blank')
-        app.win.close()
-      }
-    })
-
     ipcMain.handle('webxdc.getAllUpdates', async (event, serial = 0) => {
       const app = lookupAppFromEvent(event)
       if (!app) {


### PR DESCRIPTION
Follow-up to b3f66a5a11a60ccb61ae4381d41abb729a1a235d
(https://github.com/deltachat/deltachat-desktop/pull/5451),
I missed it there.
