### PR TITLE
fix: clear "N messages in M chats" notifs

### DIFF
--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -222,7 +222,7 @@ function showNotification(_event: IpcMainInvokeEvent, data: DcNotification) {
   }
 }
 
-function clearNotificationsForMessage(
+function _clearNotificationsForMessage(
   _: unknown,
   accountId: number,
   chatId: number,
@@ -237,6 +237,63 @@ function clearNotificationsForMessage(
   })
   delete notifications[accountId][chatId][messageId]
 }
+function clearNotificationsForMessage(
+  _: unknown,
+  accountId: number,
+  chatId: number,
+  messageId: number
+) {
+  _clearNotificationsForMessage(_, accountId, chatId, messageId)
+
+  // A message in this chat and account is noticed.
+  // This means that this chat and account is noticed,
+  // so also clear generic notificaions that apply to this chat and account.
+  clearGenericPerChatNotifications(_, accountId, chatId)
+  clearGenericPerAccountNotifications(_, accountId)
+}
+// Unfortunately we've come to rely on `chatId` or `messageId` of 0
+// having special meaning. Namely we produce those
+// for `n_messages_in_m_chats` and `chat_n_new_messages` notifications.
+// Also possibly Core is firing events with `chatId` or `messageId`
+// set to 0.
+// So when it comes to clearing notifications, we should treat 0
+// as a "wildcard" value, meaning
+// "this notification might belong to any chat in this account"
+// (when `chatId === 0`),
+// or "any message in this chat" (when `chatId !== 0 && messageId === 0`).
+// See https://github.com/deltachat/deltachat-desktop/issues/3937#issuecomment-2261541284.
+/**
+ * Clear notifications that have `messageId === 0`,
+ * such as `chat_n_new_messages`.
+ */
+function clearGenericPerChatNotifications(
+  _: unknown,
+  accountId: number,
+  chatId: number
+) {
+  _clearNotificationsForMessage(_, accountId, chatId, 0)
+}
+/**
+ * Clear notifications that have `chatId === 0`,
+ * such as `n_messages_in_m_chats`.
+ */
+function clearGenericPerAccountNotifications(_: unknown, accountId: number) {
+  const chatIdZero = 0
+  // Yes, this is copy-pasted from `clearNotificationsForChat`.
+  // We're not using that function directly to avoid recursion.
+  //
+  // Also note that simply doing
+  // `clearNotificationsForMessage_(_, accountId, 0, 0)`
+  // would have been enough because we don't expect
+  // 0-chat to have non-0 `messageId`s,
+  // but let's properly loop through all keys.
+  if (notifications[accountId]?.[chatIdZero]) {
+    for (const messageId of Object.keys(notifications[accountId][chatIdZero])) {
+      _clearNotificationsForMessage(_, accountId, chatIdZero, Number(messageId))
+    }
+    delete notifications[accountId][chatIdZero]
+  }
+}
 
 function clearNotificationsForChat(
   _: unknown,
@@ -250,6 +307,15 @@ function clearNotificationsForChat(
     }
     delete notifications[accountId][chatId]
   }
+  // No need to `clearGenericPerChatNotifications()`,
+  // because we've already cleared notifications
+  // for _all_ message IDs just above, including 0.
+
+  // A chat in this account is noticed.
+  // This means that this account is noticed,
+  // so also clear generic notificaions that apply to this account.
+  clearGenericPerAccountNotifications(_, accountId)
+
   log.debug('after cleared Notifications', { accountId, chatId, notifications })
 }
 
@@ -259,6 +325,9 @@ function clearAccount(_event: IpcMainInvokeEvent | null, accountId: number) {
       clearNotificationsForChat(null, Number(accountId), Number(chatId))
     }
   }
+  // No need to `clearGenericPerAccountNotifications()`,
+  // because we've already cleared notifications
+  // for _all_ chat IDs just above, including 0.
 }
 
 function clearAll() {

--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -158,7 +158,7 @@ function showNotification(_event: IpcMainInvokeEvent, data: DcNotification) {
   }
 }
 
