### PR TITLE
fix: more space/height for connectivity dialog, because it can be larger since adding quota for multi transport core#7591

### DIFF
--- a/packages/frontend/src/components/dialogs/ConnectivityDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConnectivityDialog.tsx
@@ -63,9 +63,9 @@ function ConnectivityDialogInner() {
         <iframe
           style={{
             border: 0,
-            height: '100%',
+            height: '620px',
             width: '100%',
-            minHeight: '320px',
+            maxHeight: '76vh',
             backgroundColor: bgColor,
             color: textColor,
           }}


### PR DESCRIPTION
dialog got larger in https://github.com/chatmail/core/pull/7630
The new height is enough for the current limit of 5 transports.