### PR TITLE
feat: `Ctrl + Alt + PageDown` to switch accounts

### DIFF
--- a/docs/KEYBINDINGS.md
+++ b/docs/KEYBINDINGS.md
@@ -2,6 +2,8 @@
 
 > If you are on mac replace alt with the option key.
 
+Switch between accounts: `Ctrl + Alt + PageUp`, `Ctrl + Alt + PageDown`
+
 Switch between chats: `alt + arrow down`, `alt + arrow up`,
 `Ctrl + PageDown`, `Ctrl + PageUp`,
 `Ctrl + Tab`, `Ctrl + Shift + Tab`

--- a/packages/e2e-tests/tests/keyboard.spec.ts
+++ b/packages/e2e-tests/tests/keyboard.spec.ts
@@ -13,13 +13,23 @@ test.describe.configure({
 
 expect.configure({ timeout: 5_000 })
 
+// Why so many? Mainly for the "switch account" shortcuts.
+const numberOfProfiles = 4
+
 // https://playwright.dev/docs/next/test-retries#reuse-single-page-between-tests
 let page: Page
 
 test.beforeAll(async ({ browser }) => {
   page = await browser.newPage()
   await reloadPage(page)
+
+  let i = 0
   await importDummyProfileFromBackup(page)
+  i++
+  for (; i < numberOfProfiles; i++) {
+    await page.getByRole('button', { name: 'Add Profile' }).click()
+    await importDummyProfileFromBackup(page)
+  }
 
   // Shortcuts don't seem to work otherwise. Maybe a Playwright issue.
   await page.locator('body').click()
@@ -39,7 +49,14 @@ test.afterAll(async ({ browser }) => {
   const context = await browser.newContext()
   const pageForProfileDeletion = await context.newPage()
   await reloadPage(pageForProfileDeletion)
-  await deleteSelectedProfile(pageForProfileDeletion)
+  for (let i = 0; i < numberOfProfiles; i++) {
+    await pageForProfileDeletion
+      .getByLabel('Switch Profile')
+      .getByRole('tab')
+      .last()
+      .click()
+    await deleteSelectedProfile(pageForProfileDeletion)
+  }
   await context.close()
 })
 
@@ -84,4 +101,48 @@ test.describe('keyboard shortcuts', () => {
 
     await page.keyboard.press('Escape')
   })
+})
+
+test('Ctrl + Alt + PageUp/PageDown to switch accounts', async () => {
+  const accs = page.getByLabel('Switch Profile').getByRole('tab')
+  async function expectSelected(ind: number) {
+    await expect(accs.nth(ind)).toHaveAttribute('aria-selected', 'true')
+  }
+
+  await accs.first().click()
+  await expectSelected(0)
+
+  await page.keyboard.press('ControlOrMeta+Alt+PageDown')
+  await expectSelected(1)
+  await page.keyboard.press('ControlOrMeta+Alt+PageDown')
+  await expectSelected(2)
+  await page.keyboard.press('ControlOrMeta+Alt+PageDown')
+  await expectSelected(3)
+  await page.keyboard.press('ControlOrMeta+Alt+PageDown')
+  await expectSelected(3)
+
+  await page.keyboard.press('ControlOrMeta+Alt+PageUp')
+  await expectSelected(2)
+  await page.keyboard.press('ControlOrMeta+Alt+PageUp')
+  await expectSelected(1)
+  await page.keyboard.press('ControlOrMeta+Alt+PageUp')
+  await expectSelected(0)
+  await page.keyboard.press('ControlOrMeta+Alt+PageUp')
+  await expectSelected(0)
+
+  await page.keyboard.press('ControlOrMeta+Alt+PageDown')
+  await expectSelected(1)
+  // Having a dialog disables the shortcut.
+  await page.keyboard.press('ControlOrMeta+N')
+  await expect(page.getByRole('dialog')).toHaveCount(1)
+  await page.keyboard.press('ControlOrMeta+Alt+PageDown')
+  await expectSelected(1)
+  await page.keyboard.press('ControlOrMeta+Alt+PageUp')
+  await expectSelected(1)
+
+  // Dialog closed, shortcut works again.
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+  await page.keyboard.press('ControlOrMeta+Alt+PageUp')
+  await expectSelected(0)
 })

--- a/packages/e2e-tests/tests/keyboard.spec.ts
+++ b/packages/e2e-tests/tests/keyboard.spec.ts
@@ -1,12 +1,10 @@
 import { expect, type Page } from '@playwright/test'
 
 import {
-  createProfiles,
-  User,
-  loadExistingProfiles,
-  deleteAllProfiles,
   reloadPage,
   test,
+  importDummyProfileFromBackup,
+  deleteSelectedProfile,
 } from '../playwright-helper'
 
 test.describe.configure({
@@ -15,33 +13,13 @@ test.describe.configure({
 
 expect.configure({ timeout: 5_000 })
 
-let existingProfiles: User[] = []
-
-const numberOfProfiles = 1
-
 // https://playwright.dev/docs/next/test-retries#reuse-single-page-between-tests
 let page: Page
 
-test.beforeAll(async ({ browser, isChatmail }) => {
-  const contextForProfileCreation = await browser.newContext()
-  const pageForProfileCreation = await contextForProfileCreation.newPage()
-
-  await reloadPage(pageForProfileCreation)
-
-  existingProfiles =
-    (await loadExistingProfiles(pageForProfileCreation)) ?? existingProfiles
-
-  await createProfiles(
-    numberOfProfiles,
-    existingProfiles,
-    pageForProfileCreation,
-    browser.browserType().name(),
-    isChatmail
-  )
-
-  await contextForProfileCreation.close()
+test.beforeAll(async ({ browser }) => {
   page = await browser.newPage()
   await reloadPage(page)
+  await importDummyProfileFromBackup(page)
 
   // Shortcuts don't seem to work otherwise. Maybe a Playwright issue.
   await page.locator('body').click()
@@ -61,7 +39,7 @@ test.afterAll(async ({ browser }) => {
   const context = await browser.newContext()
   const pageForProfileDeletion = await context.newPage()
   await reloadPage(pageForProfileDeletion)
-  await deleteAllProfiles(pageForProfileDeletion, existingProfiles)
+  await deleteSelectedProfile(pageForProfileDeletion)
   await context.close()
 })
 

--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -33,6 +33,10 @@ import classNames from 'classnames'
 import { useRpcFetch } from '../../hooks/useFetch'
 import AlertDialog from '../dialogs/AlertDialog'
 import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
+import useKeyBindingAction from '../../hooks/useKeyBindingAction'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+
+const log = getLogger('AccountListSidebar')
 
 type Props = {
   onAddAccount: () => Promise<number>
@@ -105,6 +109,45 @@ export default function AccountListSidebar({
     /// now this workaround is only used when changing background sync setting
     window.__updateAccountListSidebar = throttledRefreshSyncAllAccounts
   }, [])
+
+  const selectNextOrPrevAcc = (offset: number) => {
+    if (!accountsFetch.lingeringResult?.ok) {
+      return
+    }
+    const list = accountsFetch.lingeringResult.value
+
+    if (selectedAccountId == undefined) {
+      if (list.length > 0) {
+        selectAccount(list[0])
+      }
+      return
+    }
+
+    const currInd = list.indexOf(selectedAccountId)
+    if (currInd === -1) {
+      log.warn(
+        `tried to handle "select next / prev account" keyboard shortcut, but couldn't find the current one (${selectedAccountId}) in the list`,
+        list
+      )
+      return
+    }
+    const newId = list[currInd + offset]
+    if (newId == undefined) {
+      // Out of bounds
+      return
+    }
+
+    selectAccount(newId)
+  }
+  // We probably should have this event handler in a more "global" place,
+  // but we're adding it here because this is one of the places
+  // where we already have the list of account IDs.
+  useKeyBindingAction(KeybindAction.AccountsList_SelectNextAccount, () => {
+    selectNextOrPrevAcc(+1)
+  })
+  useKeyBindingAction(KeybindAction.AccountsList_SelectPreviousAccount, () => {
+    selectNextOrPrevAcc(-1)
+  })
 
   const [accountForHoverInfo, internalSetAccountForHoverInfo] =
     useState<T.Account | null>(null)

--- a/packages/frontend/src/components/KeyboardShortcutHint.tsx
+++ b/packages/frontend/src/components/KeyboardShortcutHint.tsx
@@ -176,6 +176,13 @@ export function getKeybindings(
         ],
       },
       {
+        title: tx('switch_account'),
+        keyBindings: [
+          ['Control', 'Alt', 'PageUp'],
+          ['Control', 'Alt', 'PageDown'],
+        ],
+      },
+      {
         title: tx('scroll_messages'),
         keyBindings: [['PageUp'], ['PageDown']],
       },

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -3,6 +3,8 @@ import { getLogger } from '../../shared/logger'
 const log = getLogger('renderer/keybindings')
 
 export enum KeybindAction {
+  AccountsList_SelectNextAccount = 'accountslist:select-next-chat',
+  AccountsList_SelectPreviousAccount = 'accountslist:select-previous-chat',
   ChatList_SelectNextChat = 'chatlist:select-next-chat',
   ChatList_SelectPreviousChat = 'chatlist:select-previous-chat',
   ChatList_ScrollToSelectedChat = 'chatlist:scroll-to-selected-chat',
@@ -145,9 +147,17 @@ export function keyDownEvent2Action(
     } else if (ev.altKey && ev.code === 'ArrowUp') {
       return KeybindAction.ChatList_SelectPreviousChat
     } else if (ev.ctrlKey && ev.code === 'PageDown') {
-      return KeybindAction.ChatList_SelectNextChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectNextAccount
+      } else {
+        return KeybindAction.ChatList_SelectNextChat
+      }
     } else if (ev.ctrlKey && ev.code === 'PageUp') {
-      return KeybindAction.ChatList_SelectPreviousChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectPreviousAccount
+      } else {
+        return KeybindAction.ChatList_SelectPreviousChat
+      }
     } else if (ev.ctrlKey && ev.code === 'Tab') {
       return !ev.shiftKey
         ? KeybindAction.ChatList_SelectNextChat
@@ -225,9 +235,17 @@ export function keyDownEvent2Action(
   } else {
     // fire continuesly as long as button is pressed
     if (ev.ctrlKey && ev.code === 'PageDown') {
-      return KeybindAction.ChatList_SelectNextChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectNextAccount
+      } else {
+        return KeybindAction.ChatList_SelectNextChat
+      }
     } else if (ev.ctrlKey && ev.code === 'PageUp') {
-      return KeybindAction.ChatList_SelectPreviousChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectPreviousAccount
+      } else {
+        return KeybindAction.ChatList_SelectPreviousChat
+      }
     } else if (ev.code === 'PageUp') {
       if (
         (ev.target as HTMLElement)?.classList.contains(

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -4,6 +4,8 @@ import { runtime } from '@deltachat-desktop/runtime-interface'
 const log = getLogger('renderer/keybindings')
 
 export enum KeybindAction {
+  AccountsList_SelectNextAccount = 'accountslist:select-next-chat',
+  AccountsList_SelectPreviousAccount = 'accountslist:select-previous-chat',
   ChatList_SelectNextChat = 'chatlist:select-next-chat',
   ChatList_SelectPreviousChat = 'chatlist:select-previous-chat',
   ChatList_ScrollToSelectedChat = 'chatlist:scroll-to-selected-chat',
@@ -166,9 +168,17 @@ export function keyDownEvent2Action(
     } else if (ev.altKey && ev.code === 'ArrowUp') {
       return KeybindAction.ChatList_SelectPreviousChat
     } else if (ev.ctrlKey && ev.code === 'PageDown') {
-      return KeybindAction.ChatList_SelectNextChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectNextAccount
+      } else {
+        return KeybindAction.ChatList_SelectNextChat
+      }
     } else if (ev.ctrlKey && ev.code === 'PageUp') {
-      return KeybindAction.ChatList_SelectPreviousChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectPreviousAccount
+      } else {
+        return KeybindAction.ChatList_SelectPreviousChat
+      }
     } else if (ev.ctrlKey && ev.code === 'Tab') {
       return !ev.shiftKey
         ? KeybindAction.ChatList_SelectNextChat
@@ -249,9 +259,17 @@ export function keyDownEvent2Action(
   } else {
     // fire continuesly as long as button is pressed
     if (ev.ctrlKey && ev.code === 'PageDown') {
-      return KeybindAction.ChatList_SelectNextChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectNextAccount
+      } else {
+        return KeybindAction.ChatList_SelectNextChat
+      }
     } else if (ev.ctrlKey && ev.code === 'PageUp') {
-      return KeybindAction.ChatList_SelectPreviousChat
+      if (ev.altKey) {
+        return KeybindAction.AccountsList_SelectPreviousAccount
+      } else {
+        return KeybindAction.ChatList_SelectPreviousChat
+      }
     } else if (ev.code === 'PageUp') {
       if (
         (ev.target as HTMLElement)?.classList.contains(


### PR DESCRIPTION
Why not `Ctrl + Shift + PageDown`? Because it feels like
an "alternative action" on the message list
where we have `Ctrl + PageDown` to switch between chats.
Whereas "Alt" is a little more awkward,
so it feels further from the action of switching between chats.

Closes https://support.delta.chat/t/can-you-provide-a-shortcut-key-to-switch-between-different-accounts/3259?u=wofwca.

<img width="352" height="479" alt="image" src="https://github.com/user-attachments/assets/965f03a2-1f45-406f-bc52-07d6be855c8b" />