### PR TITLE
fix: `canOutsideClickClose=false` for "New Group"

### DIFF
--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -93,7 +93,13 @@ export default function CreateChat(props: DialogProps) {
   const [viewMode, setViewMode] = useState<ViewMode>('main_')
 
   return (
-    <Dialog width={400} onClose={onClose} fixed dataTestid='create-chat-dialog'>
+    <Dialog
+      width={400}
+      onClose={onClose}
+      canOutsideClickClose={viewMode === 'main_'}
+      fixed
+      dataTestid='create-chat-dialog'
+    >
       {viewMode == 'main_' && <CreateChatMain {...{ setViewMode, onClose }} />}
       {viewMode == GroupType.REGULAR_GROUP && (
         <>


### PR DESCRIPTION
The non-`main_` "view modes" can have some unsaved data,
such as group / channel name and channel members.
