### PR TITLE
chore: move back to `esbenp.prettier-vscode`

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,6 @@
   "recommendations": [
     "tauri-apps.tauri-vscode",
     "rust-lang.rust-analyzer",
-    "prettier.prettier-vscode"
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,11 +3,11 @@
   "rust-analyzer.cargo.targetDir": "target/target-rust-analyzer",
   "files.eol": "\n",
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "prettier.prettier-vscode",
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[typescript]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[typescriptreact]": {
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }


### PR DESCRIPTION
Looks like they have moved back to the old name
https://github.com/prettier/prettier-vscode/issues/3872#issuecomment-3662898646.

Also see
https://github.com/deltachat/deltachat-desktop/pull/5818
