### PR TITLE
fix: don't close dialog when closing menu with Esc

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -445,6 +445,25 @@ test('focuses first visible item on arrow down key on input in create chat dialo
   await expect(page.locator('*:focus')).toContainText('New Contact')
 })
 
+test("closing context menu with Escape doesn't close dialog", async () => {
+  await page.keyboard.press('ControlOrMeta+N')
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Bob' })
+    .click({ button: 'right' })
+  await expect(page.getByRole('menuitem')).toHaveText([
+    'View Profile',
+    'Delete Contact',
+  ])
+
+  await expect(page.getByRole('menu')).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('menu')).not.toBeVisible()
+  await expect(page.getByRole('dialog')).toBeVisible()
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog')).not.toBeVisible()
+})
+
 test('correct handling of changed profile displaynames', async () => {
   const userA = existingProfiles[0]
   const userB = existingProfiles[1]

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -167,10 +167,7 @@ export function ContextMenuLayer({
     // Prevent default since ContextMenuLayer is only visible
     // when a context menu is already open
     evt?.preventDefault()
-    window.__setContextMenuActive(false)
-    setCurrentItems([])
     layerRef.current?.close()
-    endPromiseRef.current?.()
   }, [])
 
   useEffect(() => {
@@ -184,6 +181,11 @@ export function ContextMenuLayer({
       ref={layerRef}
       className='dc-context-menu-layer'
       onClick={cancel}
+      onClose={() => {
+        window.__setContextMenuActive(false)
+        setCurrentItems([])
+        endPromiseRef.current?.()
+      }}
       onContextMenuCapture={cancel}
       // The `<dialog>` is only used to make sure that the menu is on top
       // of other content, and to trap focus.
@@ -367,9 +369,6 @@ export function ContextMenu(props: {
             keyboardFocus.current = 0
           }
         }
-      } else if (ev.code === 'Escape') {
-        closeCallback()
-        keyboardFocus.current = -1
       }
       // preventDefaultForScrollKeys
       else if (ScrollKeysToBlock.includes(ev.code)) {
@@ -382,7 +381,7 @@ export function ContextMenu(props: {
     return () => {
       document.removeEventListener('keydown', onKeyDown)
     }
-  }, [openSublevels, closeCallback, expandMenu])
+  }, [openSublevels, expandMenu])
 
   return (
     <div>


### PR DESCRIPTION
Affected places:
- "New Chat" dialog
- "View Contact" dialog, the three-dot menu
- Maybe more

What seems to have been happening is that pressing Escape
would trigger `closeCallback` which would close the context menu dialog.
Which would then cause the keydown event to be handled
by the currently open dialog.
What this commit does is it makes the context menu dialog
only close once using the native behavior of `<dialog>` elements.

The manual Escape handling has been written
before we started utilizing the `<dialog>` element for the context menu.
Now we can simplify things.
