### PR TITLE
feat: WebXDC: support more link click schemes

### DIFF
--- a/packages/target-electron/src/deltachat/link-clicks.ts
+++ b/packages/target-electron/src/deltachat/link-clicks.ts
@@ -2,8 +2,30 @@ import { shell, dialog, clipboard, type BrowserWindow } from 'electron'
 import { tx } from '../load-translations.js'
 
 /**
- * Opens the link externally (in the browser) if it's an HTTP(S) link,
- * or opens a dialog suggesting to copy the link if it's not an HTTP(S) link.
+ * @see the white list on Android
+ * https://github.com/deltachat/deltachat-android/blob/c2f492463fb0b5e0278f25c6e92c897d11764eea/src/main/java/org/thoughtcrime/securesms/WebViewActivity.java#L108-L119
+ */
+const whitelist = [
+  'http:',
+  'https:',
+  'gemini:',
+  'tel:',
+  'sms:',
+  // Note that `mailto:` and `openpgp4fpr:` links
+  // are usually already handled otherwise,
+  // e.g. with `open_url`, instead of getting passed to
+  // `openExternalWhitelistedOrPromptToCopy`.
+  'mailto:',
+  'openpgp4fpr:',
+  'geo:',
+  'dcaccount:',
+  'dclogin:',
+]
+
+/**
+ * Opens the link externally (e.g. in the browser if it's an HTTP(S) link),
+ * or opens a dialog suggesting to copy the link
+ * if the protocol is not in the whitelist.
  *
  * This should only be called if the user confirmed their intent
  * to open the link. Preferably the user also got a chance to look
@@ -14,6 +36,21 @@ import { tx } from '../load-translations.js'
  *
  * @see `useOpenLinkSafely`
  * @see `open_url`
+ */
+export async function openExternalWhitelistedOrPromptToCopy(
+  win: BrowserWindow,
+  url: string
+): Promise<void> {
+  const lowercase = url.toLowerCase()
+  if (whitelist.some(scheme => lowercase.startsWith(scheme))) {
+    shell.openExternal(url)
+  } else if (url) {
+    promptToCopy(win, url)
+  }
+}
+/**
+ * Like {@linkcode openExternalWhitelistedOrPromptToCopy},
+ * but only `http:` and `https:` are whitelisted.
  */
 export async function openExternalHttpOrPromptToCopy(
   win: BrowserWindow,

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -142,7 +142,7 @@ import {
   WEBXDC_PARTITION_PREFIX,
   webxdcStartUpCleanup,
 } from './deltachat/webxdc.js'
-import { openExternalHttpOrPromptToCopy } from './deltachat/link-clicks.js'
+import { openExternalWhitelistedOrPromptToCopy } from './deltachat/link-clicks.js'
 import {
   cleanupDraftTempDir,
   cleanupInternalTempDirs,
@@ -418,7 +418,7 @@ app.on('web-contents-created', (_ev, contents) => {
           break
         }
         case 2: {
-          await openExternalHttpOrPromptToCopy(win, url)
+          await openExternalWhitelistedOrPromptToCopy(win, url)
           break
         }
         default: {


### PR DESCRIPTION
- **refactor: factor out `promptToCopy` link**
- **feat: WebXDC: support more link click schemes**

Together with https://github.com/deltachat/deltachat-desktop/pull/5852 this closes https://github.com/deltachat/deltachat-desktop/issues/5785.

TODO:
- [x] merge the base such that only 2 commits remain.