### PR TITLE
refactor: DRY `AppStoreUrl`

### DIFF
--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -417,7 +417,7 @@ const Composer = forwardRef<
         const downloadUrl = AppStoreUrl + appInfo.cache_relname
         const responseP = BackendRemote.rpc.getHttpResponse(
           selectedAccountId(),
-          AppStoreUrl + appInfo.cache_relname
+          downloadUrl
         )
         let response: Awaited<typeof responseP>
         try {


### PR DESCRIPTION
This was the intent of the commit that introduced this variable
but I guess I forgot to actually use it.
