### PR TITLE
test: don't require TLS cert to run tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,64 +16,6 @@ on:
       - 'README_ASSETS/**'
       - 'README.md'
 
-env: # dummy certificates for testing
-  PRIVATE_CERTIFICATE_KEY: |
-    -----BEGIN PRIVATE KEY-----
-    MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCkARDceole0+De
-    GNRL7jDFUcm8YmrCbWNp/hT4IxQyavmYkLWZz5T1M8E4cDgnlM+n63owtS/bKENC
-    m0AeyZaTvktJXmCVsFIGZyS5yF13Ddp5qVU7VSAQz1/bqXmyppzSleJzl4q6S5+I
-    RIWvJuF/Nfs5lCuIwQ8ciyH2ceT+fAsPR0mTdOKYLdLzE9kAn0XVI28C/Z1z2E1M
-    Ck6yQsvJcHXZQ0ncGkVRv2ureujN5btpAc1RctUUXzPn8Pxh5AEfAVCR5tDXwy1V
-    /pI3GM/xcd4xsqa3rT+AcH6FPH7/8ltdlNVXH6DHZ8QW6NH/KGG75BP06YycVDOR
-    947dhrCZAgMBAAECggEAbI6YDpi9nRs6WUiuHaSIe9PraNrsN84YY+xfDPCLSeQt
-    WqNO0YTp4HRljWoagXirC0d/FgaYqsQ34TrKcpaVKS5ovyPNYsfXQ426bY8G7uso
-    lidT13Y9R2M83DWN7IcEfw/fWQwSM8YizxwsMQfXc1DT/gTp3BeOXSJrVKmHHjsF
-    0Op/kfRSytWwsfuobbYIUMjm0KxU5rX0iqftDmlUpCpR9eIQ2R0xUvyLZ3g+p8ic
-    z8UuhX/qANgj3cvvRt4Qz5T5ZO0ev1ke3L8+eamvToXUiy2Qh4pN2OKYXKZOLp3m
-    iax7A8Z8BM5/pW+m1X9cCsqIxZ7eMWUDWGh8ICsOQQKBgQDFK2B7xGQ4Jy85LKbV
-    hKTZH8Gck1+eU2V+hrGgTpdORReFpiSyp5A/64y0KIX5LVxNWyRLJuBd4pkh/jyf
-    Hl97UN4TD36v8UIUN78JFN3TQprIt/WE4lNtq715t8qaNr1Uc+EsBHPxBSkEnTEH
-    saGGYPQQvIHz5Bp5JzszRTNwTQKBgQDU8GMPQ4jWEaxcx+Mk5sEZUVvsTFUL+UU0
-    4k6ypep/ofRj+5Nx0bcRvmZ4IZAtBkGwkl+5w8Gn1y/1mUI54uqqN/MsjK8Qg/nx
-    x9cWK5nN0zuf5C+84/IjA7Hm5iTaTLxTd7Gai2KtKpbpR+ovokHNWDUtx6TgjJV6
-    Ue10KhHHfQKBgHo7svvnu83IFRGX6fHS4rOsaUYdYxjvUKuI61ObhVfDo5p6bqPH
-    F7lY2QjTWoMoqOFYEH76ofvyP8cAKyrmFIGJl7MvVvXSVoncKXWC1yZiUzz+Nppk
-    CR6jarqrw1Gpf+R8VmsIc6xG66/tl3jSmXWKY6SAiPvfPL5BIQVe8E29AoGAEFEz
-    ZhIIxE6qZJm0oDlGhsgjQSJASiCZ2wmUekAYjhs8/QRkMg6d9rAebgo0YB7gncU5
-    rKSBjHkC5dEOsBzhWpXa/ojxSVSzrIFhzAMfUBRlt0TnG5RkE6bO1SDBpjDHJaZA
-    Z9VShG6FDe9C1M+cNz4RJSbtTX+4XJ02kvY+UokCgYB2W/oKoOTSnCqejRvppRAP
-    rZNtJ6vOTS1U96poX7l2wKjcxa9WZmf4dXZjKR2IcEwbobektyArBZQkhEAdiZIG
-    JgJ2qyhVDUhz1i48BA1emGZLT78j6EThYb61T5BlhNf/95g/01Td6pTuCEyexDBn
-    8faJWpToLywABHOE1nKPaQ==
-    -----END PRIVATE KEY-----
-  
-  PRIVATE_CERTIFICATE_CERT: |
-    -----BEGIN CERTIFICATE-----
-    MIIEKzCCApOgAwIBAgIRAONXUH7qbHcyReFt2tumxXswDQYJKoZIhvcNAQELBQAw
-    czEeMBwGA1UEChMVbWtjZXJ0IGRldmVsb3BtZW50IENBMSQwIgYDVQQLDBtuZGhA
-    bmRoLWF1cmEgKE5pY28gZGUgSGFlbikxKzApBgNVBAMMIm1rY2VydCBuZGhAbmRo
-    LWF1cmEgKE5pY28gZGUgSGFlbikwHhcNMjQxMDE4MTUyOTM1WhcNMjcwMTE4MTYy
-    OTM1WjBPMScwJQYDVQQKEx5ta2NlcnQgZGV2ZWxvcG1lbnQgY2VydGlmaWNhdGUx
-    JDAiBgNVBAsMG25kaEBuZGgtYXVyYSAoTmljbyBkZSBIYWVuKTCCASIwDQYJKoZI
-    hvcNAQEBBQADggEPADCCAQoCggEBAKQBENx6iV7T4N4Y1EvuMMVRybxiasJtY2n+
-    FPgjFDJq+ZiQtZnPlPUzwThwOCeUz6frejC1L9soQ0KbQB7JlpO+S0leYJWwUgZn
-    JLnIXXcN2nmpVTtVIBDPX9upebKmnNKV4nOXirpLn4hEha8m4X81+zmUK4jBDxyL
-    IfZx5P58Cw9HSZN04pgt0vMT2QCfRdUjbwL9nXPYTUwKTrJCy8lwddlDSdwaRVG/
-    a6t66M3lu2kBzVFy1RRfM+fw/GHkAR8BUJHm0NfDLVX+kjcYz/Fx3jGypretP4Bw
-    foU8fv/yW12U1VcfoMdnxBbo0f8oYbvkE/TpjJxUM5H3jt2GsJkCAwEAAaNeMFww
-    DgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMB8GA1UdIwQYMBaA
-    FM2ncK48RqCtnwRcMPHCbqwnp8n+MBQGA1UdEQQNMAuCCWxvY2FsaG9zdDANBgkq
-    hkiG9w0BAQsFAAOCAYEAJS0oh36ZwKZ6KDuN64j2JTjRP5WAwLaMfUtR/vebdUte
-    Ju7e6m3XgzRCbKOc4s2XOv5ONFVESgry6/DUBxPnibAFE41TKwp7+bLio4kcWpy1
-    ac5PxNXDxgdIkzMQrw6WTzBByOdJdvmtXfmjQdwtzQEgX41fddaHW2MV6mkJtoig
-    icyDUE98wrjdUPCHzxg9iFLrwmY/yS+gjoauZmHRCL5T66zURHskO+BinonPTe2P
-    xeFxysxsefVKTm3nlldpav4/FuHElJ1um8rMkZ3O8zfgn6WS/4W7gZpgjS6QuFsK
-    24bA9W3URqEZuHxRLGdBAcfE/E2YqFkgJ3FHt5UpivVbWkYybH1kd75Ng0TsbZBt
-    8vjGkIPMplcAo72nq7z+xkYE7/SHa6dXXuR+4TBoR72fhDJKiY4tJmLQ7f8n1jDP
-    orZZUaJvUBF/bamf6VyJB+4DYr8bsUCVpcnFfXzhzs1jfhwM6T08ywFVDVb1ShCP
-    LqYfg2Ehy45AAnnOPD6p
-    -----END CERTIFICATE-----
-
 jobs:
   test:
     name: E2E Tests
