### PR TITLE
refactor: remove duplicate `will-navigate`

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -302,20 +302,6 @@ app.on('web-contents-created', (_ev, contents) => {
       }
     }
 
-    contents.on('will-navigate', (ev, navigationUrl) => {
-      if (navigationUrl.startsWith('webxdc://')) {
-        // allow internal webxdc nav
-        return
-      } else if (navigationUrl.startsWith('mailto:')) {
-        // handle mailto in dc
-        ev.preventDefault()
-        webxdcOpenUrl(navigationUrl)
-      } else {
-        // prevent navigation to unknown scheme
-        ev.preventDefault()
-      }
-    })
-
     contents.on('will-frame-navigate', ev => {
       if (ev.url.startsWith('webxdc://')) {
         // allow internal webxdc nav


### PR DESCRIPTION
The handlers' code is exactly equivalent.
`will-frame-navigate` fuly covers `will-navigate`.
`will-navigate` is simply a subset of `will-frame-navigate`.

https://www.electronjs.org/docs/latest/api/web-contents#event-will-frame-navigate :
> Unlike will-navigate, will-frame-navigate is fired
> when the main frame or any of its subframes attempts to navigate.

Additionally, we already `preventDefault()`
all `will-navigate` events for WebXDC inside of `webxdc.ts`.

This partially reverts 6d7be7d260c7dab918509de6d5569e08f53c37fd
(https://github.com/deltachat/deltachat-desktop/issues/3355).
