### PR TITLE
fix: crash on adding invalid .xdc to draft

### DIFF
--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -247,7 +247,10 @@ export function DraftAttachment({
     isViewTypeWebxdc ? [selectedAccountId(), attachmentIdToLoad] : null
   )
   const hasFileNameChanged = useHasChanged2(attachment.fileName)
-  if (hasFileNameChanged || webxdcInfoFetch?.result?.ok === false) {
+  if (
+    (hasFileNameChanged || webxdcInfoFetch?.result?.ok === false) &&
+    attachmentIdToLoad !== attachment.id
+  ) {
     // Only reload webxdc info if filename has changed, because
     // the `id` itself could be changing as often as we update the draft.
     //


### PR DESCRIPTION
Fixes https://github.com/deltachat/deltachat-desktop/issues/5899.

This has apparently been introduced in
e701aec874c7c3e7363068d2f7395345aa2d37ba.

The issue is that even if the new state is the same
as per `Object.is`,
> React may still need to call your component
> before skipping the children

so we have to perform this equality check ourself.

https://react.dev/reference/react/useState#setstate-caveats.

I have confirmed that this fixes the bug.

I suspect that I might have planted similar bugs in the codebase.
I am not really sure how to search for them,
except maybe some complex regex.