### PR TITLE
fix: ugly "Already have profile" dialog button

### DIFF
--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -89,12 +89,11 @@ $paddingVertical: 20px;
   padding-inline-end: $paddingHorizontal;
   line-height: 22px;
 
-  /* override additional top padding/margins of the first element
+  /* override additional top margins of the first element
      in dialog content, the whole dialog already has 20px
    */
   &:not(.allowTopPadding) > :first-child {
     margin-top: 0 !important;
-    padding-top: 0 !important;
   }
 }
 


### PR DESCRIPTION
While it is understandable why we'd want to override margins,
overriding paddings is way too intrusive.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/410439f3-17f8-4eaf-8d61-3424b5c31eb5" />

This partially reverts 820deb5fcb0b0f350fce1041122dddad60196948
(https://github.com/deltachat/deltachat-desktop/pull/5977).
