### PR TITLE
refactor: remove unused `onClickMessageBody`

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -90,14 +90,6 @@ $info-text-max-width: 400px;
     padding-bottom: 10px;
 
     .msg-body {
-      &.msg-body--clickable {
-        @include mixins.button-reset;
-        display: block;
-
-        > .text {
-          cursor: pointer;
-        }
-      }
       &.call {
         > .text {
           --call-icon-size: 24px;

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -801,8 +801,6 @@ export default function Message(props: {
     openViewProfileDialog(accountId, contact.id)
   }
 
-  let onClickMessageBody
-
   // Check if the message is saved or has a saved message
   // in both cases we display the bookmark icon
   const isOrHasSavedMessage = message.originalMsgId
@@ -924,11 +922,8 @@ export default function Message(props: {
         )}
         <div
           className={classNames('msg-body', {
-            'msg-body--clickable': onClickMessageBody,
             call: message.viewType === 'Call',
           })}
-          onClick={onClickMessageBody}
-          tabIndex={onClickMessageBody ? tabindexForInteractiveContents : -1}
         >
           {message.quote !== null && (
             <Quote


### PR DESCRIPTION
It's unused since 3e90f2715612f9d7a0498383676690809003bad0
(https://github.com/deltachat/deltachat-desktop/pull/4822).

Also the whole concept of the an entire message being clickable
is generally not great accessibility-wise,
so let's get rid of this and hope that we don't need this again.

Related:
- e107ae9f44282d2d6c7c1d54b1dde9a833d45084
- f9634a77232969eb8c13ec8fcfbec1d1c6b9a696
