### PR TITLE
feat: sticker groups, search, and inline suggestions

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -112,5 +112,11 @@
   },
   "messages_are_e2ee": {
     "message": "Messages are end-to-end encrypted."
+  },
+  "search_sticker_placeholder_desktop": {
+    "message": "Search stickers…"
+  },
+  "all": {
+    "message": "All"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -114,7 +114,7 @@
     "message": "Messages are end-to-end encrypted."
   },
   "search_sticker_placeholder_desktop": {
-    "message": "Search stickers…"
+    "message": "Search"
   },
   "all": {
     "message": "All"

--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -1,4 +1,5 @@
 .composer {
+  position: relative;
   border-left: 1px solid rgba(16, 22, 26, 0.1);
   background-color: var(--composerBg);
 

--- a/packages/frontend/scss/composer/_emoji-sticker-picker.scss
+++ b/packages/frontend/scss/composer/_emoji-sticker-picker.scss
@@ -85,25 +85,6 @@ $emojimart-search-height: 31px + 6px;
       padding-bottom: var(--em-padding-small);
       flex-shrink: 0;
 
-      .sticker-search-icon {
-        z-index: 1;
-        color: rgba(var(--picker-text-rgb), 0.7);
-        position: absolute;
-        // Match input top padding (12px container + 10px input)
-        top: var(--em-padding);
-        bottom: var(--em-padding-small);
-        display: flex;
-        align-items: center;
-        pointer-events: none;
-        inset-inline-start: calc(var(--em-padding) + 0.7em);
-
-        svg {
-          fill: currentColor;
-          width: 1em;
-          height: 1em;
-        }
-      }
-
       .sticker-search-input {
         width: 100%;
         background-color: var(--picker-border-and-hover-color, $esp-border-color);
@@ -113,7 +94,7 @@ $emojimart-search-height: 31px + 6px;
         border: 0;
         border-radius: 10px;
         outline: 0;
-        padding: 10px 2em 10px 2.2em;
+        padding: 10px 1em;
         display: block;
         font-size: calc(var(--em-font-size) - 1px);
         font-family: var(--font-family);
@@ -249,88 +230,87 @@ $emojimart-search-height: 31px + 6px;
       }
     }
 
-    // --- Bottom pack nav: matches emoji-mart #nav ---
+    // --- Same vars as emoji-mart uses internally ---
+    --em-rgb-color: var(--picker-text-rgb);
+    --em-rgb-accent: var(--picker-accent-rgb);
+    --em-color-border: var(--picker-border-and-hover-color);
+    --color-a: rgb(var(--em-rgb-color));
+    --color-b: rgba(var(--em-rgb-color), 0.65);
+    --duration: 225ms;
+    --easing: cubic-bezier(0.4, 0, 0.2, 1);
+    --category-icon-size: 18px;
+    --sidebar-width: 16px;
+
+    // --- Bottom pack nav: copy of emoji-mart #nav CSS ---
     .sticker-pack-nav {
       z-index: 2;
-      display: flex;
-      align-items: center;
       padding-top: 12px;
-      padding-bottom: 12px;
-      padding-inline-start: 12px;
-      padding-inline-end: 0;
+      padding-bottom: 0;
+      padding-inline-end: var(--sidebar-width);
       position: relative;
+      display: flex;
+      align-items: stretch;
       flex-shrink: 0;
-      gap: 0;
 
-      // Fade border at top like emoji-mart nav
+      // copy of #nav:before (bottom position)
       &::before {
         content: '';
         height: 2px;
         position: absolute;
         left: 0;
         right: 0;
-        top: 0;
-        background: linear-gradient(to bottom, var(--picker-border-and-hover-color, $esp-border-color), transparent);
+        bottom: 100%;
+        background: linear-gradient(to top, var(--em-color-border), transparent);
       }
 
       .sticker-pack-nav-items {
         display: flex;
-        align-items: center;
+        align-items: stretch;
         flex: 1;
         min-width: 0;
         overflow-x: auto;
         overflow-y: hidden;
-
-        // Hide scrollbar but keep scrollable
         scrollbar-width: none;
-        &::-webkit-scrollbar {
-          display: none;
-        }
+        &::-webkit-scrollbar { display: none; }
       }
 
+      // copy of #nav button
       .sticker-pack-nav-item {
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 36px;
-        height: 36px;
-        min-width: 36px;
-        padding: 4px;
-        border: none;
+        padding: 0 12px 12px;
+        border: 0;
+        border-bottom: 3px solid transparent;
         border-radius: 0;
-        background-color: transparent;
+        background: transparent;
         cursor: pointer;
-        color: rgba(var(--picker-text-rgb), 0.65);
-        transition: color 225ms cubic-bezier(0.4, 0, 0.2, 1);
-        position: relative;
+        color: var(--color-b);
+        transition:
+          color var(--duration) var(--easing),
+          border-bottom-color var(--duration) var(--easing);
 
         &:hover {
-          color: rgb(var(--picker-text-rgb));
+          color: var(--color-a);
         }
 
+        // copy of #nav button[aria-selected]
+        &[aria-selected],
         &.selected {
-          color: rgb(var(--picker-accent-rgb));
-
-          &::after {
-            content: '';
-            position: absolute;
-            bottom: -12px;
-            left: 0;
-            width: 100%;
-            height: 3px;
-            background-color: rgb(var(--picker-accent-rgb));
-            border-radius: 3px 3px 0 0;
-          }
+          color: rgb(var(--em-rgb-accent));
+          border-bottom-color: rgb(var(--em-rgb-accent));
         }
 
+        // copy of #nav svg, #nav img
         img {
-          max-width: 22px;
-          max-height: 22px;
+          width: var(--category-icon-size);
+          height: var(--category-icon-size);
           object-fit: contain;
         }
 
         .all-packs-icon {
-          font-size: 20px;
+          font-size: 13px;
+          font-weight: 500;
           line-height: 1;
         }
       }
@@ -339,27 +319,17 @@ $emojimart-search-height: 31px + 6px;
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 36px;
-        height: 36px;
-        min-width: 36px;
-        margin-inline-start: auto;
-        margin-inline-end: 12px;
-        padding: 4px;
-        border: none;
+        padding: 0 12px 12px;
+        border: 0;
+        border-bottom: 3px solid transparent;
         border-radius: 0;
-        background-color: transparent;
+        background: transparent;
         cursor: pointer;
-        color: rgba(var(--picker-text-rgb), 0.65);
-        transition: color 225ms cubic-bezier(0.4, 0, 0.2, 1);
+        color: var(--color-b);
+        transition: color var(--duration) var(--easing);
 
         &:hover {
-          color: rgb(var(--picker-text-rgb));
-        }
-
-        svg {
-          fill: currentColor;
-          width: 20px;
-          height: 20px;
+          color: var(--color-a);
         }
       }
     }