@@ -105,6 +47,8 @@ jobs:
     - name: create data dir
       run: mkdir -p packages/target-browser/data
     - name: Run e2e tests
+      env:
+        DC_FRONTEND_NO_TLS: true
       run: pnpm e2e
     - uses: actions/upload-artifact@v4
       # We may want to not upload artifacts if tests pass,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -44,8 +44,6 @@ jobs:
     - name: Install Playwright Browsers
       working-directory: ./packages/e2e-tests
       run: npx playwright install --with-deps --only-shell chromium
-    - name: create data dir
-      run: mkdir -p packages/target-browser/data
     - name: Run e2e tests
       env:
         DC_FRONTEND_NO_TLS: true

--- a/docs/E2E-TESTING.md
+++ b/docs/E2E-TESTING.md
@@ -16,7 +16,8 @@ Be aware that the tests in each spec file are NOT isolated, so the order they ar
 
 ## Usage
 
-This package depends on the target-browser so make sure you prepared that to run (adding custom certificates). See [README](../packages/target-browser/Readme.md)
+This package depends on the target-browser so consider taking a look at its [README](../packages/target-browser/Readme.md),
+e.g. if you want to enable TLS.
 
 But don't run the browser at the same time, it will be started inside the test routine.
 

--- a/packages/e2e-tests/_env
+++ b/packages/e2e-tests/_env
@@ -1,4 +1,5 @@
 DC_ACCOUNTS_DIR=../../e2e-tests/data/accounts
