### PR TITLE
improvement: add "Downloading..." in app picker

### DIFF
--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -67,7 +67,7 @@ const getJsonFromBase64 = (base64: string): any => {
 }
 
 type Props = {
-  onAppSelected: (app: AppInfo) => void
+  onAppSelected: (app: AppInfo) => Promise<void>
 }
 
 export function AppPicker({ onAppSelected }: Props) {
@@ -201,9 +201,12 @@ export function AppPicker({ onAppSelected }: Props) {
   const AppInfoOverlay = (props: {
     app: AppInfo
     setSelectedAppInfo: (app: AppInfo | null) => void
-    onSelect: (app: AppInfo) => void
+    onSelect: (app: AppInfo) => Promise<void>
   }) => {
     const { app, setSelectedAppInfo, onSelect } = props
+
+    const [isDownloading, setIsDownloading] = useState(false)
+
     const onClose = () => {
       setSelectedAppInfo(null)
     }
@@ -237,13 +240,25 @@ export function AppPicker({ onAppSelected }: Props) {
           </DialogContent>
           <DialogFooter>
             <FooterActions>
-              <FooterActionButton
-                data-testid='add-app-to-chat'
-                onClick={() => onSelect(app)}
-                styling='primary'
-              >
-                {tx('add_to_chat')}
-              </FooterActionButton>
+              {!isDownloading && (
+                <FooterActionButton
+                  data-testid='add-app-to-chat'
+                  onClick={() => {
+                    setIsDownloading(true)
+                    onSelect(app).finally(() => setIsDownloading(false))
+                  }}
+                  styling='primary'
+                >
+                  {tx('add_to_chat')}
+                </FooterActionButton>
+              )}
+              <div role='status'>
+                {isDownloading && (
+                  <div className={styles.appDownloadingStatus}>
+                    {tx('downloading')}
+                  </div>
+                )}
+              </div>
             </FooterActions>
           </DialogFooter>
         </DialogBody>

--- a/packages/frontend/src/components/AppPicker/styles.module.scss
+++ b/packages/frontend/src/components/AppPicker/styles.module.scss
@@ -130,6 +130,13 @@
   line-height: 20px;
 }
 
+.appDownloadingStatus {
+  // Simply copy-pasted from `.footerActionButton` to preserve height.
+  min-width: 100px;
+  padding: 8px 12px;
+  margin: 10px 0;
+}
+
 .appName {
   font-size: 16px;
   font-weight: bold;

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -167,6 +167,7 @@ $paddingVertical: 20px;
 }
 
 .footerActionButton {
+  // `.appDownloadingStatus` copy-pated these styles.
   min-width: 100px;
   padding: 8px 12px !important;
   margin: 10px 0;


### PR DESCRIPTION
<img width="400" height="367" alt="image" src="https://github.com/user-attachments/assets/15118d6c-27f0-4663-a4a2-fc3fe23cfe17" />


Some apps are quite big, but we provide no feedback
when the user clicks "Add to Chat".
This commit adds "Downloading..." indicator
in place of the "Add to Chat" button when that is clicked.