-function clearNotificationsForMessage(
+function _clearNotificationsForMessage(
   _: unknown,
   accountId: number,
   chatId: number,
@@ -172,6 +172,63 @@ function clearNotificationsForMessage(
     notify.close()
   })
   delete notifications[accountId][chatId][messageId]
+}
+function clearNotificationsForMessage(
+  _: unknown,
+  accountId: number,
+  chatId: number,
+  messageId: number
+) {
+  _clearNotificationsForMessage(_, accountId, chatId, messageId)
+
+  // A message in this chat and account is noticed.
+  // This means that this chat and account is noticed,
+  // so also clear generic notificaions that apply to this chat and account.
+  clearGenericPerChatNotifications(_, accountId, chatId)
+  clearGenericPerAccountNotifications(_, accountId)
+}
+// Unfortunately we've come to rely on `chatId` or `messageId` of 0
+// having special meaning. Namely we produce those
+// for `n_messages_in_m_chats` and `chat_n_new_messages` notifications.
+// Also possibly Core is firing events with `chatId` or `messageId`
+// set to 0.
+// So when it comes to clearing notifications, we should treat 0
+// as a "wildcard" value, meaning
+// "this notification might belong to any chat in this account"
+// (when `chatId === 0`),
+// or "any message in this chat" (when `chatId !== 0 && messageId === 0`).
+// See https://github.com/deltachat/deltachat-desktop/issues/3937#issuecomment-2261541284.
+/**
+ * Clear notifications that have `messageId === 0`,
+ * such as `chat_n_new_messages`.
+ */
+function clearGenericPerChatNotifications(
+  _: unknown,
+  accountId: number,
+  chatId: number
+) {
+  _clearNotificationsForMessage(_, accountId, chatId, 0)
+}
+/**
+ * Clear notifications that have `chatId === 0`,
+ * such as `n_messages_in_m_chats`.
+ */
+function clearGenericPerAccountNotifications(_: unknown, accountId: number) {
+  const chatIdZero = 0
+  // Yes, this is copy-pasted from `clearNotificationsForChat`.
+  // We're not using that function directly to avoid recursion.
+  //
+  // Also note that simply doing
+  // `clearNotificationsForMessage_(_, accountId, 0, 0)`
+  // would have been enough because we don't expect
+  // 0-chat to have non-0 `messageId`s,
+  // but let's properly loop through all keys.
+  if (notifications[accountId]?.[chatIdZero]) {
+    for (const messageId of Object.keys(notifications[accountId][chatIdZero])) {
+      _clearNotificationsForMessage(_, accountId, chatIdZero, Number(messageId))
+    }
+    delete notifications[accountId][chatIdZero]
+  }
 }
 
 function clearNotificationsForChat(
@@ -188,6 +245,15 @@ function clearNotificationsForChat(
     }
     delete notifications[accountId][chatId]
   }
+  // No need to `clearGenericPerChatNotifications()`,
+  // because we've already cleared notifications
+  // for _all_ message IDs just above, including 0.
+
+  // A chat in this account is noticed.
+  // This means that this account is noticed,
+  // so also clear generic notificaions that apply to this account.
+  clearGenericPerAccountNotifications(_, accountId)
+
   log.debug('after cleared Notifications', { accountId, chatId, notifications })
 }
 
@@ -197,6 +263,9 @@ function clearAccount(_event: IpcMainInvokeEvent | null, accountId: number) {
       clearNotificationsForChat(null, Number(accountId), Number(chatId))
     }
   }
+  // No need to `clearGenericPerAccountNotifications()`,
+  // because we've already cleared notifications
+  // for _all_ chat IDs just above, including 0.
 }
 
 function clearAll() {


### PR DESCRIPTION
For example, when when we get an event that would clear
any notification of an account,
we also clear the "N messages in M chats".
When we get an event to clear a notification that affects a chat,
we clear its "N messages" notification of that chat.

Together with
- 8e54899f4adf699cb70f727c030c6a97aef62855
  (https://github.com/deltachat/deltachat-desktop/pull/6130)
- 4dec38433fe8068de571d78afe7d26d32c4e0713
  (https://github.com/deltachat/deltachat-desktop/pull/6059)

...closes https://github.com/deltachat/deltachat-desktop/issues/3937.

Still a lot of work to do on notification clearing,
such as clearing "Bob reacted to your message"
(https://github.com/deltachat/deltachat-desktop/issues/6061,
https://github.com/chatmail/core/issues/7884),
but this is much better than what we had before those few MRs.

Note that there exists an alternative approach
of clearing the notifications when _all_ messages
of the affected scope (either an account or a chat)
have been read.
But I think that for that it's enough to have these number badges
on chats and accounts, and the app icon in the taskbar.

Note that this MR only affects Electron.

TODO:
- [ ] There is a bit of a problem now.
  The "N messages in M chats" (per-account) notifications
  get immediately cleared on startup right after appearing
  This is because we unconditionally call
  `rpc.marknoticedChat()` for device chats.
  
  https://github.com/deltachat/deltachat-desktop/blob/c50896f1d529b09ea584f8fccca3f5fca7fe6ed7/packages/frontend/src/deviceMessages.ts#L35-L44

  We probably need to rewrite all this "device message" logic,
  it's a bit of a mess TBH IMO.
