### PR TITLE
chore: add python3 to nix flake, because `bin/link_core/build_and_link_local_core.py` script needs it

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
 
           # coding
           pnpm
+          python3 # for bin/link_core/build_and_link_local_core.py script
           rustToolchain
           rust-analyzer
           typescript-language-server


### PR DESCRIPTION
related to #5917

#skip-changelog