### PR TITLE
chore: upgrade Electron to 41

### DIFF
--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -81,7 +81,7 @@
     "application-config": "^3.0.0",
     "chai": "^5.1.1",
     "debounce": "^1.2.0",
-    "electron": "^40.6.0",
+    "electron": "^41.0.0",
     "electron-builder": "^26.7.0",
     "esbuild": "^0.25.0",
     "mocha": "^10.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -440,8 +440,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.1
       electron:
-        specifier: ^40.6.0
-        version: 40.6.0
+        specifier: ^41.0.0
+        version: 41.0.0
       electron-builder:
         specifier: ^26.7.0
         version: 26.7.0(electron-builder-squirrel-windows@24.13.3)
@@ -2218,8 +2218,8 @@ packages:
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
 
-  electron@40.6.0:
-    resolution: {integrity: sha512-ett8W+yOFGDuM0vhJMamYSkrbV3LoaffzJd9GfjI96zRAxyrNqUSKqBpf/WGbQCweDxX2pkUCUfrv4wwKpsFZA==}
+  electron@41.0.0:
+    resolution: {integrity: sha512-U7QueSj1cFj9QM0Qamgh/MK08662FVK555iMfapqU7mcAmIm4A8bZuZptpjMXrT4JNAMGjgWu9sOeO1+RPCJNw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -6282,7 +6282,7 @@ snapshots:
 
   electron-to-chromium@1.5.267: {}
 
-  electron@40.6.0:
+  electron@41.0.0:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.10.9


### PR DESCRIPTION
We don't seem to be affected by breaking changes
https://github.com/electron/website/pull/1030.

Regarding "PDFs no longer create a separate WebContents":
we still disable PDF in WebXDC, disabling mime sniffing.
And overall, I have not investigated this, but it sounds
like a positive security change.

Regarding "Updated Cookie Change Cause
in the Cookie 'changed' Event":
we don't utilize cookies.

I have tested this a little. Works well.
Disabling `IsolateSandboxedIframes` still seems to be required
to make the "connectivity" dialog work.
