### PR TITLE
hardening: add `sandbox` CSP for HTML email viewer

### DIFF
--- a/packages/target-electron/src/windows/html_email.ts
+++ b/packages/target-electron/src/windows/html_email.ts
@@ -409,6 +409,7 @@ export function openHtmlEmailWindow(
 }
 
 const CSP_DENY = `default-src 'none';
+sandbox;
 font-src 'self' data:;
 frame-src 'none';
 img-src 'self' data:;
@@ -418,6 +419,7 @@ form-action 'none';
 script-src 'none';`.replace(/\n/g, '')
 const CSP_ALLOW = `
 default-src 'none';
+sandbox;
 font-src 'self' data: http: https:;
 frame-src 'none';
 img-src 'self' blob: data: https: http:;

--- a/packages/target-tauri/src-tauri/src/html_window/email_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/html_window/email_scheme.rs
@@ -5,6 +5,7 @@ use tauri::{Manager, UriSchemeContext, UriSchemeResponder};
 use crate::HtmlEmailInstancesState;
 
 const CSP_DENY: &str = "default-src 'none';
+sandbox;
 font-src 'self' data:;
 frame-src 'none';
 img-src 'self' data:;
@@ -15,6 +16,7 @@ script-src 'none';";
 
 const CSP_ALLOW: &str = "
 default-src 'none';
+sandbox;
 font-src 'self' data: http: https:;
 frame-src 'none';
 img-src 'self' blob: data: https: http:;


### PR DESCRIPTION
We already have JavaScript disabled, and we don't need
any of the `allow-...` values:
https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy/sandbox.

I have checked that it still shows some email messages properly,
and "Load remote content" also works.
Clicking on links also works as usual.
But I didn't check this on Tauri.
