### PR TITLE
feat: custom app picker URL setting

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -64,5 +64,8 @@
   },
   "paste_in_qr_scanner": {
     "message": "Click to paste it in QR scanner"
+  },
+  "webxdc_store_url_explain_2_desktop": {
+    "message": "This is different from the same feature on Android and iOS.\nThis must be the path containing the xdcget-lock.json file."
   }
 }

--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -420,6 +420,34 @@ test('add app from picker to chat', async () => {
   expect(finalAppIconsCount).toBeGreaterThan(initialAppIconsCount)
 })
 
+test('custom app picker URL', async () => {
+  // It's the default URL but still let's check if things work.
+  // Change casing to check if changing the setting value works
+  const newUrl = 'HTTPS://APPS.TESTRUN.ORG/'
+
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await page.getByRole('button', { name: 'Advanced' }).click()
+  const settingsDialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Advanced' })
+
+  await expect(settingsDialog).not.toContainText(newUrl, { ignoreCase: false })
+  await page.getByRole('button', { name: 'App Picker URL' }).click()
+  await page.getByRole('dialog').last().getByRole('textbox').fill(newUrl)
+  await page.keyboard.press('Enter')
+  await expect(settingsDialog).toContainText(newUrl, { ignoreCase: false })
+
+  await page.keyboard.press('Escape')
+  await page.keyboard.press('Escape')
+
+  await page.getByRole('button', { name: 'Attach' }).click()
+  await page.getByRole('menuitem', { name: 'App' }).click()
+  await page.getByRole('button', { name: 'Poll' }).first().click()
+  await page.getByRole('button', { name: 'Add to Chat' }).click()
+  await page.getByRole('button', { name: 'Send', exact: true }).click()
+  await expect(page.locator(`.message`).last()).toContainText('Poll')
+})
+
 test('recent apps context menu', async () => {
   await page
     .getByTestId('last-used-apps')

--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -11,6 +11,7 @@ import {
   reloadPage,
   sendMessage,
   test,
+  selectChat,
 } from '../playwright-helper'
 
 /**
@@ -419,6 +420,41 @@ test('add app from picker to chat', async () => {
     .locator('img')
     .count()
   expect(finalAppIconsCount).toBeGreaterThan(initialAppIconsCount)
+})
+
+test('custom app picker URL', async () => {
+  const userA = existingProfiles[0]
+  const userB = existingProfiles[1]
+  await switchToProfile(page, userA.id)
+  await selectChat(page, userB.name)
+
+  // It's the default URL but with different casing.
+  // The behavior will remain the same network-wise,
+  // but this still allows us to check that the setting change is stored
+  // and that the picker still works after that.
+  const newUrl = 'HTTPS://APPS.testRUN.ORG/'
+
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await page.getByRole('button', { name: 'Advanced' }).click()
+  const settingsDialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Advanced' })
+
+  await expect(settingsDialog).not.toContainText(newUrl, { ignoreCase: false })
+  await page.getByRole('button', { name: 'App Picker URL' }).click()
+  await page.getByRole('dialog').last().getByRole('textbox').fill(newUrl)
+  await page.keyboard.press('Enter')
+  await expect(settingsDialog).toContainText(newUrl, { ignoreCase: false })
+
+  await page.keyboard.press('Escape')
+  await page.keyboard.press('Escape')
+
+  await page.getByRole('button', { name: 'Attach' }).click()
+  await page.getByRole('menuitem', { name: 'App' }).click()
+  await page.getByRole('button', { name: 'Poll' }).first().click()
+  await page.getByRole('button', { name: 'Add to Chat' }).click()
+  await page.getByRole('button', { name: 'Send', exact: true }).click()
+  await expect(page.locator(`.message`).last()).toContainText('Poll')
 })
 
 test('recent apps context menu', async () => {

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -3,6 +3,8 @@ import classNames from 'classnames'
 import { filesize } from 'filesize'
 import moment from 'moment'
 import { C } from '@deltachat/jsonrpc-client'
+import { useSettingsStore } from '../../stores/settings'
+import { defaultAppStoreBaseUrl } from '@deltachat-desktop/shared/state'
 import { getLogger } from '../../../../shared/logger'
 
 import useTranslationFunction from '../../hooks/useTranslationFunction'
@@ -42,8 +44,6 @@ export interface AppInfo {
   icon_relname: string
 }
 
-const AppStoreUrl = 'https://apps.testrun.org/'
-
 const enum AppCategoryEnum {
   home = 'home',
   tool = 'tool',
@@ -72,6 +72,7 @@ type Props = {
 
 export function AppPicker({ onAppSelected }: Props) {
   const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState(AppCategoryEnum.home)
   const [selectedAppInfo, setSelectedAppInfo] = useState<AppInfo | null>(null)
@@ -82,15 +83,26 @@ export function AppPicker({ onAppSelected }: Props) {
     AppCategoryEnum.game,
   ]
 
-  const fetchApps = useCallback(async () => {
+  const appStoreUrl: `${string}/` = useMemo(() => {
+    if (settingsStore == undefined) {
+      log.warn('settingsStore not initialized yet, using default appStoreUrl')
+      return defaultAppStoreBaseUrl
+    }
+    const res =
+      settingsStore.desktopSettings.appStoreBaseUrl || defaultAppStoreBaseUrl
+    // Ensure that it ends with a slash.
+    return res.endsWith('/') ? (res as `${string}/`) : (`${res}/` as const)
+  }, [settingsStore])
+
+  const fetchApps = useCallback(async (appStoreUrl: string) => {
     // This may throw, e.g. on network error.
     const response = await BackendRemote.rpc.getHttpResponse(
       selectedAccountId(),
-      AppStoreUrl + 'xdcget-lock.json'
+      appStoreUrl + 'xdcget-lock.json'
     )
     const apps = getJsonFromBase64(response.blob) as AppInfo[]
     if (apps == null) {
-      throw new Error(`Received \`null\` response from ${AppStoreUrl}`)
+      throw new Error(`Received \`null\` response from ${appStoreUrl}`)
     }
     apps.sort((a: AppInfo, b: AppInfo) => {
       const dateA = new Date(a.date)
@@ -106,7 +118,7 @@ export function AppPicker({ onAppSelected }: Props) {
     }
     return apps
   }, [])
-  const appsFetch = useFetch(fetchApps, [])
+  const appsFetch = useFetch(fetchApps, [appStoreUrl])
   const apps = appsFetch.result?.ok ? appsFetch.result.value : null
 
   const appsFetchFailed = appsFetch.result?.ok === false
@@ -134,7 +146,13 @@ export function AppPicker({ onAppSelected }: Props) {
       let count = 0
       for (const app of apps) {
         BackendRemote.rpc
-          .getHttpResponse(selectedAccountId(), AppStoreUrl + app.icon_relname)
+          .getHttpResponse(
+            selectedAccountId(),
+            // Note that here we're still using the default store URL.
+            // This is because we don't expect the custom store to host icons.
+            // We only expect the `xdc-lock.json` file from it.
+            defaultAppStoreBaseUrl + app.icon_relname
+          )
           .then((response: { blob: string }) => {
             if (response?.blob !== undefined) {
               newIcons[app.app_id] = `data:image/png;base64,${response.blob}`
@@ -346,7 +364,18 @@ export function AppPicker({ onAppSelected }: Props) {
                   app={selectedAppInfo}
                   setSelectedAppInfo={setSelectedAppInfo}
                   onSelect={async appInfo => {
-                    const downloadUrl = AppStoreUrl + appInfo.cache_relname
+                    // For the default store we normally utilize
+                    // `cache_relname`, but it it's a custom store
+                    // then we don't expect it to host the .xdc files,
+                    // so load them from app developers directly.
+                    // Also see https://github.com/webxdc/website/issues/135
+                    //
+                    // Maybe it's not nice to have this undocumented behavior.
+                    const downloadUrl =
+                      appStoreUrl === defaultAppStoreBaseUrl
+                        ? appStoreUrl + appInfo.cache_relname
+                        : appInfo.url
+
                     await onAppSelected(appInfo, downloadUrl)
                   }}
                 />

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -42,7 +42,7 @@ export interface AppInfo {
   icon_relname: string
 }
 
-export const AppStoreUrl = 'https://apps.testrun.org/'
+const AppStoreUrl = 'https://apps.testrun.org/'
 
 const enum AppCategoryEnum {
   home = 'home',
@@ -67,7 +67,7 @@ const getJsonFromBase64 = (base64: string): any => {
 }
 
 type Props = {
-  onAppSelected: (app: AppInfo) => Promise<void>
+  onAppSelected: (app: AppInfo, downloadUrl: string) => Promise<void>
 }
 
 export function AppPicker({ onAppSelected }: Props) {
@@ -345,7 +345,10 @@ export function AppPicker({ onAppSelected }: Props) {
                 <AppInfoOverlay
                   app={selectedAppInfo}
                   setSelectedAppInfo={setSelectedAppInfo}
-                  onSelect={onAppSelected}
+                  onSelect={async appInfo => {
+                    const downloadUrl = AppStoreUrl + appInfo.cache_relname
+                    await onAppSelected(appInfo, downloadUrl)
+                  }}
                 />
               )}
               {/* `appsFetch.result.ok === true` implies that

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -3,6 +3,8 @@ import classNames from 'classnames'
 import { filesize } from 'filesize'
 import moment from 'moment'
 import { C } from '@deltachat/jsonrpc-client'
+import { useSettingsStore } from '../../stores/settings'
+import { defaultAppStoreBaseUrl } from '@deltachat-desktop/shared/state'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 
 import useTranslationFunction from '../../hooks/useTranslationFunction'
@@ -42,8 +44,6 @@ export interface AppInfo {
   icon_relname: string
 }
 
-const AppStoreUrl = 'https://apps.testrun.org/'
-
 const enum AppCategoryEnum {
   home = 'home',
   tool = 'tool',
@@ -72,6 +72,7 @@ type Props = {
 
 export function AppPicker({ onAppSelected }: Props) {
   const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState(AppCategoryEnum.home)
   const [selectedAppInfo, setSelectedAppInfo] = useState<AppInfo | null>(null)
@@ -82,15 +83,26 @@ export function AppPicker({ onAppSelected }: Props) {
     AppCategoryEnum.game,
   ]
 
-  const fetchApps = useCallback(async () => {
+  const appStoreUrl: `${string}/` = useMemo(() => {
+    if (settingsStore == undefined) {
+      log.warn('settingsStore not initialized yet, using default appStoreUrl')
+      return defaultAppStoreBaseUrl
+    }
+    const res =
+      settingsStore.desktopSettings.appStoreBaseUrl || defaultAppStoreBaseUrl
+    // Ensure that it ends with a slash.
+    return res.endsWith('/') ? (res as `${string}/`) : (`${res}/` as const)
+  }, [settingsStore])
+
+  const fetchApps = useCallback(async (appStoreUrl: string) => {
     // This may throw, e.g. on network error.
     const response = await BackendRemote.rpc.getHttpResponse(
       selectedAccountId(),
-      AppStoreUrl + 'xdcget-lock.json'
+      appStoreUrl + 'xdcget-lock.json'
     )
     const apps = getJsonFromBase64(response.blob) as AppInfo[]
     if (apps == null) {
-      throw new Error(`Received \`null\` response from ${AppStoreUrl}`)
+      throw new Error(`Received \`null\` response from ${appStoreUrl}`)
     }
     apps.sort((a: AppInfo, b: AppInfo) => {
       const dateA = new Date(a.date)
@@ -106,7 +118,7 @@ export function AppPicker({ onAppSelected }: Props) {
     }
     return apps
   }, [])
-  const appsFetch = useFetch(fetchApps, [])
+  const appsFetch = useFetch(fetchApps, [appStoreUrl])
   const apps = appsFetch.result?.ok ? appsFetch.result.value : null
 
   const appsFetchFailed = appsFetch.result?.ok === false
@@ -134,7 +146,13 @@ export function AppPicker({ onAppSelected }: Props) {
       let count = 0
       for (const app of apps) {
         BackendRemote.rpc
-          .getHttpResponse(selectedAccountId(), AppStoreUrl + app.icon_relname)
+          .getHttpResponse(
+            selectedAccountId(),
+            // Note that here we're still using the default store URL.
+            // This is because we don't expect the custom store to host icons.
+            // We only expect the `xdcget-lock.json` file from it.
+            defaultAppStoreBaseUrl + app.icon_relname
+          )
           .then((response: { blob: string }) => {
             if (response?.blob !== undefined) {
               newIcons[app.app_id] = `data:image/png;base64,${response.blob}`
@@ -346,7 +364,18 @@ export function AppPicker({ onAppSelected }: Props) {
                   app={selectedAppInfo}
                   setSelectedAppInfo={setSelectedAppInfo}
                   onSelect={async appInfo => {
-                    const downloadUrl = AppStoreUrl + appInfo.cache_relname
+                    // For the default store we normally utilize
+                    // `cache_relname`, but it it's a custom store
+                    // then we don't expect it to host the .xdc files,
+                    // so load them from app developers directly.
+                    // Also see https://github.com/webxdc/website/issues/135
+                    //
+                    // Maybe it's not nice to have this undocumented behavior.
+                    const downloadUrl =
+                      appStoreUrl === defaultAppStoreBaseUrl
+                        ? appStoreUrl + appInfo.cache_relname
+                        : appInfo.url
+
                     await onAppSelected(appInfo, downloadUrl)
                   }}
                 />

--- a/packages/frontend/src/components/Login-Styles.tsx
+++ b/packages/frontend/src/components/Login-Styles.tsx
@@ -94,7 +94,8 @@ export const DeltaInput = React.memo(
         event: React.FormEvent<HTMLElement> & React.FocusEvent<HTMLInputElement>
       ) => void
       dataTestId?: string
-    }>
+    }> &
+      Pick<React.ComponentProps<'input'>, 'name' | 'defaultValue'>
   ) => {
     const defaultId = useId()
     const id = props.id ?? `delta-input-${defaultId}`
@@ -113,8 +114,10 @@ export const DeltaInput = React.memo(
         </label>
         <input
           id={id}
+          name={props.name}
           type={props.type}
           value={props.value === null ? '' : props.value}
+          defaultValue={props.defaultValue}
           onChange={props.onChange}
           placeholder={props.placeholder}
           min={props.min}

--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -10,9 +10,25 @@ import SettingsSwitch from './SettingsSwitch'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import useDialog from '../../hooks/dialog/useDialog'
 import AlertDialog from '../dialogs/AlertDialog'
+import Dialog, {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  FooterActionButton,
+  FooterActions,
+} from '../Dialog'
+import { DialogProps } from '../../contexts/DialogContext'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+import { DeltaInput } from '../Login-Styles'
+import SettingsSelector from './SettingsSelector'
+import { defaultAppStoreBaseUrl } from '@deltachat-desktop/shared/state'
+
+const log = getLogger('ExperimentalFeatures')
 
 export function ExperimentalFeatures() {
   const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
   const { openDialog } = useDialog()
 
   const showExperimentalInfoDialog = async (
@@ -94,6 +110,17 @@ export function ExperimentalFeatures() {
         />
       )}
       <SyncAllAccountsSwitch />
+      <SettingsSelector
+        onClick={() => openDialog(AppPickerUrlDialog)}
+        currentValue={
+          settingsStore == undefined
+            ? undefined
+            : settingsStore.desktopSettings.appStoreBaseUrl ||
+              defaultAppStoreBaseUrl
+        }
+      >
+        {tx('webxdc_store_url')}
+      </SettingsSelector>
       <DesktopSettingsSwitch
         settingsKey='enableWebxdcDevTools'
         label='Enable Webxdc Devtools'
@@ -130,5 +157,60 @@ export default function SyncAllAccountsSwitch() {
         )
       }}
     />
+  )
+}
+
+function AppPickerUrlDialog({ onClose }: DialogProps) {
+  const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
+
+  return (
+    <Dialog onClose={onClose}>
+      <DialogHeader title={tx('webxdc_store_url')} onClose={onClose} />
+      <form
+        action={formData => {
+          const url = formData.get('url')
+          if (typeof url !== 'string') {
+            log.error('App picker URL form submitted, but URL is', url)
+            return
+          }
+          SettingsStoreInstance.effect.setDesktopSetting(
+            'appStoreBaseUrl',
+            url === '' ? undefined : url
+          )
+          onClose()
+        }}
+      >
+        <DialogBody>
+          <DialogContent>
+            {/* Note that this string originates from Android
+            where the entire markup of the app picker gets loaded from that URL,
+            whereas for us (Desktop) it's only the list of apps.
+            So this string might not be entirely correct. */}
+            <p>{tx('webxdc_store_url_explain')}</p>
+            {settingsStore && (
+              <DeltaInput
+                value={undefined}
+                placeholder={defaultAppStoreBaseUrl}
+                onChange={() => {}}
+                type='url'
+                name='url'
+                defaultValue={settingsStore.desktopSettings.appStoreBaseUrl}
+              />
+            )}
+          </DialogContent>
+        </DialogBody>
+        <DialogFooter>
+          <FooterActions>
+            <FooterActionButton onClick={onClose}>
+              {tx('cancel')}
+            </FooterActionButton>
+            <FooterActionButton type='submit' styling='primary'>
+              {tx('save')}
+            </FooterActionButton>
+          </FooterActions>
+        </DialogFooter>
+      </form>
+    </Dialog>
   )
 }

