### PR TITLE
feat: add button to clear all relay storage

### DIFF
--- a/packages/frontend/src/components/dialogs/ConnectivityDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConnectivityDialog.tsx
@@ -4,6 +4,7 @@ import { debounceWithInit } from '../chat/ChatListHelpers'
 import { BackendRemote, onDCEvent } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import Dialog, { DialogBody, DialogContent, DialogHeader } from '../Dialog'
+import Button from '../Button'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import type { DialogProps } from '../../contexts/DialogContext'
@@ -57,9 +58,16 @@ function ConnectivityDialogInner() {
     return onDCEvent(accountId, 'ConnectivityChanged', updateConnectivity)
   }, [accountId, updateConnectivity])
 
+  const onClearAllRelayStorage = async () => {
+    await BackendRemote.rpc.clearAllRelayStorage(selectedAccountId())
+  }
+
   return (
     <DialogBody>
       <DialogContent>
+        <Button onClick={onClearAllRelayStorage}>
+          Clear all relay storage
+        </Button>
         <iframe
           style={{
             border: 0,


### PR DESCRIPTION
This is a PR for testing https://github.com/chatmail/core/pull/8105

Not meant as a final UI, I have just put the button somewhere so I can click it and see if it works, currently looks like this:
<img width="621" height="684" alt="image" src="https://github.com/user-attachments/assets/1cc9275a-d4da-4055-ac7c-9c48217f0cb5" />

It successfully wiped all my storage, now quota is reset to 0.
