### PR TITLE
refactor: dedup `marknoticedChat` helper

### DIFF
--- a/packages/frontend/src/backend-com.ts
+++ b/packages/frontend/src/backend-com.ts
@@ -40,11 +40,6 @@ export namespace EffectfulBackendActions {
     await BackendRemote.rpc.deleteChat(accountId, chatId)
     clearNotificationsForChat(accountId, chatId)
   }
-
-  export async function marknoticedChat(accountId: number, chatId: number) {
-    await BackendRemote.rpc.marknoticedChat(accountId, chatId)
-    clearNotificationsForChat(accountId, chatId)
-  }
 }
 
 type ContextEvents = { ALL: (event: DcEvent) => void } & {

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -4,7 +4,8 @@ import { T, C } from '@deltachat/jsonrpc-client'
 
 import Timestamp from '../conversations/Timestamp'
 import { Avatar } from '../Avatar'
-import { Type, EffectfulBackendActions } from '../../backend-com'
+import { Type } from '../../backend-com'
+import { markChatAsSeen } from '../../backend/chat'
 import { mapCoreMsgStatus2String } from '../helpers/MapMsgStatus'
 import { getLogger } from '../../../../shared/logger'
 import { useContextMenuWithActiveState } from '../ContextMenu'
@@ -157,10 +158,7 @@ function ChatListItemArchiveLink({
     {
       label: tx('mark_all_as_read'),
       action: () => {
-        EffectfulBackendActions.marknoticedChat(
-          selectedAccountId(),
-          C.DC_CHAT_ID_ARCHIVED_LINK
-        )
+        markChatAsSeen(selectedAccountId(), C.DC_CHAT_ID_ARCHIVED_LINK)
       },
     },
   ])


### PR DESCRIPTION
This partially reverts 0a7f897757f49c14cc61c0de11bdb16291d2b63a
(https://github.com/deltachat/deltachat-desktop/pull/4010).

The `EffectfulBackendActions.marknoticedChat` and `markChatAsSeen`
function are equivalent,
except the former has an `await`, but it has no effect
where the function is used.
