### PR TITLE
fix: don't `marknoticedChat` on chat select & jump

### DIFF
--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -31,7 +31,6 @@ import {
   RovingTabindexProvider,
   useRovingTabindex,
 } from '../../contexts/RovingTabindex'
-import { markChatAsSeen } from '../../backend/chat'
 
 const onWindowFocus = (accountId: number) => {
   log.debug('window focused')
@@ -1061,13 +1060,6 @@ function JumpDownButton({
               scrollIntoViewArg: { block: 'center' },
               focus: false,
             })
-            if (stackIsEmpty) {
-              // We're jumping to the very bottom, so let's mark all messages
-              // as seen, even if we're skipping over many messages
-              // without the user actually seeing them.
-              // See https://github.com/deltachat/deltachat-desktop/issues/3072.
-              markChatAsSeen(accountId, chat.id)
-            }
           }}
           // Technically this is not always "to bottom",
           // but perhaps it's good enough.

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -1,7 +1,8 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { ActionEmitter, KeybindAction } from '../keybindings'
-import { markChatAsSeen, saveLastChatId } from '../backend/chat'
+import { saveLastChatId } from '../backend/chat'
+import { clearNotificationsForChat } from '../system-integration/notifications'
 import { BackendRemote } from '../backend-com'
 
 import type { RefObject, PropsWithChildren } from 'react'
@@ -149,8 +150,7 @@ export const ChatProvider = ({
       // Already set known state
       setChatId(nextChatId)
 
-      // Clear system notifications and mark chat as seen in backend
-      markChatAsSeen(accountId, nextChatId)
+      clearNotificationsForChat(accountId, nextChatId)
 
       // Remember that user selected this chat to open it again when they come back
       saveLastChatId(accountId, nextChatId)


### PR DESCRIPTION
This addresses
https://github.com/chatmail/core/issues/7965#issuecomment-4123439128.

Note that as of Core 2.48.0 this would re-introduce this bug
https://github.com/deltachat/deltachat-desktop/issues/3072.
Waiting for Core to do its thing so that this can be merged.
