### PR TITLE
Remove some unneeded heap allocs

### DIFF
--- a/packages/target-tauri/src-tauri/src/chat_background_image.rs
+++ b/packages/target-tauri/src-tauri/src/chat_background_image.rs
@@ -97,7 +97,7 @@ async fn copy_background_image_file_<R: tauri::Runtime>(
     let bg_images_dir = get_background_images_dir(&app)
         .context("failed to get the chat background images directory")?;
 
-    log::info!("Copying the new chat background image {src_path:?} to the backgroud images directory {bg_images_dir:?}...");
+    log::info!("Copying the new chat background image {src_path:?} to the background images directory {bg_images_dir:?}...");
 
     if let Err(err) = fs::create_dir(&bg_images_dir).await {
         if err.kind() == std::io::ErrorKind::AlreadyExists {

--- a/packages/target-tauri/src-tauri/src/deeplink.rs
+++ b/packages/target-tauri/src-tauri/src/deeplink.rs
@@ -1,4 +1,4 @@
-use std::{env::current_dir, path::PathBuf, str::FromStr};
+use std::{env::current_dir, path::PathBuf};
 
 use anyhow::{bail, Context};
 use base64::Engine;
@@ -102,13 +102,13 @@ pub async fn handle_deep_link(
     }
 
     if deeplink_or_xdc.ends_with(".xdc") {
-        let mut path = if potential_scheme == Some("file".to_owned()) {
+        let mut path = if potential_scheme.as_deref() == Some("file") {
             let path = deeplink_or_xdc
                 .strip_prefix("file://")
                 .context("failed to remove file scheme prefix from {deeplink_or_xdc}")?;
-            PathBuf::from_str(path)?
+            PathBuf::from(path)
         } else {
-            PathBuf::from_str(&deeplink_or_xdc)?
+            PathBuf::from(&deeplink_or_xdc)
         };
         if !path.is_absolute() {
             path = alternative_cwd

--- a/packages/target-tauri/src-tauri/src/html_window/mod.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/mod.rs
@@ -119,10 +119,7 @@ pub(crate) async fn open_html_window(
     #[allow(unused_mut)]
     let mut header_webview_builder = WebviewBuilder::new(
         format!("{window_id}-header"),
-        WebviewUrl::App(
-            PathBuf::from_str("tauri_html_email_view/html_email_view.html")
-                .expect("path conversion failed"),
-        ),
+        WebviewUrl::App(PathBuf::from("tauri_html_email_view/html_email_view.html")),
     );
     #[cfg(target_os = "macos")]
     {

--- a/packages/target-tauri/src-tauri/src/lib.rs
+++ b/packages/target-tauri/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr, time::SystemTime};
+use std::{path::PathBuf, time::SystemTime};
 
 use anyhow::Context;
 use cli::parse_cli_options_from_args;
@@ -156,7 +156,7 @@ fn get_current_logfile(state: tauri::State<AppState>) -> String {
 
 #[tauri::command]
 async fn get_current_logfile_content(state: tauri::State<'_, AppState>) -> Result<String, String> {
-    read_to_string(PathBuf::from_str(&state.current_log_file_path).map_err(|err| err.to_string())?)
+    read_to_string(&state.current_log_file_path)
         .await
         .map_err(|err| err.to_string())
 }
@@ -201,7 +201,7 @@ pub fn run() -> i32 {
             .plugin(tauri_plugin_single_instance::init(move |app, args, cwd| {
                 log::info!("second instance launched, focusing the original instance instead");
 
-                let cwd = PathBuf::from_str(&cwd).unwrap();
+                let cwd = PathBuf::from(cwd);
                 log::debug!("tauri_plugin_single_instance {args:?} {cwd:?}");
 
                 let options = parse_cli_options_from_args(args);
@@ -233,7 +233,7 @@ pub fn run() -> i32 {
         // registering here does not seem to work
     }
 
-    // sepcified here, so the open handler does not rely on appstate to be ready
+    // specified here, so the open handler does not rely on appstate to be ready
     // (that it can be used "outside" of tauri)
     let inner_appstate = InnerAppState::new();
     let cloned_inner_appstate = inner_appstate.clone();

--- a/packages/target-tauri/src-tauri/src/notifications.rs
+++ b/packages/target-tauri/src-tauri/src/notifications.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 use tauri::{path::SafePathBuf, Runtime, State};
@@ -129,10 +129,9 @@ pub(crate) async fn show_notification(
                         Ok(tmp_file) => {
                             // IDEA: on non macos set icon of webxdc instead?
                             if cfg!(target_os = "windows") {
-                                notification = notification.set_icon(PathBuf::from_str(&tmp_file)?);
+                                notification = notification.set_icon(PathBuf::from(&tmp_file));
                             } else {
-                                notification =
-                                    notification.set_image(PathBuf::from_str(&tmp_file)?);
+                                notification = notification.set_image(PathBuf::from(&tmp_file));
                             }
                             temp_file_to_clean_up.replace(tmp_file);
                         }
@@ -144,10 +143,10 @@ pub(crate) async fn show_notification(
             }
         } else if cfg!(target_os = "windows") && icon_is_avatar {
             notification = notification
-                .set_icon(PathBuf::from_str(&icon)?)
+                .set_icon(PathBuf::from(icon))
                 .set_icon_round_crop(true);
         } else {
-            notification = notification.set_image(PathBuf::from_str(&icon)?);
+            notification = notification.set_image(PathBuf::from(icon));
         };
     }
 
@@ -159,7 +158,7 @@ pub(crate) async fn show_notification(
     if let Some(tmp_file) = temp_file_to_clean_up {
         remove_temp_file(
             app_clone.clone(),
-            SafePathBuf::from_str(&tmp_file).map_err(|_| Error::FailedToDeleteTmpFile)?,
+            SafePathBuf::new(tmp_file.into()).map_err(|_| Error::FailedToDeleteTmpFile)?,
         )
         .await
         .map_err(|_| Error::FailedToDeleteTmpFile)?;

--- a/packages/target-tauri/src-tauri/src/themes/commands.rs
+++ b/packages/target-tauri/src-tauri/src/themes/commands.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use tauri::{path::SafePathBuf, AppHandle, Manager};
 use tauri_plugin_store::StoreExt;
 use tokio::fs::{create_dir_all, read_to_string};
@@ -75,13 +73,13 @@ pub async fn get_theme(
         }
     };
 
-    let file_name = SafePathBuf::from_str(&format!("{name}.css"))
-        .map_err(|_| Error::InvalidAddress(theme_address.clone()))?
+    let file_path = SafePathBuf::new(format!("{name}.css").into())
+        .map_err(|_| Error::InvalidAddress(theme_address.clone()))?;
+    let file_name = file_path
         .as_ref()
         .file_name()
         .ok_or(Error::InvalidAddress(theme_address.clone()))?
-        .to_string_lossy()
-        .to_string();
+        .to_string_lossy();
 
     let theme_content = if prefix == "dc" {
         if app.asset_resolver().iter().count() == 0 {
@@ -90,7 +88,7 @@ pub async fn get_theme(
                 .path()
                 .resource_dir()?
                 .join("../../packages/target-tauri/html-dist/themes");
-            read_to_string(themes_dir.join(&file_name)).await?
+            read_to_string(themes_dir.join(&*file_name)).await?
         } else {
             let filename = format!("/themes/{file_name}");
             // search in assets
@@ -105,7 +103,7 @@ pub async fn get_theme(
     } else if prefix == "custom" {
         // search in folder
         let themes_dir = custom_theme_dir(&app)?;
-        read_to_string(themes_dir.join(&file_name)).await?
+        read_to_string(themes_dir.join(&*file_name)).await?
     } else {
         return Err(Error::InvalidAddressPrefixUnknown(
             prefix.to_owned(),


### PR DESCRIPTION
This is in no way exhaustive, but if it's accepted I can fix a few of the other simple cases I found as well.

Most of the fixes for this batch involve taking ownership of a &str to create a PathBuf or String. In the fixed cases, a borrowed Path or the &str or Cow could be used directly. In other cases, Strings were cloned to make PathBufs instead of consumed directly. SafePathBufs cloned PathBufs instead of using them directly as well.

I removed a few unneeded from_strs too. `PathBuf::from_str` is infallible so it would never return an error.

I force pushed to fix the `cargo fmt` check failing. It doesn't seem like the fix is related to this patch though.