### PR TITLE
feat: add "Who can call me" setting

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -100,5 +100,17 @@
   },
   "prevent_dialog_spam_checkbox": {
     "message": "Don't allow the app to open this dialog again"
+  },
+  "who_can_call_me": {
+    "message": "Who can call me"
+  },
+  "who_can_call_me_everybody": {
+    "message": "Everybody"
+  },
+  "who_can_call_me_contacts": {
+    "message": "Contacts"
+  },
+  "who_can_call_me_nobody": {
+    "message": "Nobody"
   }
 }

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -24,6 +24,7 @@ export interface SettingsStoreState {
       only_fetch_mvbox: string
       media_quality: string
       is_chatmail: '0' | '1'
+      who_can_call_me: '0' | '1' | '2'
     }[P]
   }
   desktopSettings: DesktopSettingsType
@@ -44,6 +45,7 @@ const settingsKeys = [
   'only_fetch_mvbox',
   'media_quality',
   'is_chatmail',
+  'who_can_call_me',
 ] as const
 
 class SettingsStore extends Store<SettingsStoreState | null> {


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6042.

<img height="400" alt="image" src="https://github.com/user-attachments/assets/e1a43e5c-f064-4d8f-a0ea-7e1c76503b6f" />

<img height="200" alt="image" src="https://github.com/user-attachments/assets/f9b799f1-559b-4426-80f5-a3675dad2159" />

I have tested this. Setting to "nobody" makes the "incoming call window" not show up.
However, on Desktop it's then impossible to accept the call from the notification - we do not have any "click" handling for "call" messages.

TODO:
- [ ] Agree on the wordings, the position of the menu item, the condition when it's shown.

Related:
- https://github.com/chatmail/core/pull/7682.
- https://github.com/deltachat/deltachat-android/issues/4152.