--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -10,9 +10,25 @@ import SettingsSwitch from './SettingsSwitch'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import useDialog from '../../hooks/dialog/useDialog'
 import AlertDialog from '../dialogs/AlertDialog'
+import Dialog, {
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  FooterActionButton,
+  FooterActions,
+} from '../Dialog'
+import { DialogProps } from '../../contexts/DialogContext'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+import { DeltaInput } from '../Login-Styles'
+import SettingsSelector from './SettingsSelector'
+import { defaultAppStoreBaseUrl } from '@deltachat-desktop/shared/state'
+
+const log = getLogger('ExperimentalFeatures')
 
 export function ExperimentalFeatures() {
   const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
   const { openDialog } = useDialog()
 
   const showExperimentalInfoDialog = async (
@@ -63,6 +79,17 @@ export function ExperimentalFeatures() {
         />
       )}
       <SyncAllAccountsSwitch />
+      <SettingsSelector
+        onClick={() => openDialog(AppPickerUrlDialog)}
+        currentValue={
+          settingsStore == undefined
+            ? undefined
+            : settingsStore.desktopSettings.appStoreBaseUrl ||
+              defaultAppStoreBaseUrl
+        }
+      >
+        {tx('webxdc_store_url')}
+      </SettingsSelector>
       <DesktopSettingsSwitch
         settingsKey='enableWebxdcDevTools'
         label='Enable Webxdc Devtools'
@@ -99,5 +126,59 @@ export default function SyncAllAccountsSwitch() {
         )
       }}
     />
