### PR TITLE
refactor: remove pointless `key={index}`

### DIFF
--- a/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
@@ -70,8 +70,8 @@ const VolumeMeter = (prop: { volume: number }) => {
     >
       <div className={styles.volumeBar}>
         <div className={styles.mask}>
-          {Array.from({ length: steps }).map((_, index) => (
-            <div key={index} className={styles.step} />
+          {Array.from({ length: steps }).map(() => (
+            <div className={styles.step} />
           ))}
         </div>
         <div className={styles.level} style={{ width: levelPercentage }} />

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -401,7 +401,7 @@ export function ContextMenu(props: {
         >
           {level.items.map((item, index) => {
             if (item.type === 'separator') {
-              return <hr className='separator' key={index} />
+              return <hr className='separator' />
             }
             const isExpanded = index === openSublevels[levelIdx]
             return (
@@ -435,7 +435,6 @@ export function ContextMenu(props: {
                 tabIndex={-1}
                 data-testid={item.dataTestid}
                 role='menuitem'
-                key={index}
                 aria-haspopup={item.subitems ? 'menu' : undefined}
                 aria-expanded={item.subitems ? isExpanded : undefined}
                 {...(item.subitems && { 'data-expandable-index': index })}

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -94,13 +94,8 @@ export function ShortcutGroup({ title, keyBindings }: ShortcutAction) {
   const non_empty = keyBindings.filter(
     e => typeof e !== 'boolean'
   ) as string[][]
-  const bindings = non_empty.map((elements, index) => {
-    return (
-      <KeyboardShortcut
-        elements={elements}
-        key={`${index}-${elements.length}`}
-      />
-    )
+  const bindings = non_empty.map(elements => {
+    return <KeyboardShortcut elements={elements} />
   })
 
   return (

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -87,14 +87,13 @@ export default function ReactionsBar({
           ref={reactionsBarRef}
           className={styles.reactionsBar}
         >
-          {DEFAULT_EMOJIS.map((emoji, index) => {
+          {DEFAULT_EMOJIS.map(emoji => {
             const isChecked = myReaction === emoji
             return (
               <button
                 type='button'
                 role='menuitemradio'
                 aria-checked={isChecked}
-                key={`emoji-${index}`}
                 onClick={() => toggleReaction(emoji)}
                 className={classNames(styles.reactionsBarButton, {
                   [styles.isFromSelf]: isChecked,

--- a/packages/frontend/src/components/SmallSelectDialog.tsx
+++ b/packages/frontend/src/components/SmallSelectDialog.tsx
@@ -59,11 +59,9 @@ export default function SmallSelectDialog({
             selectedValue={selectedValue}
             name='small-dialog-value'
           >
-            {values.map((element, index) => {
+            {values.map(element => {
               const [value, label] = element
-              return (
-                <Radio key={'select-' + index} label={label} value={value} />
-              )
+              return <Radio label={label} value={value} />
             })}
           </RadioGroup>
         </DialogContent>

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -66,9 +66,8 @@ const DisplayedStickerPack = ({
           wrapperElementRef={listRef}
           direction='horizontal'
         >
-          {stickerPackImages.map((filePath, index) => (
+          {stickerPackImages.map(filePath => (
             <StickersListItem
-              key={index}
               filePath={filePath}
               onClick={() => onClickSticker(filePath)}
             />

--- a/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
+++ b/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
@@ -404,7 +404,6 @@ export default function ProxyConfiguration(
           <div className={styles.proxyList} role='radiogroup'>
             {proxyState.proxies.map((proxyUrl, index) => (
               <ProxyItemRow
-                key={index}
                 proxyUrl={proxyUrl}
                 index={index}
                 isActive={proxyUrl === proxyState.activeProxy}


### PR DESCRIPTION
From <https://react.dev/learn/rendering-lists>:

> You might be tempted to use an item’s index
> in the array as its key.
> In fact, that’s what React will use
> if you don’t specify a key at all.
