### PR TITLE
style: fix poor visibility of timestamp

### DIFF
--- a/packages/frontend/scss/message/_message-detail.scss
+++ b/packages/frontend/scss/message/_message-detail.scss
@@ -17,7 +17,3 @@
   font-weight: 300;
   padding-inline-end: 5px;
 }
-
-.module-message-detail__unix-timestamp {
-  color: #eeefef;
-}

--- a/packages/frontend/src/components/dialogs/MessageDetail/MessageDetail.tsx
+++ b/packages/frontend/src/components/dialogs/MessageDetail/MessageDetail.tsx
@@ -79,10 +79,7 @@ class MessageInfo extends React.Component<
                   {tx('message_detail_sent_desktop')}
                 </td>
                 <td>
-                  {moment(sentAt).format('LLLL')}{' '}
-                  <span className='module-message-detail__unix-timestamp'>
-                    ({sentAt})
-                  </span>
+                  {moment(sentAt).format('LLLL')} <span>({sentAt})</span>
                 </td>
               </tr>
               {receivedAt ? (
@@ -92,9 +89,7 @@ class MessageInfo extends React.Component<
                   </td>
                   <td>
                     {moment(receivedAt).format('LLLL')}{' '}
-                    <span className='module-message-detail__unix-timestamp'>
-                      ({receivedAt})
-                    </span>
+                    <span>({receivedAt})</span>
                   </td>
                 </tr>
               ) : null}


### PR DESCRIPTION
See previous attempt:
https://github.com/deltachat/deltachat-desktop/pull/4259.

Apparently the color was initially written for the light theme,
but now the color is not much different from the regular color text
in the light theme, but in the dark theme it's really pale.

Let's not be introducing another color just for this,
and let's simply use the normal color for this.
