### PR TITLE
fix: always use core viewType for compatibility

### DIFF
--- a/packages/frontend/src/components/attachment/Attachment.tsx
+++ b/packages/frontend/src/components/attachment/Attachment.tsx
@@ -2,60 +2,30 @@ import mimeTypes from 'mime-types'
 import { Type } from '../../backend-com'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 
-/* Section - Data Copied in part from Signal */
-// Supported media types in google chrome
-// See: https://en.wikipedia.org/wiki/Comparison_of_web_browsers#Image_format_support
-const SUPPORTED_IMAGE_MIME_TYPES = Object.freeze([
-  'image/bmp',
-  'image/gif',
-  'image/jpeg',
-  'image/jpg',
-  'image/svg+xml',
-  'image/webp',
-  'image/x-xbitmap',
-  // ICO
-  'image/vnd.microsoft.icon',
-  'image/ico',
-  'image/icon',
-  'image/x-icon',
-  // PNG
-  'image/apng',
-  'image/png',
-  // for opening avatars
-  'image/x',
-])
-// See: https://www.chromium.org/audio-video
-const SUPPORTED_VIDEO_MIME_TYPES = Object.freeze([
-  'video/mp4',
-  'video/ogg',
-  'video/webm',
-  'video/quicktime',
-])
-/* EndSection - Data Copied in part from Signal */
-
-export function isImage(filemime: string | null) {
-  return SUPPORTED_IMAGE_MIME_TYPES.includes(filemime || '')
+export function isImage(viewType: Type.Viewtype | null) {
+  return viewType === 'Image' || viewType === 'Gif'
 }
 
 export function hasAttachment(attachment: MessageTypeAttachmentSubset | null) {
   return attachment && attachment.file
 }
 
-export function isVideo(filemime: string | null) {
-  return SUPPORTED_VIDEO_MIME_TYPES.includes(filemime || '')
+// note that we rely on the viewTypes from core here to make sure all Deltachat clients
+// display the same attachment types in the same way - although this could result in not
+// showing some attachments even if we could show them (like svg for example)
+// see guess_msgtype_from_path_suffix in https://github.com/chatmail/core/blob/main/src/message.rs
+const MEDIA_VIEW_TYPES = ['Image', 'Gif', 'Video', 'Audio', 'Voice'] as const
+
+export function isDisplayableByFullscreenMedia(viewType: Type.Viewtype | null) {
+  return MEDIA_VIEW_TYPES.includes(
+    viewType as (typeof MEDIA_VIEW_TYPES)[number]
+  )
 }
 
-export function isAudio(filemime: string | null) {
-  if (!filemime) return false
-  return filemime.startsWith('audio/')
-}
-
-export function isDisplayableByFullscreenMedia(filemime: string | null) {
-  return isImage(filemime) || isAudio(filemime) || isVideo(filemime)
-}
-
-export function isGenericAttachment(filemime: string | null) {
-  return !(isImage(filemime) || isVideo(filemime) || isAudio(filemime))
+export function isGenericAttachment(viewType: Type.Viewtype | null) {
+  return !MEDIA_VIEW_TYPES.includes(
+    viewType as (typeof MEDIA_VIEW_TYPES)[number]
+  )
 }
 
 export function getExtension({

--- a/packages/frontend/src/components/attachment/Attachment.tsx
+++ b/packages/frontend/src/components/attachment/Attachment.tsx
@@ -10,9 +10,9 @@ export function hasAttachment(attachment: MessageTypeAttachmentSubset | null) {
   return attachment && attachment.file
 }
 
-// note that we rely on the viewTypes from core here to make sure all Deltachat clients
+// note that we rely on the viewTypes from core here to make sure all Delta Chat clients
 // display the same attachment types in the same way - although this could result in not
-// showing some attachments even if we could show them (like svg for example)
+// showing some attachments as files even if we could show them as media (like svg for example)
 // see guess_msgtype_from_path_suffix in https://github.com/chatmail/core/blob/main/src/message.rs
 const MEDIA_VIEW_TYPES = ['Image', 'Gif', 'Video', 'Audio', 'Voice'] as const
 

--- a/packages/frontend/src/components/attachment/galleryAttachment.tsx
+++ b/packages/frontend/src/components/attachment/galleryAttachment.tsx
@@ -47,7 +47,7 @@ const contextMenuFactory = (
   openDialog: OpenDialog,
   jumpToMessage: JumpToMessage
 ) => {
-  const showCopyImage = isImage(message.viewType)
+  const showCopyImage = isImage(message.viewType) && message.viewType !== 'Gif'
   const tx = window.static_translate
   const { id: msgId, viewType } = message
   return [

--- a/packages/frontend/src/components/attachment/galleryAttachment.tsx
+++ b/packages/frontend/src/components/attachment/galleryAttachment.tsx
@@ -6,13 +6,7 @@ import {
   onDownload,
   openWebxdc,
 } from '../message/messageFunctions'
-import {
-  isImage,
-  isVideo,
-  isAudio,
-  getExtension,
-  dragAttachmentOut,
-} from './Attachment'
+import { isImage, getExtension, dragAttachmentOut } from './Attachment'
 import Timestamp from '../conversations/Timestamp'
 import { makeContextMenu, OpenContextMenu } from '../ContextMenu'
 import { runtime } from '@deltachat-desktop/runtime-interface'
@@ -53,7 +47,7 @@ const contextMenuFactory = (
   openDialog: OpenDialog,
   jumpToMessage: JumpToMessage
 ) => {
-  const showCopyImage = message.viewType === 'Image'
+  const showCopyImage = isImage(message.viewType)
   const tx = window.static_translate
   const { id: msgId, viewType } = message
   return [
@@ -235,7 +229,7 @@ export function ImageAttachment({
       accountId
     )
     const { file, fileMime } = message
-    const hasSupportedFormat = isImage(fileMime)
+    const hasSupportedFormat = isImage(message.viewType)
     const isBroken = !file || !hasSupportedFormat
 
     return (
@@ -324,7 +318,7 @@ export function VideoAttachment({
       accountId
     )
     const { file, fileMime } = message
-    const hasSupportedFormat = isVideo(fileMime)
+    const hasSupportedFormat = message.viewType === 'Video'
     const isBroken = !file || !hasSupportedFormat
     return (
       <button
@@ -416,7 +410,8 @@ export function AudioAttachment({
     )
     const { file, fileMime } = message
     const src = runtime.transformBlobURL(file || '')
-    const hasSupportedFormat = isAudio(fileMime)
+    const hasSupportedFormat =
+      message.viewType === 'Audio' || message.viewType === 'Voice'
     const isBroken = !file || !hasSupportedFormat
     return (
       <div

--- a/packages/frontend/src/components/attachment/galleryAttachment.tsx
+++ b/packages/frontend/src/components/attachment/galleryAttachment.tsx
@@ -153,17 +153,10 @@ function getBrokenMediaContextMenu(
   )
 }
 
-function squareBrokenMediaContent(
-  hasSupportedFormat: boolean,
-  contentType: string | null
-) {
+function squareBrokenMediaContent() {
   const tx = window.static_translate
   return (
-    <div className='attachment-content'>
-      {hasSupportedFormat
-        ? tx('attachment_failed_to_load')
-        : tx('cannot_display_unsuported_file_type', contentType || 'null')}
-    </div>
+    <div className='attachment-content'>{tx('attachment_failed_to_load')}</div>
   )
 }
 
@@ -180,7 +173,6 @@ export function ImageAttachment({
   openFullscreenMedia: (message: T.Message) => void
 }) {
   const { openDialog } = useDialog()
-  const tx = useTranslationFunction()
   const contextMenu = useContext(ContextMenuContext)
   const { jumpToMessage, deleteMessage } = useMessage()
   const accountId = selectedAccountId()
@@ -214,9 +206,7 @@ export function ImageAttachment({
         aria-haspopup='menu'
         {...rovingTabindexProps}
       >
-        <div className='attachment-content'>
-          {tx('attachment_failed_to_load')}
-        </div>
+        {squareBrokenMediaContent()}
       </div>
     )
   } else {
@@ -228,9 +218,8 @@ export function ImageAttachment({
       message,
       accountId
     )
-    const { file, fileMime } = message
-    const hasSupportedFormat = isImage(message.viewType)
-    const isBroken = !file || !hasSupportedFormat
+    const { file } = message
+    const isBroken = !file
 
     return (
       <button
@@ -251,7 +240,7 @@ export function ImageAttachment({
         {...rovingTabindexProps}
       >
         {isBroken ? (
-          squareBrokenMediaContent(hasSupportedFormat, fileMime)
+          squareBrokenMediaContent()
         ) : (
           <img
             className='attachment-content'
@@ -272,7 +261,6 @@ export function VideoAttachment({
   openFullscreenMedia: (message: T.Message) => void
 }) {
   const { openDialog } = useDialog()
-  const tx = useTranslationFunction()
   const contextMenu = useContext(ContextMenuContext)
   const { deleteMessage, jumpToMessage } = useMessage()
   const accountId = selectedAccountId()
@@ -303,9 +291,7 @@ export function VideoAttachment({
         aria-haspopup='menu'
         {...rovingTabindexProps}
       >
-        <div className='attachment-content'>
-          {tx('attachment_failed_to_load')}
-        </div>
+        {squareBrokenMediaContent()}
       </div>
     )
   } else {
@@ -317,7 +303,7 @@ export function VideoAttachment({
       message,
       accountId
     )
-    const { file, fileMime } = message
+    const { file } = message
     const hasSupportedFormat = message.viewType === 'Video'
     const isBroken = !file || !hasSupportedFormat
     return (
@@ -335,7 +321,7 @@ export function VideoAttachment({
         {...rovingTabindexProps}
       >
         {isBroken ? (
-          squareBrokenMediaContent(hasSupportedFormat, fileMime || '')
+          squareBrokenMediaContent()
         ) : (
           <>
             <video
@@ -359,7 +345,6 @@ export function AudioAttachment({
   loadResult,
 }: GalleryAttachmentElementProps) {
   const { openDialog } = useDialog()
-  const tx = useTranslationFunction()
   const nextVoiceMessagePlayerCtx = useContext(NextVoiceMessagePlayerContext)
   const contextMenu = useContext(ContextMenuContext)
   const { deleteMessage, jumpToMessage } = useMessage()
@@ -394,9 +379,7 @@ export function AudioAttachment({
           <div className='name'>? Error ?</div>
           <span className='date'>?</span>
         </div>
-        <div className='attachment-content'>
-          {tx('attachment_failed_to_load')}
-        </div>
+        {squareBrokenMediaContent()}
       </div>
     )
   } else {
@@ -408,11 +391,9 @@ export function AudioAttachment({
       message,
       accountId
     )
-    const { file, fileMime } = message
+    const { file } = message
     const src = runtime.transformBlobURL(file || '')
-    const hasSupportedFormat =
-      message.viewType === 'Audio' || message.viewType === 'Voice'
-    const isBroken = !file || !hasSupportedFormat
+    const isBroken = !file
     return (
       <div
         ref={interactiveElRef}
@@ -462,7 +443,9 @@ export function AudioAttachment({
             module='date'
           />
         </div>
-        {hasSupportedFormat ? (
+        {isBroken ? (
+          squareBrokenMediaContent()
+        ) : (
           <AudioPlayer
             src={src}
             // Despite the element having multiple interactive
@@ -477,13 +460,6 @@ export function AudioAttachment({
               })
             }
           />
-        ) : (
-          <div>
-            {window.static_translate(
-              'cannot_display_unsuported_file_type',
-              fileMime || 'null'
-            )}
-          </div>
         )}
       </div>
     )

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -6,8 +6,6 @@ import { openAttachmentInShell } from '../message/messageFunctions'
 import {
   isDisplayableByFullscreenMedia,
   isImage,
-  isVideo,
-  isAudio,
   getExtension,
   dragAttachmentOut,
   MessageTypeAttachmentSubset,
@@ -65,7 +63,7 @@ export default function Attachment({
       }
       return
     }
-    if (isDisplayableByFullscreenMedia(message.fileMime)) {
+    if (isDisplayableByFullscreenMedia(message.viewType)) {
       openDialog(FullscreenMedia, {
         msg: message,
         neighboringMedia: NeighboringMediaMode.Chat,
@@ -141,7 +139,7 @@ export default function Attachment({
   const withCaption = Boolean(text)
   // For attachments which aren't full-frame
   const withContentBelow = withCaption
-  if (isImage(message.fileMime) || message.viewType === 'Sticker') {
+  if (isImage(message.viewType) || message.viewType === 'Sticker') {
     if (!message.file) {
       return (
         <div
@@ -173,7 +171,7 @@ export default function Attachment({
         />
       </button>
     )
-  } else if (isVideo(message.fileMime)) {
+  } else if (message.viewType === 'Video') {
     if (!message.file) {
       return (
         <button
@@ -206,7 +204,7 @@ export default function Attachment({
         />
       </div>
     )
-  } else if (isAudio(message.fileMime)) {
+  } else if (message.viewType === 'Audio' || message.viewType === 'Voice') {
     return (
       <div
         className={classNames(
@@ -314,7 +312,7 @@ export function DraftAttachment({
   if (!attachment) {
     return null
   }
-  if (isImage(attachment.fileMime)) {
+  if (isImage(attachment.viewType)) {
     return (
       <div className={classNames('message-attachment-media')}>
         <img
@@ -323,7 +321,7 @@ export function DraftAttachment({
         />
       </div>
     )
-  } else if (isVideo(attachment.fileMime)) {
+  } else if (attachment.viewType === 'Video') {
     return (
       <div className={classNames('message-attachment-media')}>
         <video
@@ -333,7 +331,10 @@ export function DraftAttachment({
         />
       </div>
     )
-  } else if (isAudio(attachment.fileMime)) {
+  } else if (
+    attachment.viewType === 'Audio' ||
+    attachment.viewType === 'Voice'
+  ) {
     return <AudioPlayer src={runtime.transformBlobURL(attachment.file || '')} />
   } else if (isViewTypeWebxdc) {
     const iconUrl = runtime.getWebxdcIconURL(selectedAccountId(), attachment.id)

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -11,12 +11,10 @@ import {
   MessageTypeAttachmentSubset,
 } from './Attachment'
 import { runtime } from '@deltachat-desktop/runtime-interface'
-import { getDirection } from '../../utils/getDirection'
 import { Type } from '../../backend-com'
 import FullscreenMedia, {
   NeighboringMediaMode,
 } from '../dialogs/FullscreenMedia'
-import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useDialog from '../../hooks/dialog/useDialog'
 import useConfirmationDialog from '../../hooks/dialog/useConfirmationDialog'
 import { AudioPlayer } from '../AudioPlayer'
@@ -28,6 +26,7 @@ import { selectedAccountId } from '../../ScreenController'
 import { BackendRemote } from '../../backend-com'
 import { useRpcFetch } from '../../hooks/useFetch'
 import { useHasChanged2 } from '../../hooks/useHasChanged'
+import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 type AttachmentProps = {
   text?: string
@@ -40,13 +39,12 @@ export default function Attachment({
   message,
   tabindexForInteractiveContents,
 }: AttachmentProps) {
-  const tx = useTranslationFunction()
   const { openDialog } = useDialog()
   const openConfirmationDialog = useConfirmationDialog()
+  const tx = useTranslationFunction()
   if (!message.file) {
     return null
   }
-  const direction = getDirection(message)
   const onClickAttachment = async (ev: any) => {
     ev.stopPropagation()
     if (message.viewType === 'Sticker') {
@@ -140,15 +138,6 @@ export default function Attachment({
   // For attachments which aren't full-frame
   const withContentBelow = withCaption
   if (isImage(message.viewType) || message.viewType === 'Sticker') {
-    if (!message.file) {
-      return (
-        <div
-          className={classNames('message-attachment-broken-media', direction)}
-        >
-          {tx('attachment_failed_to_load')}
-        </div>
-      )
-    }
     return (
       <button
         type='button'
@@ -172,19 +161,6 @@ export default function Attachment({
       </button>
     )
   } else if (message.viewType === 'Video') {
-    if (!message.file) {
-      return (
-        <button
-          type='button'
-          onClick={onClickAttachment}
-          tabIndex={tabindexForInteractiveContents}
-          style={{ cursor: 'pointer' }}
-          className={classNames('message-attachment-broken-media', direction)}
-        >
-          {tx('attachment_failed_to_load')}
-        </button>
-      )
-    }
     // the native fullscreen option is better right now so we don't need to open our own one
     return (
       <div

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -2,7 +2,11 @@ import React, { useContext } from 'react'
 import { dirname, basename } from 'path'
 
 import { runtime } from '@deltachat-desktop/runtime-interface'
-import { IMAGE_EXTENSIONS } from '../../../../shared/constants'
+import {
+  AUDIO_EXTENSIONS,
+  IMAGE_EXTENSIONS,
+  VIDEO_EXTENSIONS,
+} from '../../../../shared/constants'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import useDialog from '../../hooks/dialog/useDialog'
 import SelectContactDialog from '../dialogs/SelectContact'
@@ -86,7 +90,18 @@ export default function MenuAttachment({
 
     if (files.length === 1) {
       setLastPath(dirname(files[0]))
-      addFileToDraft(files[0], basename(files[0]), 'File')
+      // for Audio, Video & Vcard set a ViewType that has a preview here
+      let viewType = 'File' as T.Viewtype
+      if (AUDIO_EXTENSIONS.some(ext => files[0].toLowerCase().endsWith(ext))) {
+        viewType = 'Audio'
+      } else if (
+        VIDEO_EXTENSIONS.some(ext => files[0].toLowerCase().endsWith(ext))
+      ) {
+        viewType = 'Video'
+      } else if (files[0].toLowerCase().endsWith('.vcf')) {
+        viewType = 'Vcard'
+      }
+      addFileToDraft(files[0], basename(files[0]), viewType)
     } else if (files.length > 1) {
       confirmSendMultipleFiles(files, 'File')
     }

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -92,10 +92,12 @@ export default function MenuAttachment({
       setLastPath(dirname(files[0]))
       // for Audio, Video & Vcard set a ViewType that has a preview here
       let viewType = 'File' as T.Viewtype
-      if (AUDIO_EXTENSIONS.some(ext => files[0].toLowerCase().endsWith(ext))) {
+      if (
+        AUDIO_EXTENSIONS.some(ext => files[0].toLowerCase().endsWith('.' + ext))
+      ) {
         viewType = 'Audio'
       } else if (
-        VIDEO_EXTENSIONS.some(ext => files[0].toLowerCase().endsWith(ext))
+        VIDEO_EXTENSIONS.some(ext => files[0].toLowerCase().endsWith('.' + ext))
       ) {
         viewType = 'Video'
       } else if (files[0].toLowerCase().endsWith('.vcf')) {

--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -6,7 +6,7 @@ import Dialog from '../Dialog'
 import { IconButton } from '../Icon'
 import { onDownload } from '../message/messageFunctions'
 import { runtime } from '@deltachat-desktop/runtime-interface'
-import { isImage, isVideo, isAudio } from '../attachment/Attachment'
+
 import { getLogger } from '../../../../shared/logger'
 import { gitHubIssuesUrl } from '../../../../shared/constants'
 import { useInitEffect } from '../helpers/hooks'
@@ -18,6 +18,7 @@ import useMessage from '../../hooks/chat/useMessage'
 import { useZoomKeyboardShortcuts } from '../../hooks/useZoomKeyboardShortcuts'
 
 import type { DialogProps } from '../../contexts/DialogContext'
+import { isImage } from '../attachment/Attachment'
 
 const log = getLogger('renderer/fullscreen_media')
 
@@ -68,12 +69,11 @@ export default function FullscreenMedia(props: Props & DialogProps) {
       } else {
         const { viewType, chatId } = props.msg
         // workaround to get gifs and images into the same media list
-        let additionalViewType: Type.Viewtype | null = null
-        if (props.msg.viewType === 'Image') {
-          additionalViewType = 'Gif'
-        } else if (props.msg.viewType === 'Gif') {
-          additionalViewType = 'Image'
-        }
+        const additionalViewType: Type.Viewtype | null = isImage(viewType)
+          ? viewType === 'Image'
+            ? 'Gif'
+            : 'Image'
+          : null
         const scope =
           props.neighboringMedia === NeighboringMediaMode.Global ? null : chatId
         BackendRemote.rpc
@@ -128,7 +128,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
 
   let elm = null
 
-  if (isImage(fileMime)) {
+  if (isImage(msg.viewType)) {
     const imageHeight =
       msg.dimensionsHeight < 300 ? 2 * msg.dimensionsHeight : ''
     elm = (
@@ -178,9 +178,9 @@ export default function FullscreenMedia(props: Props & DialogProps) {
         </TransformWrapper>
       </div>
     )
-  } else if (isAudio(fileMime)) {
+  } else if (msg.viewType === 'Audio' || msg.viewType === 'Voice') {
     elm = <audio src={runtime.transformBlobURL(file)} controls />
-  } else if (isVideo(fileMime)) {
+  } else if (msg.viewType === 'Video') {
     elm = <video src={runtime.transformBlobURL(file)} controls autoPlay />
   } else if (!fileMime) {
     // no file mime

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -288,7 +288,8 @@ function buildContextMenu(
   }
 
   const showAttachmentOptions = !!message.file
-  const showCopyImage = !!message.file && isImage(message.viewType)
+  const showCopyImage =
+    !!message.file && isImage(message.viewType) && message.viewType !== 'Gif'
   const showResend =
     message.sender.id === C.DC_CONTACT_ID_SELF && message.viewType !== 'Call'
 

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -25,7 +25,7 @@ import {
   enterEditMessageMode,
 } from './messageFunctions'
 import Attachment from '../attachment/messageAttachment'
-import { isGenericAttachment, isImage, isVideo } from '../attachment/Attachment'
+import { isGenericAttachment, isImage } from '../attachment/Attachment'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { ConversationType } from './MessageList'
 import { getDirection } from '../../utils/getDirection'
@@ -288,7 +288,7 @@ function buildContextMenu(
   }
 
   const showAttachmentOptions = !!message.file
-  const showCopyImage = !!message.file && message.viewType === 'Image'
+  const showCopyImage = !!message.file && isImage(message.viewType)
   const showResend =
     message.sender.id === C.DC_CONTACT_ID_SELF && message.viewType !== 'Call'
 
@@ -388,7 +388,7 @@ function buildContextMenu(
     // Open Attachment
     showAttachmentOptions &&
       message.viewType !== 'Webxdc' &&
-      isGenericAttachment(message.fileMime) && {
+      isGenericAttachment(message.viewType) && {
         label: tx('open_attachment'),
         action: openAttachmentInShell.bind(null, message),
       },
@@ -694,7 +694,8 @@ export default function Message(props: {
         // set message width which is used by reaction component
         // to adapt the number of visible reactions
         if (
-          (message.fileMime && isImage(message.fileMime)) ||
+          isImage(message.viewType) ||
+          message.viewType === 'Sticker' ||
           window.innerWidth < 900
         ) {
           // image messages have a defined width
@@ -714,7 +715,7 @@ export default function Message(props: {
     return () => {
       window.removeEventListener('resize', resizeHandler)
     }
-  }, [message.fileMime])
+  }, [message.viewType])
 
   // Info Message
   if (message.isInfo) {
@@ -868,7 +869,7 @@ export default function Message(props: {
 
   const hasText = text !== null && text !== ''
   const fileMime = message.fileMime || null
-  const isWithoutText = isMediaWithoutText(fileMime, hasText, message.viewType)
+  const isWithoutText = isMediaWithoutText(hasText, message.viewType)
   const showAttachment = (message: T.Message) =>
     message.file &&
     message.viewType !== 'Webxdc' &&
@@ -883,7 +884,7 @@ export default function Message(props: {
         direction,
         styles.message,
         rovingTabindex.className,
-        isWithoutText && isVideo(fileMime) ? 'video-only' : '',
+        isWithoutText && viewType === 'Video' ? 'video-only' : '',
         {
           [styles.withReactions]: message.reactions,
           'type-sticker': viewType === 'Sticker',

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { T } from '@deltachat/jsonrpc-client'
 
 import Timestamp from '../conversations/Timestamp'
-import { isImage, isVideo } from '../attachment/Attachment'
+import { isImage } from '../attachment/Attachment'
 import { msgStatus } from '../../types-app'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { useRpcFetch } from '../../hooks/useFetch'
@@ -37,7 +37,6 @@ export default function MessageMetaData(props: Props) {
   const {
     messageId,
     encrypted,
-    fileMime,
     direction,
     status,
     error,
@@ -56,11 +55,7 @@ export default function MessageMetaData(props: Props) {
   return (
     <div
       className={classNames('metadata', {
-        'with-image-no-caption': isMediaWithoutText(
-          fileMime,
-          hasText,
-          viewType
-        ),
+        'with-image-no-caption': isMediaWithoutText(hasText, viewType),
       })}
     >
       {/* FYI the email doesn't need `aria-live`
@@ -217,12 +212,11 @@ function ViewCount(props: { messageId: number }) {
  * without any further text.
  **/
 export function isMediaWithoutText(
-  fileMime: string | null,
   hasText: boolean,
   viewType: T.Viewtype
 ): boolean {
   const withImageNoCaption = Boolean(
-    !hasText && (isImage(fileMime) || isVideo(fileMime))
+    !hasText && (isImage(viewType) || viewType === 'Video')
   )
 
   return withImageNoCaption || viewType === 'Sticker'

--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -2,7 +2,7 @@ import { appName } from '../../../shared/constants'
 import { getLogger } from '../../../shared/logger'
 import { NOTIFICATION_TYPE } from '../../../shared/constants'
 import { BackendRemote } from '../backend-com'
-import { isImage } from '../components/attachment/Attachment'
+
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import SettingsStoreInstance, {
   mentionsEnabledDefaultVal,
@@ -468,7 +468,7 @@ export function clearAllNotifications() {
 function getNotificationIcon(
   notification: T.MessageNotificationInfo
 ): [icon: string | null, iconIsAvatar: boolean] {
-  if (notification.image && isImage(notification.imageMimeType)) {
+  if (notification.image && notification.imageMimeType?.startsWith('image/')) {
     return [notification.image, false]
   } else if (notification.chatProfileImage) {
     return [notification.chatProfileImage, true]

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -27,7 +27,23 @@ export const enum AutodeleteDuration {
   ONE_YEAR = Timespans.ONE_YEAR_IN_SECONDS,
 }
 
-export const IMAGE_EXTENSIONS = ['jpg', 'jpeg', 'png', 'apng', 'gif', 'webp']
+// see fn guess_msgtype_from_path_suffix in https://github.com/chatmail/core/blob/main/src/message.rs
+
+export const IMAGE_EXTENSIONS = [
+  'jpg',
+  'jpeg',
+  'jpe',
+  'png',
+  'apng',
+  'gif',
+  'webp',
+  'heic',
+  'heif',
+]
+
+export const VIDEO_EXTENSIONS = ['mp4', 'mov', 'avi', 'wmv', '3gp']
+
+export const AUDIO_EXTENSIONS = ['mp3', 'wav', 'aac', 'flac', 'ogg', 'oga']
 
 export const enum NOTIFICATION_TYPE {
   MESSAGE,


### PR DESCRIPTION
resolves #6049

As mentioned in the comment for MEDIA_VIEW_TYPES: the compatibilty with other clients now has higher priority to avoid one client sending media that the other clients won't be able to run/see for the cost that not all media types that could be displayed will be displayed
