### PR TITLE
refactor: remove dead CSS

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -200,11 +200,6 @@ $info-text-max-width: 400px;
         // https://github.com/deltachat/deltachat-desktop/pull/5227#discussion_r2173774006.
         min-height: calc($font-size * $line-height);
       }
-      div.experimental {
-        color: var(--colorDanger);
-        background: var(--contextMenuBg);
-        border-radius: 8px;
-      }
     }
   }
 


### PR DESCRIPTION
It's unused since 6664e64ac1c60127ea9eb864b22d051940c358c5
(https://github.com/deltachat/deltachat-desktop/pull/4380).
