### PR TITLE
refactor: remove unnecessary React hook dep

### DIFF
--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -339,7 +339,6 @@ export default function MessageList({
     messageListItems.length,
     newestFetchedMessageListItemIndex,
     scheduler,
-    setShowJumpDownButton,
     showJumpDownButton,
   ])
   const onScrollEnd = useCallback((_ev: Event) => {


### PR DESCRIPTION
`setShowJumpDownButton` is `useState(...)[1]`,
which means that it never changes (see `useState` docs),
which is also confirmed by the fact that the linter doesn't complain.
