### PR TITLE
refactor: remove unused `areAllContactsVerified()`

### DIFF
--- a/packages/frontend/src/backend/chat.ts
+++ b/packages/frontend/src/backend/chat.ts
@@ -91,23 +91,6 @@ export async function createChatByContactId(
 }
 
 /**
- * Returns true if all contacts of a given list are verified, otherwise false.
- */
-export async function areAllContactsVerified(
-  accountId: number,
-  contactIds: number[]
-): Promise<boolean> {
-  const contacts = await BackendRemote.rpc.getContactsByIds(
-    accountId,
-    contactIds
-  )
-
-  return !contactIds.some(contactId => {
-    return !contacts[contactId].isVerified
-  })
-}
-
-/**
  * Helper method to determine the chat id of the "Device Messages" read-only chat.
  *
  * Note that there's currently no API to retrieve this id from the backend, this

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -46,7 +46,6 @@ import {
 } from '../../../utils/lastUsedPaths'
 import { dirname } from 'path'
 import QrCode from '../QrCode'
-import { areAllContactsVerified } from '../../../backend/chat'
 import AlertDialog from '../AlertDialog'
 import { unknownErrorToString } from '../../helpers/unknownErrorToString'
 
@@ -921,11 +920,10 @@ function useCreateGroup<
     let chatId: ChatId
     switch (groupType) {
       case GroupType.REGULAR_GROUP: {
-        const isVerified = await areAllContactsVerified(accountId, groupMembers)
         chatId = await BackendRemote.rpc.createGroupChat(
           accountId,
           groupName,
-          isVerified
+          false
         )
         break
       }


### PR DESCRIPTION
Core's `rpc.createGroupChat()` docs state:

> `protect` argument is deprecated as of 2025-10-22
> and is left for compatibility.
> Pass `false` here.
