### PR TITLE
chore: add FreeBSD to list of OSes for esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       "os": [
         "darwin",
         "win32",
-        "linux"
+        "linux",
+        "freebsd"
       ],
       "cpu": [
         "x64",


### PR DESCRIPTION
This saves me from having to patch this in our build environment for each new release