### PR TITLE
fix: a little better drag regions

### DIFF
--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -136,7 +136,8 @@
 }
 
 .webxdcIcons {
-  margin: 0px 12px -4px 0px;
+  line-height: 0;
+  margin-right: 12px;
   img.webxdcIcon {
     width: 25px;
     height: 25px;


### PR DESCRIPTION
Properly vertically align the buttons with `line-height`
instead of hacking around with negative margin.

This does not affect the size of the buttons.
It only makes use of the previously dead undraggable space
just below the buttons.

Before / after:

<img width="176" height="156" alt="image" src="https://github.com/user-attachments/assets/f8d765d5-564d-4b04-8b70-f51431ff1bcb" />

See previous MRs that touched this place:
- https://github.com/deltachat/deltachat-desktop/pull/5671.
- https://github.com/deltachat/deltachat-desktop/pull/5889.
