### PR TITLE
refactor: remove unnecessary check in Composer

### DIFF
--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -80,9 +80,7 @@ export default class ComposerMessageInput extends React.Component<
 
   focus() {
     log.debug('Focus composer message input')
-    if (!this.context.hasOpenDialogs) {
-      setTimeout(() => this.textareaRef?.current?.focus())
-    }
+    setTimeout(() => this.textareaRef?.current?.focus())
   }
 
   componentDidUpdate(prevProps: ComposerMessageInputProps) {


### PR DESCRIPTION
This reverts commit 116d23d2e0645dfddd1dde9d605e45b9a2dd9797
(https://github.com/deltachat/deltachat-desktop/pull/3816).

We now use native `<dialog>`s which already do not allow focusing
anything outside of them.

Related:
- 0c1de2505731b6fc420c8d30cc683a57606d4a4b
  (https://github.com/deltachat/deltachat-desktop/pull/5127).
- https://github.com/deltachat/deltachat-desktop/issues/4590.
