### PR TITLE
improvement: WebXDC: respond with /index.html to /

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -1122,6 +1122,9 @@ async function webxdcProtocolHandler(
   const cspAllowHttpsImgSrc = open_apps[id].internet_access
 
   let filename = url.pathname
+  if (filename === '/' || filename === '') {
+    filename = '/index.html'
+  }
   // remove leading / trailing "/"
   if (filename.endsWith('/')) {
     filename = filename.substring(0, filename.length - 1)


### PR DESCRIPTION
This is useful for apps that utilize various "routers".
It is common for websites not to have this explicit `/index.html`,
so let's support this behavior.

See
- https://support.delta.chat/t/web-server-behavior-index-html-etc/2735?u=wofwca.
- https://github.com/webxdc/webxdc_docs/issues/61.
