### PR TITLE
fix: also define 'process.env.NODE_ENV' in the build script for electron backend

### DIFF
--- a/packages/target-electron/bin/build.js
+++ b/packages/target-electron/bin/build.js
@@ -26,6 +26,7 @@ await build({
   inject: ['src/cjs-shim.ts'],
   define: {
     BUILD_INFO_JSON_STRING: `"${BuildInfoString.replace(/"/g, '\\"')}"`,
+    'process.env.NODE_ENV': isProduction ? '"production"' : '"development"',
   },
 })
 


### PR DESCRIPTION
this may fix the issue where it tries to load `.env` file in production release builds that were made with `pnpm build4production`.
