### PR TITLE
refactor: improve multiselect docs

### DIFF
--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -37,7 +37,6 @@ const none = Symbol()
  *         <button
  *           role='option' // Or 'tab' or whatever.
  *           aria-selected={multiselect.selectedItems.has(id)}
- *           className={multiselect.selectedItems.has(id) ? 'selected' : ''}
  *           onClick={event => {
  *             const shouldPreventDefault = multiselect.onClick(event, id)
  *             if (shouldPreventDefault) {


### PR DESCRIPTION
No need to add class name, CSS can select by `aria-selected` attribute.
