### PR TITLE
refactor: remove redundant dev `getAllAccounts` fn

### DIFF
--- a/packages/frontend/src/experimental.ts
+++ b/packages/frontend/src/experimental.ts
@@ -28,10 +28,6 @@ only for debugging:
     window.exp = this
   }
 
-  getAllAccounts() {
-    return BackendRemote.listAccounts()
-  }
-
   async importContacts(contacts: [string, string][]) {
     const accountId = selectedAccountId()
     let error_count = 0


### PR DESCRIPTION
One can just `rpc.getAllAccounts()`.
`listAccounts` is deprecated anyway.
