### PR TITLE
feat: calls: don't enable video if caller did not

### DIFF
--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -28,7 +28,9 @@ export function startOutgoingVideoCall(accountId: number, chatId: number) {
     accountId,
     chatId,
     CallDirection.Outgoing,
-    {}
+    {
+      noOutgoingVideoInitially: false,
+    }
   )
 
   const jsonrpcRemote = getDCJsonrpcRemote()
@@ -88,15 +90,23 @@ export function startHandlingIncomingVideoCalls(
       chat_id,
       msg_id,
       place_call_info,
-    }: { chat_id: number; msg_id: number; place_call_info: string }
+      has_video,
+    }: {
+      chat_id: number
+      msg_id: number
+      place_call_info: string
+      has_video: boolean
+    }
   ) => {
-    log.info('got IncomingCall event', eventAccountId, msg_id)
+    log.info('got IncomingCall event', { eventAccountId, msg_id, has_video })
 
+    const noOutgoingVideoInitially = !has_video
     openIncomingVideoCallWindow(
       eventAccountId,
       chat_id,
       msg_id,
-      place_call_info
+      place_call_info,
+      noOutgoingVideoInitially
     )
   }
 
@@ -108,9 +118,15 @@ function openIncomingVideoCallWindow(
   accountId: number,
   chatId: number,
   callMessageId: number,
-  callerWebrtcOffer: string
+  callerWebrtcOffer: string,
+  noOutgoingVideoInitially: boolean
 ) {
-  log.info('received incoming call', { accountId, chatId, callMessageId })
+  log.info('received incoming call', {
+    accountId,
+    chatId,
+    callMessageId,
+    noOutgoingVideoInitially,
+  })
 
   const { answerPromise, windowClosed, closeWindow } = openVideoCallWindow(
     accountId,
@@ -118,6 +134,7 @@ function openIncomingVideoCallWindow(
     CallDirection.Incoming,
     {
       callerWebrtcOffer,
+      noOutgoingVideoInitially,
     }
   )
 
@@ -158,13 +175,14 @@ function openVideoCallWindow<D extends CallDirection>(
   callDirection: D,
   {
     callerWebrtcOffer,
-  }: D extends CallDirection.Incoming
+    noOutgoingVideoInitially,
+  }: { noOutgoingVideoInitially: boolean } & (D extends CallDirection.Incoming
     ? {
         callerWebrtcOffer: string
       }
     : {
         callerWebrtcOffer?: undefined
-      }
+      })
 ): {
   closeWindow: () => void
   windowClosed: Promise<void>
@@ -385,7 +403,13 @@ function openVideoCallWindow<D extends CallDirection>(
   webAppMessagePort.start()
 
   const host = formatHost(accountId, chatId)
-  const query = callDirection === CallDirection.Incoming ? '?playRingtone' : ''
+  const query = new URLSearchParams()
+  if (noOutgoingVideoInitially) {
+    query.set('noOutgoingVideoInitially', '')
+  }
+  if (callDirection === CallDirection.Incoming) {
+    query.set('playRingtone', '')
+  }
   const hash =
     callDirection === CallDirection.Outgoing
       ? '' // We'll `#startCall` after a "grace period" below.
@@ -393,7 +417,7 @@ function openVideoCallWindow<D extends CallDirection>(
         ? `#offerIncomingCall=${btoa(callerWebrtcOffer!)}`
         : // Otherwise we'll set the hash later, when the call gets accepted.
           ''
-  win.webContents.loadURL(`${SCHEME_NAME}://${host}${query}${hash}`, {
+  win.webContents.loadURL(`${SCHEME_NAME}://${host}?${query}${hash}`, {
     extraHeaders: 'Content-Security-Policy: ' + CSP,
   })
 


### PR DESCRIPTION
Related:
- https://github.com/deltachat/deltachat-desktop/pull/5798.
- https://github.com/deltachat/calls-webapp/issues/78.

I have tested this, but I did not test the caller not enabling video (I don't have a version that supports this).