### PR TITLE
refactor: ensure `notif.close()` on remove

### DIFF
--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -134,6 +134,9 @@ function showNotification(_event: IpcMainInvokeEvent, data: DcNotification) {
           notifications[accountId]?.[chatId]?.[data.messageId]?.filter(
             n => n !== notify
           ) || []
+        // But now that we've removed the references to the notification,
+        // make sure that it really is closed.
+        notify.close()
       }
       // eslint-disable-next-line no-console
       console.log('Notification close event triggered', notify)


### PR DESCRIPTION
This is a follow-up to 0fb58eac1edd15bd5dbd1cf68890004cb6bdbc4f
(https://github.com/deltachat/deltachat-desktop/pull/4010).
