### PR TITLE
fix: video overlapping with text below

### DIFF
--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -174,7 +174,12 @@ export default function Attachment({
     }
     // the native fullscreen option is better right now so we don't need to open our own one
     return (
-      <div className={classNames('message-attachment-media')}>
+      <div
+        className={classNames(
+          'message-attachment-media',
+          withCaption ? 'content-below' : null
+        )}
+      >
         <video
           className='attachment-content video-content'
           src={runtime.transformBlobURL(message.file)}


### PR DESCRIPTION
This partially reverts
ac5e5979e7f84a38ca18a74106278e67d62f4d6b
(https://github.com/deltachat/deltachat-desktop/pull/6096),
which introduced this issue.

What I meant in
[my suggestion](https://github.com/deltachat/deltachat-desktop/pull/6096#discussion_r2919693993)
on that MR is that we don't need to _change_ the condition
when `content-below` is applied, and not to completely remove it.

I have tested that the metadata still doesn't overlap
with video controls if there is no text,
and that the video doesn't overlap with text if there _is_ text.
