### PR TITLE
Warn about existing accounts & migration for macos data

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -117,6 +117,6 @@
     "message": "Warning"
   },
   "data_found_other_installation_message": {
-    "message": "Your profiles from another Delta Chat installation are not accessible - different installations store their data in separate locations.\n\nTo keep the existing profiles:\n1. Exit now\n2. Open the other Delta Chat - you may need to reinstall it from %1$s\n3. Create a backup there at \"Settings / Chats\"\n4. Relaunch this version\n5. Restore the backup on the next page at \"I already have a profile\"\n\nContinue without your previous profiles?"
+    "message": "Your profiles from another Delta Chat installation are not accessible - different installations store their data in separate locations.\n\nTo keep existing profiles:\n1. Quit now\n2. Open the other Delta Chat - if needed, reinstall it from %1$s\n3. Back up each profile at \"Settings/Chats\"\n4. Relaunch this version\n5. Restore the backups using \"I already have a profile\"\n\nContinue without your previous profiles?"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -113,10 +113,10 @@
   "messages_are_e2ee": {
     "message": "Messages are end-to-end encrypted."
   },
-  "data_found_other_installation_title": {
-    "message": "Data found from a previous %1$s installation"
+  "warning": {
+    "message": "Warning"
   },
   "data_found_other_installation_message": {
-    "message": "A previous %1$s installation left account data that this version will not see.\nWe recommend to avoid running different versions of Delta Chat simultaneously.\nTo keep your existing profiles, you can create a backup in the previous app before launching the new version and import it again."
+    "message": "Your profiles from another Delta Chat installation are not accessible - different installations store their data in separate locations.\n\nTo keep the existing profiles:\n1. Exit now\n2. Open the other Delta Chat - you may need to reinstall it from %1$s\n3. Create a backup there at \"Settings / Chats\"\n4. Relaunch this version\n5. Restore the backup on the next page at \"I already have a profile\"\n\nContinue without your previous profiles?"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -112,5 +112,11 @@
   },
   "messages_are_e2ee": {
     "message": "Messages are end-to-end encrypted."
+  },
+  "data_found_other_installation_title": {
+    "message": "Data found from a previous %1$s installation"
+  },
+  "data_found_other_installation_message": {
+    "message": "A previous %1$s installation left account data that this version will not see.\nWe recommend to avoid running different versions of Delta Chat simultaneously.\nTo keep your existing profiles, you can create a backup in the previous app before launching the new version and import it again."
   }
 }

--- a/packages/target-electron/build/container-migration.plist
+++ b/packages/target-electron/build/container-migration.plist
@@ -4,7 +4,7 @@
 <dict>
 	<key>Move</key>
 	<array>
-		<string>${Application Support}/DeltaChat</string>
+		<string>${ApplicationSupport}/DeltaChat</string>
 	</array>
 </dict>
 </plist>

--- a/packages/target-electron/build/container-migration.plist
+++ b/packages/target-electron/build/container-migration.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Move</key>
+	<array>
+		<string>${Application Support}/DeltaChat</string>
+	</array>
+</dict>
+</plist>

--- a/packages/target-electron/build/gen-electron-builder-config.js
+++ b/packages/target-electron/build/gen-electron-builder-config.js
@@ -123,6 +123,12 @@ build['mas'] = {
   // binaries // Paths of any extra binaries that need to be signed.
   // For universal builds: allow these binaries to be x64 in both ASAR files
   x64ArchFiles: '**/*darwin*/**',
+  extraResources: [
+    {
+      from: 'build/container-migration.plist',
+      to: '../container-migration.plist',
+    },
+  ],
 }
 
 build['dmg'] = {

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -221,7 +221,7 @@ async function onReady([
         type: 'warning',
         title: tx('warning'),
         message: tx('data_found_other_installation_message', otherStoreName),
-        buttons: [tx('perm_continue'), tx('global_menu_file_quit_desktop')],
+        buttons: [tx('ok'), tx('cancel')],
         defaultId: 0,
         cancelId: 1,
       })

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -6,7 +6,7 @@ import { app as rawApp, dialog, ipcMain, protocol, clipboard } from 'electron'
 import { BrowserWindow } from 'electron/main'
 import rc from './rc.js'
 import contextMenu from './electron-context-menu.js'
-import { initIsWindowsStorePackageVar } from './isAppx.js'
+import { appx, initIsWindowsStorePackageVar } from './isAppx.js'
 import { getHelpMenu } from './help_menu.js'
 import { initialisePowerMonitor } from './resume_from_sleep.js'
 
@@ -183,35 +183,43 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
   acceptThemeCLI()
   setLanguage(DesktopSettings.state.locale || app.getLocale().split('-')[0]) // can consist of 2 strings like in en-GB
 
-  // Warn non-MAS macOS users if data exists in the sandbox container path
-  // (left over from a previous Mac App Store installation),
-  // but only when there are no accounts yet in the non-sandbox location.
-  if (
-    process.platform === 'darwin' &&
-    !process.mas &&
-    !existsSync(getAccountsPath())
-  ) {
-    const { homedir } = await import('os')
-    const sandboxAccountsPath = join(
-      homedir(),
-      'Library/Containers/chat.delta.desktop.electron/Data/Library/Application Support/DeltaChat/accounts'
-    )
-    if (existsSync(sandboxAccountsPath)) {
+  // Warn users if data exists from a different installation variant
+  // (e.g. Mac App Store vs DMG, or Windows Store APPX vs Setup.exe),
+  // but only when there are no accounts yet in the current location.
+  if (!existsSync(getAccountsPath())) {
+    let otherStoreName: string | undefined
+    let otherAccountsPath: string | undefined
+
+    if (process.platform === 'darwin' && !process.mas) {
+      const { homedir } = await import('os')
+      const sandboxPath = join(
+        homedir(),
+        'Library/Containers/chat.delta.desktop.electron/Data/Library/Application Support/DeltaChat/accounts'
+      )
+      if (existsSync(sandboxPath)) {
+        otherStoreName = 'Mac App Store'
+        otherAccountsPath = sandboxPath
+      }
+    } else if (process.platform === 'win32') {
+      const { homedir } = await import('os')
+      const normalPath = join(homedir(), 'AppData/Local/DeltaChat/accounts')
+      const appxPath = join(
+        homedir(),
+        'AppData/Local/Packages/merlinux.DeltaChat_v2ry5hvxhdhyy/LocalCache/Local/DeltaChat/accounts'
+      )
+      const otherPath = appx ? normalPath : appxPath
+      if (existsSync(otherPath)) {
+        otherStoreName = appx ? 'non-store' : 'Microsoft Store'
+        otherAccountsPath = otherPath
+      }
+    }
+
+    if (otherStoreName && otherAccountsPath) {
       const result = await dialog.showMessageBox({
         type: 'warning',
-        title: 'Data found from previous Mac App Store installation',
-        message:
-          'A previous Mac App Store installation left account data in the location:\n\n' +
-          sandboxAccountsPath +
-          '\n\n' +
-          'This non-store version uses a different location and will not see that data. ' +
-          '\n' +
-          'We recommend to avoid running different versions of Delta Chat simultaneously. ' +
-          '\n' +
-          'To keep your existing profiles, you can create a backup in the previous app before launching the new version and import it again.' +
-          '\n\n' +
-          'Would you like to continue launching?',
-        buttons: ['Continue', 'Quit'],
+        title: tx('data_found_other_installation_title', otherStoreName),
+        message: tx('data_found_other_installation_message', otherStoreName),
+        buttons: [tx('ok'), tx('cancel')],
         defaultId: 0,
         cancelId: 1,
       })

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -221,7 +221,7 @@ async function onReady([
         type: 'warning',
         title: tx('warning'),
         message: tx('data_found_other_installation_message', otherStoreName),
-        buttons: [tx('ok'), tx('cancel')],
+        buttons: [tx('perm_continue'), tx('global_menu_file_quit_desktop')],
         defaultId: 0,
         cancelId: 1,
       })

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -155,7 +155,7 @@ app.isQuitting = false
 Promise.all([
   new Promise((resolve, _reject) => app.on('ready', resolve)),
   DesktopSettings.load(),
-  initIsWindowsStorePackageVar(),
+  initIsWindowsStorePackageVar().then(() => existsSync(getAccountsPath())),
   webxdcStartUpCleanup(),
 ])
   .then(onReady)
@@ -173,12 +173,12 @@ Also make sure you are not trying to run multiple instances of deltachat.`
 
 let ipc_shutdown_function: (() => void) | null = null
 
-async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
-  any,
-  any,
-  any,
-  any,
-]) {
+async function onReady([
+  _appReady,
+  _loadedState,
+  accountsPathExists,
+  _webxdc_cleanup,
+]: [any, any, boolean, any]) {
   // can fail due to user error so running it first is better (cli argument)
   acceptThemeCLI()
   setLanguage(DesktopSettings.state.locale || app.getLocale().split('-')[0]) // can consist of 2 strings like in en-GB
@@ -186,7 +186,7 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
   // Warn users if data exists from a different installation variant
   // (e.g. Mac App Store vs DMG, or Windows Store APPX vs Setup.exe),
   // but only when there are no accounts yet in the current location.
-  if (!existsSync(getAccountsPath())) {
+  if (!accountsPathExists) {
     let otherStoreName: string | undefined
     let otherAccountsPath: string | undefined
 
@@ -209,7 +209,9 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
       )
       const otherPath = appx ? normalPath : appxPath
       if (existsSync(otherPath)) {
-        otherStoreName = appx ? 'non-store' : 'Microsoft Store'
+        // note that it seems per default if data exists in normalPath it will be used by the appx version
+        // but in that case we expect the previous accounts to be used, so this warning will not appear
+        otherStoreName = appx ? 'get.delta.chat' : 'Microsoft Store'
         otherAccountsPath = otherPath
       }
     }
@@ -217,7 +219,7 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
     if (otherStoreName && otherAccountsPath) {
       const result = await dialog.showMessageBox({
         type: 'warning',
-        title: tx('data_found_other_installation_title', otherStoreName),
+        title: tx('warning'),
         message: tx('data_found_other_installation_message', otherStoreName),
         buttons: [tx('ok'), tx('cancel')],
         defaultId: 0,

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-console
 console.time('init')
 
-import { mkdirSync, Stats, watchFile } from 'fs'
+import { existsSync, mkdirSync, Stats, watchFile } from 'fs'
 import { app as rawApp, dialog, ipcMain, protocol, clipboard } from 'electron'
 import { BrowserWindow } from 'electron/main'
 import rc from './rc.js'
@@ -182,6 +182,45 @@ async function onReady([_appReady, _loadedState, _appx, _webxdc_cleanup]: [
   // can fail due to user error so running it first is better (cli argument)
   acceptThemeCLI()
   setLanguage(DesktopSettings.state.locale || app.getLocale().split('-')[0]) // can consist of 2 strings like in en-GB
+
+  // Warn non-MAS macOS users if data exists in the sandbox container path
+  // (left over from a previous Mac App Store installation),
+  // but only when there are no accounts yet in the non-sandbox location.
+  if (
+    process.platform === 'darwin' &&
+    !process.mas &&
+    !existsSync(getAccountsPath())
+  ) {
+    const { homedir } = await import('os')
+    const sandboxAccountsPath = join(
+      homedir(),
+      'Library/Containers/chat.delta.desktop.electron/Data/Library/Application Support/DeltaChat/accounts'
+    )
+    if (existsSync(sandboxAccountsPath)) {
+      const result = await dialog.showMessageBox({
+        type: 'warning',
+        title: 'Data found from previous Mac App Store installation',
+        message:
+          'A previous Mac App Store installation left account data in the location:\n\n' +
+          sandboxAccountsPath +
+          '\n\n' +
+          'This non-store version uses a different location and will not see that data. ' +
+          '\n' +
+          'We recommend to avoid running different versions of Delta Chat simultaneously. ' +
+          '\n' +
+          'To keep your existing profiles, you can create a backup in the previous app before launching the new version and import it again.' +
+          '\n\n' +
+          'Would you like to continue launching?',
+        buttons: ['Continue', 'Quit'],
+        defaultId: 0,
+        cancelId: 1,
+      })
+      if (result.response === 1) {
+        app.quit()
+        return
+      }
+    }
+  }
 
   const cwd = getAccountsPath()
   log.info(`cwd ${cwd}`)

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -187,7 +187,7 @@ async function onReady([
   // (e.g. Mac App Store vs DMG, or Windows Store APPX vs Setup.exe),
   // but only when there are no accounts yet in the current location.
   if (!accountsPathExists) {
-    let otherStoreName: string | undefined
+    let otherStoreName = 'App Store'
     let otherAccountsPath: string | undefined
 
     if (process.platform === 'darwin' && !process.mas) {
@@ -197,7 +197,6 @@ async function onReady([
         'Library/Containers/chat.delta.desktop.electron/Data/Library/Application Support/DeltaChat/accounts'
       )
       if (existsSync(sandboxPath)) {
-        otherStoreName = 'Mac App Store'
         otherAccountsPath = sandboxPath
       }
     } else if (process.platform === 'win32') {
@@ -211,7 +210,9 @@ async function onReady([
       if (existsSync(otherPath)) {
         // note that it seems per default if data exists in normalPath it will be used by the appx version
         // but in that case we expect the previous accounts to be used, so this warning will not appear
-        otherStoreName = appx ? 'get.delta.chat' : 'Microsoft Store'
+        if (appx) {
+          otherStoreName = 'get.delta.chat'
+        }
         otherAccountsPath = otherPath
       }
     }
@@ -221,7 +222,7 @@ async function onReady([
         type: 'warning',
         title: tx('warning'),
         message: tx('data_found_other_installation_message', otherStoreName),
-        buttons: [tx('ok'), tx('cancel')],
+        buttons: [tx('perm_continue'), tx('global_menu_file_quit_desktop')],
         defaultId: 0,
         cancelId: 1,
       })


### PR DESCRIPTION
Related to #6177

shows a warning if

- a previous Apple Store install exists and the user starts a dmg install
- a previous MS Store install exists and the user starts a Setup/Portable exe
- a previous Setup.exe install exists and the user starts a MS Store install

The added MacOS container-migration.plist should transfer the data into the sandbox container if a first time MacOS Store install is started and a previous install exists

This is how it will look like on macOS 15:

<img width="590" height="351" alt="Screenshot 2026-04-09 at 13 51 32" src="https://github.com/user-attachments/assets/b339eec9-9f71-4186-80ae-657c6d709531" />

This is how it will look on a (german)  windows 11 OS (text outdated)

<img width="720" alt="screenshot-dc-desktop-windows" src="https://github.com/user-attachments/assets/93d99b17-b3ce-4c65-ab55-9b0f27e360d3" />

