### PR TITLE
style: apply "move" cursor on account list drag

### DIFF
--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -200,7 +200,7 @@ export default function AccountListSidebar({
                 <li
                   key={id}
                   draggable
-                  onDragStart={() => handleDragStart(id)}
+                  onDragStart={e => handleDragStart(e, id)}
                   onDragOver={e => handleDragOver(e, index)}
                   onDrop={handleDrop}
                   onDragEnd={handleDragEnd}

--- a/packages/frontend/src/hooks/useAccountDragAndDrop.ts
+++ b/packages/frontend/src/hooks/useAccountDragAndDrop.ts
@@ -10,7 +10,7 @@ export interface DropIndicator {
 export interface UseAccountDragAndDropReturn {
   draggedAccountId: number | null
   dropIndicator: DropIndicator | null
-  handleDragStart: (accountId: number) => void
+  handleDragStart: (e: React.DragEvent, accountId: number) => void
   handleDragOver: (e: React.DragEvent, index: number) => void
   handleDragLeave: () => void
   handleDragEnd: () => void
@@ -29,7 +29,8 @@ export function useAccountDragAndDrop(
   const [draggedAccountId, setDraggedAccountId] = useState<number | null>(null)
   const [dropIndicator, setDropIndicator] = useState<DropIndicator | null>(null)
 
-  const handleDragStart = (accountId: number) => {
+  const handleDragStart = (e: React.DragEvent, accountId: number) => {
+    e.dataTransfer.effectAllowed = 'move'
     setDraggedAccountId(accountId)
   }
 


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5856.

There is more that can be done to improve the drag and drop feedback,
e.g. to show the "not allowed" cursor when trying to drag an account
over a message list, but this shoud cover the most common cases.

Please test this on macOS, check whether the issue is resolved.