### PR TITLE
fix: initialize `ConnectivityToast` immediately

### DIFF
--- a/packages/frontend/src/components/ConnectivityToast.tsx
+++ b/packages/frontend/src/components/ConnectivityToast.tsx
@@ -127,6 +127,9 @@ export default function ConnectivityToast() {
   useKeyBindingAction(KeybindAction.Debug_MaybeNetwork, maybeNetwork)
 
   useEffect(() => {
+    onConnectivityChanged()
+  }, [onConnectivityChanged])
+  useEffect(() => {
     if (navigator.onLine === false) onBrowserOffline()
 
     window.addEventListener('online', onBrowserOnline)


### PR DESCRIPTION
Instead of only initializing when we get a `ConnectivityChanged`
event.

Otherwise when not connected we wouldn't show
the "Not Connected" toast e.g. after switching the account.

Related:
- https://github.com/deltachat/deltachat-desktop/issues/6196.
