### PR TITLE
fix: remove notifs of read chats

### DIFF
--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -221,4 +221,7 @@ DCJsonrpcRemoteInitializedP.then(jsonrpcRemote => {
   jsonrpcRemote.on('MsgDeleted', (accountId, { chatId, msgId }) => {
     clearNotificationsForMessage(null, accountId, chatId, msgId)
   })
+  jsonrpcRemote.on('MsgsNoticed', (accountId, { chatId }) => {
+    clearNotificationsForChat(null, accountId, chatId)
+  })
 })


### PR DESCRIPTION
Also when messages get read from second device.
This makes old notifications much less infuriatingly useless.

Closes https://github.com/deltachat/deltachat-desktop/issues/5205.
I haven't checked how exactly this fixes the issue,
but I suspect that this happens due to us calling
`rpc.markseenMsgs()` inside of `onWindowFocus`.

Follow-up to 4dec38433fe8068de571d78afe7d26d32c4e0713
(https://github.com/deltachat/deltachat-desktop/pull/6059).

Same code on Delta Chat Android, for reference:
https://github.com/deltachat/deltachat-android/blob/ade21a2cb858e2982c43555bd4dbfb1c10cf8ffc/src/main/java/org/thoughtcrime/securesms/connect/DcEventCenter.java#L212-L214

Related issues:
- https://github.com/deltachat/deltachat-desktop/issues/3937.
- https://github.com/deltachat/deltachat-desktop/issues/2199.
