### PR TITLE
refactor: remove duplicate `composer.focus()`

### DIFF
--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -598,13 +598,9 @@ export default function MessageList({
   }, [refComposer, chat.id])
 
   useLayoutEffect(() => {
-    if (!messageListRef.current || !refComposer.current) {
+    if (!messageListRef.current) {
       return
     }
-    const composerTextarea = refComposer.current.querySelector(
-      '.create-or-edit-message-input'
-    )
-    composerTextarea && composerTextarea.focus()
     messageListRef.current.scrollTop = messageListRef.current.scrollHeight
   }, [refComposer])
 


### PR DESCRIPTION
I am not 100% sure that this will have no side effects.
But semantically this is correct.

This duplicate `focus()` has been introduced in
199ea232539e77ea9b4c903451b90a56dc880554
(https://github.com/deltachat/deltachat-desktop/pull/2007).
It's not really clear why it was added.
Maybe by mistake, or due to a misunderstand of how React works.
Whatever it was, it indeed simply duplicated the other `useEffect`.

Regarding the removal of the `!refComposer.current` condition:
that condition does not seem to be related to scrolling at all
but is rather there to simply make the possible
"refComposer.current is undefined" error not get printed.
It has been added in abc12674df7a976e9bb12604f70c09ea887aa99d
(https://github.com/deltachat/deltachat-desktop/pull/2490),
with a bunch of other changes.
