### PR TITLE
improvement: HTML viewer: move Load Remote Images

### DIFF
--- a/packages/target-electron/src/windows/html_email.ts
+++ b/packages/target-electron/src/windows/html_email.ts
@@ -255,7 +255,7 @@ export function openHtmlEmailWindow(
         label: tx('load_remote_content'),
         checked: loadRemoteContent,
         click() {
-          update_restrictions(null, !loadRemoteContent)
+          update_restrictions(!loadRemoteContent)
         },
       }),
       always_show: () => ({
@@ -270,7 +270,7 @@ export function openHtmlEmailWindow(
             HTMLEmailAlwaysLoadRemoteContent: newValue,
           })
           // apply change
-          update_restrictions(null, newValue, true)
+          update_restrictions(newValue, true)
         },
       }),
       dont_ask: () => ({
@@ -332,7 +332,6 @@ export function openHtmlEmailWindow(
   })
 
   const update_restrictions = async (
-    _ev: any,
     allow_network: boolean,
     skip_sideeffects = false
   ) => {

--- a/packages/target-electron/src/windows/html_email.ts
+++ b/packages/target-electron/src/windows/html_email.ts
@@ -107,15 +107,13 @@ export function openHtmlEmailWindow(
     300
   )
 
-  const loadRemoteContentAtStart =
+  let loadRemoteContent =
     DesktopSettings.state.HTMLEmailAlwaysLoadRemoteContent && !isContactRequest
 
   window.webContents.ipc.handle('html_email:get_info', _ => ({
     subject,
     from,
     receiveTime,
-    networkButtonLabelText: tx('load_remote_content'),
-    toggle_network: loadRemoteContentAtStart,
   }))
 
   nativeTheme.on('updated', () => {
@@ -236,7 +234,7 @@ export function openHtmlEmailWindow(
    */
   let sandboxedView: WebContentsView = makeBrowserView(
     account_id,
-    loadRemoteContentAtStart,
+    loadRemoteContent,
     htmlEmail,
     window
   )
@@ -251,6 +249,15 @@ export function openHtmlEmailWindow(
       [key: string]: () => MenuItemConstructorOptions
     } = {
       separator: () => ({ type: 'separator' }),
+      load_remote_images: () => ({
+        id: 'load_remote_images',
+        type: 'checkbox',
+        label: tx('load_remote_content'),
+        checked: loadRemoteContent,
+        click() {
+          update_restrictions(null, !loadRemoteContent)
+        },
+      }),
       always_show: () => ({
         id: 'always_show',
         type: 'checkbox',
@@ -264,11 +271,6 @@ export function openHtmlEmailWindow(
           })
           // apply change
           update_restrictions(null, newValue, true)
-          window.webContents.executeJavaScript(
-            `document.getElementById('toggle_network').checked = window.network_enabled= ${Boolean(
-              newValue
-            )}`
-          )
         },
       }),
       dont_ask: () => ({
@@ -286,9 +288,13 @@ export function openHtmlEmailWindow(
     }
     let menu: Electron.Menu
     if (isContactRequest) {
-      menu = electron.Menu.buildFromTemplate([menuItems.dont_ask()])
+      menu = electron.Menu.buildFromTemplate([
+        menuItems.load_remote_images(),
+        menuItems.dont_ask(),
+      ])
     } else {
       menu = electron.Menu.buildFromTemplate([
+        menuItems.load_remote_images(),
         menuItems.always_show(),
         menuItems.dont_ask(),
       ])
@@ -379,13 +385,14 @@ export function openHtmlEmailWindow(
       buttons[result.response].action()
     }
 
+    loadRemoteContent = allow_network
     const bounds = sandboxedView?.getBounds()
     window.contentView.removeChildView(sandboxedView)
     context_menu_handle()
     sandboxedView.webContents.close()
     sandboxedView = makeBrowserView(
       account_id,
-      allow_network,
+      loadRemoteContent,
       htmlEmail,
       window
     )
@@ -396,8 +403,6 @@ export function openHtmlEmailWindow(
     // for debugging email
     // sandboxedView.webContents.openDevTools({ mode: 'detach' })
   }
-  // handle toggle network button
-  window.webContents.ipc.handle('html-view:change-network', update_restrictions)
 
   window.loadFile(
     join(

--- a/packages/target-electron/static/electron_html_email_view/electron_html_email_view.css
+++ b/packages/target-electron/static/electron_html_email_view/electron_html_email_view.css
@@ -41,17 +41,11 @@ div.header > div.network-toggle {
   display: flex;
   align-items: center;
   margin: 4px;
-  font-family: Arial, Helvetica, sans-serif;
   padding: 6px;
   font-size: 0.8em;
 }
 
-div.header > div.network-toggle > input {
-  margin-inline-end: 5px;
-}
-
 div.header > div.network-toggle > button#toggle_network_more_button {
-  margin-left: 6px;
   background-color: transparent;
   border: 1px grey solid;
   font-size: 0.8em;

--- a/packages/target-electron/static/electron_html_email_view/electron_html_email_view.html
+++ b/packages/target-electron/static/electron_html_email_view/electron_html_email_view.html
@@ -26,8 +26,6 @@
         </p>
       </div>
       <div class="network-toggle">
-        <input type="checkbox" id="toggle_network" />
-        <label for="toggle_network" id="toggle_network_label"></label>
         <button id="toggle_network_more_button">⋮</button>
       </div>
     </div>

--- a/packages/target-electron/static/electron_html_email_view/electron_html_email_view.js
+++ b/packages/target-electron/static/electron_html_email_view/electron_html_email_view.js
@@ -1,37 +1,14 @@
 const subjectElement = document.getElementById('subject')
 const fromElement = document.getElementById('sender')
 const receiveTimeElement = document.getElementById('receive-time')
-const networkCheckbox = document.getElementById('toggle_network')
-const networkButtonLabel = document.getElementById('toggle_network_label')
 const networkMoreButton = document.getElementById('toggle_network_more_button')
-
-window.network_enabled = false
 
 let promise = window.htmlview
   .getInfo()
-  .then(
-    ({
-      subject,
-      from,
-      receiveTime,
-      toggle_network,
-      networkButtonLabelText,
-    }) => {
-      ;((subjectElement.innerText = subject), (fromElement.innerText = from))
-      networkButtonLabel.innerText = networkButtonLabelText
-      networkCheckbox.checked = window.network_enabled = toggle_network
-      receiveTimeElement.innerText = receiveTime
-    }
-  )
-
-networkCheckbox.onclick = ev => {
-  ev.preventDefault()
-  const new_value = !window.network_enabled
-  window.htmlview.changeAllowNetwork(new_value).then(() => {
-    networkCheckbox.checked = new_value
-    window.network_enabled = new_value
+  .then(({ subject, from, receiveTime }) => {
+    ;((subjectElement.innerText = subject), (fromElement.innerText = from))
+    receiveTimeElement.innerText = receiveTime
   })
-}
 
 networkMoreButton.onclick = ev => {
   /** @type {MouseEvent} */

--- a/packages/target-electron/static/electron_html_email_view/electron_html_email_view_preload.js
+++ b/packages/target-electron/static/electron_html_email_view/electron_html_email_view_preload.js
@@ -4,8 +4,6 @@ contextBridge.exposeInMainWorld('htmlview', {
   getInfo: () => ipcRenderer.invoke('html_email:get_info'),
   setContentBounds: bounds =>
     ipcRenderer.invoke('html-view:resize-content', bounds),
-  changeAllowNetwork: allow_network =>
-    ipcRenderer.invoke('html-view:change-network', allow_network),
   openMoreMenu: ({ x, y }) => {
     ipcRenderer.invoke('html-view:more-menu', { x, y })
   },


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/4344.

The point is to make it more "hidden" so that people don't click it
just to see what it does.

Although the original issue is about the option being displayed
even when there are no remote images,
this commit improves the situation with that.

Note that this MR doesn't affect Tauri. In Tauri things remain as is.