### PR TITLE
feat: a way to select multiple messages

### DIFF
--- a/packages/e2e-tests/tests/message-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/message-list-multiselect.spec.ts
@@ -1,0 +1,156 @@
+import { expect, type Page } from '@playwright/test'
+
+import {
+  importDummyProfileFromBackup,
+  deleteSelectedProfile,
+  reloadPage,
+  test,
+  createDummyChat,
+  selectChat,
+} from '../playwright-helper'
+
+test.describe.configure({
+  mode: 'serial',
+})
+
+// As of writing we use the same code for managing multiselect
+// in both the message list and the chat list.
+// These tests have mostly been copy-pasted from `chat-list-multiselet.spec.ts`.
+
+expect.configure({ timeout: 5_000 })
+test.setTimeout(30_000)
+
+// https://playwright.dev/docs/next/test-retries#reuse-single-page-between-tests
+let page: Page
+const textarea = () => page.locator('textarea.create-or-edit-message-input')
+function getMessageText(i: number) {
+  return `Some message ${i}`
+}
+const makeMessageRegex = (messageNum: number) =>
+  new RegExp(`Some message ${messageNum}(?!\\d)`)
+const getMessage = (messageNum: number) =>
+  page
+    .getByRole('list', { name: 'Messages' })
+    .getByRole('listitem')
+    .getByText(new RegExp(`Some message ${messageNum}(?!\\d)`))
+const expectSelectedMessages = async (messageNums: number[]) => {
+  await expect(
+    page
+      .getByRole('list', { name: 'Messages' })
+      .getByRole('listitem')
+      .locator('[aria-selected="true"]')
+  ).toHaveText(messageNums.map(n => makeMessageRegex(n)))
+}
+const expectMessages = async (messageNums: number[]) => {
+  await expect(
+    page
+      .getByRole('list', { name: 'Messages' })
+      .getByRole('listitem')
+      .filter({ hasText: 'Some message' })
+  ).toHaveText(messageNums.map(n => makeMessageRegex(n)))
+}
+
+test.beforeAll(async ({ browser }) => {
+  page = await browser.newPage()
+  await reloadPage(page)
+  await importDummyProfileFromBackup(page)
+
+  await createDummyChat(page, 'Some chat')
+  await selectChat(page, 'Some chat')
+
+  for (let i = 1; i <= 9; i++) {
+    await textarea().fill(getMessageText(i))
+    await textarea().press('ControlOrMeta+Enter')
+    await expect(textarea()).toBeEmpty()
+  }
+  await expectMessages([1, 2, 3, 4, 5, 6, 7, 8, 9])
+})
+
+test.afterAll(async ({ browser }) => {
+  await page?.close()
+
+  const context = await browser.newContext()
+  const pageForProfileDeletion = await context.newPage()
+  await reloadPage(pageForProfileDeletion)
+  await deleteSelectedProfile(pageForProfileDeletion)
+  await context.close()
+})
+
+test.describe('Ctrl + Click', () => {
+  test('add messages to selection', async () => {
+    await getMessage(8).click()
+    await expectSelectedMessages([])
+    await getMessage(5).click({
+      modifiers: ['ControlOrMeta'],
+    })
+    await expectSelectedMessages([5])
+    await getMessage(3).click({
+      modifiers: ['ControlOrMeta'],
+    })
+    await getMessage(1).click({
+      modifiers: ['ControlOrMeta'],
+    })
+    await expectSelectedMessages([1, 3, 5])
+  })
+
+  test('remove messages from selection', async () => {
+    await getMessage(5).click({
+      modifiers: ['ControlOrMeta'],
+    })
+    await expectSelectedMessages([1, 3])
+    await getMessage(3).click({
+      modifiers: ['ControlOrMeta'],
+    })
+    await expectSelectedMessages([1])
+    await getMessage(1).click({
+      modifiers: ['ControlOrMeta'],
+    })
+    await expectSelectedMessages([])
+  })
+
+  test('Ctrl + Space', async () => {
+    await expectSelectedMessages([])
+
+    await getMessage(4).click()
+    await page.keyboard.press('ControlOrMeta+Space')
+    await expectSelectedMessages([4])
+
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('ControlOrMeta+Space')
+    await expectSelectedMessages([4, 5])
+    await page.keyboard.press('ControlOrMeta+Space')
+    await expectSelectedMessages([4])
+    await page.keyboard.press('ArrowDown')
+    await page.keyboard.press('ControlOrMeta+Space')
+    await expectSelectedMessages([4, 6])
+  })
+})
+
+test('delete several', async () => {
+  await getMessage(7).click()
+  await getMessage(5).click({
+    modifiers: ['Shift'],
+  })
+  await getMessage(2).click({
+    modifiers: ['ControlOrMeta'],
+  })
+  await expectSelectedMessages([2, 5, 6, 7])
+
+  await getMessage(6).click({
+    button: 'right',
+  })
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+
+  await expect(page.getByRole('dialog')).toContainText('Delete 4 messages?')
+  await expect(page.getByRole('dialog').getByRole('button')).toHaveText([
+    'Cancel',
+    'Delete for Me',
+    'Delete for Everyone',
+  ])
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Delete for Everyone' })
+    .click()
+  await expectMessages([1, 3, 4, 8, 9])
+  await expectSelectedMessages([])
+})

--- a/packages/e2e-tests/tests/message-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/message-list-multiselect.spec.ts
@@ -126,6 +126,27 @@ test.describe('Ctrl + Click', () => {
   })
 })
 
+test('Click on dead space', async () => {
+  await getMessage(5).click()
+  await expectSelectedMessages([])
+
+  await getMessage(5).click({
+    modifiers: ['ControlOrMeta'],
+  })
+  await expectSelectedMessages([5])
+
+  // Space between message bubbles.
+  const deadSpace = page
+    .getByRole('list', { name: 'Messages' })
+    .filter({ has: page.getByText(makeMessageRegex(5)) })
+  await deadSpace.click({ modifiers: ['ControlOrMeta'] })
+  await expectSelectedMessages([5])
+  await deadSpace.click({ modifiers: ['Shift'] })
+  await expectSelectedMessages([5])
+  await deadSpace.click({ modifiers: [] })
+  await expectSelectedMessages([])
+})
+
 test('delete several', async () => {
   await getMessage(7).click()
   await getMessage(5).click({

--- a/packages/e2e-tests/tests/message-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/message-list-multiselect.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from '@playwright/test'
+import path from 'path'
 
 import {
   importDummyProfileFromBackup,
@@ -32,7 +33,9 @@ const getMessage = (messageNum: number) =>
   page
     .getByRole('list', { name: 'Messages' })
     .getByRole('listitem')
-    .getByText(new RegExp(`Some message ${messageNum}(?!\\d)`))
+    .locator('.message')
+    .filter({ hasText: new RegExp(`Some message ${messageNum}(?!\\d)`) })
+
 const expectSelectedMessages = async (messageNums: number[]) => {
   await expect(
     page
@@ -49,6 +52,9 @@ const expectMessages = async (messageNums: number[]) => {
       .filter({ hasText: 'Some message' })
   ).toHaveText(messageNums.map(n => makeMessageRegex(n)))
 }
+
+const fixturesPath = path.join(import.meta.dirname, '..', 'fixtures')
+const imagePath = path.join(fixturesPath, 'Deltachat-Logo.png')
 
 test.beforeAll(async ({ browser }) => {
   page = await browser.newPage()
@@ -124,6 +130,62 @@ test.describe('Ctrl + Click', () => {
     await page.keyboard.press('ControlOrMeta+Space')
     await expectSelectedMessages([4, 6])
   })
+})
+
+test("Ctrl+Click and Shift+Click don't activate clickable elements", async () => {
+  await getMessage(4).click()
+  await expectSelectedMessages([])
+
+  // Prepare a message with an image and a link.
+  const fileChooserPromise = page.waitForEvent('filechooser')
+  await page.getByRole('button', { name: 'Attach' }).click()
+  await page.getByRole('menuitem', { name: 'Image' }).click()
+  const fileChooser = await fileChooserPromise
+  await fileChooser.setFiles(imagePath)
+  await expect(
+    page.getByRole('region', { name: 'Write a message' }).getByRole('img')
+  ).toBeVisible()
+  await textarea().fill(
+    getMessageText(42) + '\nhttps://localhost/somepage.html'
+  )
+  await textarea().press('ControlOrMeta+Enter')
+
+  const image = getMessage(42).getByRole('img')
+  const link = getMessage(42).getByRole('link', {
+    name: 'https://localhost/somepage.html',
+  })
+  // Normally clicking the image opens the "View Image" dialog.
+  await image.click()
+  const closeDialogButton = page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Close' })
+  await closeDialogButton.click()
+
+  await getMessage(2).click({ modifiers: ['ControlOrMeta'] })
+  await expectSelectedMessages([2])
+
+  await link.click({ modifiers: ['ControlOrMeta'] })
+  await expectSelectedMessages([2, 42])
+  // If a "view image" dialog has been opened then the rest should not work,
+  // because the dialog makes outside content inert.
+  await image.click({ modifiers: ['ControlOrMeta'] })
+  await expectSelectedMessages([2])
+  await link.click({ modifiers: ['Shift'] })
+  await expectSelectedMessages([42])
+
+  await expect(closeDialogButton).not.toBeVisible()
+
+  await image.click()
+  await closeDialogButton.click()
+
+  // Clean up.
+  await image.click({ button: 'right' })
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Delete' })
+    .last()
+    .click()
 })
 
 test('Click on dead space', async () => {

--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -184,5 +184,21 @@
         -moz-animation: none;
       }
     }
+
+    // If you Shift+Click some messages then their text
+    // also gets selected, which looks pretty ugly.
+    // However, some people might still want to select text this way,
+    // so let's keep a really faint color for them.
+    //
+    // We apply this to the whole `<ol>` and not `<li>`
+    // because otherwise daymarkers are not affected by this
+    // (because they're not selectable).
+    &:has(.multiselectable-message[aria-selected='true'])::selection {
+      background-color: color-mix(
+        in srgb,
+        var(--messageHightlightColor) 5%,
+        transparent
+      );
+    }
   }
 }

--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -174,6 +174,15 @@
           background-color: transparent;
         }
       }
+
+      &:has(.multiselectable-message[aria-selected='true']) {
+        background-color: var(--messageHightlightColor);
+
+        // Don't play the color fade animation in case the message is both
+        // `.highlight`ed and selected.
+        -webkit-animation: none;
+        -moz-animation: none;
+      }
     }
   }
 }

