### PR TITLE
fix: prevent crash on MacOS when closing notify twice

### DIFF
--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -111,6 +111,12 @@ const notifications: {
 } = {}
 
 /**
+ * Track closed notifications to prevent calling close() on
+ * already-closed notifications, which crashes app immediately on macOS.
+ */
+const closedNotifications = new WeakSet<Notification>()
+
+/**
  * triggers creation of a notification, adds appropriate
  * callbacks and shows it via electron Notification API
  *
@@ -133,23 +139,23 @@ function showNotification(_event: IpcMainInvokeEvent, data: DcNotification) {
         notifications[accountId]?.[chatId]?.[data.messageId]?.filter(
           n => n !== notify
         ) || []
-      notify.close()
+      if (!closedNotifications.has(notify)) {
+        closedNotifications.add(notify)
+        notify.close()
+      }
     })
     notify.on('close', () => {
+      // Mark as closed to prevent calling close() again later
+      closedNotifications.add(notify)
       // on Window and Linux this can be triggered by system time out
-      // when the message is moved to notification center so only close
-      // the notification on this event on Mac
+      // when the message is moved to notification center so only clear
+      // the notification tracking on Mac
       if (isMac) {
         notifications[accountId][chatId][data.messageId] =
           notifications[accountId]?.[chatId]?.[data.messageId]?.filter(
             n => n !== notify
           ) || []
-        // But now that we've removed the references to the notification,
-        // make sure that it really is closed.
-        notify.close()
       }
-      // eslint-disable-next-line no-console
-      console.log('Notification close event triggered', notify)
     })
     notify.on('reply', async e => {
       // See the Android's implementation:
@@ -221,7 +227,10 @@ function clearNotificationsForMessage(
     return
   }
   arr.forEach(notify => {
-    notify.close()
+    if (!closedNotifications.has(notify)) {
+      closedNotifications.add(notify)
+      notify.close()
+    }
   })
   delete notifications[accountId][chatId][messageId]
 }

--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -111,7 +111,7 @@ const notifications: {
 } = {}
 
 /**
- * Track closed notifications to prevent calling close() on
+ * Track closed notifications on Mac to prevent calling close() on
  * already-closed notifications, which crashes app immediately on macOS.
  */
 const closedNotifications = new WeakSet<Notification>()
@@ -140,13 +140,17 @@ function showNotification(_event: IpcMainInvokeEvent, data: DcNotification) {
           n => n !== notify
         ) || []
       if (!closedNotifications.has(notify)) {
-        closedNotifications.add(notify)
+        if (isMac) {
+          closedNotifications.add(notify)
+        }
         notify.close()
       }
     })
     notify.on('close', () => {
       // Mark as closed to prevent calling close() again later
-      closedNotifications.add(notify)
+      if (isMac) {
+        closedNotifications.add(notify)
+      }
       // on Window and Linux this can be triggered by system time out
       // when the message is moved to notification center so only clear
       // the notification tracking on Mac
@@ -228,7 +232,9 @@ function clearNotificationsForMessage(
   }
   arr.forEach(notify => {
     if (!closedNotifications.has(notify)) {
-      closedNotifications.add(notify)
+      if (isMac) {
+        closedNotifications.add(notify)
+      }
       notify.close()
     }
   })


### PR DESCRIPTION
fixes #6210

Closing a already closd notification crashes the app immediately on MacOS

Besides reverting d78646d83c this adds a WeakSet to keep references to closed notifications (without preventing them from being garbage collected)