### PR TITLE
refactor: remove weird log entry in translations

### DIFF
--- a/packages/target-electron/src/load-translations.ts
+++ b/packages/target-electron/src/load-translations.ts
@@ -79,7 +79,6 @@ export function loadTranslations(locale: string): LocaleData {
     log.debug(`No experimental language file (${experimentalFile}) found`)
   }
 
-  log.debug(messages['no_chat_selected_suggestion_desktop'])
   return { messages, locale, dir: metaData?.dir ?? 'ltr' }
 }
 


### PR DESCRIPTION
It prints `DEBUG {"message":"Select a chat or create a new chat"}`.
