### PR TITLE
Show second device hints above qr code

### DIFF
--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
@@ -131,7 +131,7 @@ export function SendBackupDialog({ onClose }: DialogProps) {
       canEscapeKeyClose={true}
       canOutsideClickClose={false}
       onClose={cancel}
-      width={680}
+      width={500}
     >
       <DialogHeader title={tx('multidevice_title')} />
       {!inProgress && (
@@ -161,6 +161,7 @@ export function SendBackupDialog({ onClose }: DialogProps) {
           <DialogBody>
             <DialogContent>
               <SendBackup>
+                {stage !== 'transferring' && <SendBackupSteps />}
                 <SendBackupMain>
                   {stage === 'awaiting_scan' && svgUrl && qrContent && (
                     <img className={styles.qrCode} src={svgUrl} />
@@ -178,7 +179,6 @@ export function SendBackupDialog({ onClose }: DialogProps) {
                     )}
                   </SendBackupMainProgress>
                 </SendBackupMain>
-                {stage !== 'transferring' && <SendBackupSteps />}
               </SendBackup>
               {error}
             </DialogContent>

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/styles.module.scss
@@ -1,8 +1,7 @@
 .sendBackup {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
   min-width: 300px;
-  justify-content: space-between;
 }
 
 .sendBackupMain {
@@ -10,7 +9,7 @@
   flex-grow: 1;
   align-items: center;
   justify-content: center;
-  margin-bottom: 20px;
+  width: 100%;
 }
 
 .sendBackupMainProgress {
@@ -23,10 +22,7 @@
 }
 
 .sendBackupSteps {
-  margin-top: 20px;
-  margin-inline-start: 20px;
-  max-width: 300px;
-  min-width: 200px;
+  width: 100%;
 }
 
 .sendBackupStepsList {
@@ -59,6 +55,7 @@
 
 .qrCode {
   width: 100%;
+  max-height: 60vh;
 }
 
 .linkIcon {


### PR DESCRIPTION
Show the hints above the qr code to avoid space problems

resolves #6010 

<img width="550" height="896" alt="image" src="https://github.com/user-attachments/assets/39ad98a9-cc97-46f8-bb40-4fa7b22aa09a" />


Very small window

<img width="389" height="484" alt="image" src="https://github.com/user-attachments/assets/3b0bbc2f-915d-4ee8-a598-f4348564569e" />

extreme landscape ratio 

<img width="817" height="446" alt="image" src="https://github.com/user-attachments/assets/54576273-5e8b-4c66-a16b-c6e64da3618e" />
