### PR TITLE
fix: WebXDC: host-rules `~NOTFOUND` -> `^NOTFOUND`

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -10,12 +10,12 @@ import { getHelpMenu } from './help_menu.js'
 import { initialisePowerMonitor } from './resume_from_sleep.js'
 
 // Hardening: prohibit all DNS queries
-// The `~NOTFOUND` string is here:
-// https://chromium.googlesource.com/chromium/src/+/6459548ee396bbe1104978b01e19fcb1bb68d0e5/net/dns/mapped_host_resolver.cc#46
+// The `^NOTFOUND` string is here:
+// https://source.chromium.org/chromium/chromium/src/+/main:net/dns/mapped_host_resolver.cc;l=71;drc=c1b102f35ec290df46da5093c2ab90d6616134c6
 // Chromium docs that touch on `--host-resolver-rules` and DNS:
 // https://www.chromium.org/developers/design-documents/network-stack/socks-proxy/
 // https://www.chromium.org/developers/design-documents/dns-prefetching/
-const hostRules = 'MAP * ~NOTFOUND'
+const hostRules = 'MAP * ^NOTFOUND'
 rawApp.commandLine.appendSwitch('host-resolver-rules', hostRules)
 rawApp.commandLine.appendSwitch('host-rules', hostRules)
 

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -640,9 +640,9 @@ fn get_chromium_hardening_browser_args(dummy_proxy_url: &Url) -> String {
     // TODO refactior: probably need to DRY this, make a Tauri MR.
     let default_tauri_browser_args = "--disable-features=msWebOOUI,msPdfOOUI,msSmartScreenProtection --enable-features=RemoveRedirectionBitmap";
 
-    // The `~NOTFOUND` string is here:
-    // https://chromium.googlesource.com/chromium/src/+/6459548ee396bbe1104978b01e19fcb1bb68d0e5/net/dns/mapped_host_resolver.cc#46
-    let host_rules = "MAP * ~NOTFOUND";
+    // The `^NOTFOUND` string is here:
+    // https://source.chromium.org/chromium/chromium/src/+/main:net/dns/mapped_host_resolver.cc;l=71;drc=c1b102f35ec290df46da5093c2ab90d6616134c6
+    let host_rules = "MAP * ^NOTFOUND";
 
     // `host-resolver-rules` and `host-rules` primarily block
     // DNS prefetching. But they also block `fetch()` requests.


### PR DESCRIPTION
The relevant Chromium commit:
https://source.chromium.org/chromium/chromium/src/+/33c9a1f7a52a0ede7cc158b4c58f2bbfe8f187e1.
It was made in 2023-09.

Apparently what this has been leading to was that Chromium
would actually try to resolve `~NOTFOUND` to an address,
instead of hitting the special case.
However, I didn't check that.
