### PR TITLE
refactor: `noUncheckedIndexedAccess` to TSConfig

### DIFF
--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "nodenext",
     "target": "ES2022",
     "allowJs": false,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["./**/*.ts", "./**/*.js"]
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit --noUncheckedIndexedAccess false",
     "build": "pnpm build:ts && pnpm build:themes && pnpm build:static && pnpm build:source-map-support && pnpm build:scss",
     "build:ts": "node ./bin/build-frontend-ts.mjs",
     "build:source-map-support": "node ./bin/build-frontend-source_map_support.js",

--- a/packages/frontend/src/tests/botcommand.test.ts
+++ b/packages/frontend/src/tests/botcommand.test.ts
@@ -135,7 +135,7 @@ describe('parseElements functionality', () => {
       (el: any) => el.t === 'botcommand'
     )
     expect(botCommandElements).to.have.length(1)
-    expect(botCommandElements[0].v).to.equal('/help')
+    expect(botCommandElements[0]?.v).to.equal('/help')
   })
 
   it('should identify different types of content in mixed text', () => {
@@ -152,9 +152,9 @@ describe('parseElements functionality', () => {
     expect(emails).to.have.length(1)
     expect(botCommands).to.have.length(1)
 
-    expect(urls[0].v).to.equal('https://example.com')
-    expect(emails[0].v).to.equal('test@example.com')
-    expect(botCommands[0].v).to.equal('/help')
+    expect(urls[0]?.v).to.equal('https://example.com')
+    expect(emails[0]?.v).to.equal('test@example.com')
+    expect(botCommands[0]?.v).to.equal('/help')
   })
 
   it('should identify bot commands at start of text and after spaces', () => {
@@ -178,8 +178,8 @@ describe('parseElements functionality', () => {
     expect(elements !== null).to.equal(true)
 
     expect(elements).to.have.length(1)
-    expect(elements![0].t).to.equal('text')
-    expect(elements![0].v).to.equal('Hello world')
+    expect(elements![0]?.t).to.equal('text')
+    expect(elements![0]?.v).to.equal('Hello world')
   })
 
   it('should handle error cases gracefully', () => {
@@ -229,7 +229,7 @@ describe('parseElements functionality', () => {
           0,
           `Expected bot command to be found in: "${text}"`
         )
-        expect(botCommandElements[0].v).to.include('/help')
+        expect(botCommandElements[0]?.v).to.include('/help')
       } else {
         expect(botCommandElements).to.have.length(
           0,

--- a/packages/frontend/src/utils/linkify/parseElements.ts
+++ b/packages/frontend/src/utils/linkify/parseElements.ts
@@ -14,7 +14,8 @@ export function parseElements(message: string): linkify.MultiToken[] {
       const start = element.startIndex()
       // do not render botcommands if they
       // not start at index 0 or after a space
-      if (start > 0 && !/\s/.test(message[start - 1])) {
+      const char = message[start - 1]
+      if (start > 0 && char && !/\s/.test(char)) {
         element.t = 'text'
       }
     }

--- a/packages/frontend/src/utils/linkify/plugin-bot-command/botCommand.ts
+++ b/packages/frontend/src/utils/linkify/plugin-bot-command/botCommand.ts
@@ -41,15 +41,15 @@ export const botcommand: Plugin = ({ scanner, parser }) => {
   // a slash to form a valid bot command
 
   // Only allow alphabetic characters immediately after the slash.
-  Slash.ta(alpha, BotCommand)
+  Slash.ta(alpha!, BotCommand)
 
   // Allow alphanumeric tokens (which contain at least one letter)
   Slash.tt(ASCIINUMERICAL, BotCommand)
   Slash.tt(ALPHANUMERICAL, BotCommand)
 
   // Allow alphanumeric character groups to continue the command
-  BotCommand.ta(alphanumeric, BotCommand)
-  BotCommand.ta(numeric, BotCommand)
+  BotCommand.ta(alphanumeric!, BotCommand)
+  BotCommand.ta(numeric!, BotCommand)
 
   // Allow specific alphanumeric tokens
   BotCommand.tt(NUM, BotCommand)

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
+    "noUncheckedIndexedAccess": true,
     "plugins": [{ "name": "typescript-plugin-css-modules" }]
   }
 }

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "runtime.ts",
   "scripts": {
-    "check:types": "tsc --noEmit"
+    "check:types": "tsc --noEmit --noUncheckedIndexedAccess false"
   },
   "dependencies": {
     "@deltachat-desktop/shared": "link:../shared",

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "preserve",
     "target": "es2018",
     "allowJs": false,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,7 +3,7 @@
   "name": "@deltachat-desktop/shared",
   "type": "module",
   "scripts": {
-    "check:types": "tsc --noEmit",
+    "check:types": "tsc --noEmit --noUncheckedIndexedAccess false",
     "pretest": "esbuild *.ts --outdir=ts-compiled-for-tests --sourcemap",
     "test": "NODE_OPTIONS=--enable-source-maps mocha 'tests/**/*.js'"
   },

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -5,7 +5,8 @@
     "module": "preserve",
     "target": "es2022",
     "allowJs": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["./**/*.ts", "./**/*.js", "../../_locales/*.json"],
   "exclude": ["./ts-compiled-for-tests"]

--- a/packages/target-browser/package.json
+++ b/packages/target-browser/package.json
@@ -5,7 +5,7 @@
   "version": "2.53.1",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "check:types": "tsc --noEmit && tsc --noEmit -p runtime-browser",
+    "check:types": "tsc --noEmit --noUncheckedIndexedAccess false && tsc --noEmit --noUncheckedIndexedAccess false -p runtime-browser",
     "build": "pnpm build:locales && pnpm build:backend && pnpm --filter=@deltachat-desktop/frontend build && pnpm run build:compose-frontend",
     "build:locales": "pnpm -w translations:convert",
     "build:backend": "node ./bin/build.js",

--- a/packages/target-browser/runtime-browser/tsconfig.json
+++ b/packages/target-browser/runtime-browser/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "target": "es2018",
     "allowJs": false,
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/packages/target-browser/tsconfig.json
+++ b/packages/target-browser/tsconfig.json
@@ -8,7 +8,8 @@
     "allowJs": false,
     "esModuleInterop": true,
     "moduleResolution": "bundler",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["./src/**/*"]
 }

--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -29,7 +29,7 @@
   "productName": "DeltaChat",
   "homepage": "https://delta.chat",
   "scripts": {
-    "check:types": "tsc --noEmit && tsc --noEmit -p runtime-electron || node ./bin/printCheckWarning.js",
+    "check:types": "tsc --noEmit --noUncheckedIndexedAccess false && tsc --noEmit --noUncheckedIndexedAccess false -p runtime-electron || node ./bin/printCheckWarning.js",
     "build4production": "NODE_ENV=production pnpm build && pnpm -w check:types",
     "build": "pnpm build:locales && pnpm build:backend && pnpm --filter=@deltachat-desktop/frontend build && pnpm build:compose-frontend && pnpm build:calls-webapp",
     "build:locales": "pnpm -w translations:convert",

--- a/packages/target-electron/runtime-electron/tsconfig.json
+++ b/packages/target-electron/runtime-electron/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "NodeNext",
     "target": "es2022",
     "allowJs": false,
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "NodeNext",
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/packages/target-electron/tsconfig.json
+++ b/packages/target-electron/tsconfig.json
@@ -6,7 +6,8 @@
     "target": "es2022",
     "allowJs": false,
     "esModuleInterop": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true
   },
   "include": ["./**/*.ts", "./**/*.js"]
 }

--- a/packages/target-tauri/package.json
+++ b/packages/target-tauri/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "license": "GPL-3.0-or-later",
   "scripts": {
-    "check:types": "tsc --noEmit -p runtime-tauri",
+    "check:types": "tsc --noEmit --noUncheckedIndexedAccess false -p runtime-tauri",
     "check:webxdc-denied-permissions": "node ../../bin/webxdc-check-permissions-policy-count.js",
     "start": "tauri dev",
     "build4production": "NODE_ENV=production pnpm build",

--- a/packages/target-tauri/runtime-tauri/tsconfig.json
+++ b/packages/target-tauri/runtime-tauri/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "preserve",
     "target": "es2018",
     "allowJs": false,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/packages/target-tauri/tauri-html-email-view/tsconfig.json
+++ b/packages/target-tauri/tauri-html-email-view/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "preserve",
     "target": "es2018",
     "allowJs": false,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true
   }
 }

--- a/packages/target-tauri/tsconfig.json
+++ b/packages/target-tauri/tsconfig.json
@@ -13,6 +13,7 @@
     "noEmit": true,
 
     /* Linting */
+    "noUncheckedIndexedAccess": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true

--- a/packages/target-tauri/webxdc-js-implementation/tsconfig.json
+++ b/packages/target-tauri/webxdc-js-implementation/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "preserve",
     "target": "es2018",
     "allowJs": false,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "noUncheckedIndexedAccess": true
   }
 }


### PR DESCRIPTION
Here are its docs: https://www.typescriptlang.org/tsconfig/#noUncheckedIndexedAccess

It happens often that we have to catch such errors manually.
I think it would be better to just force ourselves to handle the possibility
of the index access returning `undefined`,
or at the very least using the "trust me bro" operator, a.k.a. "no-null assertion",
a.k.a. the `!` (`arr[num]!.stuff()`).

TODO:
- [x] At the current state of the MR it shows waaaaay too many errors, and breaks the build.
  We need to introduce it gradually somehow, if we do decide that we want `noUncheckedIndexedAccess` at all.