### PR TITLE
fix: don't refresh message list unnecessarily

### DIFF
--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -122,21 +122,37 @@ export function useMessageList(
         }
       }),
       onDCEvent(accountId, 'MsgsChanged', ({ chatId: eventChatId, msgId }) => {
-        if (msgId === 0 && (eventChatId === 0 || eventChatId === chatId)) {
+        if (eventChatId === 0) {
           store.effect.refresh()
-        } else {
-          store.effect.onEventMessagesChanged(msgId)
+          return
         }
+        if (eventChatId !== chatId) {
+          return
+        }
+        if (msgId === 0) {
+          store.effect.refresh()
+          return
+        }
+
+        store.effect.onEventMessagesChanged(msgId)
       }),
       onDCEvent(
         accountId,
         'ReactionsChanged',
         ({ chatId: eventChatId, msgId }) => {
-          if (msgId === 0 && (eventChatId === 0 || eventChatId === chatId)) {
+          if (eventChatId === 0) {
             store.effect.refresh()
-          } else {
-            store.effect.onEventMessagesChanged(msgId)
+            return
           }
+          if (eventChatId !== chatId) {
+            return
+          }
+          if (msgId === 0) {
+            store.effect.refresh()
+            return
+          }
+
+          store.effect.onEventMessagesChanged(msgId)
         }
       ),
       onDCEvent(accountId, 'MsgFailed', ({ chatId: eventChatId, msgId }) => {


### PR DESCRIPTION
The issue is, as you can see by looking at the event handlers,
that we always run either `onEventMessagesChanged()` or `refresh()`:
regardless of the value `eventChatId`,
which means that even if the event is about a different chat
then we still run the functions.

The bug has apparently been introduced in
cf9eb1f9c81b9d20d7eb36b76a664ae2e1363b75
(https://github.com/deltachat/deltachat-desktop/pull/2987).
We used to have the `if (eventChatId !== this.state.chat?.id) return`
condition, but it has been lost.

In the end this sometimes seems to cause the chat not to scroll down
when a new message arrives, which seems to involve
`scrollToLastKnownPosition`.
This has apparently been surfaced by
d1fbb309793934b3ca09ed5a0266b6c84e333dd0
(https://github.com/deltachat/deltachat-desktop/pull/6077).
