### PR TITLE
fix: show 'block contact' in red everywhere

### DIFF
--- a/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
@@ -125,6 +125,7 @@ export default function useViewProfileMenu(
           label: tx('menu_block_contact'),
           action: () => openBlockContactById(accountId, contact.id),
           dataTestid: 'block-contact',
+          danger: true,
         },
   ]
 


### PR DESCRIPTION
"block contact" is shown in danger-red also elsewhere, so it needs to be like that also in the profile-three-dot-menu

<img width="595" height="244" alt="Screenshot 2026-01-22 at 13 34 45" src="https://github.com/user-attachments/assets/9ec55caf-7f4b-4bdc-a1c8-a37710a27565" />
