### PR TITLE
style: fix account size on deletion text contrast

### DIFF
--- a/packages/frontend/src/components/screens/AccountDeletionScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/AccountDeletionScreen/styles.module.scss
@@ -54,5 +54,5 @@
 
 .accountSize {
   font-size: smaller;
-  color: #c0c0c0;
+  color: var(--textSecondary);
 }


### PR DESCRIPTION
Partially supersedes
https://github.com/deltachat/deltachat-desktop/pull/4259.

Before / after:

<img width="642" height="183" alt="image" src="https://github.com/user-attachments/assets/e8730875-bae6-4d61-8f08-0595e8c31842" />