### PR TITLE
fix: remove wrong keybinding

### DIFF
--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -161,14 +161,6 @@ function Shortcut(action: ShortcutAction): CheatSheetEntryType {
   return { action, type: 'shortcut' }
 }
 
-export function CheatSheetKeyboardShortcut() {
-  if (runtime.getRuntimeInfo().isMac) {
-    return <KeyboardShortcut elements={['Meta', '/']} />
-  } else {
-    return <KeyboardShortcut elements={['Control', '/']} />
-  }
-}
-
 export function getKeybindings(
   settings: DesktopSettingsType
 ): CheatSheetEntryType[] {

--- a/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
+++ b/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
@@ -1,11 +1,7 @@
 import React, { useEffect } from 'react'
 
 import { useSettingsStore } from '../../stores/settings'
-import {
-  CheatSheetKeyboardShortcut,
-  getKeybindings,
-  ShortcutGroup,
-} from '../KeyboardShortcutHint'
+import { getKeybindings, ShortcutGroup } from '../KeyboardShortcutHint'
 import Dialog, { DialogBody, DialogHeader, DialogHeading } from '../Dialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
@@ -27,11 +23,7 @@ export default function KeybindingCheatSheet(props: DialogProps) {
   return (
     <Dialog onClose={onClose} className='keyboard-hint-cheatsheet-dialog'>
       <DialogHeader onClose={onClose}>
-        <DialogHeading>
-          {tx('keybindings')}
-          &nbsp;&nbsp;
-          <CheatSheetKeyboardShortcut />
-        </DialogHeading>
+        <DialogHeading>{tx('keybindings')}</DialogHeading>
       </DialogHeader>
       <DialogBody className='dialog-body'>
         <div className='keyboard-hint-dialog-body'>


### PR DESCRIPTION
the shortcut `⌘/` is wrong for opening the keybinding hints on german mac - it is `⌘ß` there, as also stated correctly in the menu itself.

instead of adding more conditions,
it is fine to remove that hint completely:
the user just opened the dialog, and will know how to do it again. also, ppl familiar with and interested in shortcuts will notice the shortcut in the menu itself

closes #5930
