### PR TITLE
refactor: add React `key=`s to suppress warnings

### DIFF
--- a/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
@@ -70,8 +70,8 @@ const VolumeMeter = (prop: { volume: number }) => {
     >
       <div className={styles.volumeBar}>
         <div className={styles.mask}>
-          {Array.from({ length: steps }).map(() => (
-            <div className={styles.step} />
+          {Array.from({ length: steps }).map((_, index) => (
+            <div key={index} className={styles.step} />
           ))}
         </div>
         <div className={styles.level} style={{ width: levelPercentage }} />

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -401,7 +401,7 @@ export function ContextMenu(props: {
         >
           {level.items.map((item, index) => {
             if (item.type === 'separator') {
-              return <hr className='separator' />
+              return <hr className='separator' key={index} />
             }
             const isExpanded = index === openSublevels[levelIdx]
             return (
@@ -435,6 +435,9 @@ export function ContextMenu(props: {
                 tabIndex={-1}
                 data-testid={item.dataTestid}
                 role='menuitem'
+                // Context menus are not expected to change,
+                // so it's fine to have index-based keys.
+                key={item.dataTestid ?? index}
                 aria-haspopup={item.subitems ? 'menu' : undefined}
                 aria-expanded={item.subitems ? isExpanded : undefined}
                 {...(item.subitems && { 'data-expandable-index': index })}

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -80,7 +80,7 @@ export function ShortcutGroup({ title, keyBindings }: ShortcutAction) {
     e => typeof e !== 'boolean'
   ) as string[][]
   const bindings = non_empty.map(elements => {
-    return <KeyboardShortcut elements={elements} />
+    return <KeyboardShortcut key={elements.join('+')} elements={elements} />
   })
 
   return (

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -98,6 +98,7 @@ export default function ReactionsBar({
             {DEFAULT_EMOJIS.map(emoji => {
               return (
                 <ReactionButton
+                  key={emoji}
                   emoji={emoji}
                   isChecked={myReaction === emoji}
                   onClick={() => toggleReaction(emoji)}

--- a/packages/frontend/src/components/SmallSelectDialog.tsx
+++ b/packages/frontend/src/components/SmallSelectDialog.tsx
@@ -61,7 +61,7 @@ export default function SmallSelectDialog({
           >
             {values.map(element => {
               const [value, label] = element
-              return <Radio label={label} value={value} />
+              return <Radio key={value} label={label} value={value} />
             })}
           </RadioGroup>
         </DialogContent>

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -68,6 +68,7 @@ const DisplayedStickerPack = ({
         >
           {stickerPackImages.map(filePath => (
             <StickersListItem
+              key={filePath}
               filePath={filePath}
               onClick={() => onClickSticker(filePath)}
             />

--- a/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
+++ b/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
@@ -404,6 +404,7 @@ export default function ProxyConfiguration(
           <div className={styles.proxyList} role='radiogroup'>
             {proxyState.proxies.map((proxyUrl, index) => (
               <ProxyItemRow
+                key={proxyUrl}
                 proxyUrl={proxyUrl}
                 index={index}
                 isActive={proxyUrl === proxyState.activeProxy}


### PR DESCRIPTION
Partially reverts 7fb10c290543804899b9f56effc0820fbd2b1272 (https://github.com/deltachat/deltachat-desktop/pull/6002).
In some places this adds proper keys,
in others this just goes back to how things were before that commit,
i.e. simply index-based keys.
