### PR TITLE
fix: don't scroll to active chat on order change

### DIFF
--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -250,6 +250,17 @@ export default function ChatList(props: {
     () => (activeChatId != null ? chatListIds.indexOf(activeChatId) : -1),
     [chatListIds, activeChatId]
   )
+  /**
+   * Can be `false` when `chatListIds` is still loading (it's empty then)
+   * or if we're switching between the "archived" and normal view.
+   */
+  const activeChatIsInList = activeChatIndex !== -1
+  const scrollActiveChatIntoView = useEffectEvent(() => {
+    if (!activeChatIsInList) {
+      return
+    }
+    scrollChatIntoView(activeChatIndex)
+  })
   const lastShowArchivedChatsState = useRef(showArchivedChats)
   const lastQuery = useRef(queryStr)
   // on select chat - scroll to selected chat - chatView
@@ -263,7 +274,7 @@ export default function ChatList(props: {
     }
     // when showArchivedChats changes, select selected chat if it is archived/not-archived otherwise select first item
     if (activeChatIndex !== -1) {
-      scrollChatIntoView(activeChatIndex)
+      scrollActiveChatIntoView()
     } else {
       if (lastShowArchivedChatsState.current !== showArchivedChats) {
         scrollChatIntoView(0)

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -264,7 +264,7 @@ export default function ChatList(props: {
   const lastShowArchivedChatsState = useRef(showArchivedChats)
   const lastQuery = useRef(queryStr)
   // on select chat - scroll to selected chat - chatView
-  // follow chat after loading or when it's position in the chatlist changes
+  // follow chat after loading
   useEffect(() => {
     if (isSearchActive && lastQuery.current !== queryStr) {
       scrollChatIntoView(0)
@@ -273,7 +273,7 @@ export default function ChatList(props: {
       return
     }
     // when showArchivedChats changes, select selected chat if it is archived/not-archived otherwise select first item
-    if (activeChatIndex !== -1) {
+    if (activeChatIsInList) {
       scrollActiveChatIntoView()
     } else {
       if (lastShowArchivedChatsState.current !== showArchivedChats) {
@@ -282,7 +282,8 @@ export default function ChatList(props: {
     }
     lastShowArchivedChatsState.current = showArchivedChats
   }, [
-    activeChatIndex,
+    activeChatId,
+    activeChatIsInList,
     isSearchActive,
     scrollChatIntoView,
     showArchivedChats,


### PR DESCRIPTION
- **refactor: `useEffectEvent` for scroll chat in view**
- **fix: don't scroll to active chat on order change**

Closes https://github.com/deltachat/deltachat-desktop/issues/6087.

Some more cases where we'd scroll:
1. Receive a message in the active chat
    such that it order in the chat list moves up.
2. Archive a chat that is above the current chat.

Instead let's only scroll on load
(or on switch between archived or normal)
and when switching between chats.

I tested those use cases, it works fine in them.

FTR the logic that I'm changing has been introduced in
https://github.com/deltachat/deltachat-desktop/pull/1659.