### PR TITLE
fix: add missing aria-labels for various buttons

### DIFF
--- a/packages/frontend/src/components/VerifiedIcon.tsx
+++ b/packages/frontend/src/components/VerifiedIcon.tsx
@@ -1,7 +1,14 @@
 import React, { CSSProperties } from 'react'
+import useTranslationFunction from '../hooks/useTranslationFunction'
 
 export function InlineVerifiedIcon({ style }: { style?: CSSProperties }) {
+  const tx = useTranslationFunction()
   return (
-    <img className='verified-icon' src='./images/verified.svg' style={style} />
+    <img
+      className='verified-icon'
+      src='./images/verified.svg'
+      style={style}
+      alt={tx('verified_by_unknown')}
+    />
   )
 }

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -1071,7 +1071,7 @@ function JumpDownButton({
           }}
           // Technically this is not always "to bottom",
           // but perhaps it's good enough.
-          aria-label={tx('menu_scroll_to_bottom')}
+          aria-label={stackIsEmpty ? tx('menu_scroll_to_bottom') : tx('back')}
         >
           <div className={'icon ' + (!stackIsEmpty ? 'back' : 'down')} />
         </button>


### PR DESCRIPTION
This PR addresses some of the missing aria-labels identified in #4611.

### Changes:
- Added `alt` label to `InlineVerifiedIcon` using the `verified_by_unknown` (Introduced) translation.
- Updated `JumpDownButton` to use different `aria-label` strings depending on whether it is in "scroll to bottom" or "jump back" mode.

Fixes #4611