### PR TITLE
feat: consistent summaries across platforms

### DIFF
--- a/packages/frontend/scss/chat/_chat-list-item.scss
+++ b/packages/frontend/scss/chat/_chat-list-item.scss
@@ -126,18 +126,6 @@
           overflow: hidden;
         }
 
-        & > .summary_thumbnail {
-          height: 18px;
-          width: 18px;
-          min-width: 18px;
-          min-height: 18px;
-          border-radius: 3px;
-          margin-inline-start: 3px;
-          margin-inline-end: 4px;
-          background-size: cover;
-          background-position: center;
-        }
-
         & > .summary {
           float: inline-start;
           margin-inline-end: 2px;

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -9,7 +9,6 @@ import { mapCoreMsgStatus2String } from '../helpers/MapMsgStatus'
 import { getLogger } from '../../../../shared/logger'
 import { useContextMenuWithActiveState } from '../ContextMenu'
 import { selectedAccountId } from '../../ScreenController'
-import { runtime } from '@deltachat-desktop/runtime-interface'
 import { parseAndRenderMessage } from '../message/MessageParser'
 import { useRovingTabindex } from '../../contexts/RovingTabindex'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
@@ -77,8 +76,6 @@ const Message = React.memo<
     | 'freshMessageCounter'
     | 'isArchived'
     | 'isContactRequest'
-    | 'summaryPreviewImage'
-    | `lastMessageId`
   >
 >(function ({
   summaryStatus,
@@ -87,8 +84,6 @@ const Message = React.memo<
   freshMessageCounter,
   isArchived,
   isContactRequest,
-  summaryPreviewImage,
-  lastMessageId,
 }) {
   const isIncoming =
     summaryStatus === C.DC_STATE_IN_FRESH ||
@@ -96,8 +91,6 @@ const Message = React.memo<
     summaryStatus === C.DC_STATE_IN_NOTICED
 
   const status = isIncoming ? '' : mapCoreMsgStatus2String(summaryStatus)
-
-  const iswebxdc = summaryPreviewImage === 'webxdc-icon://last-msg-id'
 
   return (
     <div className='chat-list-item-message'>
@@ -110,27 +103,6 @@ const Message = React.memo<
           >
             {summaryText1 + ': '}
           </div>
-        )}
-        {summaryPreviewImage && !iswebxdc && (
-          <div
-            className='summary_thumbnail'
-            style={{
-              backgroundImage: `url(${JSON.stringify(
-                runtime.transformBlobURL(summaryPreviewImage)
-              )})`,
-            }}
-          />
-        )}
-        {iswebxdc && lastMessageId && (
-          <div
-            className='summary_thumbnail'
-            style={{
-              backgroundImage: `url("${runtime.getWebxdcIconURL(
-                selectedAccountId(),
-                lastMessageId
-              )}")`,
-            }}
-          />
         )}
         {parseAndRenderMessage(summaryText2 || '', true, -1)}
       </div>
@@ -401,11 +373,9 @@ function RegularChatListItem({
           summaryStatus={chat.summaryStatus}
           summaryText1={chat.summaryText1}
           summaryText2={chat.summaryText2}
-          summaryPreviewImage={chat.summaryPreviewImage}
           freshMessageCounter={chat.freshMessageCounter}
           isArchived={chat.isArchived}
           isContactRequest={chat.isContactRequest}
-          lastMessageId={chat.lastMessageId}
         />
       </div>
     </button>


### PR DESCRIPTION
after some internal discussions,
we decided that the existing "chatlist preview micro images" stand in the way of an easy, coherent layout across platforms.

- the preview often enough look bad, eg. just some black points, if the background is white. or the whole summary looks unaligned and broken. sure, it could be improved, but we decided to not put resources into it (ftr, telegram does more effort here, antialias, translucent margin etc, but even there it is still questionable and looks bad often enough. most other messagers do not display a preview in the chatlist at all)

- murphy: _if_ the image contains private data, an over-the-shoulder person should not see, of course, it _will_ be detailed enough :)

- we meanwhile use an emoji to indicate "there is an image"

- the combination with the preview and the emoji is too much noise

- the preview is not exhaustive, eg. video never got a preview

- other platforms would need adaption if we keep it

- if summaries are shown elsewhere, they are shown differently (notifications, reactions) so we have an unstable experience with patterns harder to recognize as needed

one may disagree and some points might be fixable or are minor - but others are not. all in all, it will hardly become a noticealbe overall improvement atm. so resources are spent better elsewhere.
ftr, in the past, already quite some resources were put into the preview.

<img width="125" height="26" alt="Screenshot 2026-01-07 at 00 02 07" src="https://github.com/user-attachments/assets/663c8bb8-a42f-4c2b-b301-6c5faeb3283f" />
<img width="206" height="29" alt="Screenshot 2026-01-07 at 00 01 40" src="https://github.com/user-attachments/assets/02c11a53-7d40-4550-9456-9e3f512cd423" />
<img width="206" height="24" alt="Screenshot 2026-01-07 at 00 00 53" src="https://github.com/user-attachments/assets/322a0fad-e597-4030-9816-497057578bd9" />
<img width="125" height="26" alt="Screenshot 2026-01-07 at 11 38 14" src="https://github.com/user-attachments/assets/442d38a3-5bd6-4d10-8b61-a2997becfd68" />

ref https://github.com/chatmail/core/pull/4311 https://github.com/chatmail/core/pull/5344 https://github.com/chatmail/core/issues/5782 https://github.com/chatmail/core/pull/5789 #3167 #4062 #4064 #4101 #4139 #4222 #4247 ...


