### PR TITLE
fix: show active chat as selected after archive

### DIFF
--- a/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
@@ -380,6 +380,38 @@ test('resets selection when the active chat changes', async () => {
   await expectSelectedChats([6])
 })
 
+test.describe("doesn't unselect active chat after switching to archive", () => {
+  test.beforeAll(async () => {
+    // Archive a chat
+    await getChat(7).click()
+    await expectSelectedChats([7])
+    await getChat(7).click({
+      button: 'right',
+    })
+    await page.getByRole('menuitem', { name: 'Archive Chat' }).click()
+  })
+  test.afterAll(async () => {
+    // Un-archive
+    await chatList.getByRole('button', { name: 'Archived Chats' }).click()
+    await getChat(7).click({
+      button: 'right',
+    })
+    await page.getByRole('menuitem', { name: 'Unarchive' }).click()
+    await page.getByLabel('Chats').getByRole('button', { name: 'Back' }).click()
+  })
+
+  test("doesn't unselect active chat after switching to archive", async () => {
+    await getChat(5).click()
+    await expectSelectedChats([5])
+
+    await chatList.getByRole('button', { name: 'Archived Chats' }).click()
+    await expectSelectedChats([])
+
+    await page.getByLabel('Chats').getByRole('button', { name: 'Back' }).click()
+    await expectSelectedChats([5])
+  })
+})
+
 test("selection doesn't reset if items get reordered", async () => {
   await getChat(7).click()
   await expectSelectedChats([7])

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -1030,6 +1030,8 @@ function useChatListMultiselect(
     selectedChats,
     useCallback(
       newSelectedChats => {
+        const origSize = newSelectedChats.size
+
         // `chatListIds` might include `C.DC_CHAT_ID_ARCHIVED_LINK`.
         // Let's make sure that only normal chat list items can be selected
         // with multiselect.
@@ -1040,6 +1042,16 @@ function useChatListMultiselect(
         // other weird chat list items.
         for (let i = 0; i <= C.DC_CHAT_ID_LAST_SPECIAL; i++) {
           newSelectedChats.delete(i)
+        }
+
+        const newSelectionOnlyHasSpecialChats =
+          origSize > 0 && newSelectedChats.size === 0
+        if (newSelectionOnlyHasSpecialChats) {
+          // This is so that when you click on "Archived Chats"
+          // and go back to the normal chat list view,
+          // you don't get "0 chats selected".
+          // We want to have the active chat selected instead.
+          return
         }
 
         // TODO perf: to avoid re-renders, maybe store this into a ref,

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -250,7 +250,15 @@ export function useMultiselect<T>(
         return true // shouldPreventDefault
       }
 
-      onSelectionChange(new Set([item]))
+      if (
+        // Check if it's already selected.
+        !(
+          selectedItemsRef.current.size === 1 &&
+          selectedItemsRef.current.has(item)
+        )
+      ) {
+        onSelectionChange(new Set([item]))
+      }
       lastActivatedItem.current = item
       return false
     },


### PR DESCRIPTION
Reproduction steps:
1. Click on a chat (to make it active).
   We'll display it as selected in the chat list.
2. Go to "Archived Chats".
3. Go back to normal chat list view.

You'll see that the active chat is not displayed as selected,
i.e. there are 0 selected chats.

The change in `ChatList` makes sure that
when clicking on "Archived Chats" we don't unselect all chats.

The change in `useMultiselect.ts` makes sure that
clicking on a chat a second time doesn't change selection.
That is: the selection becomes "invalid"
when the active chat changes,
but clicking on the newly active chat again
would "validate" the selection (IOW we'd enter the multiselect mode)
so when the newly selected chat
gets removed from the list then the selection becomes empty.