--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -105,6 +105,22 @@
     &::-webkit-scrollbar-track {
       background: transparent;
     }
+
+    // If you Shift+Click some messages then their text
+    // also gets selected, which looks pretty ugly.
+    // However, some people might still want to select text this way,
+    // so let's keep a really faint color for them.
+    //
+    // We apply this to the whole `<ol>` and not `<li>`
+    // because otherwise daymarkers are not affected by this
+    // (because they're not selectable).
+    &.multiselected-one-or-more::selection {
+      background-color: color-mix(
+        in srgb,
+        var(--messageHightlightColor) 5%,
+        transparent
+      );
+    }
   }
 
   ol {

--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -114,7 +114,12 @@
     // We apply this to the whole `<ol>` and not `<li>`
     // because otherwise daymarkers are not affected by this
     // (because they're not selectable).
-    &.multiselected-one-or-more::selection {
+    //
+    // Only apply this if two or more are selected because if the user
+    // tries to simply select text in a message with Shift + Click
+    // then that will select the message,
+    // in which case we should not faint the color.
+    &.multiselected-two-or-more::selection {
       background-color: color-mix(
         in srgb,
         var(--messageHightlightColor) 5%,

--- a/packages/frontend/src/components/attachment/galleryAttachment.tsx
+++ b/packages/frontend/src/components/attachment/galleryAttachment.tsx
@@ -101,7 +101,8 @@ const contextMenuFactory = (
         )
         openDialog(ConfirmDeleteMessageDialog, {
           accountId,
-          msg: message,
+          messageIds: [message.id],
+          loadedMessages: { [message.id]: message },
           chat,
         })
       },

--- a/packages/frontend/src/components/attachment/galleryAttachment.tsx
+++ b/packages/frontend/src/components/attachment/galleryAttachment.tsx
@@ -95,7 +95,8 @@ const contextMenuFactory = (
         )
         openDialog(ConfirmDeleteMessageDialog, {
           accountId,
-          msg: message,
+          messageIds: [message.id],
+          loadedMessages: { [message.id]: message },
           chat,
         })
       },

--- a/packages/frontend/src/components/dialogs/ConfirmDeleteMessage.tsx
+++ b/packages/frontend/src/components/dialogs/ConfirmDeleteMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useCallback, useContext } from 'react'
 
 import Dialog, {
   DialogBody,
@@ -13,10 +13,17 @@ import type { DialogProps } from '../../contexts/DialogContext'
 import { BackendRemote, Type } from '../../backend-com'
 import { C } from '@deltachat/jsonrpc-client'
 import { ScreenContext } from '../../contexts/ScreenContext'
+import { useFetch } from '../../hooks/useFetch'
+import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
 
 export type Props = {
   accountId: number
-  msg: Type.Message
+  messageIds: Array<Type.Message['id']>
+  /**
+   * If some messages from {@linkcode messageIds} are already loaded,
+   * provide them here for better performance.
+   */
+  loadedMessages: { [id: Type.Message['id']]: Type.Message | undefined }
   chat: Type.FullChat
 } & DialogProps
 
@@ -24,19 +31,65 @@ export default function ConfirmDeleteMessageDialog(props: Props) {
   const tx = useTranslationFunction()
   const { userFeedback } = useContext(ScreenContext)
 
-  const { accountId, msg, chat, onClose } = props
+  const { accountId, chat, onClose, messageIds, loadedMessages } = props
 
-  const deleteForAllPossible =
-    msg.sender.id === C.DC_CONTACT_ID_SELF &&
-    !msg.isInfo &&
-    chat.canSend &&
-    !chat.isSelfTalk &&
-    chat.isEncrypted
+  const deleteForAllPossibleFetch = useFetch(
+    useCallback(async () => {
+      if (!chat.canSend || chat.isSelfTalk || !chat.isEncrypted) {
+        return false
+      }
+
+      // Check all the loaded messages
+      function msgDeleteForAllPossible(msg: Type.Message): boolean {
+        return msg.sender.id === C.DC_CONTACT_ID_SELF && !msg.isInfo
+      }
+      if (
+        messageIds
+          .map(id => loadedMessages[id])
+          .filter(m => m != undefined)
+          .some(m => !msgDeleteForAllPossible(m))
+      ) {
+        return false
+      }
+      const missingMessageIds = messageIds.filter(
+        id => loadedMessages[id] == undefined
+      )
+      if (missingMessageIds.length === 0) {
+        return true
+      }
+
+      // Still not decided. Load missing messages and check them as well.
+      if (
+        Object.values(
+          await BackendRemote.rpc.getMessages(accountId, missingMessageIds)
+        ).some((m, ind) => {
+          if (m.kind === 'loadingError') {
+            throw new Error(
+              `Could not load message with ID ${missingMessageIds[ind]}`
+            )
+          }
+
+          return !msgDeleteForAllPossible(m)
+        })
+      ) {
+        return false
+      }
+      return true
+    }, [
+      accountId,
+      chat.canSend,
+      chat.isEncrypted,
+      chat.isSelfTalk,
+      loadedMessages,
+      messageIds,
+    ]),
+    []
+  )
 
   const deleteMessage = (deleteForEveryone: boolean) => {
     if (deleteForEveryone) {
       BackendRemote.rpc
-        .deleteMessagesForAll(accountId, [msg.id])
+        .deleteMessagesForAll(accountId, messageIds)
         .catch((err: Error) => {
           userFeedback({
             type: 'error',
@@ -45,7 +98,7 @@ export default function ConfirmDeleteMessageDialog(props: Props) {
         })
     } else {
       BackendRemote.rpc
-        .deleteMessages(accountId, [msg.id])
+        .deleteMessages(accountId, messageIds)
         .catch((err: Error) => {
           userFeedback({
             type: 'error',
@@ -60,29 +113,66 @@ export default function ConfirmDeleteMessageDialog(props: Props) {
     <Dialog onClose={onClose}>
       <DialogBody>
         <DialogContent>
-          <p className='whitespace'>{tx('ask_delete_message')}</p>
+          <p className='whitespace'>
+            {messageIds.length > 1
+              ? tx('ask_delete_messages', messageIds.length.toString(), {
+                  quantity: messageIds.length,
+                })
+              : tx('ask_delete_message')}
+          </p>
         </DialogContent>
+        {deleteForAllPossibleFetch.result?.ok === false && (
+          <p>
+            {tx(
+              'error_x',
+              'Failed to check if we can delete the messages for everyone:\n' +
+                unknownErrorToString(deleteForAllPossibleFetch.result.err)
+            )}
+          </p>
+        )}
       </DialogBody>
       <DialogFooter>
         <FooterActions>
-          <FooterActionButton onClick={() => onClose()} data-testid='cancel'>
-            {tx('cancel')}
-          </FooterActionButton>
+          {/* Don't show any buttons while loading
+          to ensure that the user doesn't click the wrong one
+          due to layout shifting when we finish loading.
+          But display the actual (disabled) button element
+          to ensure that the height of the dialog remains the same. */}
           <FooterActionButton
-            styling={'danger'}
-            onClick={() => deleteMessage(false)}
-            data-testid='delete_for_me'
+            onClick={() => onClose()}
+            data-testid='cancel'
+            disabled={deleteForAllPossibleFetch.loading}
           >
-            {chat.isSelfTalk ? tx('delete') : tx('delete_for_me')}
+            {deleteForAllPossibleFetch.loading ? tx('loading') : tx('cancel')}
           </FooterActionButton>
-          {deleteForAllPossible && (
-            <FooterActionButton
-              styling={'danger'}
-              onClick={() => deleteMessage(true)}
-              data-testid='delete_for_everyone'
-            >
-              {tx('delete_for_everyone')}
-            </FooterActionButton>
+          {deleteForAllPossibleFetch.loading ? (
+            <p>{tx('loading')}</p>
+          ) : (
+            <>
+              <FooterActionButton
+                styling={'danger'}
+                onClick={() => deleteMessage(false)}
+                data-testid='delete_for_me'
+              >
+                {chat.isSelfTalk ? tx('delete') : tx('delete_for_me')}
+              </FooterActionButton>
+              {/* The error is handled above.
+              One might think that it's better to show the button by default
+              if we failed to check if deleting for everyone is possible,
+              and then simply showing an error if Core returns an error.
+              But we shouldn't do it until the behavior
+              of `deleteMessagesForAll()` is clearly defined and documented. */}
+              {deleteForAllPossibleFetch.result.ok &&
+                deleteForAllPossibleFetch.result.value && (
+                  <FooterActionButton
+                    styling={'danger'}
+                    onClick={() => deleteMessage(true)}
+                    data-testid='delete_for_everyone'
+                  >
+                    {tx('delete_for_everyone')}
+                  </FooterActionButton>
+                )}
+            </>
           )}
         </FooterActions>
       </DialogFooter>

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -120,13 +120,14 @@ export default function ForwardMessage(props: ForwardMessageProps) {
         }
         // get the (new) id of forwarded message
         // and jump to the message
-        const messageIds = await BackendRemote.rpc.getMessageIds(
+        const targetChatMessageIds = await BackendRemote.rpc.getMessageIds(
           targetAccountId,
           chatId,
           false,
           true
         )
-        const lastMessage = messageIds[messageIds.length - 1]
+        const lastMessage =
+          targetChatMessageIds[targetChatMessageIds.length - 1]
         if (lastMessage) {
           if (isCrossAccountForward) {
             // For cross-account, use the internal jump mechanism

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -26,12 +26,16 @@ import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToSt
 const log = getLogger('ForwardMessage')
 
 type ForwardMessageProps = {
-  message: T.Message
+  messageIds: Array<T.Message['id']>
+  /**
+   * ID of the chat that the {@linkcode messageIds} belong to.
+   */
+  sourceChatId: T.Message['chatId'] | T.BasicChat['id']
   onClose: DialogProps['onClose']
 }
 
 export default function ForwardMessage(props: ForwardMessageProps) {
-  const { message, onClose } = props
+  const { messageIds, sourceChatId, onClose } = props
 
   const currentAccountId = selectedAccountId()
   const [targetAccountId, setTargetAccountId] = useState(currentAccountId)
@@ -99,7 +103,7 @@ export default function ForwardMessage(props: ForwardMessageProps) {
             // Cross-account forward
             await BackendRemote.rpc.forwardMessagesToAccount(
               currentAccountId,
-              [message.id],
+              messageIds,
               targetAccountId,
               chat.id
             )
@@ -107,7 +111,7 @@ export default function ForwardMessage(props: ForwardMessageProps) {
             // Same-account forward
             await BackendRemote.rpc.forwardMessages(
               currentAccountId,
-              [message.id],
+              messageIds,
               chat.id
             )
           }
@@ -156,10 +160,10 @@ export default function ForwardMessage(props: ForwardMessageProps) {
       } else {
         // If user cancels and we switched accounts, go back to original account and chat
         if (isCrossAccountForward) {
-          await saveLastChatId(currentAccountId, message.chatId)
+          await saveLastChatId(currentAccountId, sourceChatId)
           await window.__selectAccount(currentAccountId)
         } else {
-          selectChat(currentAccountId, message.chatId)
+          selectChat(currentAccountId, sourceChatId)
         }
       }
     } else {
@@ -168,14 +172,14 @@ export default function ForwardMessage(props: ForwardMessageProps) {
         if (isCrossAccountForward) {
           await BackendRemote.rpc.forwardMessagesToAccount(
             currentAccountId,
-            [message.id],
+            messageIds,
             targetAccountId,
             chat.id
           )
         } else {
           await BackendRemote.rpc.forwardMessages(
             currentAccountId,
-            [message.id],
+            messageIds,
             chat.id
           )
         }

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -21,12 +21,16 @@ import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToSt
 const log = getLogger('ForwardMessage')
 
 type ForwardMessageProps = {
-  message: T.Message
+  messageIds: Array<T.Message['id']>
+  /**
+   * ID of the chat that the {@linkcode messageIds} belong to.
+   */
+  sourceChatId: T.Message['chatId'] | T.BasicChat['id']
   onClose: DialogProps['onClose']
 }
 
 export default function ForwardMessage(props: ForwardMessageProps) {
-  const { message, onClose } = props
+  const { messageIds, sourceChatId, onClose } = props
 
   const currentAccountId = selectedAccountId()
 
@@ -75,7 +79,7 @@ export default function ForwardMessage(props: ForwardMessageProps) {
             // Cross-account forward
             await BackendRemote.rpc.forwardMessagesToAccount(
               currentAccountId,
-              [message.id],
+              messageIds,
               targetAccountId,
               chat.id
             )
@@ -83,7 +87,7 @@ export default function ForwardMessage(props: ForwardMessageProps) {
             // Same-account forward
             await BackendRemote.rpc.forwardMessages(
               currentAccountId,
-              [message.id],
+              messageIds,
               chat.id
             )
           }
@@ -132,10 +136,10 @@ export default function ForwardMessage(props: ForwardMessageProps) {
       } else {
         // If user cancels and we switched accounts, go back to original account and chat
         if (isCrossAccountForward) {
-          await saveLastChatId(currentAccountId, message.chatId)
+          await saveLastChatId(currentAccountId, sourceChatId)
           await window.__selectAccount(currentAccountId)
         } else {
-          selectChat(currentAccountId, message.chatId)
+          selectChat(currentAccountId, sourceChatId)
         }
       }
     } else {
@@ -144,14 +148,14 @@ export default function ForwardMessage(props: ForwardMessageProps) {
         if (isCrossAccountForward) {
           await BackendRemote.rpc.forwardMessagesToAccount(
             currentAccountId,
-            [message.id],
+            messageIds,
             targetAccountId,
             chat.id
           )
         } else {
           await BackendRemote.rpc.forwardMessages(
             currentAccountId,
-            [message.id],
+            messageIds,
             chat.id
           )
         }

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -96,13 +96,14 @@ export default function ForwardMessage(props: ForwardMessageProps) {
         }
         // get the (new) id of forwarded message
         // and jump to the message
-        const messageIds = await BackendRemote.rpc.getMessageIds(
+        const targetChatMessageIds = await BackendRemote.rpc.getMessageIds(
           targetAccountId,
           chatId,
           false,
           true
         )
-        const lastMessage = messageIds[messageIds.length - 1]
+        const lastMessage =
+          targetChatMessageIds[targetChatMessageIds.length - 1]
         if (lastMessage) {
           if (isCrossAccountForward) {
             // For cross-account, use the internal jump mechanism

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -474,6 +474,8 @@ export default function Message(props: {
   const openViewGroupDialog = useOpenViewGroupDialog()
   const { jumpToMessage } = useMessage()
   const [messageWidth, setMessageWidth] = useState(0)
+  const ref = useRef<any>(null)
+  const rovingTabindex = useRovingTabindex(ref)
 
   const showContextMenu = useCallback(
     (
@@ -551,8 +553,6 @@ export default function Message(props: {
       tx,
     ]
   )
-  const ref = useRef<any>(null)
-  const rovingTabindex = useRovingTabindex(ref)
   const commonAttrs = {
     ref,
     tabIndex: rovingTabindex.tabIndex,

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -445,7 +445,8 @@ function buildContextMenu(
       action: () =>
         openDialog(ConfirmDeleteMessageDialog, {
           accountId,
-          msg: message,
+          messageIds: [message.id],
+          loadedMessages: { [message.id]: message },
           chat,
         }),
       danger: true,
@@ -454,11 +455,15 @@ function buildContextMenu(
 }
 function buildMultiselectContextMenu(
   {
+    accountId,
     messageIds,
+    message: clickedMessage,
     openDialog,
     chat,
   }: {
+    accountId: number
     messageIds: Array<T.Message['id']>
+    message: T.Message
     openDialog: OpenDialog
     chat: T.FullChat
   },
@@ -473,6 +478,17 @@ function buildMultiselectContextMenu(
           messageIds: messageIds,
           sourceChatId: chat.id,
         }),
+    },
+    {
+      label: tx('delete'),
+      action: () =>
+        openDialog(ConfirmDeleteMessageDialog, {
+          accountId,
+          messageIds,
+          loadedMessages: { [clickedMessage.id]: clickedMessage },
+          chat,
+        }),
+      danger: true,
     },
   ]
 }
@@ -550,6 +566,7 @@ export default function Message(props: {
       const target = ((event as any).t || event.target) as HTMLAnchorElement
       const common = {
         accountId,
+        message,
         text: text || undefined,
         conversationType,
         openDialog,
@@ -566,13 +583,7 @@ export default function Message(props: {
             },
             target
           )
-        : buildContextMenu(
-            {
-              ...common,
-              message,
-            },
-            target
-          )
+        : buildContextMenu(common, target)
 
       openContextMenu({
         ...showContextMenuEventPos,
@@ -687,7 +698,7 @@ export default function Message(props: {
 
       // Check if Delete key is pressed to delete message
       if (
-        onlyThisMsgSelected &&
+        thisMsgSelected &&
         !e.ctrlKey &&
         !e.metaKey &&
         !e.altKey &&
@@ -699,7 +710,8 @@ export default function Message(props: {
         e.stopPropagation()
         openDialog(ConfirmDeleteMessageDialog, {
           accountId,
-          msg: message,
+          messageIds: [...messageIds],
+          loadedMessages: { [message.id]: message },
           chat,
         })
         return

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -59,7 +59,7 @@ import type { OpenDialog } from '../../contexts/DialogContext'
 import type { PrivateReply } from '../../hooks/chat/usePrivateReply'
 import type { JumpToMessage } from '../../hooks/chat/useMessage'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
-import { useRovingTabindex } from '../../contexts/RovingTabindex'
+import { useMessageFocusAndMultiselect } from './focusAndMultiselect'
 import { avatarInitial } from '@deltachat-desktop/shared/avatarInitial'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { IconButton } from '../Icon'
@@ -452,6 +452,30 @@ function buildContextMenu(
     },
   ]
 }
+function buildMultiselectContextMenu(
+  {
+    messageIds,
+    openDialog,
+    chat,
+  }: {
+    messageIds: Array<T.Message['id']>
+    openDialog: OpenDialog
+    chat: T.FullChat
+  },
+  _clickTarget: HTMLAnchorElement | null
+): (false | ContextMenuItem)[] {
+  const tx = window.static_translate
+  return [
+    {
+      label: tx('forward'),
+      action: () =>
+        openDialog(ForwardMessage, {
+          messageIds: messageIds,
+          sourceChatId: chat.id,
+        }),
+    },
+  ]
+}
 
 export default function Message(props: {
   chat: T.FullChat
@@ -475,7 +499,12 @@ export default function Message(props: {
   const { jumpToMessage } = useMessage()
   const [messageWidth, setMessageWidth] = useState(0)
   const ref = useRef<any>(null)
-  const rovingTabindex = useRovingTabindex(ref)
+
+  const focusAndMultiselect = useMessageFocusAndMultiselect(message.id, ref)
+  const resetSelection = focusAndMultiselect.resetSelection
+  const isMultiselectMember =
+    focusAndMultiselect.selectedItems.size > 1 &&
+    focusAndMultiselect.selectedItems.has(message.id)
 
   const showContextMenu = useCallback(
     (
@@ -514,22 +543,36 @@ export default function Message(props: {
         })
       }
 
+      if (!isMultiselectMember) {
+        resetSelection()
+      }
       // the event.t is a workaround for labled links, as they will be able to contain markdown formatting in the label in the future.
       const target = ((event as any).t || event.target) as HTMLAnchorElement
-      const items = buildContextMenu(
-        {
-          accountId,
-          message,
-          text: text || undefined,
-          conversationType,
-          openDialog,
-          privateReply,
-          handleReactClick,
-          chat: props.chat,
-          jumpToMessage,
-        },
-        target
-      )
+      const common = {
+        accountId,
+        text: text || undefined,
+        conversationType,
+        openDialog,
+        privateReply,
+        handleReactClick,
+        chat: props.chat,
+        jumpToMessage,
+      }
+      const items = isMultiselectMember
+        ? buildMultiselectContextMenu(
+            {
+              ...common,
+              messageIds: [...focusAndMultiselect.selectedItems],
+            },
+            target
+          )
+        : buildContextMenu(
+            {
+              ...common,
+              message,
+            },
+            target
+          )
 
       openContextMenu({
         ...showContextMenuEventPos,
@@ -544,6 +587,9 @@ export default function Message(props: {
       props.chat,
       conversationType,
       message,
+      isMultiselectMember,
+      focusAndMultiselect.selectedItems,
+      resetSelection,
       openContextMenu,
       openDialog,
       privateReply,
@@ -553,9 +599,13 @@ export default function Message(props: {
       tx,
     ]
   )
+  const commonClassName = classNames(
+    focusAndMultiselect.className,
+    'multiselectable-message'
+  )
   const commonAttrs = {
     ref,
-    tabIndex: rovingTabindex.tabIndex,
+    tabIndex: focusAndMultiselect.tabIndex,
     onKeyDown: (e: React.KeyboardEvent) => {
       // Handle letter shortcuts with Ctrl/Cmd modifier
       const isCtrlOrMetaKeyPress =
@@ -669,15 +719,17 @@ export default function Message(props: {
         // there would be no way to switch focus to another item
         // using just the keyboard.
         // Again, at the time of writing we do not have such elements.
-        !e.target.classList.contains(rovingTabindex.className)
+        !e.target.classList.contains(focusAndMultiselect.className)
       ) {
         return
       }
 
-      rovingTabindex.onKeydown(e)
+      focusAndMultiselect.onKeyDown(e)
+      // if (e.defaultPrevented)
     },
-    onFocus: rovingTabindex.setAsActiveElement,
-  }
+    onFocus: focusAndMultiselect.onFocus,
+    'aria-selected': focusAndMultiselect.selectedItems.has(message.id),
+  } satisfies React.HTMLAttributes<Element> & React.RefAttributes<Element>
   // When the message is not the active one
   // `rovingTabindex.tabIndex === -1`, we need to set `tabindex="-1"`
   // to all its interactive (otherwise "Tabbable to") elements,
@@ -688,7 +740,7 @@ export default function Message(props: {
   // WhatsApp appears to behave similarly.
   // The implementation is similar to the "Grid" pattern:
   // https://www.w3.org/WAI/ARIA/apg/patterns/grid/#gridNav_inside
-  const tabindexForInteractiveContents = rovingTabindex.tabIndex
+  const tabindexForInteractiveContents = focusAndMultiselect.tabIndex
 
   const messageContainerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -739,7 +791,7 @@ export default function Message(props: {
       isProtectionEnabledMsg ||
       isInvalidUnencryptedMail
 
-    let onClick
+    let onClick: undefined | (() => void)
     if (isInteractive) {
       onClick = async () => {
         if (isWebxdcInfo) {
@@ -778,8 +830,14 @@ export default function Message(props: {
         onContextMenu={showContextMenu}
       >
         <TagName
-          className={'bubble ' + rovingTabindex.className}
-          onClick={onClick}
+          className={'bubble ' + commonClassName}
+          onClick={e => {
+            focusAndMultiselect.onClick(e)
+            if (e.defaultPrevented) {
+              return
+            }
+            onClick?.()
+          }}
           {...commonAttrs}
           // Note that the actual `onContextMenu` listener
           // is on the wrapper component.
@@ -886,7 +944,7 @@ export default function Message(props: {
         'message',
         direction,
         styles.message,
-        rovingTabindex.className,
+        commonClassName,
         isWithoutText && isVideo(fileMime) ? 'video-only' : '',
         {
           [styles.withReactions]: message.reactions,
@@ -897,6 +955,12 @@ export default function Message(props: {
         }
       )}
       id={message.id.toString()}
+      onClick={e => {
+        focusAndMultiselect.onClick(e)
+        if (e.defaultPrevented) {
+          return
+        }
+      }}
       {...commonAttrs}
     >
       {showAuthor && direction === 'incoming' && (

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -607,12 +607,19 @@ export default function Message(props: {
     ref,
     tabIndex: focusAndMultiselect.tabIndex,
     onKeyDown: (e: React.KeyboardEvent) => {
+      const messageIds =
+        focusAndMultiselect.selectedItems.size === 0
+          ? new Set([message.id])
+          : focusAndMultiselect.selectedItems
+      const thisMsgSelected = messageIds.has(message.id)
+      const onlyThisMsgSelected = thisMsgSelected && messageIds.size === 1
       // Handle letter shortcuts with Ctrl/Cmd modifier
       const isCtrlOrMetaKeyPress =
         (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && message
 
       // Check if Ctrl/Cmd+"e" is pressed to enter edit mode
       if (
+        onlyThisMsgSelected &&
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 'e') &&
         isMessageEditable(message, props.chat)
@@ -625,6 +632,7 @@ export default function Message(props: {
 
       // Check if Ctrl/Cmd+"r" is pressed to react to message
       if (
+        onlyThisMsgSelected &&
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 'r') &&
         showReactionsUi(message, props.chat)
@@ -649,6 +657,7 @@ export default function Message(props: {
       // Check if Ctrl/Cmd+"s" is pressed to save message
       if (
         isCtrlOrMetaKeyPress &&
+        onlyThisMsgSelected &&
         matchesLetterShortcut(e, 's') &&
         !chat.isSelfTalk &&
         message.savedMessageId === null &&
@@ -662,6 +671,7 @@ export default function Message(props: {
 
       // Check if Ctrl/Cmd+Shift+"s" is pressed to unsave message
       if (
+        onlyThisMsgSelected &&
         (e.ctrlKey || e.metaKey) &&
         e.shiftKey &&
         !e.altKey &&
@@ -677,6 +687,7 @@ export default function Message(props: {
 
       // Check if Delete key is pressed to delete message
       if (
+        onlyThisMsgSelected &&
         !e.ctrlKey &&
         !e.metaKey &&
         !e.altKey &&

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -330,7 +330,11 @@ function buildContextMenu(
     // Forward message
     {
       label: tx('forward'),
-      action: () => openDialog(ForwardMessage, { message }),
+      action: () =>
+        openDialog(ForwardMessage, {
+          messageIds: [message.id],
+          sourceChatId: message.chatId,
+        }),
     },
     // Save Message
     // For reference, the conditions when it's shown:

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -332,7 +332,11 @@ function buildContextMenu(
     // Forward message
     {
       label: tx('forward'),
-      action: () => openDialog(ForwardMessage, { message }),
+      action: () =>
+        openDialog(ForwardMessage, {
+          messageIds: [message.id],
+          sourceChatId: message.chatId,
+        }),
     },
     // Save Message
     // For reference, the conditions when it's shown:

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -59,7 +59,7 @@ import type { OpenDialog } from '../../contexts/DialogContext'
 import type { PrivateReply } from '../../hooks/chat/usePrivateReply'
 import type { JumpToMessage } from '../../hooks/chat/useMessage'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
-import { useRovingTabindex } from '../../contexts/RovingTabindex'
+import { useMessageFocusAndMultiselect } from './focusAndMultiselect'
 import { avatarInitial } from '@deltachat-desktop/shared/avatarInitial'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { IconButton } from '../Icon'
@@ -454,6 +454,30 @@ function buildContextMenu(
     },
   ]
 }
+function buildMultiselectContextMenu(
+  {
+    messageIds,
+    openDialog,
+    chat,
+  }: {
+    messageIds: Array<T.Message['id']>
+    openDialog: OpenDialog
+    chat: T.FullChat
+  },
+  _clickTarget: HTMLAnchorElement | null
+): (false | ContextMenuItem)[] {
+  const tx = window.static_translate
+  return [
+    {
+      label: tx('forward'),
+      action: () =>
+        openDialog(ForwardMessage, {
+          messageIds: messageIds,
+          sourceChatId: chat.id,
+        }),
+    },
+  ]
+}
 
 export default function Message(props: {
   chat: T.FullChat
@@ -477,7 +501,12 @@ export default function Message(props: {
   const { jumpToMessage } = useMessage()
   const [messageWidth, setMessageWidth] = useState(0)
   const ref = useRef<any>(null)
-  const rovingTabindex = useRovingTabindex(ref)
+
+  const focusAndMultiselect = useMessageFocusAndMultiselect(message.id, ref)
+  const resetSelection = focusAndMultiselect.resetSelection
+  const isMultiselectMember =
+    focusAndMultiselect.selectedItems.size > 1 &&
+    focusAndMultiselect.selectedItems.has(message.id)
 
   const showContextMenu = useCallback(
     (
@@ -516,22 +545,36 @@ export default function Message(props: {
         })
       }
 
+      if (!isMultiselectMember) {
+        resetSelection()
+      }
       // the event.t is a workaround for labled links, as they will be able to contain markdown formatting in the label in the future.
       const target = ((event as any).t || event.target) as HTMLAnchorElement
-      const items = buildContextMenu(
-        {
-          accountId,
-          message,
-          text: text || undefined,
-          conversationType,
-          openDialog,
-          privateReply,
-          handleReactClick,
-          chat: props.chat,
-          jumpToMessage,
-        },
-        target
-      )
+      const common = {
+        accountId,
+        text: text || undefined,
+        conversationType,
+        openDialog,
+        privateReply,
+        handleReactClick,
+        chat: props.chat,
+        jumpToMessage,
+      }
+      const items = isMultiselectMember
+        ? buildMultiselectContextMenu(
+            {
+              ...common,
+              messageIds: [...focusAndMultiselect.selectedItems],
+            },
+            target
+          )
+        : buildContextMenu(
+            {
+              ...common,
+              message,
+            },
+            target
+          )
 
       openContextMenu({
         ...showContextMenuEventPos,
@@ -546,6 +589,9 @@ export default function Message(props: {
       props.chat,
       conversationType,
       message,
+      isMultiselectMember,
+      focusAndMultiselect.selectedItems,
+      resetSelection,
       openContextMenu,
       openDialog,
       privateReply,
@@ -555,9 +601,13 @@ export default function Message(props: {
       tx,
     ]
   )
+  const commonClassName = classNames(
+    focusAndMultiselect.className,
+    'multiselectable-message'
+  )
   const commonAttrs = {
     ref,
-    tabIndex: rovingTabindex.tabIndex,
+    tabIndex: focusAndMultiselect.tabIndex,
     onKeyDown: (e: React.KeyboardEvent) => {
       // Handle letter shortcuts with Ctrl/Cmd modifier
       const isCtrlOrMetaKeyPress =
@@ -671,15 +721,17 @@ export default function Message(props: {
         // there would be no way to switch focus to another item
         // using just the keyboard.
         // Again, at the time of writing we do not have such elements.
-        !e.target.classList.contains(rovingTabindex.className)
+        !e.target.classList.contains(focusAndMultiselect.className)
       ) {
         return
       }
 
-      rovingTabindex.onKeydown(e)
+      focusAndMultiselect.onKeyDown(e)
+      // if (e.defaultPrevented)
     },
-    onFocus: rovingTabindex.setAsActiveElement,
-  }
+    onFocus: focusAndMultiselect.onFocus,
+    'aria-selected': focusAndMultiselect.selectedItems.has(message.id),
+  } satisfies React.HTMLAttributes<Element> & React.RefAttributes<Element>
   // When the message is not the active one
   // `rovingTabindex.tabIndex === -1`, we need to set `tabindex="-1"`
   // to all its interactive (otherwise "Tabbable to") elements,
@@ -690,7 +742,7 @@ export default function Message(props: {
   // WhatsApp appears to behave similarly.
   // The implementation is similar to the "Grid" pattern:
   // https://www.w3.org/WAI/ARIA/apg/patterns/grid/#gridNav_inside
-  const tabindexForInteractiveContents = rovingTabindex.tabIndex
+  const tabindexForInteractiveContents = focusAndMultiselect.tabIndex
 
   const messageContainerRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -737,7 +789,7 @@ export default function Message(props: {
       isProtectionEnabledMsg ||
       isInvalidUnencryptedMail
 
-    let onClick
+    let onClick: undefined | (() => void)
     if (isInteractive) {
       onClick = async () => {
         if (isWebxdcInfo) {
@@ -777,8 +829,14 @@ export default function Message(props: {
       >
         <TagName
           type='button'
-          className={'bubble ' + rovingTabindex.className}
-          onClick={onClick}
+          className={'bubble ' + commonClassName}
+          onClick={e => {
+            focusAndMultiselect.onClick(e)
+            if (e.defaultPrevented) {
+              return
+            }
+            onClick?.()
+          }}
           {...commonAttrs}
           // Note that the actual `onContextMenu` listener
           // is on the wrapper component.
@@ -885,7 +943,7 @@ export default function Message(props: {
         'message',
         direction,
         styles.message,
-        rovingTabindex.className,
+        commonClassName,
         isWithoutText && viewType === 'Video' ? 'video-only' : '',
         {
           [styles.withReactions]: message.reactions,
@@ -896,6 +954,12 @@ export default function Message(props: {
         }
       )}
       id={message.id.toString()}
+      onClick={e => {
+        focusAndMultiselect.onClick(e)
+        if (e.defaultPrevented) {
+          return
+        }
+      }}
       {...commonAttrs}
     >
       {showAuthor && direction === 'incoming' && (

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -447,7 +447,8 @@ function buildContextMenu(
       action: () =>
         openDialog(ConfirmDeleteMessageDialog, {
           accountId,
-          msg: message,
+          messageIds: [message.id],
+          loadedMessages: { [message.id]: message },
           chat,
         }),
       danger: true,
@@ -456,11 +457,15 @@ function buildContextMenu(
 }
 function buildMultiselectContextMenu(
   {
+    accountId,
     messageIds,
+    message: clickedMessage,
     openDialog,
     chat,
   }: {
+    accountId: number
     messageIds: Array<T.Message['id']>
+    message: T.Message
     openDialog: OpenDialog
     chat: T.FullChat
   },
@@ -475,6 +480,17 @@ function buildMultiselectContextMenu(
           messageIds: messageIds,
           sourceChatId: chat.id,
         }),
+    },
+    {
+      label: tx('delete'),
+      action: () =>
+        openDialog(ConfirmDeleteMessageDialog, {
+          accountId,
+          messageIds,
+          loadedMessages: { [clickedMessage.id]: clickedMessage },
+          chat,
+        }),
+      danger: true,
     },
   ]
 }
@@ -552,6 +568,7 @@ export default function Message(props: {
       const target = ((event as any).t || event.target) as HTMLAnchorElement
       const common = {
         accountId,
+        message,
         text: text || undefined,
         conversationType,
         openDialog,
@@ -568,13 +585,7 @@ export default function Message(props: {
             },
             target
           )
-        : buildContextMenu(
-            {
-              ...common,
-              message,
-            },
-            target
-          )
+        : buildContextMenu(common, target)
 
       openContextMenu({
         ...showContextMenuEventPos,
@@ -689,7 +700,7 @@ export default function Message(props: {
 
       // Check if Delete key is pressed to delete message
       if (
-        onlyThisMsgSelected &&
+        thisMsgSelected &&
         !e.ctrlKey &&
         !e.metaKey &&
         !e.altKey &&
@@ -701,7 +712,8 @@ export default function Message(props: {
         e.stopPropagation()
         openDialog(ConfirmDeleteMessageDialog, {
           accountId,
-          msg: message,
+          messageIds: [...messageIds],
+          loadedMessages: { [message.id]: message },
           chat,
         })
         return

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -977,9 +977,15 @@ export default function Message(props: {
         }
       )}
       id={message.id.toString()}
-      onClick={e => {
+      // `capture` together with `stopPropagation` makes it harder
+      // to accidentally activate links, images, etc. inside the message
+      // while actually trying to simply Ctrl + Click the message.
+      // Especially usefult for images, which occupy the majority
+      // of the message bubble's area.
+      onClickCapture={e => {
         focusAndMultiselect.onClick(e)
         if (e.defaultPrevented) {
+          e.stopPropagation()
           return
         }
       }}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -609,12 +609,19 @@ export default function Message(props: {
     ref,
     tabIndex: focusAndMultiselect.tabIndex,
     onKeyDown: (e: React.KeyboardEvent) => {
+      const messageIds =
+        focusAndMultiselect.selectedItems.size === 0
+          ? new Set([message.id])
+          : focusAndMultiselect.selectedItems
+      const thisMsgSelected = messageIds.has(message.id)
+      const onlyThisMsgSelected = thisMsgSelected && messageIds.size === 1
       // Handle letter shortcuts with Ctrl/Cmd modifier
       const isCtrlOrMetaKeyPress =
         (e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && message
 
       // Check if Ctrl/Cmd+"e" is pressed to enter edit mode
       if (
+        onlyThisMsgSelected &&
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 'e') &&
         isMessageEditable(message, props.chat)
@@ -627,6 +634,7 @@ export default function Message(props: {
 
       // Check if Ctrl/Cmd+"r" is pressed to react to message
       if (
+        onlyThisMsgSelected &&
         isCtrlOrMetaKeyPress &&
         matchesLetterShortcut(e, 'r') &&
         showReactionsUi(message, props.chat)
@@ -651,6 +659,7 @@ export default function Message(props: {
       // Check if Ctrl/Cmd+"s" is pressed to save message
       if (
         isCtrlOrMetaKeyPress &&
+        onlyThisMsgSelected &&
         matchesLetterShortcut(e, 's') &&
         !chat.isSelfTalk &&
         message.savedMessageId === null &&
@@ -664,6 +673,7 @@ export default function Message(props: {
 
       // Check if Ctrl/Cmd+Shift+"s" is pressed to unsave message
       if (
+        onlyThisMsgSelected &&
         (e.ctrlKey || e.metaKey) &&
         e.shiftKey &&
         !e.altKey &&
@@ -679,6 +689,7 @@ export default function Message(props: {
 
       // Check if Delete key is pressed to delete message
       if (
+        onlyThisMsgSelected &&
         !e.ctrlKey &&
         !e.metaKey &&
         !e.altKey &&

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -476,6 +476,8 @@ export default function Message(props: {
   const openViewGroupDialog = useOpenViewGroupDialog()
   const { jumpToMessage } = useMessage()
   const [messageWidth, setMessageWidth] = useState(0)
+  const ref = useRef<any>(null)
+  const rovingTabindex = useRovingTabindex(ref)
 
   const showContextMenu = useCallback(
     (
@@ -553,8 +555,6 @@ export default function Message(props: {
       tx,
     ]
   )
-  const ref = useRef<any>(null)
-  const rovingTabindex = useRovingTabindex(ref)
   const commonAttrs = {
     ref,
     tabIndex: rovingTabindex.tabIndex,

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -26,10 +26,11 @@ import EmptyChatMessage from './EmptyChatMessage'
 const log = getLogger('renderer/components/message/MessageList')
 
 import type { T } from '@deltachat/jsonrpc-client'
+import { useRovingTabindex } from '../../contexts/RovingTabindex'
 import {
-  RovingTabindexProvider,
-  useRovingTabindex,
-} from '../../contexts/RovingTabindex'
+  FocusAndMultiselectProvider,
+  useMessageFocusAndMultiselect,
+} from './focusAndMultiselect'
 import { marknoticedChat } from '../../backend/chat'
 
 const onWindowFocus = (accountId: number) => {
@@ -864,6 +865,12 @@ export const MessageListInner = React.memo(
       // over the lifetime of this component.
     })
 
+    const messageIds = useMemo(
+      () =>
+        messageListItems.filter(v => v.kind !== 'dayMarker').map(v => v.msg_id),
+      [messageListItems]
+    )
+
     if (!loaded) {
       return (
         <div
@@ -885,7 +892,10 @@ export const MessageListInner = React.memo(
         onWheel={onWheel}
       >
         <ol aria-label={tx('messages')}>
-          <RovingTabindexProvider wrapperElementRef={messageListRef}>
+          <FocusAndMultiselectProvider
+            messageIds={messageIds}
+            wrapperElementRef={messageListRef}
+          >
             {messageListItems.length === 0 && <EmptyChatMessage chat={chat} />}
             {activeView.map(messageId => {
               if (messageId.kind === 'dayMarker') {
@@ -927,7 +937,7 @@ export const MessageListInner = React.memo(
                 }
               }
             })}
-          </RovingTabindexProvider>
+          </FocusAndMultiselectProvider>
         </ol>
       </div>
     )
@@ -952,19 +962,25 @@ function MessageLoadingError({
   message: T.MessageLoadResult
 }) {
   const ref = useRef<HTMLDivElement>(null)
-  const rovingTabindex = useRovingTabindex(ref)
+  const focusAndMultiselect = useMessageFocusAndMultiselect(
+    messageId.msg_id,
+    ref
+  )
 
   return (
     <div className='info-message' id={String(messageId.msg_id)}>
       <div
         ref={ref}
-        className={'bubble ' + rovingTabindex.className}
+        className={
+          'bubble multiselectable-message ' + focusAndMultiselect.className
+        }
         style={{
           backgroundColor: 'rgba(55,0,0,0.5)',
         }}
-        tabIndex={rovingTabindex.tabIndex}
-        onKeyDown={rovingTabindex.onKeydown}
-        onFocus={rovingTabindex.setAsActiveElement}
+        tabIndex={focusAndMultiselect.tabIndex}
+        onClick={focusAndMultiselect.onClick}
+        onKeyDown={focusAndMultiselect.onKeyDown}
+        onFocus={focusAndMultiselect.onFocus}
       >
         loading message {messageId.msg_id} failed: {message.error}
       </div>
@@ -977,19 +993,25 @@ function MessageLoading({
   messageId: T.MessageListItem & { kind: 'message' }
 }) {
   const ref = useRef<HTMLDivElement>(null)
-  const rovingTabindex = useRovingTabindex(ref)
+  const focusAndMultiselect = useMessageFocusAndMultiselect(
+    messageId.msg_id,
+    ref
+  )
 
   return (
     <div className='info-message' id={String(messageId.msg_id)}>
       <div
         ref={ref}
-        className={'bubble ' + rovingTabindex.className}
+        className={
+          'bubble multiselectable-message ' + focusAndMultiselect.className
+        }
         style={{
           backgroundColor: 'rgba(55,0,0,0.5)',
         }}
-        tabIndex={rovingTabindex.tabIndex}
-        onKeyDown={rovingTabindex.onKeydown}
-        onFocus={rovingTabindex.setAsActiveElement}
+        tabIndex={focusAndMultiselect.tabIndex}
+        onClick={focusAndMultiselect.onClick}
+        onKeyDown={focusAndMultiselect.onKeyDown}
+        onFocus={focusAndMultiselect.onFocus}
       >
         Loading Message {messageId.msg_id}
       </div>
@@ -1085,6 +1107,9 @@ export function DayMarker(props: { timestamp: number }) {
   // See https://github.com/deltachat/deltachat-desktop/issues/2141
   // > Also make the divider items proper list items that can be focused,
   // > so users know when they traverse to the next/previous date.
+  //
+  // We usually utilize `useMessageFocusAndMultiselect()` for messages
+  // but here we only need a part of its functionality.
   const rovingTabindex = useRovingTabindex(ref)
 
   return (

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -890,6 +890,8 @@ export const MessageListInner = React.memo(
         className={classNames({
           'multiselected-one-or-more':
             focusAndMultiselectContextValue.selectedItems.size >= 1,
+          'multiselected-two-or-more':
+            focusAndMultiselectContextValue.selectedItems.size >= 2,
         })}
       >
         <ol aria-label={tx('messages')}>

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -893,6 +893,23 @@ export const MessageListInner = React.memo(
           'multiselected-two-or-more':
             focusAndMultiselectContextValue.selectedItems.size >= 2,
         })}
+        onClick={e => {
+          // If clicked on dead space, reset selection.
+
+          if (e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) {
+            return
+          }
+          if (!(e.target instanceof HTMLElement)) {
+            return
+          }
+          if (e.target.closest('.multiselectable-message') != null) {
+            // Clicked on a message. This is handled
+            // by the message click handler.
+            return
+          }
+
+          focusAndMultiselectContextValue.resetSelection()
+        }}
       >
         <ol aria-label={tx('messages')}>
           <RovingTabindexProvider wrapperElementRef={messageListRef}>

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -30,6 +30,11 @@ import {
   RovingTabindexProvider,
   useRovingTabindex,
 } from '../../contexts/RovingTabindex'
+import {
+  useMessageFocusAndMultiselect,
+  MessageMultiselectContext,
+  useMessageFocusAndMultiselectContextValue,
+} from './focusAndMultiselect'
 import { marknoticedChat } from '../../backend/chat'
 
 /**
@@ -852,6 +857,17 @@ export const MessageListInner = React.memo(
       // over the lifetime of this component.
     })
 
+    const messageIds = useMemo(
+      () =>
+        messageListItems.filter(v => v.kind !== 'dayMarker').map(v => v.msg_id),
+      [messageListItems]
+    )
+    const focusAndMultiselectContextValue =
+      useMessageFocusAndMultiselectContextValue({
+        messageIds,
+        wrapperElementRef: messageListRef,
+      })
+
     if (!loaded) {
       return (
         <div
@@ -874,47 +890,53 @@ export const MessageListInner = React.memo(
       >
         <ol aria-label={tx('messages')}>
           <RovingTabindexProvider wrapperElementRef={messageListRef}>
-            {messageListItems.length === 0 && <EmptyChatMessage chat={chat} />}
-            {activeView.map(messageId => {
-              if (messageId.kind === 'dayMarker') {
-                return (
-                  <DayMarker
-                    key={`daymarker-${messageId.timestamp}`}
-                    timestamp={messageId.timestamp}
-                  />
-                )
-              }
-
-              if (messageId.kind === 'message') {
-                const message = messageCache[messageId.msg_id]
-                if (message?.kind === 'message') {
+            <MessageMultiselectContext.Provider
+              value={focusAndMultiselectContextValue}
+            >
+              {messageListItems.length === 0 && (
+                <EmptyChatMessage chat={chat} />
+              )}
+              {activeView.map(messageId => {
+                if (messageId.kind === 'dayMarker') {
                   return (
-                    <MessageWrapper
-                      key={messageId.msg_id}
-                      key2={`${messageId.msg_id}`}
-                      chat={chat}
-                      message={message}
-                      conversationType={conversationType}
-                      unreadMessageInViewIntersectionObserver={
-                        unreadMessageInViewIntersectionObserver
-                      }
+                    <DayMarker
+                      key={`daymarker-${messageId.timestamp}`}
+                      timestamp={messageId.timestamp}
                     />
                   )
-                } else if (message?.kind === 'loadingError') {
-                  return (
-                    <MessageLoadingError
-                      messageId={messageId}
-                      message={message}
-                    />
-                  )
-                } else {
-                  // setTimeout tells it to call method in next event loop iteration, so after rendering
-                  // it is debounced later so we can call it here multiple times and it's ok
-                  setTimeout(loadMissingMessages)
-                  return <MessageLoading messageId={messageId} />
                 }
-              }
-            })}
+
+                if (messageId.kind === 'message') {
+                  const message = messageCache[messageId.msg_id]
+                  if (message?.kind === 'message') {
+                    return (
+                      <MessageWrapper
+                        key={messageId.msg_id}
+                        key2={`${messageId.msg_id}`}
+                        chat={chat}
+                        message={message}
+                        conversationType={conversationType}
+                        unreadMessageInViewIntersectionObserver={
+                          unreadMessageInViewIntersectionObserver
+                        }
+                      />
+                    )
+                  } else if (message?.kind === 'loadingError') {
+                    return (
+                      <MessageLoadingError
+                        messageId={messageId}
+                        message={message}
+                      />
+                    )
+                  } else {
+                    // setTimeout tells it to call method in next event loop iteration, so after rendering
+                    // it is debounced later so we can call it here multiple times and it's ok
+                    setTimeout(loadMissingMessages)
+                    return <MessageLoading messageId={messageId} />
+                  }
+                }
+              })}
+            </MessageMultiselectContext.Provider>
           </RovingTabindexProvider>
         </ol>
       </div>
@@ -940,19 +962,25 @@ function MessageLoadingError({
   message: T.MessageLoadResult
 }) {
   const ref = useRef<HTMLDivElement>(null)
-  const rovingTabindex = useRovingTabindex(ref)
+  const focusAndMultiselect = useMessageFocusAndMultiselect(
+    messageId.msg_id,
+    ref
+  )
 
   return (
     <div className='info-message' id={String(messageId.msg_id)}>
       <div
         ref={ref}
-        className={'bubble ' + rovingTabindex.className}
+        className={
+          'bubble multiselectable-message ' + focusAndMultiselect.className
+        }
         style={{
           backgroundColor: 'rgba(55,0,0,0.5)',
         }}
-        tabIndex={rovingTabindex.tabIndex}
-        onKeyDown={rovingTabindex.onKeydown}
-        onFocus={rovingTabindex.setAsActiveElement}
+        tabIndex={focusAndMultiselect.tabIndex}
+        onClick={focusAndMultiselect.onClick}
+        onKeyDown={focusAndMultiselect.onKeyDown}
+        onFocus={focusAndMultiselect.onFocus}
       >
         loading message {messageId.msg_id} failed: {message.error}
       </div>
@@ -965,19 +993,25 @@ function MessageLoading({
   messageId: T.MessageListItem & { kind: 'message' }
 }) {
   const ref = useRef<HTMLDivElement>(null)
-  const rovingTabindex = useRovingTabindex(ref)
+  const focusAndMultiselect = useMessageFocusAndMultiselect(
+    messageId.msg_id,
+    ref
+  )
 
   return (
     <div className='info-message' id={String(messageId.msg_id)}>
       <div
         ref={ref}
-        className={'bubble ' + rovingTabindex.className}
+        className={
+          'bubble multiselectable-message ' + focusAndMultiselect.className
+        }
         style={{
           backgroundColor: 'rgba(55,0,0,0.5)',
         }}
-        tabIndex={rovingTabindex.tabIndex}
-        onKeyDown={rovingTabindex.onKeydown}
-        onFocus={rovingTabindex.setAsActiveElement}
+        tabIndex={focusAndMultiselect.tabIndex}
+        onClick={focusAndMultiselect.onClick}
+        onKeyDown={focusAndMultiselect.onKeyDown}
+        onFocus={focusAndMultiselect.onFocus}
       >
         Loading Message {messageId.msg_id}
       </div>
@@ -1073,6 +1107,9 @@ export function DayMarker(props: { timestamp: number }) {
   // See https://github.com/deltachat/deltachat-desktop/issues/2141
   // > Also make the divider items proper list items that can be focused,
   // > so users know when they traverse to the next/previous date.
+  //
+  // We usually utilize `useMessageFocusAndMultiselect()` for messages
+  // but here we only need a part of its functionality.
   const rovingTabindex = useRovingTabindex(ref)
 
   return (

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -887,6 +887,10 @@ export const MessageListInner = React.memo(
         ref={messageListRef}
         onScroll={onScroll2}
         onWheel={onWheel}
+        className={classNames({
+          'multiselected-one-or-more':
+            focusAndMultiselectContextValue.selectedItems.size >= 1,
+        })}
       >
         <ol aria-label={tx('messages')}>
           <RovingTabindexProvider wrapperElementRef={messageListRef}>

--- a/packages/frontend/src/components/message/focusAndMultiselect.tsx
+++ b/packages/frontend/src/components/message/focusAndMultiselect.tsx
@@ -1,0 +1,121 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import type { T } from '@deltachat/jsonrpc-client'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+import {
+  RovingTabindexProvider,
+  useRovingTabindex,
+} from '../../contexts/RovingTabindex'
+import { useMultiselect } from '../../hooks/useMultiselect'
+
+const log = getLogger('messageFocusAndMultiselect')
+
+type MessageMultiselectContextValue = ReturnType<
+  typeof useMultiselect<T.Message['id']>
+> & {
+  resetSelection: () => void
+}
+const MessageMultiselectContext =
+  React.createContext<MessageMultiselectContextValue>({
+    onClick: () => false,
+    onFocus: () => {},
+    onKeyDown: () => false,
+    selectedItems: new Set(),
+    resetSelection: () => {},
+  })
+
+export function FocusAndMultiselectProvider(
+  props: React.PropsWithChildren<{
+    wrapperElementRef: Parameters<
+      typeof RovingTabindexProvider
+    >[0]['wrapperElementRef']
+    messageIds: Array<T.Message['id']>
+  }>
+) {
+  const [selectedMessages_, setSelectedMessages] = useState(
+    new Set<T.Message['id']>()
+  )
+  // As messages get deleted (possibly by other chat members
+  // or from another device), remove them from selection.
+  const selectedMessages = useMemo(() => {
+    const newSelectedMessages = new Set(selectedMessages_)
+    for (const id of selectedMessages_) {
+      if (!props.messageIds.includes(id)) {
+        newSelectedMessages.delete(id)
+      }
+    }
+    return selectedMessages_.size === newSelectedMessages.size
+      ? selectedMessages_
+      : newSelectedMessages
+  }, [props.messageIds, selectedMessages_])
+
+  const resetSelection = useCallback(() => {
+    setSelectedMessages(s => {
+      if (s.size === 0) {
+        return s
+      }
+      return new Set()
+    })
+  }, [])
+
+  const multiselect = useMultiselect(
+    props.messageIds,
+    selectedMessages,
+    setSelectedMessages,
+    log
+  )
+  return (
+    <RovingTabindexProvider wrapperElementRef={props.wrapperElementRef}>
+      <MessageMultiselectContext.Provider
+        value={{ ...multiselect, resetSelection }}
+      >
+        {props.children}
+      </MessageMultiselectContext.Provider>
+    </RovingTabindexProvider>
+  )
+}
+
+export function useMessageFocusAndMultiselect(
+  messageId: T.Message['id'],
+  elementRef: Parameters<typeof useRovingTabindex>[0]
+) {
+  const rovingTabindex = useRovingTabindex(elementRef)
+  const multiselect = React.useContext(MessageMultiselectContext)
+
+  return {
+    ...(rovingTabindex as Omit<
+      typeof rovingTabindex,
+      'onKeydown' | 'setAsActiveElement'
+    >),
+    ...multiselect,
+    onClick: useCallback(
+      (e: React.MouseEvent) => {
+        const shouldPreventDefault = multiselect.onClick(e, messageId)
+        if (shouldPreventDefault) {
+          e.preventDefault()
+        }
+      },
+      [messageId, multiselect]
+    ),
+    onFocus: useCallback(() => {
+      rovingTabindex.setAsActiveElement()
+
+      // Commented out for now. This disables the "Shift + ArrowDown
+      // for contiguous selection" behavior, because it's a little buggy:
+      // Pressing Shift + Tab would change selection
+      // even if the user is simply trying to tab through the app.
+      // Keyboard users can still utilize Shift + Space.
+      // multiselect.onFocus(messageId)
+    }, [rovingTabindex]),
+
+    onKeyDown: useCallback(
+      (e: React.KeyboardEvent) => {
+        rovingTabindex.onKeydown(e)
+        const shouldPreventDefault = multiselect.onKeyDown(e, messageId)
+        if (shouldPreventDefault) {
+          e.preventDefault()
+        }
+      },
+      [messageId, multiselect, rovingTabindex]
+    ),
+  }
+}

--- a/packages/frontend/src/components/message/focusAndMultiselect.tsx
+++ b/packages/frontend/src/components/message/focusAndMultiselect.tsx
@@ -61,7 +61,12 @@ export function FocusAndMultiselectProvider(
     props.messageIds,
     selectedMessages,
     setSelectedMessages,
-    log
+    log,
+    // Only enter "multi-select mode" on Shift + Click or Ctrl + Click.
+    // Multi-selecting messages is not something that people do all the time.
+    // It's annoying that a message keeps being displayed as selected
+    // even though all you did is click a link inside of it.
+    { onNormalClick: 'unselectAll' }
   )
   return (
     <RovingTabindexProvider wrapperElementRef={props.wrapperElementRef}>

--- a/packages/frontend/src/components/message/focusAndMultiselect.tsx
+++ b/packages/frontend/src/components/message/focusAndMultiselect.tsx
@@ -1,0 +1,111 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import type { T } from '@deltachat/jsonrpc-client'
+import { getLogger } from '@deltachat-desktop/shared/logger'
+import {
+  RovingTabindexProvider,
+  useRovingTabindex,
+} from '../../contexts/RovingTabindex'
+import { useMultiselect } from '../../hooks/useMultiselect'
+
+const log = getLogger('messageFocusAndMultiselect')
+
+type MessageMultiselectContextValue = ReturnType<
+  typeof useMultiselect<T.Message['id']>
+> & {
+  resetSelection: () => void
+}
+export const MessageMultiselectContext =
+  React.createContext<MessageMultiselectContextValue>({
+    onClick: () => false,
+    onFocus: () => {},
+    onKeyDown: () => false,
+    selectedItems: new Set(),
+    resetSelection: () => {},
+  })
+
+export function useMessageFocusAndMultiselectContextValue(props: {
+  wrapperElementRef: Parameters<
+    typeof RovingTabindexProvider
+  >[0]['wrapperElementRef']
+  messageIds: Array<T.Message['id']>
+}) {
+  const [selectedMessages_, setSelectedMessages] = useState(
+    new Set<T.Message['id']>()
+  )
+  // As messages get deleted (possibly by other chat members
+  // or from another device), remove them from selection.
+  const selectedMessages = useMemo(() => {
+    const newSelectedMessages = new Set(selectedMessages_)
+    for (const id of selectedMessages_) {
+      if (!props.messageIds.includes(id)) {
+        newSelectedMessages.delete(id)
+      }
+    }
+    return selectedMessages_.size === newSelectedMessages.size
+      ? selectedMessages_
+      : newSelectedMessages
+  }, [props.messageIds, selectedMessages_])
+
+  const resetSelection = useCallback(() => {
+    setSelectedMessages(s => {
+      if (s.size === 0) {
+        return s
+      }
+      return new Set()
+    })
+  }, [])
+
+  const multiselect = useMultiselect(
+    props.messageIds,
+    selectedMessages,
+    setSelectedMessages,
+    log
+  )
+  return { ...multiselect, resetSelection }
+}
+
+export function useMessageFocusAndMultiselect(
+  messageId: T.Message['id'],
+  elementRef: Parameters<typeof useRovingTabindex>[0]
+) {
+  const rovingTabindex = useRovingTabindex(elementRef)
+  const multiselect = React.useContext(MessageMultiselectContext)
+
+  return {
+    ...(rovingTabindex as Omit<
+      typeof rovingTabindex,
+      'onKeydown' | 'setAsActiveElement'
+    >),
+    ...multiselect,
+    onClick: useCallback(
+      (e: React.MouseEvent) => {
+        const shouldPreventDefault = multiselect.onClick(e, messageId)
+        if (shouldPreventDefault) {
+          e.preventDefault()
+        }
+      },
+      [messageId, multiselect]
+    ),
+    onFocus: useCallback(() => {
+      rovingTabindex.setAsActiveElement()
+
+      // Commented out for now. This disables the "Shift + ArrowDown
+      // for contiguous selection" behavior, because it's a little buggy:
+      // Pressing Shift + Tab would change selection
+      // even if the user is simply trying to tab through the app.
+      // Keyboard users can still utilize Shift + Space.
+      // multiselect.onFocus(messageId)
+    }, [rovingTabindex]),
+
+    onKeyDown: useCallback(
+      (e: React.KeyboardEvent) => {
+        rovingTabindex.onKeydown(e)
+        const shouldPreventDefault = multiselect.onKeyDown(e, messageId)
+        if (shouldPreventDefault) {
+          e.preventDefault()
+        }
+      },
+      [messageId, multiselect, rovingTabindex]
+    ),
+  }
+}

--- a/packages/frontend/src/components/message/focusAndMultiselect.tsx
+++ b/packages/frontend/src/components/message/focusAndMultiselect.tsx
@@ -59,7 +59,12 @@ export function useMessageFocusAndMultiselectContextValue(props: {
     props.messageIds,
     selectedMessages,
     setSelectedMessages,
-    log
+    log,
+    // Only enter "multi-select mode" on Shift + Click or Ctrl + Click.
+    // Multi-selecting messages is not something that people do all the time.
+    // It's annoying that a message keeps being displayed as selected
+    // even though all you did is click a link inside of it.
+    { onNormalClick: 'unselectAll' }
   )
   return { ...multiselect, resetSelection }
 }

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -101,6 +101,14 @@ export function useMultiselect<T>(
   onSelectionChange: (newSelectedItems: Set<T>) => void,
   logger?: {
     error: (...args: any) => void
+  },
+  options?: {
+    /**
+     * What to do when an item gets clicked without Ctrl or Shift being pressed.
+     *
+     * @default 'resetSelectionToClickedItem'
+     */
+    onNormalClick?: 'resetSelectionToClickedItem' | 'unselectAll'
   }
 ) {
   // TODO feat: a way to set initially active item?
@@ -229,6 +237,7 @@ export function useMultiselect<T>(
     }
   }, [])
 
+  const onNormalClick = options?.onNormalClick ?? 'resetSelectionToClickedItem'
   // Note that `keydown` and `click` events both fire
   // for a single press of "Space" for `<button>`s
   // https://w3c.github.io/uievents/#event-type-keydown
@@ -258,19 +267,34 @@ export function useMultiselect<T>(
         return true // shouldPreventDefault
       }
 
-      if (
-        // Check if it's already selected.
-        !(
-          selectedItemsRef.current.size === 1 &&
-          selectedItemsRef.current.has(item)
-        )
-      ) {
-        onSelectionChange(new Set([item]))
+      switch (onNormalClick) {
+        case 'resetSelectionToClickedItem': {
+          if (
+            selectedItemsRef.current.size === 1 &&
+            selectedItemsRef.current.has(item)
+          ) {
+            // Already selected.
+            break
+          }
+          onSelectionChange(new Set([item]))
+          break
+        }
+        case 'unselectAll': {
+          if (selectedItemsRef.current.size === 0) {
+            // Already unselected
+            break
+          }
+          onSelectionChange(new Set())
+          break
+        }
+        default: {
+          const _assert: never = onNormalClick
+        }
       }
       lastActivatedItem.current = item
       return false
     },
-    [onSelectContiguous, onSelectionChange, toggleItemSelection]
+    [onNormalClick, onSelectContiguous, onSelectionChange, toggleItemSelection]
   )
   const onClick = useCallback(
     (event: React.MouseEvent, item: T) => {


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/2892.

<img width="279" height="280" alt="image" src="https://github.com/user-attachments/assets/c39edc8b-3977-42eb-a3c4-088002f2fd69" />

In the end the functionality is quite conservative, one will not notice that we support multiselect until they Ctrl + Click or Shift + Click.

TODO:
- [x] Address TODOs.
- [x] Tests.
  https://github.com/deltachat/deltachat-desktop/pull/6361
- [x] Clean up the code.
- [x] Merge the base MRs (containing the first few commits) so that this one's easier to review.
  - https://github.com/deltachat/deltachat-desktop/pull/6284
  - https://github.com/deltachat/deltachat-desktop/pull/6285
- [ ] Consider adding a safeguard (maybe a confirmation dialog) if more than 100 or 1000 messages are selected.
  Telegram simply won't let you select more than 100 messages.
  https://github.com/deltachat/deltachat-desktop/issues/2892#issuecomment-4406316861
  Edit: ~~https://github.com/deltachat/deltachat-desktop/pull/6366~~
  Edit 2: https://github.com/deltachat/deltachat-desktop/pull/6369
- [ ] (maybe later) add more context menu items, such as "Save / Unsave Messages", "download attachment" and whatever else Android and iOS already support.
- [x] Consider squashing some commits, especially the ones made in follow-up MRs.