### PR TITLE
fix: focus composer on already active chat click

### DIFF
--- a/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
@@ -150,6 +150,7 @@ test.describe('Shift + Click', () => {
   test('Shift + Space', async () => {
     await getChat(7).click()
     await expectSelectedChats([7])
+    await getChat(7).focus()
 
     await page.keyboard.press('ArrowDown')
     await page.keyboard.press('ArrowDown')
@@ -168,6 +169,7 @@ test.describe('Shift + Click', () => {
   test('Shift + ArrowDown', async () => {
     await getChat(7).click()
     await expectSelectedChats([7])
+    await getChat(7).focus()
     await page.keyboard.press('Shift+ArrowDown')
     await expectSelectedChats([7, 6])
     await page.keyboard.press('Shift+ArrowDown')

--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -488,3 +488,18 @@ test.describe('draft', () => {
     await testDraftIsEmpty()
   })
 })
+
+test('gets focused when selecting a chat', async () => {
+  await selectChat(1)
+  await page.getByRole('button').first().focus() // Focus a random button
+  await expect(textarea).not.toBeFocused()
+
+  await selectChat(2)
+  await expect(textarea).toBeFocused()
+
+  await textarea.blur()
+  // When clicking on a chat that is already active, still focus the composer.
+  await expect(textarea).not.toBeFocused()
+  await selectChat(2)
+  await expect(textarea).toBeFocused()
+})

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -88,6 +88,7 @@ export const ChatProvider = ({
       // Remember that there might be no messages in the chat.
       // @TODO: We probably want this to be part of the UI logic instead
       if (nextChatId === chatId) {
+        const focusMessage = false
         window.__internal_jump_to_message_asap = {
           accountId,
           chatId: nextChatId,
@@ -95,7 +96,7 @@ export const ChatProvider = ({
             {
               msgId: undefined,
               highlight: false,
-              focus: false,
+              focus: focusMessage,
               addMessageIdToStack: undefined,
               // `scrollIntoViewArg:` doesn't really have effect when
               // jumping to the last message.
@@ -103,6 +104,23 @@ export const ChatProvider = ({
           ],
         }
         window.__internal_check_jump_to_message?.()
+
+        // Yes, we only run this in the `nextChatId === chatId` case.
+        // Otherwise the composer will get focused when the chat loads,
+        // in another `useEffect`.
+        if (!focusMessage) {
+          const composerTextarea = document.getElementsByClassName(
+            'create-or-edit-message-input'
+          )[0]
+          if (composerTextarea instanceof HTMLElement) {
+            composerTextarea.focus()
+          } else {
+            log.warn(
+              'Failed to focus composer: not an HTMLElement',
+              composerTextarea
+            )
+          }
+        }
       }
 
       // Already set known state


### PR DESCRIPTION
To be consistent. You might notice and get annoyed by this
when using Delta Chat with only keyboard.

I have tested this.