### PR TITLE
change: split transport label

### DIFF
--- a/packages/frontend/src/components/dialogs/Transports/index.tsx
+++ b/packages/frontend/src/components/dialogs/Transports/index.tsx
@@ -186,8 +186,12 @@ export default function TransportsDialog(
                     />
                   </span>
                   <label id={`transport-label-${index}`}>
-                    {transport.addr}{' '}
-                    {transport.isDefault ? ` (${tx('def')})` : ''}
+                    <strong>
+                      {transport.addr.split('@')[1]}
+                      {transport.isDefault && ` (${tx('def')})`}
+                    </strong>
+                    <br />
+                    {transport.addr.split('@')[0]}
                   </label>
                 </div>
                 <div>


### PR DESCRIPTION
This is how the other clients show the transport list

<img width="541" height="349" alt="image" src="https://github.com/user-attachments/assets/e49b6239-aa51-46ae-a731-4b436e5f2ef6" />
