### PR TITLE
fix: improve 3-dot menu size in html mails

### DIFF
--- a/packages/target-electron/static/electron_html_email_view/electron_html_email_view.css
+++ b/packages/target-electron/static/electron_html_email_view/electron_html_email_view.css
@@ -47,10 +47,11 @@ div.header > div.network-toggle {
 
 div.header > div.network-toggle > button#toggle_network_more_button {
   background-color: transparent;
-  border: 1px grey solid;
-  font-size: 0.8em;
-  border-radius: 2px;
+  border-color: transparent;
+  font-size: 1.5em;
   color: var(--htmlEmail-color);
+  font-weight: bold;
+  cursor: pointer;
 }
 
 div#content {


### PR DESCRIPTION
new | old

<img width="181" height="91" alt="image" src="https://github.com/user-attachments/assets/a9a3be7e-7ca0-4803-b502-32bfb7ef350e" />

