### PR TITLE
refactor: remove code for Core <= 2.43.0

### DIFF
--- a/packages/target-electron/src/deltachat/controller.ts
+++ b/packages/target-electron/src/deltachat/controller.ts
@@ -125,16 +125,6 @@ export default class DeltaChatController {
               for (const event of result) {
                 handleEventResponse(event, this._jsonrpcRemote)
               }
-            } else if (isEventResponse(result)) {
-              /** Handle {@linkcode RawClient.getNextEvent} */
-
-              // We can remove this "else" branch
-              // after we have upgraded to Core with
-              // https://github.com/chatmail/core/pull/7825,
-              // because then the transport is not gonna use
-              // `getNextEvent`.
-
-              handleEventResponse(result, this._jsonrpcRemote)
             }
           } catch (_error) {
             // ignore json parse errors


### PR DESCRIPTION
Side note: in fact this code already works only for Core >= 2.44.0,
because for 2.43.0 the first `isEventResponse` throws
and we never get to `if else`.
It was buggy right from the start,
0a2d69e74116cece0106c8a8143b119c4dcdad6d.
