### PR TITLE
fix: WebXDC, HTML viewer: handle all invite links

### DIFF
--- a/packages/shared/util.ts
+++ b/packages/shared/util.ts
@@ -18,6 +18,20 @@ export function isInviteLink(url: string) {
 }
 
 /**
+ * Whether a potentially untrustworthy link,
+ * coming from places such as WebXDC apps or HTML email viewer,
+ * can and should be handled by the main app.
+ * @see `useProcessQR`
+ */
+export function shouldHandleLinkInMainApp(url: string): boolean {
+  return (
+    url.startsWith('mailto:') ||
+    url.startsWith('openpgp4fpr:') ||
+    isInviteLink(url)
+  )
+}
+
+/**
  * Like [Lodash `throttle`](https://lodash.com/docs/4.17.15#throttle)
  * with default options (`{ leading: true, trailing: true }`).
  */

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -147,7 +147,7 @@ import {
   cleanupDraftTempDir,
   cleanupInternalTempDirs,
 } from './cleanup_temp_dir.js'
-import { isInviteLink } from '@deltachat-desktop/shared/util.js'
+import { shouldHandleLinkInMainApp } from '@deltachat-desktop/shared/util.js'
 
 app.ipcReady = false
 app.isQuitting = false
@@ -316,11 +316,7 @@ app.on('web-contents-created', (_ev, contents) => {
     let preventOpeningLinkClickDialogs = false
 
     const webxdcOpenUrl = async (url: string) => {
-      if (
-        url.startsWith('mailto:') ||
-        url.startsWith('openpgp4fpr:') ||
-        isInviteLink(url)
-      ) {
+      if (shouldHandleLinkInMainApp(url)) {
         // handle mailto in dc, without any prompt.
         // Note that such links can also lead to exfiltration,
         // however this has been regarded as acceptable,

--- a/packages/target-electron/src/windows/html_email.ts
+++ b/packages/target-electron/src/windows/html_email.ts
@@ -16,7 +16,10 @@ import { platform } from 'os'
 
 import { appIcon, htmlDistDir } from '../application-constants.js'
 import { DesktopSettings } from '../desktop_settings.js'
-import { isInviteLink, truncateText } from '@deltachat-desktop/shared/util.js'
+import {
+  shouldHandleLinkInMainApp,
+  truncateText,
+} from '@deltachat-desktop/shared/util.js'
 import { tx } from '../load-translations.js'
 import { open_url } from '../open_url.js'
 import { loadTheme } from '../themes.js'
@@ -509,11 +512,7 @@ function makeBrowserView(
     }`)
 
   const openLink = (url: string) => {
-    if (
-      url.startsWith('mailto:') ||
-      url.startsWith('openpgp4fpr:') ||
-      isInviteLink(url)
-    ) {
+    if (shouldHandleLinkInMainApp(url)) {
       open_url(url)
       mainWindow.window?.show()
     } else {


### PR DESCRIPTION
The `openpgp4fpr:` and `https://i.delta.chat` links
are pretty much the same.
I see no reason why we need to handle one kind only in WebXDC
and the other only in the HTML email viewer.
The handling in these two places has been introduced
in separate MRs several months apart,
and thus it's probably just an oversight.
See
- 14f3f45119abacddcebed059b4d069b7e246b906
  (https://github.com/deltachat/deltachat-desktop/pull/3683).
- 6d7be7d260c7dab918509de6d5569e08f53c37fd
  (https://github.com/deltachat/deltachat-desktop/pull/3457).
