### PR TITLE
refactor: remove dead CSS

### DIFF
--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -68,29 +68,6 @@
     }
   }
 
-  & > .video-play-btn {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-
-    width: 48px;
-    height: 48px;
-    background-color: var(--videoPlayBtnBg);
-    border-radius: 24px;
-
-    & > .video-play-btn-icon {
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-
-      height: 36px;
-      width: 36px;
-      @include mixins.color-svg('./images/play.svg', var(--videoPlayBtnIcon));
-    }
-  }
-
   &.content-below,
   /* needed to avoid metadata video controls overlap */
   &.video {


### PR DESCRIPTION
These styles have been introduced in
cc516c84ab6d34779017f4eae90242ab56a61354
(https://github.com/deltachat/deltachat-desktop/pull/1395),
which says

> clone file to make a media-attachment
and remove some unused stuff

> Mostly renaming and cloning the attachment file
> so we can have two completely different attachment styles
> for inline and gallery.

We don't have the "play" button in message list,
we simply use the `<video>` element.
