### PR TITLE
refactor: remove `window.__refetchChatlist`

### DIFF
--- a/packages/frontend/src/backend-com.ts
+++ b/packages/frontend/src/backend-com.ts
@@ -25,10 +25,8 @@ export namespace EffectfulBackendActions {
     runtime.deleteWebxdcAccountData(account_id)
   }
 
-  // TODO make a core events for these chatlist events instead of faking them in desktop
   export async function acceptChat(account_id: number, chatId: number) {
     await BackendRemote.rpc.acceptChat(account_id, chatId)
-    window.__refetchChatlist && window.__refetchChatlist()
   }
 
   export async function blockChat(accountId: number, chatId: number) {

--- a/packages/frontend/src/backend-com.ts
+++ b/packages/frontend/src/backend-com.ts
@@ -25,10 +25,6 @@ export namespace EffectfulBackendActions {
     runtime.deleteWebxdcAccountData(account_id)
   }
 
-  export async function acceptChat(account_id: number, chatId: number) {
-    await BackendRemote.rpc.acceptChat(account_id, chatId)
-  }
-
   export async function blockChat(accountId: number, chatId: number) {
     await BackendRemote.rpc.blockChat(accountId, chatId)
     clearNotificationsForChat(accountId, chatId)

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -561,7 +561,7 @@ const Composer = forwardRef<
           type='button'
           className='contact-request-button accept'
           onClick={() => {
-            EffectfulBackendActions.acceptChat(selectedAccountId(), chatId)
+            BackendRemote.rpc.acceptChat(selectedAccountId(), chatId)
           }}
         >
           {tx('accept')}

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -50,7 +50,6 @@ declare global {
     __chatlistSetSearch:
       | ((searchTerm: string, chatId: number | null) => void)
       | undefined
-    __refetchChatlist: undefined | (() => void)
     /**
      * Setting this will make the MessageList component `jumpToMessage`
      * as soon as it renders with the chat for `accountId` and `chatId`,


### PR DESCRIPTION
Follow-up to 5c770b9689113efb10a2ce7c12a08e24dacb6061
(https://github.com/deltachat/deltachat-desktop/pull/3268).
That MR removed the assignment to the variable,
making it always `undefined`,
but apparently mistakenly didn't remove the variable altogether.

Also remove the comment which apparently referenced the fact
that we had to reload the chat list when doing certain actions,
such as deleting a chat.
It was introduced in e969ce4bca25a10980e90ca54df437ed6018518c
(https://github.com/deltachat/deltachat-desktop/pull/2874),
before we had the core event.