--- a/packages/frontend/scss/composer/_emoji-sticker-picker.scss
+++ b/packages/frontend/scss/composer/_emoji-sticker-picker.scss
@@ -60,26 +60,128 @@ $emojimart-search-height: 31px + 6px;
     height: calc(#{$esp-height} - #{$esp-header-height});
   }
 
+  $sticker-pack-nav-height: 48px;
+  $sticker-search-height: 40px;
+
   div.sticker-picker {
     background: var(--emojiMartBg);
     width: 100%;
     display: flex;
-    overflow: auto;
+    overflow: hidden;
     flex-direction: column;
 
-    $pack-title-vertical-padding: 8px;
-    $pack-title-font-size: 16px;
-    $pack-title-line-height: 1.15;
+    // --- Emoji-mart variables mirrored for sticker picker ---
+    --em-padding: 12px;
+    --em-padding-small: 6px;
+    --em-font-size: 15px;
+    --em-duration: 225ms;
+    --em-easing: cubic-bezier(0.4, 0, 0.2, 1);
+
+    // --- Search bar: pixel-copy of emoji-mart .search ---
+    .sticker-search-bar {
+      z-index: 2;
+      position: relative;
+      padding: var(--em-padding);
+      padding-bottom: var(--em-padding-small);
+      flex-shrink: 0;
+
+      .sticker-search-icon {
+        z-index: 1;
+        color: rgba(var(--picker-text-rgb), 0.7);
+        position: absolute;
+        // Match input top padding (12px container + 10px input)
+        top: var(--em-padding);
+        bottom: var(--em-padding-small);
+        display: flex;
+        align-items: center;
+        pointer-events: none;
+        inset-inline-start: calc(var(--em-padding) + 0.7em);
+
+        svg {
+          fill: currentColor;
+          width: 1em;
+          height: 1em;
+        }
+      }
+
+      .sticker-search-input {
+        width: 100%;
+        background-color: var(--picker-border-and-hover-color, $esp-border-color);
+        transition-duration: var(--em-duration);
+        transition-property: background-color, box-shadow;
+        transition-timing-function: var(--em-easing);
+        border: 0;
+        border-radius: 10px;
+        outline: 0;
+        padding: 10px 2em 10px 2.2em;
+        display: block;
+        font-size: calc(var(--em-font-size) - 1px);
+        font-family: var(--font-family);
+        color: rgb(var(--picker-text-rgb));
+        box-sizing: border-box;
+        line-height: normal;
+        -webkit-appearance: none;
+        appearance: none;
+        -webkit-font-smoothing: antialiased;
+
+        &:focus {
+          background-color: rgb(var(--picker-selected-input-bg-rgb));
+          box-shadow: inset 0 0 0 1px rgb(var(--picker-accent-rgb)),
+            0 1px 3px rgba(65, 69, 73, 0.2);
+        }
+
+        &::placeholder {
+          color: inherit;
+          opacity: 0.6;
+        }
+
+        &::-webkit-search-decoration,
+        &::-webkit-search-cancel-button,
+        &::-webkit-search-results-button,
+        &::-webkit-search-results-decoration {
+          -webkit-appearance: none;
+          appearance: none;
+        }
+      }
+    }
+
+    // --- Sticker grid container ---
     .sticker-container {
       display: flex;
       flex-direction: column;
       flex: 1;
-      padding: 0px 12px 12px;
+      padding: 0;
+      padding-inline-start: var(--em-padding);
       overflow-y: auto;
+      overflow-x: hidden;
 
-      // To account for the `position: sticky` title.
-      scroll-padding-top: $pack-title-font-size * $pack-title-line-height +
-        $pack-title-vertical-padding * 2;
+      // Scrollbar matching emoji-mart
+      &::-webkit-scrollbar {
+        width: 16px;
+        height: 16px;
+      }
+      &::-webkit-scrollbar-track {
+        border: 0;
+      }
+      &::-webkit-scrollbar-button {
+        width: 0;
+        height: 0;
+        display: none;
+      }
+      &::-webkit-scrollbar-corner {
+        background-color: transparent;
+      }
+      &::-webkit-scrollbar-thumb {
+        min-height: 65px;
+        border: 4px solid rgb(var(--picker-background-rgb));
+        border-radius: 8px;
+      }
+      &::-webkit-scrollbar-thumb:hover {
+        background-color: var(--picker-border-and-hover-color) !important;
+      }
+      &:hover::-webkit-scrollbar-thumb {
+        background-color: var(--picker-border-and-hover-color);
+      }
 
       .no-stickers {
         display: flex;
@@ -87,32 +189,36 @@ $emojimart-search-height: 31px + 6px;
         justify-content: center;
         align-items: center;
         flex: 1;
+        padding: var(--em-padding);
 
         & > .description {
-          font-size: large;
+          font-size: var(--em-font-size);
           text-align: center;
+          color: rgba(var(--picker-text-rgb), 0.65);
         }
       }
 
+      // --- Pack section: header matches emoji-mart .sticky category ---
       .sticker-pack {
         & > .title {
-          padding: $pack-title-vertical-padding 0px;
-          color: grey;
-          font-size: large;
-          font-weight: 500;
-          text-transform: capitalize;
-          font-family: var(--font-family);
-          font-size: $pack-title-font-size;
-          line-height: $pack-title-line-height;
+          z-index: 1;
+          background-color: rgba(var(--picker-background-rgb), 0.9);
+          -webkit-backdrop-filter: blur(4px);
+          backdrop-filter: blur(4px);
           font-weight: 500;
           position: sticky;
           top: -1px;
-          background-color: var(--picker-Background);
+          padding: var(--em-padding-small) 0;
+          font-family: var(--font-family);
+          font-size: calc(var(--em-font-size) - 1px);
+          line-height: normal;
+          color: rgb(var(--picker-text-rgb));
+          text-transform: capitalize;
         }
         & > .container {
           display: flex;
           flex-wrap: wrap;
-          justify-content: space-between;
+          padding-bottom: var(--em-padding);
 
           & > .sticker {
             display: flex;
@@ -129,7 +235,7 @@ $emojimart-search-height: 31px + 6px;
 
             &:hover,
             &:focus {
-              background-color: lightgrey;
+              background-color: var(--picker-border-and-hover-color, rgba(0, 0, 0, 0.05));
               cursor: pointer;
             }
 
@@ -143,9 +249,179 @@ $emojimart-search-height: 31px + 6px;
       }
     }
 
-    .sticker-actions-container {
-      border-top: 1px solid $esp-border-color;
-      padding: 0px 12px;
+    // --- Bottom pack nav: matches emoji-mart #nav ---
+    .sticker-pack-nav {
+      z-index: 2;
+      display: flex;
+      align-items: center;
+      padding-top: 12px;
+      padding-bottom: 12px;
+      padding-inline-start: 12px;
+      padding-inline-end: 0;
+      position: relative;
+      flex-shrink: 0;
+      gap: 0;
+
+      // Fade border at top like emoji-mart nav
+      &::before {
+        content: '';
+        height: 2px;
+        position: absolute;
+        left: 0;
+        right: 0;
+        top: 0;
+        background: linear-gradient(to bottom, var(--picker-border-and-hover-color, $esp-border-color), transparent);
+      }
+
+      .sticker-pack-nav-items {
+        display: flex;
+        align-items: center;
+        flex: 1;
+        min-width: 0;
+        overflow-x: auto;
+        overflow-y: hidden;
+
+        // Hide scrollbar but keep scrollable
+        scrollbar-width: none;
+        &::-webkit-scrollbar {
+          display: none;
+        }
+      }
+
+      .sticker-pack-nav-item {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        min-width: 36px;
+        padding: 4px;
+        border: none;
+        border-radius: 0;
+        background-color: transparent;
+        cursor: pointer;
+        color: rgba(var(--picker-text-rgb), 0.65);
+        transition: color 225ms cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+
+        &:hover {
+          color: rgb(var(--picker-text-rgb));
+        }
+
+        &.selected {
+          color: rgb(var(--picker-accent-rgb));
+
+          &::after {
+            content: '';
+            position: absolute;
+            bottom: -12px;
+            left: 0;
+            width: 100%;
+            height: 3px;
+            background-color: rgb(var(--picker-accent-rgb));
+            border-radius: 3px 3px 0 0;
+          }
+        }
+
+        img {
+          max-width: 22px;
+          max-height: 22px;
+          object-fit: contain;
+        }
+
+        .all-packs-icon {
+          font-size: 20px;
+          line-height: 1;
+        }
+      }
+
+      .sticker-folder-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        min-width: 36px;
+        margin-inline-start: auto;
+        margin-inline-end: 12px;
+        padding: 4px;
+        border: none;
+        border-radius: 0;
+        background-color: transparent;
+        cursor: pointer;
+        color: rgba(var(--picker-text-rgb), 0.65);
+        transition: color 225ms cubic-bezier(0.4, 0, 0.2, 1);
+
+        &:hover {
+          color: rgb(var(--picker-text-rgb));
+        }
+
+        svg {
+          fill: currentColor;
+          width: 20px;
+          height: 20px;
+        }
+      }
+    }
+  }
+}
+
+// --- Inline sticker suggestions popup (triggered by :query in compose box) ---
+.sticker-suggestions {
+  position: absolute;
+  bottom: 100%;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
+  z-index: map.get(variables.$z-index, emoji-sticker-picker);
+  background: var(--emojiMartBg);
+  border-radius: var(--picker-BorderRadius) var(--picker-BorderRadius) 0 0;
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.15);
+  max-height: 160px;
+  overflow: hidden;
+
+  .sticker-suggestions-list {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overflow-y: hidden;
+    padding: 8px;
+    gap: 4px;
+
+    // Scrollbar
+    &::-webkit-scrollbar {
+      height: 6px;
+    }
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+    &::-webkit-scrollbar-thumb {
+      background-color: var(--picker-border-and-hover-color);
+      border-radius: 3px;
+    }
+  }
+
+  .sticker-suggestion-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 80px;
+    height: 80px;
+    min-width: 80px;
+    padding: 4px;
+    border: none;
+    border-radius: 6px;
+    background-color: transparent;
+    cursor: pointer;
+
+    &:hover,
+    &:focus {
+      background-color: var(--picker-border-and-hover-color, rgba(0, 0, 0, 0.05));
+    }
+
+    img {
+      max-width: 70px;
+      max-height: 70px;
+      object-fit: contain;
     }
   }
 }

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -15,6 +15,7 @@ import MenuAttachment from './menuAttachment'
 import ComposerMessageInput from './ComposerMessageInput'
 import { getLogger } from '../../../../shared/logger'
 import { EmojiAndStickerPicker } from './EmojiAndStickerPicker'
