### PR TITLE
Show shortcuts for messages

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -181,15 +181,15 @@ test('message menu items presence', async () => {
     .first()
   await someRegularOutgoingMessage.click({ button: 'right' })
   await expect(page.getByRole('menu').getByRole('menuitem')).toHaveText([
-    'Reply',
+    'ReplyCtrl+R',
     'Forward',
-    'Save Message',
+    'Save MessageCtrl+S',
     'React',
-    'Edit',
-    'Copy Text',
+    'EditCtrl+E',
+    'Copy TextCtrl+C',
     'Resend',
     'Info',
-    'Delete Message',
+    'Delete MessageCtrl+D',
   ])
   await page.keyboard.press('Escape')
 
@@ -200,9 +200,9 @@ test('message menu items presence', async () => {
   await someInfoMessage.click({ button: 'right' })
   await expect(page.getByRole('menu').getByRole('menuitem')).toHaveText([
     'Forward',
-    'Copy Text',
+    'Copy TextCtrl+C',
     'Info',
-    'Delete Message',
+    'Delete MessageCtrl+D',
   ])
   await page.keyboard.press('Escape')
 })

--- a/packages/frontend/scss/misc/_context_menu.scss
+++ b/packages/frontend/scss/misc/_context_menu.scss
@@ -70,6 +70,17 @@
       margin: 0 5px 0 0;
     }
 
+    & .menu-label {
+      flex: 1;
+    }
+
+    & .keyboard-shortcut {
+      margin-left: 2em;
+      opacity: 0.6;
+      font-size: 0.9em;
+      font-weight: 500;
+    }
+
     & .right-icon {
       width: 18px;
       height: 18px;

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -262,6 +262,7 @@ function buildContextMenu(
     action: () => {
       text && runtime.writeClipboardText(text)
     },
+    keyboardShortcut: ['Ctrl', 'C'],
   }
 
   if (textSelected) {
@@ -270,11 +271,13 @@ function buildContextMenu(
       action: () => {
         runtime.writeClipboardText(selectedText as string)
       },
+      keyboardShortcut: ['Ctrl', 'C'],
     }
   } else if (email) {
     copy_item = {
       label: tx('menu_copy_email_to_clipboard'),
       action: () => runtime.writeClipboardText(email),
+      keyboardShortcut: ['Ctrl', 'C'],
     }
   }
   if (copy_item && message.viewType === 'Sticker') {
@@ -313,6 +316,7 @@ function buildContextMenu(
     showReply && {
       label: tx('notify_reply_button'),
       action: setQuoteInDraft.bind(null, message),
+      keyboardShortcut: ['Ctrl', 'R'],
     },
     // Reply privately
     showReplyPrivately && {
@@ -335,6 +339,7 @@ function buildContextMenu(
         label: tx('save_message'),
         action: () =>
           BackendRemote.rpc.saveMsgs(selectedAccountId(), [message.id]),
+        keyboardShortcut: ['Ctrl', 'S'],
       },
     // Unsave
     isSavedMessage && {
@@ -346,6 +351,7 @@ function buildContextMenu(
           ])
         }
       },
+      keyboardShortcut: ['Ctrl', 'U'],
     },
     // Send emoji reaction
     showSendReaction && {
@@ -357,6 +363,7 @@ function buildContextMenu(
       // See https://github.com/deltachat/deltachat-desktop/issues/4695#issuecomment-2688716592
       label: tx('global_menu_edit_desktop'),
       action: enterEditMessageMode.bind(null, message),
+      keyboardShortcut: ['Ctrl', 'E'],
     },
     { type: 'separator' },
     // Save attachment as
@@ -440,6 +447,7 @@ function buildContextMenu(
         chat
       ),
       danger: true,
+      keyboardShortcut: ['Ctrl', 'D'],
     },
   ]
 }
@@ -547,11 +555,12 @@ export default function Message(props: {
     ref,
     tabIndex: rovingTabindex.tabIndex,
     onKeyDown: (e: React.KeyboardEvent) => {
-      // Handle letter shortcuts with Ctrl/Cmd modifier
+      // Handle letter shortcuts without modifiers
+
       const isCtrlOrMetaKeyPress =
         (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && message
 
-      // Check if Ctrl/Cmd+"e" is pressed to enter edit mode
+      // Check if the "e" key is pressed to enter edit mode
       if (
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 'e') &&
@@ -563,7 +572,7 @@ export default function Message(props: {
         return
       }
 
-      // Check if Ctrl/Cmd+"r" is pressed to reply to message
+      // Check if the "r" key is pressed to reply to message
       if (
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 'r') &&
@@ -576,7 +585,7 @@ export default function Message(props: {
         return
       }
 
-      // Check if Ctrl/Cmd+"s" is pressed to save message
+      // Check if the "s" key is pressed to save message
       if (
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 's') &&
@@ -590,7 +599,7 @@ export default function Message(props: {
         return
       }
 
-      // Check if Ctrl/Cmd+"u" is pressed to unsave message
+      // Check if the "u" key is pressed to unsave message
       if (
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 'u') &&
@@ -602,12 +611,19 @@ export default function Message(props: {
         return
       }
 
-      // Check if Ctrl/Cmd+"d" is pressed to delete message
       if (isCtrlOrMetaKeyPress && matchesLetterShortcut(e, 'd')) {
         e.preventDefault()
         e.stopPropagation()
-        confirmDeleteMessage(openDialog, accountId, message, props.chat)
+        confirmDeleteMessage(openDialog, accountId, message, chat)
         return
+      }
+
+      if (isCtrlOrMetaKeyPress && matchesLetterShortcut(e, 'c')) {
+        e.preventDefault()
+        e.stopPropagation()
+        if (text) {
+          runtime.writeClipboardText(text)
+        }
       }
 
       // Audio / video elements have controls that utilize


### PR DESCRIPTION
Related to #5890

Based on #5963

Show shortcuts for save, edit, reply, copy and delete in context menu

<img width="217" height="337" alt="image" src="https://github.com/user-attachments/assets/5dc75bbf-8a98-4477-a707-371f18fe2d29" />

tbd: showing the shortcuts in the context menu seems helpful, but comes with a price: we have to add more key event listener logic to the ContextMenu.

Maybe in a followup - if we want this also for other context menues - we can extract that logic to a hook
