### PR TITLE
fix: chat list switching between archive by itself

### DIFF
--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react'
 
 import { ActionEmitter, KeybindAction } from '../keybindings'
 import { markChatAsSeen, saveLastChatId } from '../backend/chat'
@@ -166,7 +166,17 @@ export const ChatProvider = ({
   // eslint-disable-next-line react-hooks/refs
   unselectChatRef.current = unselectChat
 
-  if (useHasChanged2(chatNoLinger?.id) && chatNoLinger != undefined) {
+  const isArchivedChecked = useRef(false)
+  if (useHasChanged2(chatId) && chatId != undefined) {
+    // eslint-disable-next-line react-hooks/refs
+    isArchivedChecked.current = false
+  }
+  if (
+    // eslint-disable-next-line react-hooks/refs
+    !isArchivedChecked.current &&
+    chatNoLinger != undefined
+  ) {
+    isArchivedChecked.current = true
     // Switch to "archived" view if selected chat is there
     // @TODO: We probably want this to be part of the UI logic instead
     ActionEmitter.emitAction(

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -8,7 +8,6 @@ import type { RefObject, PropsWithChildren } from 'react'
 import type { T } from '@deltachat/jsonrpc-client'
 import { useFetch } from '../hooks/useFetch'
 import { getLogger } from '@deltachat-desktop/shared/logger'
-import { useHasChanged2 } from '../hooks/useHasChanged'
 
 const log = getLogger('ChatContext')
 
@@ -166,17 +165,14 @@ export const ChatProvider = ({
   // eslint-disable-next-line react-hooks/refs
   unselectChatRef.current = unselectChat
 
-  const isArchivedChecked = useRef(false)
-  if (useHasChanged2(chatId) && chatId != undefined) {
-    // eslint-disable-next-line react-hooks/refs
-    isArchivedChecked.current = false
-  }
+  const lastArchivedCheckChatId = useRef<number | undefined>(undefined)
   if (
+    chatNoLinger != undefined &&
     // eslint-disable-next-line react-hooks/refs
-    !isArchivedChecked.current &&
-    chatNoLinger != undefined
+    chatId !== lastArchivedCheckChatId.current
   ) {
-    isArchivedChecked.current = true
+    // eslint-disable-next-line react-hooks/refs
+    lastArchivedCheckChatId.current = chatId
     // Switch to "archived" view if selected chat is there
     // @TODO: We probably want this to be part of the UI logic instead
     ActionEmitter.emitAction(


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6253.

This bug has been introduced in
0bddb68a127f8626d81e8215c899a0c7bd94e8ce
(https://github.com/deltachat/deltachat-desktop/pull/5824).
The error is that `chatNoLinger` is `undefined` while
the chat is getting reloaded (`chatFetch.refresh`),
so `useHasChanged2()` returns `true` when the chat finishes refreshing,
whereas we only want to perform the "is archived?" check
on the initial load of the chat.

I have confirmed that this fixes the issue.

Edit: this could also be related to the archive switching bug that @ralphtheninja reported (see also https://github.com/deltachat/deltachat-desktop/issues/5993)