### PR TITLE
feat: move freely-selected emoji to end

### DIFF
--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -83,20 +83,6 @@ export default function ReactionsBar({
           ref={reactionsBarRef}
           className={styles.reactionsBar}
         >
-          {myReaction && !isMyReactionDefault && (
-            <button
-              type='button'
-              role='menuitemradio'
-              aria-checked={true}
-              onClick={() => toggleReaction(myReaction!)}
-              className={classNames(
-                styles.reactionsBarButton,
-                styles.isFromSelf
-              )}
-            >
-              <span className={styles.reactionsBarEmoji}>{myReaction}</span>
-            </button>
-          )}
           {DEFAULT_EMOJIS.map((emoji, index) => {
             const isChecked = myReaction === emoji
             return (
@@ -114,6 +100,20 @@ export default function ReactionsBar({
               </button>
             )
           })}
+          {myReaction && !isMyReactionDefault && (
+            <button
+              type='button'
+              role='menuitemradio'
+              aria-checked={true}
+              onClick={() => toggleReaction(myReaction!)}
+              className={classNames(
+                styles.reactionsBarButton,
+                styles.isFromSelf
+              )}
+            >
+              <span className={styles.reactionsBarEmoji}>{myReaction}</span>
+            </button>
+          )}
           <button
             type='button'
             role='menuitem'


### PR DESCRIPTION
android and iOS both show freely-selected, random emoji at the end of the list, but even without these examples, showing them at the end is more logical and consistent, as other emoji are also not shown at the beginning, but at its place - which is the end as '...' is at the end as well.

moreover, this leave the standard reactions always at the same place.

apart from that, it just looks better :)

a minor, sure, but annoys me since forever :)

before / after:

<img width="320" height="66" alt="Screenshot 2026-01-06 at 16 21 52" src="https://github.com/user-attachments/assets/0a2c6d17-5a2c-4752-a652-cf4f36e3706d" /> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; <img width="320" height="66" alt="Screenshot 2026-01-06 at 16 21 38" src="https://github.com/user-attachments/assets/b881f90a-c6ab-4861-837d-e20ca2f17247" />
