### PR TITLE
Render markdown in messages

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -42,6 +42,7 @@
     "path-browserify": "^1.0.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0",
     "react-string-replace": "^1.1.1",
     "react-virtualized-auto-sizer": "^1.0.26",
     "react-window": "^1.8.11",

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -634,10 +634,105 @@ $info-text-max-width: 400px;
   }
 }
 
+// Markdown container: override pre-wrap from .text so block elements
+// don't get extra whitespace from newlines in the rendered HTML
+.markdown-content {
+  white-space: normal;
+}
+
 .quoted-text,
 .msg-body > .text {
   a {
     text-decoration: underline;
+  }
+
+  // Make markdown headings more compact
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    margin: 0;
+    line-height: 1.2;
+    user-select: text;
+  }
+
+  h1 {
+    font-size: 1.5em;
+  }
+
+  h2 {
+    font-size: 1.25em;
+  }
+
+  h3 {
+    font-size: 1.1em;
+  }
+
+  h4,
+  h5,
+  h6 {
+    font-size: 1em;
+  }
+
+  code {
+    font-family: monospace;
+    background-color: var(--messageCodeBg, rgba(0, 0, 0, 0.08));
+    padding: 2px 4px;
+    border-radius: 3px;
+    font-size: 0.9em;
+  }
+
+  pre {
+    margin: 4px 0;
+    padding: 8px 12px;
+    background-color: var(--messageCodeBg, rgba(0, 0, 0, 0.08));
+    border-radius: 6px;
+    overflow-x: auto;
+    max-width: 100%;
+
+    code {
+      background-color: transparent;
+      padding: 0;
+      border-radius: 0;
+      font-size: 0.85em;
+      white-space: pre;
+    }
+  }
+
+  p {
+    margin: 0;
+  }
+
+  blockquote {
+    margin: 2px 0;
+    padding-inline-start: 12px;
+    border-inline-start: 3px solid var(--messageText, currentColor);
+    opacity: 0.85;
+  }
+
+  ul,
+  ol {
+    margin: 2px 0;
+    padding-inline-start: 1.2em;
+    white-space: normal;
+  }
+
+  ul {
+    list-style-type: disc;
+  }
+
+  ol {
+    list-style-type: decimal;
+  }
+
+  li {
+    margin: 0;
+
+    > p {
+      margin: 0;
+    }
   }
 }
 

--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -106,6 +106,10 @@ export function ExperimentalFeatures() {
         // 853b584251a5dacf60ebc616f7fb10edffb5c5e5/src/main/index.ts#L12-L21
         description='Careful: opening developer tools on a malicious webxdc app could lead to the app getting access to the Internet'
       />
+      <DesktopSettingsSwitch
+        settingsKey='enableMarkdownInMessages'
+        label='Render Markdown in Messages'
+      />
     </>
   )
 }

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -104,7 +104,7 @@ const Message = React.memo<
             {summaryText1 + ': '}
           </div>
         )}
