### PR TITLE
refactor: remove deprecated `host-rules`

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -133,7 +133,8 @@ export default class DCWebxdc {
         if (!dummyProxy_.server.listening) {
           // TODO maybe also close all WebXDC instances
           // as soon as we encounter any error?
-          // This would be more important when/if we get rid of `host-rules`.
+          // This would be more important when/if we get rid of
+          // `host-resolver-rules`.
           throw new Error(
             'the dummy proxy is not working anymore, `server.listening` is `false`'
           )
@@ -215,7 +216,7 @@ export default class DCWebxdc {
         })
         existing_sessions.push(partition)
 
-        // Thanks to the fact that we specify `host-rules`,
+        // Thanks to the fact that we specify `host-resolver-rules`,
         // no connection attempt to the proxy should occur at all,
         // at least as of now.
         // See https://www.chromium.org/developers/design-documents/network-stack/socks-proxy/ :

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -17,7 +17,12 @@ import { initialisePowerMonitor } from './resume_from_sleep.js'
 // https://www.chromium.org/developers/design-documents/dns-prefetching/
 const hostRules = 'MAP * ~NOTFOUND'
 rawApp.commandLine.appendSwitch('host-resolver-rules', hostRules)
-rawApp.commandLine.appendSwitch('host-rules', hostRules)
+// We used to also apply `host-rules` for good measure,
+// but it has been removed from Chromium:
+// https://chromium-review.googlesource.com/c/chromium/src/+/4867872.
+// We're still not sure what the differences between the two are,
+// but specifying `host-resolver-rules` appears to be enough based on our tests.
+// rawApp.commandLine.appendSwitch('host-rules', hostRules)
 
 rawApp.commandLine.appendSwitch('disable-features', 'IsolateSandboxedIframes')
 

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -647,6 +647,11 @@ fn get_chromium_hardening_browser_args(dummy_proxy_url: &Url) -> String {
     // `host-resolver-rules` and `host-rules` primarily block
     // DNS prefetching. But they also block `fetch()` requests.
     //
+    // Note that `host-rules` has been removed from Chromium in 2025-08:
+    // https://chromium-review.googlesource.com/c/chromium/src/+/4867872.
+    // `host-resolver-rules` seems to be enough to patch DNS prefetching
+    // based on tests run on Electron.
+    //
     // Chromium docs that touch on `--host-resolver-rules` and DNS:
     // https://www.chromium.org/developers/design-documents/network-stack/socks-proxy/
     // https://www.chromium.org/developers/design-documents/dns-prefetching/
@@ -656,7 +661,7 @@ fn get_chromium_hardening_browser_args(dummy_proxy_url: &Url) -> String {
     // However, since the proxy won't work, this should, in theory,
     // effectively disable WebRTC.
     //
-    // Thanks to the fact that we specify `host-rules`,
+    // Thanks to the fact that we specify `host-resolver-rules`,
     // no connection attempt to the proxy should occur at all,
     // at least as of now.
     // See https://www.chromium.org/developers/design-documents/network-stack/socks-proxy/ :


### PR DESCRIPTION
For the Electron version, it has no effect anymore
starting from Electron 39:
https://www.electronjs.org/blog/electron-39-0#deprecated---host-rules-command-line-switch.

For the Tauri version, it depends on the WebView version.

Also see Electron upgrade MR:
https://github.com/deltachat/deltachat-desktop/pull/5843.

This is probably fine to merge without waiting for the Electron upgrade,
but I'd merge after that:
https://github.com/deltachat/deltachat-desktop/pull/5843.