### PR TITLE
refactor: simplify video attachment CSS

### DIFF
--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -91,8 +91,12 @@
     }
   }
 
-  &.content-below {
+  &.content-below,
+  /* needed to avoid metadata video controls overlap */
+  &.video {
     margin-bottom: 7px;
+  }
+  &.content-below {
     border-bottom-left-radius: 0px;
     border-bottom-right-radius: 0px;
   }

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -332,15 +332,10 @@ $info-text-max-width: 400px;
   }
 }
 
-.message.outgoing.video-only,
-.message.incoming.video-only {
+.message.video-only {
   .msg-container {
     /* make the whole container black, as videos always have a black background */
     background-color: #000;
-    .message-attachment-media {
-      /* nneeded to avoid metadata video controls overlap */
-      padding-bottom: 12px;
-    }
   }
 }
 

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -177,6 +177,7 @@ export default function Attachment({
       <div
         className={classNames(
           'message-attachment-media',
+          'video',
           withCaption ? 'content-below' : null
         )}
       >


### PR DESCRIPTION
This also slightly (`7px`) increases the margin
between the video and the metadata element.

Let's not be deeply overriding `margin-bottom`
(or rather introducing a padding to compensate for negative margin)
and instead define it in the same place
where we have the `.content-below` styles.

Follow-up to de291375d, ac5e5979e7f84a38ca18a74106278e67d62f4d6b.