+DC_FRONTEND_NO_TLS=true
 NODE_ENV=test
 
 # URL of chatmail server

--- a/packages/e2e-tests/load-env.ts
+++ b/packages/e2e-tests/load-env.ts
@@ -1,0 +1,12 @@
+/* eslint-disable no-console */
+import path from 'node:path'
+
+const envPath = path.join(import.meta.dirname, '.env')
+
+export function loadEnv() {
+  try {
+    return process.loadEnvFile?.(envPath)
+  } catch (_error) {
+    console.log(`No .env file to load ${envPath}`)
+  }
+}

--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -1,14 +1,8 @@
 /* eslint-disable no-console */
-import path from 'node:path'
 import { expect, test as base, Page } from '@playwright/test'
+import { loadEnv } from './load-env'
 
-const envPath = path.join(import.meta.dirname, '.env')
-
-try {
-  process.loadEnvFile?.(envPath)
-} catch (_error) {
-  console.log(`No .env file to load ${envPath}`)
-}
+loadEnv()
 
 export const chatmailServerDomain = process.env.DC_CHATMAIL_DOMAIN
   ? process.env.DC_CHATMAIL_DOMAIN

--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -44,7 +44,7 @@ export const test = base.extend<TestOptions>({
 })
 
 export async function reloadPage(page: Page): Promise<void> {
-  await page.goto('https://localhost:3000/')
+  await page.goto(`/`)
 }
 
 export async function clickThroughTestIds(
@@ -325,7 +325,7 @@ export async function deleteAllProfiles(
  * if fixtures are used, and the profiles are already created
  */
 export async function loadExistingProfiles(page: Page): Promise<User[]> {
-  // await page.goto('https://localhost:3000/')
+  // await page.goto('/')
   const existingProfiles: User[] = []
   await page.waitForSelector('.main-container')
   await expect(page.locator('.main-container')).toBeVisible()

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -5,9 +5,12 @@ import { TestOptions } from './playwright-helper'
 
 loadEnv()
 
+export const DC_FRONTEND_NO_TLS: boolean =
+  process.env.DC_FRONTEND_NO_TLS === 'true' ||
+  process.env.DC_FRONTEND_NO_TLS === '1'
 const port = process.env.WEB_PORT ?? 3000
 
-const baseURL = `https://localhost:${port}`
+const baseURL = `${DC_FRONTEND_NO_TLS ? 'http' : 'https'}://localhost:${port}`
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -45,6 +48,7 @@ export default defineConfig<TestOptions>({
     permissions: ['notifications'],
     ignoreHTTPSErrors: true,
     launchOptions: {
+      // Only relevant with TLS.
       args: ['--ignore-certificate-errors'],
     },
   },

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from '@playwright/test'
 
 import { TestOptions } from './playwright-helper'
 
-const port = process.env.PORT ?? 3000
+const port = process.env.WEB_PORT ?? 3000
 
 const baseURL = `https://localhost:${port}`
 

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from '@playwright/test'
 
+import { loadEnv } from './load-env'
 import { TestOptions } from './playwright-helper'
+
+loadEnv()
 
 const port = process.env.WEB_PORT ?? 3000
 

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -34,9 +34,12 @@ const { WebsocketTransport } = yerpc
 
 let logJsonrpcConnection = false
 
+const baseWsUrl = new URL(location.href)
+baseWsUrl.protocol = location.protocol === 'http:' ? 'ws:' : 'wss:'
+
 class BrowserTransport extends WebsocketTransport {
   constructor(private callCounterFunction: (label: string) => void) {
-    super('wss://localhost:3000/ws/dc')
+    super(new URL('ws/dc', baseWsUrl).href)
   }
 
   protected _onmessage(message: yerpc.Message): void {
@@ -83,7 +86,7 @@ class BrowserRuntime implements Runtime {
   socket: WebSocket
   private rc_config: RC_Config | null = null
   constructor() {
-    this.socket = new WebSocket('wss://localhost:3000/ws/backend')
+    this.socket = new WebSocket(new URL('ws/backend', baseWsUrl).href)
 
     this.socket.addEventListener('open', () => {
       // eslint-disable-next-line no-console

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -49,14 +49,13 @@ if (process.env['DC_ACCOUNTS_DIR']) {
 
 export const NODE_ENV = (process.env['NODE_ENV'] ?? 'production').toLowerCase()
 
-if (!existsSync(DATA_DIR)) {
-  // eslint-disable-next-line no-console
-  console.log(
-    '\n[ERROR]: Data dir does not exist, make sure you follow the steps in the Readme file\n'
-  )
-  process.exit(1)
+try {
+  mkdirSync(DATA_DIR)
+} catch (err: any) {
+  if (err.code !== 'EEXIST') {
+    throw err
+  }
 }
-
 mkdirSync(LOGS_DIR, { recursive: true })
 
 if (

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -30,7 +30,7 @@ export const LOCALES_DIR = join(__dirname, '../../../_locales')
 
 // ENV Vars
 export const ENV_WEB_PASSWORD = process.env['WEB_PASSWORD']
-export const ENV_WEB_PORT = process.env['WEB_PORT'] || 3000 // currently only port 3000 is supported
+export const ENV_WEB_PORT = process.env['WEB_PORT'] || 3000
 // set this to one if you use this behind a proxy
 export const ENV_WEB_TRUST_FIRST_PROXY = Boolean(
   process.env['WEB_TRUST_FIRST_PROXY']

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -29,6 +29,9 @@ export let DC_ACCOUNTS_DIR = join(DATA_DIR, 'accounts')
 export const LOCALES_DIR = join(__dirname, '../../../_locales')
 
 // ENV Vars
+export const DC_FRONTEND_NO_TLS: boolean =
+  process.env['DC_FRONTEND_NO_TLS'] === 'true' ||
+  process.env['DC_FRONTEND_NO_TLS'] === '1'
 export const ENV_WEB_PASSWORD = process.env['WEB_PASSWORD']
 export const ENV_WEB_PORT = process.env['WEB_PORT'] || 3000
 // set this to one if you use this behind a proxy
@@ -57,12 +60,13 @@ if (!existsSync(DATA_DIR)) {
 mkdirSync(LOGS_DIR, { recursive: true })
 
 if (
+  !DC_FRONTEND_NO_TLS &&
   !existsSync(PRIVATE_CERTIFICATE_KEY) &&
   !process.env['PRIVATE_CERTIFICATE_KEY']
 ) {
   // eslint-disable-next-line no-console
   console.log(
-    `\n[ERROR]: Certificate at "${PRIVATE_CERTIFICATE_KEY}" not exist, make sure you follow the steps in the Readme file\n`
+    `\n[ERROR]: Certificate at "${PRIVATE_CERTIFICATE_KEY}" not exist, make sure you follow the steps in the Readme file. Or consider DC_FRONTEND_NO_TLS=true.\n`
   )
   process.exit(1)
 }

--- a/packages/target-browser/src/index.ts
+++ b/packages/target-browser/src/index.ts
@@ -215,7 +215,7 @@ if (process.env.PRIVATE_CERTIFICATE_KEY) {
   certificateKey = await readFile(PRIVATE_CERTIFICATE_KEY, 'utf8')
 }
 
-const sslserver = https.createServer(
+const server = https.createServer(
   {
     key: certificateKey,
     cert: certificate,
@@ -251,7 +251,7 @@ wssBackend.on('connection', function connection(ws) {
   log.debug('connected backend socket')
 })
 
-sslserver.on('upgrade', (request, socket, head) => {
+server.on('upgrade', (request, socket, head) => {
   // eslint-disable-next-line no-console
   socket.on('error', console.error)
 
@@ -275,13 +275,13 @@ sslserver.on('upgrade', (request, socket, head) => {
   })
 })
 
-sslserver.listen(ENV_WEB_PORT, () => {
+server.listen(ENV_WEB_PORT, () => {
   log.info(`HTTPS app listening on port ${ENV_WEB_PORT}`)
 })
 
 process.on('exit', () => {
-  sslserver.closeAllConnections()
-  sslserver.close()
+  server.closeAllConnections()
+  server.close()
   shutdownDC()
   logHandler.end()
 })

--- a/packages/target-browser/src/index.ts
+++ b/packages/target-browser/src/index.ts
@@ -1,5 +1,6 @@
 import { basename, dirname, join } from 'path'
 import express from 'express'
+import http from 'http'
 import https from 'https'
 import { readFile, stat, unlink } from 'fs/promises'
 import session from 'express-session'
@@ -23,6 +24,7 @@ import {
   LOCALES_DIR,
   DATA_DIR,
   DC_ACCOUNTS_DIR,
+  DC_FRONTEND_NO_TLS,
 } from './config'
 import { startDeltaChat } from './deltachat-rpc'
 import { helpRoute } from './help'
@@ -61,7 +63,7 @@ const sessionParser = session({
   cookie: {
     sameSite: 'strict',
     priority: 'high',
-    secure: true, // This makes it only work in https
+    secure: !DC_FRONTEND_NO_TLS, // `secure: true` makes it only work in https
     httpOnly: true,
   },
 })
@@ -201,27 +203,32 @@ app.get('/themes.json', async (_req, res) => {
   res.json(await readThemeDir())
 })
 
-let certificate = ''
-if (process.env.PRIVATE_CERTIFICATE_CERT) {
-  certificate = process.env.PRIVATE_CERTIFICATE_CERT
+let server: http.Server | https.Server
+if (DC_FRONTEND_NO_TLS) {
+  server = http.createServer({}, app)
 } else {
-  certificate = await readFile(PRIVATE_CERTIFICATE_CERT, 'utf8')
-}
+  let certificate = ''
+  if (process.env.PRIVATE_CERTIFICATE_CERT) {
+    certificate = process.env.PRIVATE_CERTIFICATE_CERT
+  } else {
+    certificate = await readFile(PRIVATE_CERTIFICATE_CERT, 'utf8')
+  }
 
-let certificateKey = ''
-if (process.env.PRIVATE_CERTIFICATE_KEY) {
-  certificateKey = process.env.PRIVATE_CERTIFICATE_KEY
-} else {
-  certificateKey = await readFile(PRIVATE_CERTIFICATE_KEY, 'utf8')
-}
+  let certificateKey = ''
+  if (process.env.PRIVATE_CERTIFICATE_KEY) {
+    certificateKey = process.env.PRIVATE_CERTIFICATE_KEY
+  } else {
+    certificateKey = await readFile(PRIVATE_CERTIFICATE_KEY, 'utf8')
+  }
 
-const server = https.createServer(
-  {
-    key: certificateKey,
-    cert: certificate,
-  },
-  app
-)
+  server = https.createServer(
+    {
+      key: certificateKey,
+      cert: certificate,
+    },
+    app
+  )
+}
 
 const wssBackend = new WebSocketServer({
   noServer: true,
@@ -276,7 +283,9 @@ server.on('upgrade', (request, socket, head) => {
 })
 
 server.listen(ENV_WEB_PORT, () => {
-  log.info(`HTTPS app listening on port ${ENV_WEB_PORT}`)
+  log.info(
+    `${DC_FRONTEND_NO_TLS ? 'HTTP' : 'HTTPS'} app listening on port ${ENV_WEB_PORT}`
+  )
 })
 
 process.on('exit', () => {


### PR DESCRIPTION
- **refactor: rename `sslserver` to `server`**
- **refactor: `target-browser`: support generic URLs**
- **refactor: tests: factor out `loadEnv()`**
- **test: don't require TLS cert to run tests**
- **test: auto-create `data` dir**

This removes the necessity for developers to install Rust
and `rustls-cert-gen`,
by adding the `DC_FRONTEND_NO_TLS` env var,
which makes the web server serve plain HTTP instead of HTTPS.

When this and https://github.com/deltachat/deltachat-desktop/pull/6230 get merged all you'll have to do to run tests will be `pnpm install` and `pnpm exec playwright install --with-deps`.