### PR TITLE
refactor: remove redundant check in EncryptionInfo

### DIFF
--- a/packages/frontend/src/components/dialogs/EncryptionInfo.tsx
+++ b/packages/frontend/src/components/dialogs/EncryptionInfo.tsx
@@ -6,7 +6,6 @@ import Dialog, { DialogBody, DialogContent, DialogHeader } from '../Dialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../contexts/DialogContext'
-import { useSettingsStore } from '../../stores/settings'
 
 export type Props = {
   chatId: number | null
@@ -32,13 +31,8 @@ export function EncryptionInfo({
         )
     ).then(setEncryptionInfo)
   }, [dmChatContact, chatId])
-  const settings = useSettingsStore()[0]
 
   const tx = useTranslationFunction()
-
-  if (!settings) {
-    throw new Error('settings store missing')
-  }
 
   return (
     <Dialog onClose={onClose}>


### PR DESCRIPTION
It stopped being necessary in
193dfd544893b75bb1f9428373f50f189643b260.
