### PR TITLE
fix: align "recent apps" vertically

### DIFF
--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -153,6 +153,7 @@
   margin-inline-end: 10px;
   padding: 0 !important;
   border-radius: 0 !important;
+  line-height: 0;
   &:last-child {
     margin-inline-end: 0;
   }


### PR DESCRIPTION
Apparently I didn't do it properly in
6e60a5e0a0a52308b697c3e76f4fa00101a4f522
(https://github.com/deltachat/deltachat-desktop/pull/6074).
