### PR TITLE
fix: better prevent `chatId` leaking between accs

### DIFF
--- a/packages/frontend/src/ScreenController.tsx
+++ b/packages/frontend/src/ScreenController.tsx
@@ -173,6 +173,14 @@ export default class ScreenController extends Component {
       return
     }
 
+    // Now that we automatically invalidate `chatId` when `accountId` changes
+    // in `ChatContext`, one might think that it's not necessary
+    // to explicitly `unselectChat()` here.
+    // But apparently without this we still get `chatId` leaking between
+    // different `accountId`s, namely when loading recent app icons
+    // while rapidly switching accounts.
+    // Maybe this has to do with us using `window.__selectedAccountId`
+    // in some places and the `accountId` prop in others.
     this.unselectChatRef.current?.()
 
     const previousAccountId = this.selectedAccountId

--- a/packages/frontend/src/ScreenController.tsx
+++ b/packages/frontend/src/ScreenController.tsx
@@ -173,7 +173,7 @@ export default class ScreenController extends Component {
       return
     }
 
-    // Now that we automatically invalidate `chatId` when `accountId` changes
+    // Since we automatically invalidate `chatId` when `accountId` changes
     // in `ChatContext`, one might think that it's not necessary
     // to explicitly `unselectChat()` here.
     // But apparently without this we still get `chatId` leaking between

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useMemo, useState } from 'react'
 
 import { ActionEmitter, KeybindAction } from '../keybindings'
 import { marknoticedChat, saveLastChatId } from '../backend/chat'
@@ -56,7 +56,45 @@ export const ChatProvider = ({
   accountId,
   unselectChatRef,
 }: PropsWithChildren<Props>) => {
-  const [chatId, setChatId] = useState<number | undefined>()
+  const sessionId = useMemo(
+    () => Symbol(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [accountId]
+  )
+  const sessionIdRef = useRef(sessionId)
+  sessionIdRef.current = sessionId
+
+  // When the `accountId` changes, we invalidate `chatId`,
+  // and the `setChatId` function.
+  //
+  // We usually utilize `key={accountId}` for this,
+  // but applying `key=` to a React context provider
+  // makes _all_ its descendants (as opposed just the components
+  // that depend on the context) re-render, including `AccountListSidebar`.
+  const [chatId_, setChatId_] = useState<
+    undefined | { sessionId: symbol; chatId: number }
+  >(undefined)
+  const chatId =
+    chatId_ == undefined || chatId_.sessionId !== sessionId
+      ? undefined
+      : chatId_.chatId
+  const setChatId = useCallback(
+    (newChatId: number | undefined) => {
+      if (sessionId !== sessionIdRef.current) {
+        // This may happen when `selectChat` gets called
+        // from `Promise.then` or `setTimeout` and such.
+        log.info(
+          "Called setChatId, but we've already switched the account after the closure was created, ignoring"
+        )
+        return
+      }
+      setChatId_(
+        newChatId == undefined ? undefined : { chatId: newChatId, sessionId }
+      )
+    },
+    [sessionId]
+  )
+
   useEffect(() => {
     window.__selectedChatId = chatId
   }, [chatId])
@@ -79,10 +117,9 @@ export const ChatProvider = ({
     // Make sure that the chat belongs to the current account,
     // to prevent data leaking between accounts, and weird race-y bugs.
     //
-    // We usually utilize `key={accountId}` for this,
-    // but applying `key=` to a React context provider
-    // makes _all_ its descendants (as opposed just the components
-    // that depend on the context) re-render, including `AccountListSidebar`.
+    // I think now that we have `sessionId` this check is no longer needed,
+    // because that basically ensures that `chatId` is always valid
+    // for the current `accountId`?
     accountId === chatFetch.lingeringResult.value.accountId
       ? chatFetch.lingeringResult.value.chat
       : undefined
@@ -154,15 +191,14 @@ export const ChatProvider = ({
       // Remember that user selected this chat to open it again when they come back
       saveLastChatId(accountId, nextChatId)
     },
-    [accountId, chatId]
+    [accountId, chatId, setChatId]
   )
 
   const unselectChat = useCallback<UnselectChat>(() => {
     setChatId(undefined)
-  }, [])
+  }, [setChatId])
 
   // Callback ref pattern: keeping ref in sync for external callers
-  // eslint-disable-next-line react-hooks/refs
   unselectChatRef.current = unselectChat
 
   const lastArchivedCheckChatId = useRef<number | undefined>(undefined)


### PR DESCRIPTION
I think we can say that
this closes https://github.com/deltachat/deltachat-desktop/issues/5993.
I have tried switching accounts rapidly with this and have not managed
to trigger any errors in the console,
besides the occasional
"Tried to jumpToMessage, but messageListItems is empty".

Swithcing between accounts rapidly does indeed print the new
"but we've already switched the account" log from time to time.

I am pretty sure that this shouldn't break things.
I was worried that there might be cases where we actually _want_
to have the `selectChat` closure stored and invoked asynchronously,
such as for "switch to another account, then select a chat with this ID
in that account", but we utilize `saveLastChatId()`
followed by `selectAccount()` in such cases,
e.g. in the notification click handler.
And the function itself already has a guard check
for whether the target account ID is the same as the account ID
that we had selected when the closure was created.

I tested that the notification click handler
does properly switch accounts and select the target chat
and highlight the target message.
Cross-account message forwarding also works fine,
also cancelling the forward.

I am not sure about why the React linter stopped complaining about
`unselectChatRef.current = unselectChat`.
I had to remove the "ignore" comment there, otherwise it complains about
"Unused eslint-disable directive".

I am TBH not happy that I have to write this.
It feels like React is missing API for this,
something like a "weaker" `key=`.
Or maybe I'm bad at looking for a library that does this.
Or maybe I'm not seeing a simpler solution.
