### PR TITLE
refactor: synchronize search input font size

### DIFF
--- a/packages/frontend/scss/misc/_search-input.scss
+++ b/packages/frontend/scss/misc/_search-input.scss
@@ -9,7 +9,7 @@ input.search-input {
   margin: 0;
   line-height: inherit;
   border: 0px;
-  font-size: 18px;
+  font-size: 16px;
   background-color: transparent;
   caret-color: var(--navBarSearchPlaceholder);
   color: var(--globalText);

--- a/packages/frontend/src/components/SearchInput/index.tsx
+++ b/packages/frontend/src/components/SearchInput/index.tsx
@@ -64,7 +64,7 @@ export default function SearchInput(props: Props) {
           autoFocus
           onChange={onChange}
           value={value}
-          className={styles.searchInput}
+          className={`${styles.searchInput} search-input`}
           data-no-drag-region
           // eslint-disable-next-line react-hooks/refs
           ref={props.inputRef}

--- a/packages/frontend/src/components/SearchInput/styles.module.scss
+++ b/packages/frontend/src/components/SearchInput/styles.module.scss
@@ -9,22 +9,14 @@ $closeButtonSize: 24px;
   border-radius: 3px;
 }
 
-.searchInput {
-  background-color: var(--searchInputBackgroundColor);
-  border: 0;
+input.searchInput {
   caret-color: var(--navBarText);
   color: var(--navBarText);
-  flex: 1;
-  font-size: 16px;
   height: $closeButtonSize;
   margin-inline-end: 5px;
-  padding-bottom: 0;
   padding-inline-start: 5px;
   padding-inline-end: 5px;
-  padding-top: 0;
   width: 100%;
-  // A blinking cursor is enough in terms of visibility. Or is it??
-  outline: none;
 
   &::placeholder {
     color: var(--navBarSearchPlaceholder);

--- a/packages/frontend/themes/_themebase.scss
+++ b/packages/frontend/themes/_themebase.scss
@@ -205,8 +205,7 @@ $scrollbarTransparency: 0.34 !default;
   --fullScreenMediaButtons: #8b8e91;
   --messageHightlightColor: rgba(66, 165, 245, 0.8);
   --addMemberChipBackgroundColor: #{$bgSecondary};
-  --searchInputBackgroundColor: ##666
-    --galleryWebxdcItem: #{changeContrast($bgPrimary, 10%)};
+  --galleryWebxdcItem: #{changeContrast($bgPrimary, 10%)};
   --galleryFileRowHover: #{changeContrast($bgPrimary, 7%)};
   --recently-seen-indicator-color: #34c759;
 


### PR DESCRIPTION
- always use font-size 16px (the only visible change in this PR)
- remove redundant search input styles
- remove unused searchInputBackgroundColor

Followup to comment in https://github.com/deltachat/deltachat-desktop/pull/5916#pullrequestreview-3646906047