### PR TITLE
style: round outline for settings button

### DIFF
--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -199,6 +199,8 @@
 
   .settingsButton {
     background-color: transparent;
+    border-radius: 9999999px;
+    line-height: 0;
     border: 0;
     height: 42px;
     margin: 0;


### PR DESCRIPTION
And also make sure that it's centered inside the outline,
by setting `line-height: 0`.

<img width="101" height="88" alt="image" src="https://github.com/user-attachments/assets/35a034b7-bc52-42a0-8367-b9819b3a2ed0" />