+import { StickerSuggestions, detectStickerQuery } from './StickerSuggestions'
 import { Quote } from '../message/Message'
 import { DraftAttachment } from '../attachment/messageAttachment'
 import { useSettingsStore } from '../../stores/settings'
@@ -93,6 +94,7 @@ const Composer = forwardRef<
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const [showAppPicker, setShowAppPicker] = useState(false)
   const [recording, setRecording] = useState(false)
+  const [stickerQuery, setStickerQuery] = useState<string | null>(null)
 
   const emojiAndStickerRef = useRef<HTMLDivElement>(null)
   const pickerButtonRef = useRef<HTMLButtonElement>(null)
@@ -133,7 +135,10 @@ const Composer = forwardRef<
     : regularMessageInputRef
 
   const onComposerMessageInputChange = useCallback(
-    (newText: string) => updateDraftText(newText, chatId),
+    (newText: string) => {
+      updateDraftText(newText, chatId)
+      setStickerQuery(detectStickerQuery(newText))
+    },
     [chatId, updateDraftText]
   )
 
@@ -316,6 +321,20 @@ const Composer = forwardRef<
       currentComposerMessageInputRef.current?.focus()
     }
   }
+
+  const onStickerSuggestionSent = useCallback(() => {
+    // Remove the `:query` text from the input
+    const textarea = regularMessageInputRef.current?.textareaRef?.current
+    if (textarea) {
+      const text = textarea.value
+      const match = text.match(/(?:^|\s)(:\S+)$/)
+      if (match) {
+        const newText = text.substring(0, text.length - match[1].length)
+        updateDraftText(newText.trimEnd(), chatId)
+      }
+    }
+    setStickerQuery(null)
+  }, [chatId, updateDraftText, regularMessageInputRef])
   // track shift key -> update [shiftPressed]
   // handle escape key for composer, emoji picker and app picker
   useEffect(() => {
@@ -327,12 +346,17 @@ const Composer = forwardRef<
             (ev.target as any).id
           ) &&
           !showEmojiPicker &&
-          !showAppPicker
+          !showAppPicker &&
+          stickerQuery === null
         ) {
           // only handle escape events in composer or related components here
           return
         }
         let handled = false
