### PR TITLE
refactor: remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "git-cliff": "^2.11.0",
     "globals": "^17.0.0",
-    "ignore-walk": "^8.0.0",
     "prettier": "^3.7.4",
     "typescript": "catalog:",
     "typescript-eslint": "^8.51.0",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -34,7 +34,6 @@
     "debounce": "^1.2.1",
     "emoji-mart": "^5.6.0",
     "filesize": "^10.1.4",
-    "immutable": "^4.3.7",
     "jsqr": "^1.4.0",
     "linkify-plugin-hashtag": "^4.3.2",
     "linkifyjs": "^4.3.2",
@@ -43,14 +42,12 @@
     "path-browserify": "^1.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "punycode": "^2.3.1",
     "react-string-replace": "^1.1.1",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",
     "react-window-infinite-loader": "^1.0.10",
     "react-zoom-pan-pinch": "^3.7.0",
-    "use-debounce": "^3.3.0",
-    "ws": "7.5.10"
+    "use-debounce": "^3.3.0"
   },
   "devDependencies": {
     "@types/chai": "catalog:",

--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -80,7 +80,6 @@
     "adm-zip": "0.5.14",
     "application-config": "^3.0.0",
     "chai": "^5.1.1",
-    "chokidar": "^3.6.0",
     "debounce": "^1.2.0",
     "electron": "^40.6.0",
     "electron-builder": "^26.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,9 +99,6 @@ importers:
       globals:
         specifier: ^17.0.0
         version: 17.0.0
-      ignore-walk:
-        specifier: ^8.0.0
-        version: 8.0.0
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
@@ -140,7 +137,7 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 2.44.0(ws@7.5.10)
+        version: 2.44.0(ws@8.18.2)
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
@@ -165,9 +162,6 @@ importers:
       filesize:
         specifier: ^10.1.4
         version: 10.1.6
-      immutable:
-        specifier: ^4.3.7
-        version: 4.3.7
       jsqr:
         specifier: ^1.4.0
         version: 1.4.0
@@ -186,9 +180,6 @@ importers:
       path-browserify:
         specifier: ^1.0.1
         version: 1.0.1
-      punycode:
-        specifier: ^2.3.1
-        version: 2.3.1
       react:
         specifier: ^19.2.0
         version: 19.2.0
@@ -213,9 +204,6 @@ importers:
       use-debounce:
         specifier: ^3.3.0
         version: 3.4.3(react@19.2.0)
-      ws:
-        specifier: 7.5.10
-        version: 7.5.10
     devDependencies:
       '@types/chai':
         specifier: 'catalog:'
@@ -448,9 +436,6 @@ importers:
       chai:
         specifier: ^5.1.1
         version: 5.2.0
-      chokidar:
-        specifier: ^3.6.0
-        version: 3.6.0
       debounce:
         specifier: ^1.2.0
         version: 1.2.1
@@ -2781,10 +2766,6 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore-walk@8.0.0:
-    resolution: {integrity: sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A==}
-    engines: {node: ^20.17.0 || >=22.9.0}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2797,9 +2778,6 @@ packages:
     resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
-
-  immutable@4.3.7:
-    resolution: {integrity: sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==}
 
   immutable@5.1.1:
     resolution: {integrity: sha512-3jatXi9ObIsPGr3N5hGw/vWWcTkq6hUYhpQz4k0wLC+owqWi/LiugIw9x0EdNZ2yGedKN/HzePiBvaJRXa0Ujg==}
@@ -7106,18 +7084,12 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  ignore-walk@8.0.0:
-    dependencies:
-      minimatch: 10.1.1
-
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
 
   image-size@0.5.5:
     optional: true
-
-  immutable@4.3.7: {}
 
   immutable@5.1.1: {}
 


### PR DESCRIPTION
`ignore-walk` is unused since
e75c0d712323734fd2ee2e8ad97c78e0bc915375
(https://github.com/deltachat/deltachat-desktop/pull/5584)

`immutable` is unused since
cf9eb1f9c81b9d20d7eb36b76a664ae2e1363b75
(https://github.com/deltachat/deltachat-desktop/pull/2958)

`punycode` was introduced in
5aff81758d1c6cbfa8992614ba8935b7cdf8714c
(https://github.com/deltachat/deltachat-desktop/pull/5502),
but apparently has never been used.

`ws` is only used by `packages/target-browser`
and apparently `packages/target-electron`.

`chokidar` is only used by our build script.