-        {parseAndRenderMessage(summaryText2 || '', true, -1)}
+        {parseAndRenderMessage(summaryText2 || '', true, -1, false)}
       </div>
       {isContactRequest && (
         <div className='label'>

--- a/packages/frontend/src/components/message/MessageBody.tsx
+++ b/packages/frontend/src/components/message/MessageBody.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import { parseAndRenderMessage } from './MessageParser'
+import { useSettingsStore } from '../../stores/settings'
 import * as linkify from 'linkifyjs'
 
 /** limit where message parser will not parse the message, limit of core is lower, this is just a failsafe */
@@ -79,6 +80,10 @@ function MessageBody({
    */
   tabindexForInteractiveContents?: -1 | 0
 }): React.ReactElement {
+  const settingsStore = useSettingsStore()[0]
+  const enableMarkdown =
+    settingsStore?.desktopSettings.enableMarkdownInMessages ?? false
+
   if (text.length >= UPPER_LIMIT_FOR_PARSED_MESSAGES) {
     return <>{text}</>
   }
@@ -97,7 +102,8 @@ function MessageBody({
   return parseAndRenderMessage(
     textTrimmed,
     nonInteractiveContent,
-    tabindexForInteractiveContents ?? 0
+    tabindexForInteractiveContents ?? 0,
+    enableMarkdown,
   )
 }
 const trimRegex = /^[\s\uFEFF\xA0\n\t]+|[\s\uFEFF\xA0\n\t]+$/g

--- a/packages/frontend/src/components/message/MessageParser.tsx
+++ b/packages/frontend/src/components/message/MessageParser.tsx
@@ -1,4 +1,6 @@
-import React, { useContext } from 'react'
+import React, { useContext, useMemo } from 'react'
+import Markdown from 'react-markdown'
+import type { Components } from 'react-markdown'
 
 import * as linkify from 'linkifyjs'
 import 'linkify-plugin-hashtag'
@@ -15,6 +17,53 @@ import useChat from '../../hooks/chat/useChat'
 import useCreateChatByEmail from '../../hooks/chat/useCreateChatByEmail'
 
 const log = getLogger('renderer/message-parser')
+
+const ALLOWED_LINK_SCHEMES = ['http', 'https']
+
+/**
+ * Build a link destination object with punycode detection for security.
+ * Detects IDN homograph attacks by comparing the original URL with the parsed URL.
+ */
+function buildLinkDestination(fullUrl: string, linkText: string) {
+  try {
+    const url = new URL(fullUrl)
+    const scheme = url.protocol.replace(':', '')
+    if (!ALLOWED_LINK_SCHEMES.includes(scheme)) {
+      return null
+    }
+    let suspicousUrl = false
+    const stripLastSlash = (url: string) => {
+      if (url.endsWith('/')) {
+        url = url.slice(0, -1)
+      }
+      return url
+    }
+    // according to https://developer.mozilla.org/docs/Web/API/URL/hostname
+    // domain names will be transformed to punycode automatically
+    // so we just need to check if the original hostname is different
+    // from the punycode one
+    if (stripLastSlash(url.href) !== stripLastSlash(fullUrl)) {
+      suspicousUrl = true
+    }
+    const destination = {
+      target: fullUrl,
+      hostname: url.hostname,
+      punycode: suspicousUrl
+        ? {
+          ascii_hostname: url.hostname,
+          punycode_encoded_url: url.href,
+          original_hostname_or_full_url: linkText,
+        }
+        : null,
+      scheme,
+      linkText,
+    }
+    return destination
+  } catch {
+    log.warn('buildLinkDestination: invalid URL', fullUrl)
+    return null
+  }
+}
 
 function renderElement(
   elm: linkify.MultiToken,
@@ -46,33 +95,9 @@ function renderElement(
         // see https://github.com/nfrasser/linkifyjs/blob/3abe9abbcb4e069aeadde2f42de7dfcc2371c0f0/packages/linkifyjs/src/text.mjs#L24
         fullUrl = 'https://' + fullUrl
       }
-      const url = new URL(fullUrl)
-      let suspicousUrl = false
-      const stripLastSlash = (url: string) => {
-        if (url.endsWith('/')) {
-          url = url.slice(0, -1)
-        }
-        return url
-      }
-      // according to https://developer.mozilla.org/docs/Web/API/URL/hostname
-      // domain names will be transformed to punycode automatically
-      // so we just need to check if the original hostname is different
-      // from the punycode one
-      if (stripLastSlash(url.href) !== stripLastSlash(fullUrl)) {
-        suspicousUrl = true
-      }
-      const destination = {
-        target: fullUrl,
-        hostname: url.hostname,
-        punycode: suspicousUrl
-          ? {
-              ascii_hostname: url.hostname,
-              punycode_encoded_url: url.href,
-              original_hostname_or_full_url: elm.v,
-            }
-          : null,
-        scheme: url.protocol.replace(':', ''),
-        linkText: elm.v,
+      const destination = buildLinkDestination(fullUrl, elm.v)
+      if (!destination) {
+        return <span key={key}>{elm.v}</span>
       }
       return (
         <Link
@@ -119,12 +144,145 @@ function renderElement(
 }
 
 /**
+ * Process text children through existing parseElements() for hashtags/emails/bot commands/URLs.
+ * This ensures that linkify detection (emails, hashtags, bot commands, URLs without markdown syntax)
+ * still works within markdown-rendered text.
+ */
+function processTextChildren(
+  children: React.ReactNode,
+  tabIndex: -1 | 0,
+  nonInteractiveContent: boolean
+): React.ReactNode {
+  if (nonInteractiveContent) {
+    // Skip linkify processing for non-interactive content
+    return children
+  }
+  return React.Children.map(children, (child, index) => {
+    if (typeof child === 'string') {
+      const elements = parseElements(child)
+      return elements.map((el, i) =>
+        renderElement(el, tabIndex, index * 1000 + i)
+      )
+    }
+    return child
+  })
+}
+
+/** Only these elements are allowed in markdown rendering. */
+const MARKDOWN_ALLOWED_ELEMENTS = [
+  'p',
+  'a',
+  'strong',
+  'em',
+  'code',
+  'pre',
+  'blockquote',
+  'ul',
+  'ol',
+  'li',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'br',
+]
+
+/**
+ * Create custom markdown components for react-markdown.
+ * These integrate with Delta Chat's existing link handling and linkify detection.
+ */
+function createMarkdownComponents(
+  tabIndex: -1 | 0,
+  nonInteractiveContent: boolean
+): Components {
+  return {
+    // Override link rendering to use existing Link component
+    a: ({ href, children }) => {
+      // Extract text content from children for display
+      const linkText =
+        typeof children === 'string'
+          ? children
+          : React.Children.toArray(children)
+            .map(child => (typeof child === 'string' ? child : ''))
+            .join('')
+
+      if (nonInteractiveContent) {
+        // Render as plain text for non-interactive content (e.g., quoted messages)
+        return <>{linkText}</>
+      }
+
+      const destination = buildLinkDestination(
+        href || '',
+        linkText || href || ''
+      )
+      if (!destination) {
+        return <>{linkText}</>
+      }
+
+      return <Link destination={destination} tabIndex={tabIndex} />
+    },
+
+    // Process text children through linkify for hashtags/emails/bot commands
+    p: ({ children }) => (
+      <p>{processTextChildren(children, tabIndex, nonInteractiveContent)}</p>
+    ),
+    li: ({ children }) => (
+      <li>{processTextChildren(children, tabIndex, nonInteractiveContent)}</li>
+    ),
+    em: ({ children }) => (
+      <em>{processTextChildren(children, tabIndex, nonInteractiveContent)}</em>
+    ),
+    strong: ({ children }) => (
+      <strong>
+        {processTextChildren(children, tabIndex, nonInteractiveContent)}
+      </strong>
+    ),
+
+    // Code blocks and inline code - no linkify processing needed
+    code: ({ children }) => {
+      return <code>{children}</code>
+    },
+    pre: ({ children }) => <pre>{children}</pre>,
+  }
+}
+
+/**
+ * Render message text with markdown support.
+ */
+function MarkdownMessage({
+  text,
+  tabIndex,
+  nonInteractiveContent,
+}: {
+  text: string
+  tabIndex: -1 | 0
+  nonInteractiveContent: boolean
+}) {
+  const components = useMemo(
+    () => createMarkdownComponents(tabIndex, nonInteractiveContent),
+    [tabIndex, nonInteractiveContent]
+  )
+  return (
+    <Markdown
+      className='markdown-content'
+      components={components}
+      allowedElements={MARKDOWN_ALLOWED_ELEMENTS}
+    >
+      {text}
+    </Markdown>
+  )
+}
+
+/**
  * parse message text (for links and interactive elements)
  * and render as React elements
  *
  * @param preview - render in preview mode for ChatListItem summary
  * and for quoted messages, without interactive elements
  * (links can not be clicked etc.)
+ * @param enableMarkdown - render markdown formatting
  */
 export function parseAndRenderMessage(
   message: string,
@@ -133,8 +291,19 @@ export function parseAndRenderMessage(
    * Has no effect if `{@link preview} === true`, because there should be
    * no interactive elements in the first place
    */
-  tabindexForInteractiveContents: -1 | 0
+  tabindexForInteractiveContents: -1 | 0,
+  enableMarkdown: boolean,
 ): React.ReactElement {
+  if (enableMarkdown) {
+    return (
+      <MarkdownMessage
+        text={message}
+        tabIndex={tabindexForInteractiveContents}
+        nonInteractiveContent={preview}
+      />
+    )
+  }
+
   if (preview) {
     return <div className='truncated'>{message}</div>
   }

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -60,8 +60,8 @@ export interface DesktopSettingsType {
   syncAllAccounts: boolean
   /** @deprecated The last used file location for the save dialog is now only kept in memory and not persisted anymore between sessions. */
   lastSaveDialogLocation: string | undefined
-  /** @deprecated */
-  experimentalEnableMarkdownInMessages?: boolean
+  /** Enable markdown rendering in chat messages (experimental) */
+  enableMarkdownInMessages: boolean
   enableWebxdcDevTools: boolean
   /** set to false to disable the confirmation dialog for loading remote content */
   HTMLEmailAskForRemoteLoadingConfirmation: boolean

--- a/packages/shared/state.ts
+++ b/packages/shared/state.ts
@@ -23,6 +23,7 @@ export function getDefaultState(): DesktopSettingsType {
     minimizeToTray: true,
     syncAllAccounts: true,
     lastSaveDialogLocation: undefined,
+    enableMarkdownInMessages: false,
     enableWebxdcDevTools: false,
     HTMLEmailAskForRemoteLoadingConfirmation: true,
     HTMLEmailAlwaysLoadRemoteContent: false,

--- a/packages/target-tauri/runtime-tauri/runtime.ts
+++ b/packages/target-tauri/runtime-tauri/runtime.ts
@@ -189,6 +189,7 @@ class TauriRuntime implements Runtime {
       enableAVCallsV2: false,
       enableBroadcastLists: false,
       enableOnDemandLocationStreaming: false,
+      enableMarkdownInMessages: false,
       chatViewBgImg: undefined,
       galleryImageKeepAspectRatio: false,
       isMentionsEnabled: false,


### PR DESCRIPTION
Add an off-by-default experimental option to render markdown in messages.

Uses react-markdown and supports headings, bold, italic, inline code, code blocks, blockquotes, and lists. Integrates existing linkify parsing for emails, hashtags, and bot commands.

<img width="758" height="1185" alt="Screenshot 2026-03-11 220916" src="https://github.com/user-attachments/assets/16a6e226-0cf1-4240-983f-c3f49d552a4d" />
