### PR TITLE
refactor: add `description` to `SettingsSelector`

### DIFF
--- a/packages/frontend/src/components/Settings/SettingsSelector.tsx
+++ b/packages/frontend/src/components/Settings/SettingsSelector.tsx
@@ -8,10 +8,11 @@ import classNames from 'classnames'
 type Props = PropsWithChildren<{
   onClick: () => void
   currentValue?: string
+  description?: string
 }>
 
 export default function SettingsSelector(props: Props) {
-  const { onClick, currentValue, children } = props
+  const { onClick, currentValue, children, description } = props
 
   return (
     // TODO a11y: this component implements `<select>` functionality,
@@ -21,7 +22,12 @@ export default function SettingsSelector(props: Props) {
       className={classNames(styles.settingsRow, styles.settingsSelector)}
       onClick={onClick}
     >
-      <div className={styles.settingsRowLabel}>{children}</div>
+      <div className={styles.settingsRowLeft}>
+        <div className={styles.settingsRowLabel}>{children}</div>
+        {description && (
+          <div className={styles.settingsRowDescription}>{description}</div>
+        )}
+      </div>
       {currentValue && (
         <div className={styles.settingsSelectorValue}>{currentValue}</div>
       )}

--- a/packages/frontend/src/components/Settings/styles.module.scss
+++ b/packages/frontend/src/components/Settings/styles.module.scss
@@ -108,6 +108,9 @@ $settingsHeight: 40px;
   font-weight: lighter;
   overflow: hidden;
   text-overflow: ellipsis;
+
+  max-width: 33.33333%;
+  flex-shrink: 0;
 }
 
 .settingsRowLeft {


### PR DESCRIPTION
This makes it similar to other such components.

This is based on https://github.com/deltachat/deltachat-desktop/pull/6119.
As with the base MR, this is not currently useful for anything. Also can be closed.

This is how it looks:

<img width="424" height="175" alt="image" src="https://github.com/user-attachments/assets/2c80806f-0d96-46fd-85b6-dc1fae97e635" />

<img width="460" height="183" alt="image" src="https://github.com/user-attachments/assets/d0ecae99-26cd-4e05-8732-83bd20c686a2" />


TODO:
- [x] Merge the base.