### PR TITLE
Show error on add relay

### DIFF
--- a/packages/frontend/src/hooks/dialog/useAddTransportDialog.ts
+++ b/packages/frontend/src/hooks/dialog/useAddTransportDialog.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react'
+
+import { BackendRemote } from '../../backend-com'
+import useAlertDialog from './useAlertDialog'
+import useConfirmationDialog from './useConfirmationDialog'
+import useTranslationFunction from '../useTranslationFunction'
+
+type AddTransportDialogFn = (
+  accountId: number,
+  transportString: string,
+  domainOrAddress: string,
+  multiDeviceMode: boolean,
+  confirmLabel?: string
+) => Promise<boolean>
+
+export default function useAddTransportDialog(): AddTransportDialogFn {
+  const tx = useTranslationFunction()
+  const openAlertDialog = useAlertDialog()
+  const openConfirmationDialog = useConfirmationDialog()
+
+  return useCallback(
+    async (
+      accountId,
+      transportString,
+      domainOrAddress,
+      multiDeviceMode,
+      confirmLabel = tx('confirm_add_transport')
+    ) => {
+      let message = `${confirmLabel}\n ${domainOrAddress}`
+      if (multiDeviceMode) {
+        message +=
+          '\n\nNote if using multi-device:\nbefore changing or adding transports make sure all other devices have at least version 2.33.0 installed. Otherwise they will run out of sync.'
+      }
+      const confirmed = await openConfirmationDialog({
+        message,
+      })
+      if (!confirmed) {
+        return false
+      }
+      try {
+        await BackendRemote.rpc.addTransportFromQr(accountId, transportString)
+      } catch (e) {
+        openAlertDialog({
+          message: 'Relay could not be added. ' + (e as Error).message,
+        })
+        return false
+      }
+      return true
+    },
+    [openAlertDialog, openConfirmationDialog, tx]
+  )
+}

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -20,9 +20,8 @@ import useChat from './chat/useChat'
 import { unknownErrorToString } from '../components/helpers/unknownErrorToString'
 import ProxyConfiguration from '../components/dialogs/ProxyConfiguration'
 import { useSettingsStore } from '../stores/settings'
-import TransportsDialog, {
-  addTransportConfirmationDialog,
-} from '../components/dialogs/Transports'
+import TransportsDialog from '../components/dialogs/Transports'
+import useAddTransportDialog from './dialog/useAddTransportDialog'
 
 const ALLOWED_QR_CODES_ON_WELCOME_SCREEN: T.Qr['kind'][] = [
   'account',
@@ -104,6 +103,7 @@ export default function useProcessQR() {
   const { openDialog } = useDialog()
   const openAlertDialog = useAlertDialog()
   const openConfirmationDialog = useConfirmationDialog()
+  const addTransportDialog = useAddTransportDialog()
 
   const openMailtoLink = useOpenMailtoLink()
   const { startInstantOnboardingFlow } = useInstantOnboarding()
@@ -298,26 +298,17 @@ export default function useProcessQR() {
        */
       if (qr.kind === 'account' || qr.kind === 'login') {
         if (isLoggedIn) {
-          const confirmed = await addTransportConfirmationDialog(
-            qr.kind === 'account' ? qr.domain : qr.address,
-            multiDeviceMode,
-            openConfirmationDialog,
-            tx('confirm_add_transport')
-          )
-          if (!confirmed) {
-            return
-          }
-          try {
-            await BackendRemote.rpc.addTransportFromQr(accountId, url)
-          } catch (e) {
-            openAlertDialog({
-              message: 'Relay could not be added. ' + (e as Error).message,
-            })
-            return
-          }
-          openDialog(TransportsDialog, {
+          const transportAdded = await addTransportDialog(
             accountId,
-          })
+            url,
+            qr.kind === 'account' ? qr.domain : qr.address,
+            multiDeviceMode
+          )
+          if (transportAdded) {
+            openDialog(TransportsDialog, {
+              accountId,
+            })
+          }
         } else {
           await startInstantOnboarding(accountId, { ...parsed, qr })
         }
@@ -468,6 +459,7 @@ export default function useProcessQR() {
       selectChat,
       isChatmail,
       multiDeviceMode,
+      addTransportDialog,
       tx,
     ]
   )


### PR DESCRIPTION
resolves #5868 
For testing: on a classic email profile set "move mails to deltachat folder" to true or "Only fetch from Deltachat folder".

Core throws an error when adding a transport which was ignored before.

Refactored to a hook to make the call easier