### PR TITLE
fix: make more text selectable

### DIFF
--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -64,7 +64,6 @@ h2,
 h3,
 h4,
 h5,
-p,
 button > span,
 label {
   user-select: none;


### PR DESCRIPTION
- "Encryption info" dialog.
  Closes https://github.com/deltachat/deltachat-desktop/issues/6073.
- Some more dialogs, such as "Delete message?"
- Maybe more

This partially reverts 0fb28899fcc59c2c332438a812f21b15386e3c1b
(https://github.com/deltachat/deltachat-desktop/pull/645)
(from 2019).

IMU we only do `user-select: none;` because it doesn't look nice
when the user accidentally drags the cursor.
But sometimes the user might actually want to select the text.
So I don't think that we should default to `user-select: none;`.

There are quite a lot of `<p`s that are affected by this.
I haven't checked all of them.
Again, let's disable selection on individual basis,
where we are sure that there could be no need for the user
to select the text.

I have confirmed that the "Encryption info" dialog contents is now selectable.