### PR TITLE
fix: WebXDC: handle non-`target=_blank` links

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -456,13 +456,9 @@ app.on('web-contents-created', (_ev, contents) => {
       if (isSaneWebxdcUrl && isSameOrigin) {
         // allow internal webxdc nav
         return
-      } else if (ev.url.startsWith('mailto:')) {
-        // handle mailto in dc
+      } else {
         ev.preventDefault()
         webxdcOpenUrl(ev.url)
-      } else {
-        // prevent navigation to unknown scheme
-        ev.preventDefault()
       }
     })
 


### PR DESCRIPTION
Prior to this commit in order for an external link click to work
it had to have `target="_blank"`
(then `setWindowOpenHandler` would handle it),
or to be a `mailto:` link.

This does not affect security because we already
unconditionally invoke `webxdcOpenUrl()` in `setWindowOpenHandler`.
An app can already invoke `webxdcOpenUrl()` with arbitrary URLs,
e.g. by using `window.open()`.

I have tested this.

Related:
- https://github.com/deltachat/deltachat-desktop/issues/5785.
- https://github.com/deltachat/deltachat-desktop/issues/3355.
- https://github.com/deltachat/deltachat-desktop/pull/3457.