+        if (stickerQuery !== null) {
+          setStickerQuery(null)
+          handled = true
+        }
         if (showEmojiPicker) {
           setShowEmojiPicker(false)
           handled = true
@@ -383,6 +407,7 @@ const Composer = forwardRef<
     smallScreenMode,
     showEmojiPicker,
     showAppPicker,
+    stickerQuery,
     draftState.quote,
     removeQuote,
   ])
@@ -789,6 +814,14 @@ const Composer = forwardRef<
             <AppPicker onAppSelected={onAppSelected!} />
           </OutsideClickHelper>
         )}
+        {stickerQuery !== null &&
+          !messageEditing.isEditingModeActive && (
+            <StickerSuggestions
+              query={stickerQuery}
+              chatId={chatId}
+              onStickerSent={onStickerSuggestionSent}
+            />
+          )}
         {showEmojiPicker && (
           <EmojiAndStickerPicker
             chatId={chatId}

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -4,6 +4,8 @@ import React, {
   forwardRef,
   PropsWithChildren,
   useRef,
+  useMemo,
+  useCallback,
 } from 'react'
 import classNames from 'classnames'
 
@@ -23,19 +25,71 @@ import {
   useRovingTabindex,
 } from '../../contexts/RovingTabindex'
 
-type Props = {
-  stickerPackName: string
-  stickerPackImages: string[]
-  chatId: number
-  setShowEmojiPicker: (enabled: boolean) => void
+/** Sticker aliases map: sticker file path -> list of emoji/text aliases */
+export type StickerAliases = { [stickerPath: string]: string[] }
+
+/**
+ * Extracts emoji aliases from sticker file paths.
+ *
+ * Filename convention: `{index}.{text_name}+{emoji}.ext`
+ * e.g. `0.smiling_face_with_heart-eyes+😍.webp` → aliases: ["😍", "smiling_face_with_heart-eyes"]
+ */
+export function parseStickerAliasesFromFilename(filePath: string): string[] {
+  const fileName = filePath.substring(filePath.lastIndexOf('/') + 1)
+  // Remove extension
+  const nameWithoutExt = fileName.replace(/\.[^.]+$/, '')
+
+  // Pattern: {index}.{text_name}+{emoji}
+  const plusIndex = nameWithoutExt.lastIndexOf('+')
+  if (plusIndex === -1) return []
+
+  const emoji = nameWithoutExt.substring(plusIndex + 1)
+  // Extract the text name part (between first dot and the +)
+  const dotIndex = nameWithoutExt.indexOf('.')
+  const textName =
+    dotIndex !== -1 && dotIndex < plusIndex
+      ? nameWithoutExt.substring(dotIndex + 1, plusIndex)
+      : ''
+
+  const result: string[] = []
+  if (emoji) result.push(emoji)
+  if (textName) result.push(textName.replace(/[-_]/g, ' '))
+  return result
 }
 
+export function loadStickerAliases(
+  stickers: { [key: string]: string[] }
+): StickerAliases {
+  const aliases: StickerAliases = {}
+
+  for (const [_packName, paths] of Object.entries(stickers)) {
+    if (paths.length === 0) continue
+
+    for (const stickerPath of paths) {
+      const parsed = parseStickerAliasesFromFilename(stickerPath)
+      if (parsed.length > 0) {
+        aliases[stickerPath] = parsed
+      }
+    }
+  }
+
+  return aliases
+}
+
+/** Show all stickers for a single pack, used when a pack is selected */
 const DisplayedStickerPack = ({
   stickerPackName,
   stickerPackImages,
   chatId,
   setShowEmojiPicker,
-}: Props) => {
+  aliases,
+}: {
+  stickerPackName: string
+  stickerPackImages: string[]
+  chatId: number
+  setShowEmojiPicker: (enabled: boolean) => void
+  aliases: StickerAliases
+}) => {
   const { jumpToMessage } = useMessage()
   const accountId = selectedAccountId()
 
@@ -59,9 +113,6 @@ const DisplayedStickerPack = ({
     <div className='sticker-pack'>
       <div className='title'>{stickerPackName}</div>
       <div ref={listRef} className='container'>
-        {/* Yes, we have separate `RovingTabindexProvider` for each
-        sticker pack, instead of having one for all stickers.
-        Users probably want to switch between sticker packs with Tab. */}
         <RovingTabindexProvider
           wrapperElementRef={listRef}
           direction='horizontal'
@@ -71,6 +122,7 @@ const DisplayedStickerPack = ({
               key={filePath}
               filePath={filePath}
               onClick={() => onClickSticker(filePath)}
+              aliases={aliases[filePath]}
             />
           ))}
         </RovingTabindexProvider>
@@ -79,10 +131,15 @@ const DisplayedStickerPack = ({
   )
 }
 
-function StickersListItem(props: { filePath: string; onClick: () => void }) {
-  const { filePath, onClick } = props
+function StickersListItem(props: {
+  filePath: string
+  onClick: () => void
+  aliases?: string[]
+}) {
+  const { filePath, onClick, aliases } = props
   const ref = useRef<HTMLButtonElement>(null)
   const rovingTabindex = useRovingTabindex(ref)
+  const title = aliases ? aliases.join(' ') : undefined
   return (
     <button
       type='button'
@@ -92,9 +149,134 @@ function StickersListItem(props: { filePath: string; onClick: () => void }) {
       tabIndex={rovingTabindex.tabIndex}
       onKeyDown={rovingTabindex.onKeydown}
       onFocus={rovingTabindex.setAsActiveElement}
+      title={title}
     >
       <img src={runtime.transformStickerURL(filePath)} />
     </button>
+  )
+}
+
+/** Bottom navigation bar showing pack thumbnails for quick switching */
+function StickerPackNav({
+  stickers,
+  selectedPack,
+  onSelectPack,
+  onOpenStickerFolder,
+}: {
+  stickers: { [key: string]: string[] }
+  selectedPack: string | null
+  onSelectPack: (packName: string | null) => void
+  onOpenStickerFolder: () => void
+}) {
+  const tx = useTranslationFunction()
+  const packNames = Object.keys(stickers)
+  const navRef = useRef<HTMLDivElement>(null)
+
+  return (
+    <div className='sticker-pack-nav' ref={navRef}>
+      <div className='sticker-pack-nav-items'>
+        <RovingTabindexProvider
+          wrapperElementRef={navRef}
+          direction='horizontal'
+        >
+          <StickerPackNavItem
+            isSelected={selectedPack === null}
+            onClick={() => onSelectPack(null)}
+            label={tx('all')}
+          />
+          {packNames.map(name => {
+            const firstSticker = stickers[name]?.[0]
+            return (
+              <StickerPackNavItem
+                key={name}
+                isSelected={selectedPack === name}
+                onClick={() => onSelectPack(name)}
+                thumbnailSrc={
+                  firstSticker
+                    ? runtime.transformStickerURL(firstSticker)
+                    : undefined
+                }
+                label={name}
+              />
+            )
+          })}
+        </RovingTabindexProvider>
+      </div>
+      <button
+        type='button'
+        className='sticker-folder-button'
+        onClick={onOpenStickerFolder}
+        title={tx('open_sticker_folder')}
+      >
+        <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>
+          <path d='M2 4a2 2 0 0 1 2-2h3.17a2 2 0 0 1 1.41.59l1.42 1.41h6a2 2 0 0 1 2 2v2h-2V6H9.83l-1.42-1.41-.29-.3-.29.3L6.41 6H4v10h7v2H4a2 2 0 0 1-2-2V4zm15 6v3h3v2h-3v3h-2v-3h-3v-2h3v-3h2z' />
+        </svg>
+      </button>
+    </div>
+  )
+}
+
+function StickerPackNavItem(props: {
+  isSelected: boolean
+  onClick: () => void
+  thumbnailSrc?: string
+  label: string
+}) {
+  const { isSelected, onClick, thumbnailSrc, label } = props
+  const ref = useRef<HTMLButtonElement>(null)
+  const rovingTabindex = useRovingTabindex(ref)
+
+  return (
+    <button
+      type='button'
+      ref={ref}
+      className={classNames('sticker-pack-nav-item', {
+        selected: isSelected,
+      })}
+      onClick={onClick}
+      title={label}
+      tabIndex={rovingTabindex.tabIndex}
+      onKeyDown={rovingTabindex.onKeydown}
+      onFocus={rovingTabindex.setAsActiveElement}
+    >
+      {thumbnailSrc ? (
+        <img src={thumbnailSrc} alt={label} />
+      ) : (
+        <span className='all-packs-icon'>⊞</span>
+      )}
+    </button>
+  )
+}
+
+/** Search bar for filtering stickers by alias or pack name */
+function StickerSearchBar({
+  searchQuery,
+  onSearchChange,
+}: {
+  searchQuery: string
+  onSearchChange: (query: string) => void
+}) {
+  const tx = useTranslationFunction()
+
+  return (
+    <div className='sticker-search-bar'>
+      <span className='sticker-search-icon'>
+        <svg
+          xmlns='http://www.w3.org/2000/svg'
+          viewBox='0 0 18 18'
+        >
+          <path d='M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z' />
+        </svg>
+      </span>
+      <input
+        type='search'
+        className='sticker-search-input'
+        placeholder={tx('search_sticker_placeholder_desktop')}
+        value={searchQuery}
+        onChange={e => onSearchChange(e.target.value)}
+        autoFocus={false}
+      />
+    </div>
   )
 }
 
@@ -114,6 +296,13 @@ export const StickerPicker = ({
   setShowEmojiPicker: (enabled: boolean) => void
 }) => {
   const tx = useTranslationFunction()
+  const [selectedPack, setSelectedPack] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [aliases, setAliases] = useState<StickerAliases>({})
+
+  useEffect(() => {
+    setAliases(loadStickerAliases(stickers))
+  }, [stickers])
 
   const onOpenStickerFolder = async () => {
     const folder =
@@ -122,6 +311,57 @@ export const StickerPicker = ({
   }
 
   const stickerPackNames = Object.keys(stickers)
+
+  // Filter stickers based on search query and selected pack
+  const filteredStickers = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+
+    if (!query && selectedPack === null) {
+      return stickers
+    }
+
+    const result: { [key: string]: string[] } = {}
+
+    for (const [packName, paths] of Object.entries(stickers)) {
+      if (selectedPack !== null && packName !== selectedPack) {
+        continue
+      }
+
+      if (!query) {
+        result[packName] = paths
+        continue
+      }
+
+      const filtered = paths.filter(filePath => {
+        // Match against pack name
+        if (packName.toLowerCase().includes(query)) return true
+        // Match against filename
+        const fileName = filePath.substring(filePath.lastIndexOf('/') + 1)
+        if (fileName.toLowerCase().includes(query)) return true
+        // Match against aliases
+        const stickerAliases = aliases[filePath]
+        if (stickerAliases) {
+          return stickerAliases.some(alias =>
+            alias.toLowerCase().includes(query)
+          )
+        }
+        return false
+      })
+
+      if (filtered.length > 0) {
+        result[packName] = filtered
+      }
+    }
+
+    return result
+  }, [stickers, selectedPack, searchQuery, aliases])
+
+  const filteredPackNames = Object.keys(filteredStickers)
+
+  const handleSelectPack = useCallback((packName: string | null) => {
+    setSelectedPack(packName)
+    setSearchQuery('')
+  }, [])
 
   return (
     <div
@@ -132,22 +372,36 @@ export const StickerPicker = ({
     >
       {stickerPackNames.length > 0 ? (
         <>
+          <StickerSearchBar
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+          />
           <div className='sticker-container'>
-            {stickerPackNames.map(name => (
-              <DisplayedStickerPack
-                chatId={chatId}
-                key={name}
-                stickerPackName={name}
-                stickerPackImages={stickers[name]}
-                setShowEmojiPicker={setShowEmojiPicker}
-              />
-            ))}
+            {filteredPackNames.length > 0 ? (
+              filteredPackNames.map(name => (
+                <DisplayedStickerPack
+                  chatId={chatId}
+                  key={name}
+                  stickerPackName={name}
+                  stickerPackImages={filteredStickers[name]}
+                  setShowEmojiPicker={setShowEmojiPicker}
+                  aliases={aliases}
+                />
+              ))
+            ) : (
+              <div className='no-stickers'>
+                <p className='description'>
+                  {tx('emoji_not_found')}
+                </p>
+              </div>
+            )}
           </div>
-          <div className='sticker-actions-container'>
-            <Button onClick={onOpenStickerFolder}>
-              {tx('open_sticker_folder')}
-            </Button>
-          </div>
+          <StickerPackNav
+            stickers={stickers}
+            selectedPack={selectedPack}
+            onSelectPack={handleSelectPack}
+            onOpenStickerFolder={onOpenStickerFolder}
+          />
         </>
       ) : (
         <div className='sticker-container'>

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -14,6 +14,7 @@ import { selectedAccountId } from '../../ScreenController'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import EmojiPicker from '../EmojiPicker'
 import Button from '../Button'
+import Icon from '../Icon'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useMessage from '../../hooks/chat/useMessage'
 
@@ -208,9 +209,7 @@ function StickerPackNav({
         onClick={onOpenStickerFolder}
         title={tx('open_sticker_folder')}
       >
-        <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'>
-          <path d='M2 4a2 2 0 0 1 2-2h3.17a2 2 0 0 1 1.41.59l1.42 1.41h6a2 2 0 0 1 2 2v2h-2V6H9.83l-1.42-1.41-.29-.3-.29.3L6.41 6H4v10h7v2H4a2 2 0 0 1-2-2V4zm15 6v3h3v2h-3v3h-2v-3h-3v-2h3v-3h2z' />
-        </svg>
+        <Icon icon='open_in_new' size={18} coloring='currentColor' />
       </button>
     </div>
   )
@@ -235,6 +234,7 @@ function StickerPackNavItem(props: {
       })}
       onClick={onClick}
       title={label}
+      aria-selected={isSelected || undefined}
       tabIndex={rovingTabindex.tabIndex}
       onKeyDown={rovingTabindex.onKeydown}
       onFocus={rovingTabindex.setAsActiveElement}
@@ -242,7 +242,7 @@ function StickerPackNavItem(props: {
       {thumbnailSrc ? (
         <img src={thumbnailSrc} alt={label} />
       ) : (
-        <span className='all-packs-icon'>⊞</span>
+        <span className='all-packs-icon'>{label}</span>
       )}
     </button>
   )
@@ -260,14 +260,6 @@ function StickerSearchBar({
 
   return (
     <div className='sticker-search-bar'>
-      <span className='sticker-search-icon'>
-        <svg
-          xmlns='http://www.w3.org/2000/svg'
-          viewBox='0 0 18 18'
-        >
-          <path d='M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42 1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12z' />
-        </svg>
-      </span>
       <input
         type='search'
         className='sticker-search-input'

--- a/packages/frontend/src/components/composer/StickerSuggestions.tsx
+++ b/packages/frontend/src/components/composer/StickerSuggestions.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+
+import { BackendRemote } from '../../backend-com'
+import { selectedAccountId } from '../../ScreenController'
+import { runtime } from '@deltachat-desktop/runtime-interface'
+import useMessage from '../../hooks/chat/useMessage'
+import {
+  loadStickerAliases,
+  StickerAliases,
+} from './EmojiAndStickerPicker'
+
+/**
+ * Detects a `:query` pattern at the end of the input text
+ * (i.e. a colon followed by 1+ non-whitespace chars with no closing colon).
+ * Returns the query string after the colon, or null if no match.
+ */
+export function detectStickerQuery(text: string): string | null {
+  // Match `:` preceded by start-of-string or whitespace, then 1+ non-space chars at end
+  const match = text.match(/(?:^|\s):(\S+)$/)
+  return match ? match[1] : null
+}
+
+type StickerSuggestionsProps = {
+  query: string
+  chatId: number
+  onStickerSent: () => void
+}
+
+export function StickerSuggestions({
+  query,
+  chatId,
+  onStickerSent,
+}: StickerSuggestionsProps) {
+  const accountId = selectedAccountId()
+  const { jumpToMessage } = useMessage()
+
+  const [stickers, setStickers] = useState<{ [key: string]: string[] }>({})
+  const [aliases, setAliases] = useState<StickerAliases>({})
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    BackendRemote.rpc.miscGetStickers(accountId).then(result => {
+      setStickers(result)
+      setAliases(loadStickerAliases(result))
+    })
+  }, [accountId])
+
+  const matchingStickers = useMemo(() => {
+    const q = query.toLowerCase()
+    const results: { path: string; packName: string }[] = []
+
+    for (const [packName, paths] of Object.entries(stickers)) {
+      for (const filePath of paths) {
+        // Match against pack name
+        if (packName.toLowerCase().includes(q)) {
+          results.push({ path: filePath, packName })
+          continue
+        }
+        // Match against filename
+        const fileName = filePath.substring(filePath.lastIndexOf('/') + 1)
+        if (fileName.toLowerCase().includes(q)) {
+          results.push({ path: filePath, packName })
+          continue
+        }
+        // Match against aliases
+        const stickerAliases = aliases[filePath]
+        if (stickerAliases) {
+          if (stickerAliases.some(alias => alias.toLowerCase().includes(q))) {
+            results.push({ path: filePath, packName })
+          }
+        }
+      }
+    }
+
+    return results.slice(0, 20)
+  }, [stickers, aliases, query])
+
+  if (matchingStickers.length === 0) {
+    return null
+  }
+
+  const onClickSticker = (filePath: string) => {
+    const stickerPath = filePath.replace('file://', '')
+    BackendRemote.rpc.sendSticker(accountId, chatId, stickerPath).then(msgId =>
+      jumpToMessage({
+        accountId,
+        msgId,
+        msgChatId: chatId,
+        highlight: false,
+        focus: false,
+      })
+    )
+    onStickerSent()
+  }
+
+  return (
+    <div className='sticker-suggestions' ref={containerRef}>
+      <div className='sticker-suggestions-list'>
+        {matchingStickers.map(({ path }) => (
+          <button
+            key={path}
+            type='button'
+            className='sticker-suggestion-item'
+            onClick={() => onClickSticker(path)}
+            title={aliases[path]?.join(' ') || undefined}
+          >
+            <img src={runtime.transformStickerURL(path)} alt='' />
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Hello! 

I implement stickers functionality: https://support.delta.chat/t/stickers-groups-stickers-alias-an-emoji-for-quick-search-and-stickers-sync/5009

Organizes stickers into groups by subfolder name with a pack navigation bar, adds a search bar to the sticker picker (filters by alias/pack name/filename), and introduces inline sticker suggestions triggered by typing `:query` in the compose box.

This feature would make stickers in Delta Chat much more organized and convenient.

What do you think? Feedback and help are appreciated.
I think need some polish for styles...

### Changes in file structure
I use Signal-like sticker file structure.
Aliases are extracted from the filename convention `{index}.{text_name}+{emoji}.ext`.
```bash
$ tree $APP/accounts/$ACCOUNT/stickers/
stickers/
├── group1/
│   ├── 0.happy+😊.webp
│   ├── 1.sad_face+😢.webp
│   └── 2.heart+❤️.webp
└── MyAwesomeGroup/
    ├── 0.wave+👋.webp
    └── 1.thumbs_up+👍.webp
```

Old way also supported!

### Screenshots
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2c7254a3-8427-4b34-8066-186fd33491ed" />
<br>
<img width="400"  alt="image" src="https://github.com/user-attachments/assets/69697887-2721-49f4-bc9a-b32379f721cf" />


