### PR TITLE
fix: extraneous padding on full screen image view

### DIFF
--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -39,10 +39,10 @@ $paddingVertical: 20px;
 
     justify-content: center;
     padding: 0;
-  }
-  &:not(.noTopPadding) {
-    /* we always add 20px top padding if not explicitly disabled */
-    padding-top: $paddingVertical;
+    &:not(.noTopPadding) {
+      /* we always add 20px top padding if not explicitly disabled */
+      padding-top: $paddingVertical;
+    }
   }
   &::backdrop {
     background-color: var(--dialogBackdropBackground);


### PR DESCRIPTION
Introduced in
https://github.com/deltachat/deltachat-desktop/pull/5977.

FYI the `unstyled` prop is only `true` on `FullscreenAvatar`
and `FullscreenMedia`,
so this change is not epxected to have side effects.

I have checked that it works.