### PR TITLE
fix: use red contact deletion confirmation button, show contact name

### DIFF
--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -294,8 +294,9 @@ function CreateChatMain(props: CreateChatMainProps) {
             label: tx('delete_contact'),
             action: async () => {
               const confirmed = await openConfirmationDialog({
-                message: tx('ask_delete_contact', contact.address),
-                confirmLabel: tx('delete'),
+                message: tx('ask_delete_contact', contact.displayName),
+                confirmLabel: tx('delete_contact'),
+                isConfirmDanger: true,
               })
 
               if (confirmed) {


### PR DESCRIPTION
this PR fixes two issues in the confirm contact deletion dialog:

- show  "delete" button  in "destructive red", as elsewhere
- show contact name, not address

## before / after

<img width="380" src="https://github.com/user-attachments/assets/86273c85-161f-4434-9c25-2ed53b3e5a9f" /> <img width="380" src="https://github.com/user-attachments/assets/96441d8a-92f2-4784-b2bd-b11a0a9cd7b0" />
