### PR TITLE
improvement: remove Cancel button from Add Device

### DIFF
--- a/packages/e2e-tests/tests/backup-tests.spec.ts
+++ b/packages/e2e-tests/tests/backup-tests.spec.ts
@@ -103,7 +103,7 @@ test('shows warning when scanning backups that are newer than supported', async 
     await navigator.clipboard.writeText(text)
   }, mutatedContent)
 
-  await sendBackupDialog.getByRole('button', { name: 'Cancel' }).click()
+  await sendBackupDialog.getByRole('button', { name: 'Close' }).click()
   // Confirm cancellation
   await page.getByTestId('confirm-dialog').getByTestId('confirm').click()
 

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
@@ -135,7 +135,7 @@ export function SendBackupDialog({ onClose }: DialogProps) {
       onClose={cancel}
       width={500}
     >
-      <DialogHeader title={tx('multidevice_title')} />
+      <DialogHeader title={tx('multidevice_title')} onClose={cancel} />
       {!inProgress && (
         <>
           <DialogBody>
@@ -144,10 +144,7 @@ export function SendBackupDialog({ onClose }: DialogProps) {
             </DialogContent>
           </DialogBody>
           <DialogFooter>
-            <FooterActions align='spaceBetween'>
-              <FooterActionButton onClick={cancel}>
-                {tx('cancel')}
-              </FooterActionButton>
+            <FooterActions>
               <FooterActionButton
                 styling='primary'
                 onClick={startNetworkedTransfer}
@@ -187,21 +184,16 @@ export function SendBackupDialog({ onClose }: DialogProps) {
           </DialogBody>
           <DialogFooter>
             <FooterActions align='spaceBetween'>
-              <span className={styles.buttonGroup}>
-                <FooterActionButton
-                  onClick={() => runtime.openHelpWindow('multiclient')}
-                >
-                  {tx('troubleshooting')}
-                </FooterActionButton>
-                {stage === 'awaiting_scan' && svgUrl && qrContent && (
-                  <FooterActionButton onClick={copyQrToClipboard}>
-                    {tx('global_menu_edit_copy_desktop')}
-                  </FooterActionButton>
-                )}
-              </span>
-              <FooterActionButton onClick={cancel}>
-                {tx('cancel')}
+              <FooterActionButton
+                onClick={() => runtime.openHelpWindow('multiclient')}
+              >
+                {tx('troubleshooting')}
               </FooterActionButton>
+              {stage === 'awaiting_scan' && svgUrl && qrContent && (
+                <FooterActionButton onClick={copyQrToClipboard}>
+                  {tx('global_menu_edit_copy_desktop')}
+                </FooterActionButton>
+              )}
             </FooterActions>
           </DialogFooter>
         </>

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/styles.module.scss
@@ -63,10 +63,6 @@
   margin-inline-start: 10px;
 }
 
-.buttonGroup {
-  display: flex;
-}
-
 .receiveSteps {
   padding: 4px 22px;
 }


### PR DESCRIPTION
Move it to the dialog header, as a "cross" (close) button.

This gives more space to the QR code itself.

Also this makes the dialog look closer to how it does on Android.
