### PR TITLE
fix: all "image" pickers to accept same formats

### DIFF
--- a/packages/frontend/src/components/ImageSelector/index.tsx
+++ b/packages/frontend/src/components/ImageSelector/index.tsx
@@ -8,6 +8,7 @@ import { LastUsedSlot, rememberLastUsedPath } from '../../utils/lastUsedPaths'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 
 import styles from './styles.module.scss'
+import { IMAGE_EXTENSIONS } from '@deltachat-desktop/shared/constants'
 
 type Props = {
   color?: string
@@ -41,7 +42,7 @@ export default function ImageSelector({
       filters: [
         {
           name: tx('images'),
-          extensions: ['jpg', 'png', 'gif', 'jpeg', 'webp'],
+          extensions: IMAGE_EXTENSIONS,
         },
       ],
       properties: ['openFile'],

--- a/packages/frontend/src/components/Settings/Appearance.tsx
+++ b/packages/frontend/src/components/Settings/Appearance.tsx
@@ -23,6 +23,7 @@ import Icon from '../Icon'
 import Callout from '../Callout'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 import { getBackgroundImageStyle } from '../message/MessageListAndComposer'
+import { IMAGE_EXTENSIONS } from '@deltachat-desktop/shared/constants'
 
 const log = getLogger('renderer/settings/appearance')
 
@@ -205,7 +206,7 @@ function BackgroundSelector({
           await runtime.showOpenFileDialog({
             title: 'Select Background Image',
             filters: [
-              { name: 'Images', extensions: ['jpg', 'png', 'gif', 'webp'] },
+              { name: tx('images'), extensions: IMAGE_EXTENSIONS },
               { name: 'All Files', extensions: ['*'] },
             ],
             properties: ['openFile'],

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -64,6 +64,7 @@ import { copyToBlobDir } from '../../../utils/copyToBlobDir'
 import { useRpcFetch } from '../../../hooks/useFetch'
 import { I18nContext } from '../../../contexts/I18nContext'
 import { SCAN_CONTEXT_TYPE } from '../../../hooks/useProcessQr'
+import { IMAGE_EXTENSIONS } from '@deltachat-desktop/shared/constants'
 
 const enum GroupType {
   /**
@@ -1006,7 +1007,7 @@ export function useGroupImage(image: string | null) {
     )
     const [file] = await runtime.showOpenFileDialog({
       title: tx('select_group_image_desktop'),
-      filters: [{ name: 'Images', extensions: ['jpg', 'png', 'gif', 'webp'] }],
+      filters: [{ name: tx('images'), extensions: IMAGE_EXTENSIONS }],
       properties: ['openFile'],
       defaultPath,
     })


### PR DESCRIPTION
...and also use the translated "Image" for the filter.

Some of the "Image" pickers would accept e.g. `.jpg`,
but not `.jpeg`. Let's unify them.

Related:
- https://support.delta.chat/t/extend-upload-filter-with-all-rendered-image-formats/4539?u=wofwca.
- https://github.com/deltachat/deltachat-desktop/issues/4663.
