### PR TITLE
refactor: remove scroll prevention code for menu

### DIFF
--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -72,8 +72,6 @@ type ContextMenuLevel = {
  */
 export type OpenContextMenu = (args: showFnArguments) => Promise<void>
 
-const ScrollKeysToBlock = ['PageUp', 'PageDown', 'End', 'Home']
-
 export function ContextMenuLayer({
   setShowFunction,
 }: {
@@ -371,11 +369,6 @@ export function ContextMenu(props: {
         closeCallback()
         keyboardFocus.current = -1
       }
-      // preventDefaultForScrollKeys
-      else if (ScrollKeysToBlock.includes(ev.code)) {
-        ev.preventDefault()
-        return false
-      }
     }
 
     document.addEventListener('keydown', onKeyDown)
@@ -512,28 +505,7 @@ export function useContextMenuWithActiveState(
   }
 }
 
-/**
- * disables scrolling on the app as long as the component is mounted
- * inspired by https://stackoverflow.com/a/4770179
- *
- * this is outside of an use function because
- * for some reason removing the listeners doesn't work for those
- */
-function preventDefault(e: Event) {
-  e.preventDefault()
-}
-const wheelEvent: 'wheel' | 'mousewheel' =
-  'onwheel' in document.createElement('div') ? 'wheel' : 'mousewheel'
-
 window.__setContextMenuActive = (newVal: boolean): void => {
-  if (newVal) {
-    // Adding the same listener twice in a row has no effect.
-    document.addEventListener(wheelEvent, preventDefault, { passive: false })
-    document.addEventListener('touchmove', preventDefault, { passive: false })
-  } else {
-    document.removeEventListener(wheelEvent, preventDefault)
-    document.removeEventListener('touchmove', preventDefault)
-  }
   type Writable<T> = {
     -readonly [P in keyof T]: T[P]
   }


### PR DESCRIPTION
Basically this reverts 07bc1d956d4f1f6939e2e4fa2ca8ddb58a0c1e94.

In 0e0d0b80d598802ebb972c8d6c05b593bd896f24
(https://github.com/deltachat/deltachat-desktop/pull/4006)
we started using `<dialog>` for the context menu,
so now we don't need to worry about scrolling prevention,
because when the dialog is open, the rest of the page content
becomes inert.