+  )
+}
+
+function AppPickerUrlDialog({ onClose }: DialogProps) {
+  const tx = useTranslationFunction()
+  const settingsStore = useSettingsStore()[0]
+
+  return (
+    <Dialog onClose={onClose}>
+      <DialogHeader title={tx('webxdc_store_url')} onClose={onClose} />
+      <form
+        action={formData => {
+          const url = formData.get('url')
+          if (typeof url !== 'string') {
+            log.error('App picker URL form submitted, but URL is', url)
+            return
+          }
+          SettingsStoreInstance.effect.setDesktopSetting(
+            'appStoreBaseUrl',
+            url === '' ? undefined : url
+          )
+          onClose()
+        }}
+      >
+        <DialogBody>
+          <DialogContent>
+            <p className='whitespace'>{tx('webxdc_store_url_explain')}</p>
+            <p className='whitespace'>
+              {tx('webxdc_store_url_explain_2_desktop')}
+            </p>
+            {settingsStore && (
+              <DeltaInput
+                value={undefined}
+                placeholder={defaultAppStoreBaseUrl}
+                onChange={() => {}}
+                type='url'
+                name='url'
+                defaultValue={settingsStore.desktopSettings.appStoreBaseUrl}
+              />
+            )}
+          </DialogContent>
+        </DialogBody>
+        <DialogFooter>
+          <FooterActions>
+            <FooterActionButton onClick={onClose}>
+              {tx('cancel')}
+            </FooterActionButton>
+            <FooterActionButton type='submit' styling='primary'>
+              {tx('save')}
+            </FooterActionButton>
+          </FooterActions>
+        </DialogFooter>
+      </form>
+    </Dialog>
   )
 }

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -417,7 +417,7 @@ const Composer = forwardRef<
         const downloadUrl = AppStoreUrl + appInfo.cache_relname
         const responseP = BackendRemote.rpc.getHttpResponse(
           selectedAccountId(),
-          AppStoreUrl + appInfo.cache_relname
+          downloadUrl
         )
         let response: Awaited<typeof responseP>
         try {

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -35,7 +35,7 @@ import useKeyBindingAction from '../../hooks/useKeyBindingAction'
 import { CloseButton } from '../Dialog'
 import { enterKeySendsKeyboardShortcuts } from '../KeyboardShortcutHint'
 import { AppPicker } from '../AppPicker'
-import { AppInfo, AppStoreUrl } from '../AppPicker'
+import { AppInfo } from '../AppPicker'
 import OutsideClickHelper from '../OutsideClickHelper'
 import { useHasChanged2 } from '../../hooks/useHasChanged'
 import { ScreenContext } from '../../contexts/ScreenContext'
@@ -412,9 +412,8 @@ const Composer = forwardRef<
 
   const onAppSelected = messageEditing.isEditingModeActive
     ? null
-    : async (appInfo: AppInfo) => {
+    : async (appInfo: AppInfo, downloadUrl: string) => {
         log.debug('App selected', appInfo)
-        const downloadUrl = AppStoreUrl + appInfo.cache_relname
         const responseP = BackendRemote.rpc.getHttpResponse(
           selectedAccountId(),
           downloadUrl

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -35,7 +35,7 @@ import useKeyBindingAction from '../../hooks/useKeyBindingAction'
 import { CloseButton } from '../Dialog'
 import { enterKeySendsKeyboardShortcuts } from '../KeyboardShortcutHint'
 import { AppPicker } from '../AppPicker'
-import { AppInfo, AppStoreUrl } from '../AppPicker'
+import { AppInfo } from '../AppPicker'
 import OutsideClickHelper from '../OutsideClickHelper'
 import { useHasChanged2 } from '../../hooks/useHasChanged'
 import { ScreenContext } from '../../contexts/ScreenContext'
@@ -442,9 +442,8 @@ const Composer = forwardRef<
 
   const onAppSelected = messageEditing.isEditingModeActive
     ? null
-    : async (appInfo: AppInfo) => {
+    : async (appInfo: AppInfo, downloadUrl: string) => {
         log.debug('App selected', appInfo)
-        const downloadUrl = AppStoreUrl + appInfo.cache_relname
         const responseP = BackendRemote.rpc.getHttpResponse(
           selectedAccountId(),
           downloadUrl

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -75,9 +75,9 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         }
       }, 'setSelfContact')
     },
-    setDesktopSetting: (
-      key: keyof DesktopSettingsType,
-      value: string | number | boolean
+    setDesktopSetting: <T extends keyof DesktopSettingsType>(
+      key: T,
+      value: DesktopSettingsType[T]
     ) => {
       this.setState(state => {
         if (state === null) {
@@ -172,9 +172,9 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         }, 'set')
       }
     },
-    setDesktopSetting: async (
-      key: keyof DesktopSettingsType,
-      value: string | number | boolean
+    setDesktopSetting: async <T extends keyof DesktopSettingsType>(
+      key: T,
+      value: (string | number | boolean) & DesktopSettingsType[T]
     ) => {
       try {
         await runtime.setDesktopSetting(key, value)

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -174,7 +174,7 @@ class SettingsStore extends Store<SettingsStoreState | null> {
     },
     setDesktopSetting: async <T extends keyof DesktopSettingsType>(
       key: T,
-      value: (string | number | boolean) & DesktopSettingsType[T]
+      value: (string | number | boolean | undefined) & DesktopSettingsType[T]
     ) => {
       try {
         await runtime.setDesktopSetting(key, value)

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -70,9 +70,9 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         }
       }, 'setSelfContact')
     },
-    setDesktopSetting: (
-      key: keyof DesktopSettingsType,
-      value: string | number | boolean
+    setDesktopSetting: <T extends keyof DesktopSettingsType>(
+      key: T,
+      value: DesktopSettingsType[T]
     ) => {
       this.setState(state => {
         if (state === null) {
@@ -167,9 +167,9 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         }, 'set')
       }
     },
-    setDesktopSetting: async (
-      key: keyof DesktopSettingsType,
-      value: string | number | boolean
+    setDesktopSetting: async <T extends keyof DesktopSettingsType>(
+      key: T,
+      value: (string | number | boolean) & DesktopSettingsType[T]
     ) => {
       try {
         await runtime.setDesktopSetting(key, value)

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -169,7 +169,7 @@ class SettingsStore extends Store<SettingsStoreState | null> {
     },
     setDesktopSetting: async <T extends keyof DesktopSettingsType>(
       key: T,
-      value: (string | number | boolean) & DesktopSettingsType[T]
+      value: (string | number | boolean | undefined) & DesktopSettingsType[T]
     ) => {
       try {
         await runtime.setDesktopSetting(key, value)

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { defaultAppStoreBaseUrl } from './state.ts'
+
 export type PromiseType<T> = T extends Promise<infer U> ? U : any
 
 type Bounds = {
@@ -83,6 +86,12 @@ export interface DesktopSettingsType {
   autostart: boolean
   /** whether to start Electron with system on supported platforms */
   autostartElectron: boolean
+  /**
+   * URL relative to which to fetch the `xdc-lock.json` file.
+   * If `undefined` or an empty string then we default to
+   * {@linkcode defaultAppStoreBaseUrl}.
+   */
+  appStoreBaseUrl?: string
 }
 
 export interface RC_Config {

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -1,3 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { defaultAppStoreBaseUrl } from './state.ts'
+
 export type PromiseType<T> = T extends Promise<infer U> ? U : any
 
 type Bounds = {
@@ -86,6 +89,12 @@ export interface DesktopSettingsType {
   autostart: boolean
   /** whether to start Electron with system on supported platforms */
   autostartElectron: boolean
+  /**
+   * URL relative to which to fetch the `xdcget-lock.json` file.
+   * If `undefined` or an empty string then we default to
+   * {@linkcode defaultAppStoreBaseUrl}.
+   */
+  appStoreBaseUrl?: string
 }
 
 export interface RC_Config {

--- a/packages/shared/state.ts
+++ b/packages/shared/state.ts
@@ -32,5 +32,8 @@ export function getDefaultState(): DesktopSettingsType {
     inChatSoundsVolume: 0.5,
     autostart: true,
     autostartElectron: false,
+    appStoreBaseUrl: undefined,
   }
 }
+
+export const defaultAppStoreBaseUrl = 'https://apps.testrun.org/'

--- a/packages/shared/state.ts
+++ b/packages/shared/state.ts
@@ -30,5 +30,8 @@ export function getDefaultState(): DesktopSettingsType {
     inChatSoundsVolume: 0.5,
     autostart: true,
     autostartElectron: false,
+    appStoreBaseUrl: undefined,
   }
 }
+
+export const defaultAppStoreBaseUrl = 'https://apps.testrun.org/'


### PR DESCRIPTION
- **refactor: DRY `AppStoreUrl`**
- **refactor: App Picker: don't export `AppStoreUrl`**
- **refactor: make `DeltaInput` support more props**
- **refactor: narrower `setDesktopSetting` types**
- **refactor: setDesktopSetting: allow `undefined` val**
- **feat: setting to set app picker URL**

<img width="387" height="237" alt="image" src="https://github.com/user-attachments/assets/fc5a2102-a4c6-4140-aa96-4c13a9037cba" />

For testing one can use https://wofwca.github.io/webxdc_website/apps/.

Related: https://github.com/webxdc/website/issues/135.
