### PR TITLE
chore: Replace once_cell with std library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,7 +2007,6 @@ dependencies = [
  "mime",
  "mime_guess",
  "notify",
- "once_cell",
  "percent-encoding",
  "png 0.18.0",
  "rand 0.9.2",

--- a/packages/target-tauri/src-tauri/Cargo.toml
+++ b/packages/target-tauri/src-tauri/Cargo.toml
@@ -54,7 +54,6 @@ unic-idna-punycode = "0.9.0"
 strum = { version = "0.27", features = ["derive"] }
 url = "*"
 mime_guess = "2.0.5"
-once_cell = "1.21.1"
 clap = { version = "4.5.35", features = ["derive"] }
 chrono = { version = "0.4.41", default-features = false }
 notify = "8.0.0"

--- a/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/commands_main_window.rs
@@ -340,7 +340,7 @@ pub(crate) async fn open_webxdc<'a>(
         )
         .await;
 
-    // Contruct window
+    // Construct window
     let initial_url = if href.is_empty() {
         webxdc_base_url()?
     } else {

--- a/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str};
+use std::{collections::HashMap, str, sync::LazyLock};
 
 use anyhow::{anyhow, Context};
 use log::{error, trace};
@@ -14,9 +14,7 @@ use crate::{
     WebxdcInstancesState,
 };
 
-use once_cell::sync::Lazy;
-
-static CSP: Lazy<String> = Lazy::new(|| {
+static CSP: LazyLock<String> = LazyLock::new(|| {
     let mut m: HashMap<String, _> = HashMap::new();
     m.insert(
         "default-src".to_owned(),


### PR DESCRIPTION
`LazyLock` is stable as of 1.80. Delta Chat's MSRV is 1.88.

I also changed a `Result<_, ()>` to an `Option<_>`. It was being used that way anyway.  :grin: 