### PR TITLE
style: fix "recent apps" white borders

### DIFF
--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -149,7 +149,6 @@
     height: 25px;
     cursor: pointer;
     border-radius: 3px;
-    background-color: #fff;
   }
 }
 


### PR DESCRIPTION
The `background-color` line has been introduced in
3bc21041bfbafea2da9c297adcdffa28528e8480
(https://github.com/deltachat/deltachat-desktop/pull/5149).
The apparent intent of it is to replace transparency with white color.
However, this causes issues with `border-radius`.
The browser tried to blend the icon color with white,
and not with the color of the chat title bar,
resulting in annoying white "glow".

Note that we don't have this `background-color` thing
in the gallery or the message list either.

See https://github.com/deltachat/deltachat-desktop/issues/6243#issuecomment-4243735849.
