### PR TITLE
fix: autostart minimized

### DIFF
--- a/packages/target-electron/src/autostart.ts
+++ b/packages/target-electron/src/autostart.ts
@@ -64,14 +64,14 @@ function getLinuxDesktopFileContent(): string {
 Type=Application
 Name=Delta Chat
 Comment=Delta Chat decentralized private messenger
-Exec=${escapeDesktopExecArg(getLinuxExecPath())} --minimized
+Exec=${escapeDesktopExecArg(getLinuxExecPath())} -- --minimized
 Hidden=false
 NoDisplay=false
 X-GNOME-Autostart-enabled=true
 `
 }
 
-const winArgs = ['--minimized']
+const winArgs = ['--', '--minimized']
 
 export async function getAutostartState(): Promise<AutostartState> {
   const currentPlatform = platform()


### PR DESCRIPTION
Turns out this wasn't a separate issue, as I said in https://github.com/deltachat/deltachat-desktop/pull/6076#pullrequestreview-3965715833

I have tested this with AppImage, and smoke-tested on Windows (the toggle works in Settings).