### PR TITLE
refactor: rename markChatAsSeen -> marknoticedChat

### DIFF
--- a/packages/frontend/src/backend/chat.ts
+++ b/packages/frontend/src/backend/chat.ts
@@ -60,7 +60,7 @@ export async function unmuteChat(accountId: number, chatId: number) {
   })
 }
 
-export function markChatAsSeen(accountId: number, chatId: number) {
+export function marknoticedChat(accountId: number, chatId: number) {
   // Mark all messages in chat as "seen" in core backend
   BackendRemote.rpc.marknoticedChat(accountId, chatId)
 

--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -5,7 +5,7 @@ import { T, C } from '@deltachat/jsonrpc-client'
 import Timestamp from '../conversations/Timestamp'
 import { Avatar } from '../Avatar'
 import { Type } from '../../backend-com'
-import { markChatAsSeen } from '../../backend/chat'
+import { marknoticedChat } from '../../backend/chat'
 import { mapCoreMsgStatus2String } from '../helpers/MapMsgStatus'
 import { getLogger } from '../../../../shared/logger'
 import { useContextMenuWithActiveState } from '../ContextMenu'
@@ -158,7 +158,7 @@ function ChatListItemArchiveLink({
     {
       label: tx('mark_all_as_read'),
       action: () => {
-        markChatAsSeen(selectedAccountId(), C.DC_CHAT_ID_ARCHIVED_LINK)
+        marknoticedChat(selectedAccountId(), C.DC_CHAT_ID_ARCHIVED_LINK)
       },
     },
   ])

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -31,7 +31,7 @@ import {
   RovingTabindexProvider,
   useRovingTabindex,
 } from '../../contexts/RovingTabindex'
-import { markChatAsSeen } from '../../backend/chat'
+import { marknoticedChat } from '../../backend/chat'
 
 const onWindowFocus = (accountId: number) => {
   log.debug('window focused')
@@ -1066,7 +1066,7 @@ function JumpDownButton({
               // as seen, even if we're skipping over many messages
               // without the user actually seeing them.
               // See https://github.com/deltachat/deltachat-desktop/issues/3072.
-              markChatAsSeen(accountId, chat.id)
+              marknoticedChat(accountId, chat.id)
             }
           }}
           // Technically this is not always "to bottom",

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from 'react'
 
 import { ActionEmitter, KeybindAction } from '../keybindings'
-import { markChatAsSeen, saveLastChatId } from '../backend/chat'
+import { marknoticedChat, saveLastChatId } from '../backend/chat'
 import { BackendRemote } from '../backend-com'
 
 import type { RefObject, PropsWithChildren } from 'react'
@@ -150,7 +150,7 @@ export const ChatProvider = ({
       setChatId(nextChatId)
 
       // Clear system notifications and mark chat as seen in backend
-      markChatAsSeen(accountId, nextChatId)
+      marknoticedChat(accountId, nextChatId)
 
       // Remember that user selected this chat to open it again when they come back
       saveLastChatId(accountId, nextChatId)

--- a/packages/frontend/src/deviceMessages.ts
+++ b/packages/frontend/src/deviceMessages.ts
@@ -1,5 +1,5 @@
 import { BackendRemote } from './backend-com'
-import { getDeviceChatId, markChatAsSeen } from './backend/chat'
+import { getDeviceChatId, marknoticedChat } from './backend/chat'
 
 export async function updateDeviceChat(
   accountId: number,
@@ -38,7 +38,7 @@ export async function updateDeviceChats() {
     await updateDeviceChat(accountId, false)
     if (accountId !== selectedAccount) {
       const devChatId = await getDeviceChatId(accountId)
-      if (devChatId) markChatAsSeen(accountId, devChatId)
+      if (devChatId) marknoticedChat(accountId, devChatId)
     }
   }
 }


### PR DESCRIPTION
Core still makes a distinction between "seen" and "noticed"
so let's not be confusing and call conform
to the same naming convention.

TODO:
- [x] Merge the base into main