### PR TITLE
refactor: remove unused `isVerified` param

### DIFF
--- a/packages/frontend/src/components/ContactName/index.tsx
+++ b/packages/frontend/src/components/ContactName/index.tsx
@@ -5,7 +5,6 @@ import styles from './styles.module.scss'
 type Props = {
   displayName: string
   address?: string
-  isVerified?: boolean
 }
 
 export default function ContactName(props: Props) {


### PR DESCRIPTION
It used to be used, but its usage has been removed in
95e7344262b7c21181afc357333dc97db6bb9333
(https://github.com/deltachat/deltachat-desktop/pull/5318).
