### PR TITLE
refactor: `useRef` -> `useMemo` for Observer

### DIFF
--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -2,7 +2,6 @@ import React, {
   useRef,
   useCallback,
   useLayoutEffect,
-  RefObject,
   useEffect,
   useState,
   useMemo,
@@ -217,14 +216,19 @@ export default function MessageList({
       }
     })
   }
-  const unreadMessageInViewIntersectionObserver: RefObject<IntersectionObserver> =
-    useRef(
-      new IntersectionObserver(onUnreadMessageInView, {
+  const unreadMessageInViewIntersectionObserver = useRef<IntersectionObserver>(
+    null
+  ) as React.RefObject<IntersectionObserver>
+  if (unreadMessageInViewIntersectionObserver.current == null) {
+    unreadMessageInViewIntersectionObserver.current = new IntersectionObserver(
+      onUnreadMessageInView,
+      {
         root: null,
         rootMargin: '0px',
         threshold: [0, 1],
-      })
+      }
     )
+  }
 
   useEffect(() => {
     const onFocus = onWindowFocus.bind(null, accountId)
@@ -234,7 +238,6 @@ export default function MessageList({
 
   useEffect(() => {
     return () => {
-      // eslint-disable-next-line react-hooks/exhaustive-deps
       unreadMessageInViewIntersectionObserver.current?.disconnect()
     }
   }, [])

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -157,78 +157,76 @@ export default function MessageList({
    */
   const maxScrollToBottomDistanceConsideredShort = 10
 
-  const onUnreadMessageInView: IntersectionObserverCallback = entries => {
-    if (!chat) return
-    // Don't mark messages as read if window is not focused
-    if (document.hasFocus() === false) return
+  const onUnreadMessageInView: IntersectionObserverCallback = useCallback(
+    (entries, observer) => {
+      if (!chat?.id) return
+      // Don't mark messages as read if window is not focused
+      if (document.hasFocus() === false) return
 
-    if (scheduler.isLocked('scroll') === true) {
-      //console.log('onScroll: locked, returning')
-      return
-    }
-
-    setTimeout(() => {
-      log.debug(`onUnreadMessageInView: entries.length: ${entries.length}`)
-
-      const messageIdsToMarkAsRead = []
-      for (const entry of entries) {
-        if (!entry.isIntersecting) continue
-        if (!(entry.target instanceof HTMLElement)) {
-          log.error(
-            'onUnreadMessageInView: entry.target is not HTMLElement:',
-            entry.target
-          )
-          continue
-        }
-        const messageId = entry.target.dataset.messageid
-          ? Number.parseInt(entry.target.dataset.messageid)
-          : undefined
-        if (messageId == undefined || !Number.isSafeInteger(messageId)) {
-          log.error(
-            'onUnreadMessageInView: failed to get message id from element',
-            entry.target
-          )
-          continue
-        }
-        const messageHeight = entry.target.clientHeight
-
-        log.debug(
-          `onUnreadMessageInView: messageId ${messageId} height: ${messageHeight} intersectionRate: ${entry.intersectionRatio}`
-        )
-        log.debug(
-          `onUnreadMessageInView: messageId ${messageId} marking as read`
-        )
-
-        messageIdsToMarkAsRead.push(messageId)
-        if (unreadMessageInViewIntersectionObserver.current === null) continue
-        unreadMessageInViewIntersectionObserver.current.unobserve(entry.target)
+      if (scheduler.isLocked('scroll') === true) {
+        //console.log('onScroll: locked, returning')
+        return
       }
 
-      if (messageIdsToMarkAsRead.length > 0) {
-        const chatId = chat?.id
-        if (!chatId) return
-        // FYI we also listen for `MsgsNoticed` event
-        // to update the badge counter,
-        // so `.then(debouncedUpdateBadgeCounter)` is probably not necessary.
-        BackendRemote.rpc
-          .markseenMsgs(accountId, messageIdsToMarkAsRead)
-          .then(throttledUpdateBadgeCounter)
-      }
+      setTimeout(() => {
+        log.debug(`onUnreadMessageInView: entries.length: ${entries.length}`)
+
+        const messageIdsToMarkAsRead = []
+        for (const entry of entries) {
+          if (!entry.isIntersecting) continue
+          if (!(entry.target instanceof HTMLElement)) {
+            log.error(
+              'onUnreadMessageInView: entry.target is not HTMLElement:',
+              entry.target
+            )
+            continue
+          }
+          const messageId = entry.target.dataset.messageid
+            ? Number.parseInt(entry.target.dataset.messageid)
+            : undefined
+          if (messageId == undefined || !Number.isSafeInteger(messageId)) {
+            log.error(
+              'onUnreadMessageInView: failed to get message id from element',
+              entry.target
+            )
+            continue
+          }
+          const messageHeight = entry.target.clientHeight
+
+          log.debug(
+            `onUnreadMessageInView: messageId ${messageId} height: ${messageHeight} intersectionRate: ${entry.intersectionRatio}`
+          )
+          log.debug(
+            `onUnreadMessageInView: messageId ${messageId} marking as read`
+          )
+
+          messageIdsToMarkAsRead.push(messageId)
+          observer.unobserve(entry.target)
+        }
+
+        if (messageIdsToMarkAsRead.length > 0) {
+          const chatId = chat?.id
+          if (!chatId) return
+          // FYI we also listen for `MsgsNoticed` event
+          // to update the badge counter,
+          // so `.then(debouncedUpdateBadgeCounter)` is probably not necessary.
+          BackendRemote.rpc
+            .markseenMsgs(accountId, messageIdsToMarkAsRead)
+            .then(throttledUpdateBadgeCounter)
+        }
+      })
+    },
+    [accountId, chat.id, scheduler]
+  )
+  const unreadMessageInViewIntersectionObserver = useMemo(() => {
+    log.debug('Creating unreadMessageInViewIntersectionObserver')
+
+    return new IntersectionObserver(onUnreadMessageInView, {
+      root: null,
+      rootMargin: '0px',
+      threshold: [0, 1],
     })
-  }
-  const unreadMessageInViewIntersectionObserver = useRef<IntersectionObserver>(
-    null
-  ) as React.RefObject<IntersectionObserver>
-  if (unreadMessageInViewIntersectionObserver.current == null) {
-    unreadMessageInViewIntersectionObserver.current = new IntersectionObserver(
-      onUnreadMessageInView,
-      {
-        root: null,
-        rootMargin: '0px',
-        threshold: [0, 1],
-      }
-    )
-  }
+  }, [onUnreadMessageInView])
 
   useEffect(() => {
     const onFocus = onWindowFocus.bind(null, accountId)
@@ -238,9 +236,9 @@ export default function MessageList({
 
   useEffect(() => {
     return () => {
-      unreadMessageInViewIntersectionObserver.current?.disconnect()
+      unreadMessageInViewIntersectionObserver.disconnect()
     }
-  }, [])
+  }, [unreadMessageInViewIntersectionObserver])
 
   const maybeJumpToMessageHack = () => {
     // FYI there is similar code in `messagelist.ts`.
@@ -743,7 +741,7 @@ export const MessageListInner = React.memo(
     messageListRef: React.RefObject<HTMLDivElement | null>
     chat: T.FullChat
     loaded: boolean
-    unreadMessageInViewIntersectionObserver: React.RefObject<IntersectionObserver | null>
+    unreadMessageInViewIntersectionObserver: IntersectionObserver
     loadMissingMessages: () => Promise<void>
   }) => {
     const tx = useTranslationFunction()

--- a/packages/frontend/src/components/message/MessageWrapper.tsx
+++ b/packages/frontend/src/components/message/MessageWrapper.tsx
@@ -12,7 +12,7 @@ type RenderMessageProps = {
   chat: T.FullChat
   message: T.Message
   conversationType: ConversationType
-  unreadMessageInViewIntersectionObserver: React.RefObject<IntersectionObserver | null>
+  unreadMessageInViewIntersectionObserver: IntersectionObserver
 }
 
 const log = getLogger('renderer/message/MessageWrapper')
@@ -35,23 +35,18 @@ export function MessageWrapper(props: RenderMessageProps) {
       )
       return
     }
-    if (
-      !props.unreadMessageInViewIntersectionObserver.current ||
-      !props.unreadMessageInViewIntersectionObserver.current.observe
-    ) {
+    if (!props.unreadMessageInViewIntersectionObserver) {
       log.error(
         `MessageWrapper: key: ${props.key2} unreadMessageInViewIntersectionObserver is null. Returning`
       )
       return
     }
 
-    props.unreadMessageInViewIntersectionObserver.current.observe(
-      messageBottomElement
-    )
+    props.unreadMessageInViewIntersectionObserver.observe(messageBottomElement)
     log.debug(`MessageWrapper: key: ${props.key2} Successfully observing ;)`)
 
     return () =>
-      props.unreadMessageInViewIntersectionObserver.current?.unobserve(
+      props.unreadMessageInViewIntersectionObserver.unobserve(
         messageBottomElement
       )
   }, [


### PR DESCRIPTION
I believe this doens't affect behavior,
because the `onUnreadMessageInView` is already re-created
when its dependencies, namely `chat.id` and `accountId`, get changed,
and that's because we have the `MessageList` behind `key={chatId}`.

This should make it harder to introduce such bugs
where the observer closure captures a value which might become outdated.
Also simplifies things a bit, makes the observer non-nullable.

I have tested that the observer only gets created once after selecting a chat,
and does not get re-created when scrolling or jumping between messages
or placing reactions on messages.
