### PR TITLE
chore: `npx playwright` -> `pnpm exec playwright`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,7 +43,7 @@ jobs:
       run: npm install -g pnpm && pnpm install
     - name: Install Playwright Browsers
       working-directory: ./packages/e2e-tests
-      run: npx playwright install --with-deps --only-shell chromium
+      run: pnpm exec playwright install --with-deps --only-shell chromium
     - name: Run e2e tests
       env:
         DC_FRONTEND_NO_TLS: true

--- a/docs/E2E-TESTING.md
+++ b/docs/E2E-TESTING.md
@@ -4,7 +4,7 @@
 
 after running `pnpm install`
 
-cd into packages/e2e-tests and run `npx playwright install --with-deps`
+cd into packages/e2e-tests and run `pnpm exec playwright install --with-deps`
 
 Copy packages/e2e-tests/\_env to packages/e2e-tests/.env
 


### PR DESCRIPTION
I believe `npx playwright` will use a version
different from the one installed with `pnpm install`.
This can cause Playwright to install browser versions
that are different from the ones that are required
by the `pnpm install` version of Playwright,
so in the end one will have to install both.

I suspect that this could also reduce the difference between CI testing env and local testing env.