### PR TITLE
refactor: fix React warning in `EditAccountInner`

### DIFF
--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -60,7 +60,7 @@ function EditAccountInner(onClose: DialogProps['onClose'], addr?: string) {
   const { openDialog } = useDialog()
   const tx = useTranslationFunction()
 
-  const loadSettings = async () => {
+  const loadSettings = useCallback(async () => {
     if (window.__selectedAccountId === undefined) {
       throw new Error('can not load settings when no account is selected')
     }
@@ -81,11 +81,11 @@ function EditAccountInner(onClose: DialogProps['onClose'], addr?: string) {
 
     setInitialAccountSettings(accountSettings)
     setAccountSettings(accountSettings)
-  }
+  }, [addr])
 
   useEffect(() => {
     loadSettings()
-  }, [])
+  }, [loadSettings])
 
   const onUpdate = useCallback(async () => {
     const onSuccess = () => onClose()


### PR DESCRIPTION
This should not change behavior because `addr`
currently never changes.
