### PR TITLE
fix: revert message min-width

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -90,7 +90,6 @@ $info-text-max-width: 400px;
     padding-bottom: 10px;
 
     .msg-body {
-      min-width: 150px;
       &.call {
         > .text {
           --call-icon-size: 24px;


### PR DESCRIPTION
closes #6116 

Since #6069 there is a fixed width for stickers and min-width is not needed any more