### PR TITLE
fix: break long words in dialogs

### DIFF
--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -269,6 +269,7 @@ audio {
 // used in alert & confirmation dialogs
 p.whitespace {
   white-space: break-spaces;
+  word-wrap: break-word;
 }
 
 // Only for screen-readers.


### PR DESCRIPTION
Resolves #5939

<img width="596" height="252" alt="image" src="https://github.com/user-attachments/assets/37ab3e9b-b1c0-47a6-a4f5-74c43110a42c" />

This also has the advantage that even very long names are completely visible
