### PR TITLE
refactor: inline some msg functions

### DIFF
--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
+import { getLogger } from '@deltachat-desktop/shared/logger'
 import { BackendRemote } from '../../../backend-com'
 import { selectedAccountId } from '../../../ScreenController'
-import { confirmForwardMessage } from '../../message/messageFunctions'
+import { confirmDialog } from '../../message/messageFunctions'
 import { getConfiguredAccounts } from '../../../backend/account'
 import { saveLastChatId } from '../../../backend/chat'
 import useChat from '../../../hooks/chat/useChat'
@@ -21,6 +22,8 @@ import { useRpcFetch } from '../../../hooks/useFetch'
 import { Avatar } from '../../Avatar'
 import AlertDialog from '../AlertDialog'
 import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
+
+const log = getLogger('ForwardMessage')
 
 type ForwardMessageProps = {
   message: T.Message
@@ -85,14 +88,36 @@ export default function ForwardMessage(props: ForwardMessageProps) {
       if (!isCrossAccountForward) {
         selectChat(currentAccountId, chat.id)
       }
-      const yes = await confirmForwardMessage(
+      const yes = await confirmDialog(
         openDialog,
-        currentAccountId,
-        message,
-        chat,
-        isCrossAccountForward ? targetAccountId : undefined
+        tx('ask_forward', [chat.name]),
+        tx('forward')
       )
       if (yes) {
+        try {
+          if (isCrossAccountForward) {
+            // Cross-account forward
+            await BackendRemote.rpc.forwardMessagesToAccount(
+              currentAccountId,
+              [message.id],
+              targetAccountId,
+              chat.id
+            )
+          } else {
+            // Same-account forward
+            await BackendRemote.rpc.forwardMessages(
+              currentAccountId,
+              [message.id],
+              chat.id
+            )
+          }
+        } catch (e) {
+          log.error('error forwarding message:', e)
+          void openDialog(AlertDialog, {
+            message: unknownErrorToString(e),
+          })
+          return false
+        }
         // get the (new) id of forwarded message
         // and jump to the message
         const messageIds = await BackendRemote.rpc.getMessageIds(

--- a/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
+++ b/packages/frontend/src/components/dialogs/ForwardMessage/index.tsx
@@ -36,7 +36,7 @@ export default function ForwardMessage(props: ForwardMessageProps) {
   const tx = useTranslationFunction()
   const { openDialog } = useDialog()
   const { selectChat } = useChat()
-  const { forwardMessage, jumpToMessage } = useMessage()
+  const { jumpToMessage } = useMessage()
 
   const configuredAccountsFetch = useRpcFetch(getConfiguredAccounts, [])
 
@@ -147,7 +147,11 @@ export default function ForwardMessage(props: ForwardMessageProps) {
             chat.id
           )
         } else {
-          await forwardMessage(currentAccountId, message.id, chat.id)
+          await BackendRemote.rpc.forwardMessages(
+            currentAccountId,
+            [message.id],
+            chat.id
+          )
         }
       } catch (e) {
         void openDialog(AlertDialog, {

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -21,7 +21,6 @@ import {
   isMessageEditable,
   setQuoteInDraft,
   openMessageHTML,
-  confirmDeleteMessage,
   downloadFullMessage,
   openWebxdc,
   enterEditMessageMode,
@@ -68,6 +67,7 @@ import { IconButton } from '../Icon'
 import { useRpcFetch } from '../../hooks/useFetch'
 import ForwardMessage from '../dialogs/ForwardMessage'
 import MessageDetail from '../dialogs/MessageDetail/MessageDetail'
+import ConfirmDeleteMessageDialog from '../dialogs/ConfirmDeleteMessage'
 
 const log = getLogger('Message')
 
@@ -439,13 +439,12 @@ function buildContextMenu(
     // Delete message
     {
       label: tx('delete_message_desktop'),
-      action: confirmDeleteMessage.bind(
-        null,
-        openDialog,
-        accountId,
-        message,
-        chat
-      ),
+      action: () =>
+        openDialog(ConfirmDeleteMessageDialog, {
+          accountId,
+          msg: message,
+          chat,
+        }),
       danger: true,
     },
   ]
@@ -634,7 +633,11 @@ export default function Message(props: {
       ) {
         e.preventDefault()
         e.stopPropagation()
-        confirmDeleteMessage(openDialog, accountId, message, props.chat)
+        openDialog(ConfirmDeleteMessageDialog, {
+          accountId,
+          msg: message,
+          chat,
+        })
         return
       }
 

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -21,7 +21,6 @@ import {
   isMessageEditable,
   setQuoteInDraft,
   openMessageHTML,
-  downloadFullMessage,
   openWebxdc,
   enterEditMessageMode,
 } from './messageFunctions'
@@ -848,7 +847,9 @@ export default function Message(props: {
         {(downloadState == 'Failure' || downloadState === 'Available') && (
           <button
             type='button'
-            onClick={downloadFullMessage.bind(null, message.id)}
+            onClick={() =>
+              BackendRemote.rpc.downloadFullMessage(accountId, message.id)
+            }
             tabIndex={tabindexForInteractiveContents}
           >
             {tx('download')}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -18,7 +18,6 @@ import MessageMetaData, { isMediaWithoutText } from './MessageMetaData'
 import {
   onDownload,
   openAttachmentInShell,
-  openForwardDialog,
   openMessageInfo,
   isMessageEditable,
   setQuoteInDraft,
@@ -68,6 +67,7 @@ import { avatarInitial } from '@deltachat-desktop/shared/avatarInitial'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { IconButton } from '../Icon'
 import { useRpcFetch } from '../../hooks/useFetch'
+import ForwardMessage from '../dialogs/ForwardMessage'
 
 const log = getLogger('Message')
 
@@ -331,7 +331,7 @@ function buildContextMenu(
     // Forward message
     {
       label: tx('forward'),
-      action: openForwardDialog.bind(null, openDialog, message),
+      action: () => openDialog(ForwardMessage, { message }),
     },
     // Save Message
     // For reference, the conditions when it's shown:

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -18,7 +18,6 @@ import MessageMetaData, { isMediaWithoutText } from './MessageMetaData'
 import {
   onDownload,
   openAttachmentInShell,
-  openMessageInfo,
   isMessageEditable,
   setQuoteInDraft,
   openMessageHTML,
@@ -68,6 +67,7 @@ import { getLogger } from '@deltachat-desktop/shared/logger'
 import { IconButton } from '../Icon'
 import { useRpcFetch } from '../../hooks/useFetch'
 import ForwardMessage from '../dialogs/ForwardMessage'
+import MessageDetail from '../dialogs/MessageDetail/MessageDetail'
 
 const log = getLogger('Message')
 
@@ -433,7 +433,7 @@ function buildContextMenu(
     // Message Info
     {
       label: tx('info'),
-      action: openMessageInfo.bind(null, openDialog, message),
+      action: () => openDialog(MessageDetail, { id: message.id }),
     },
     { type: 'separator' },
     // Delete message
@@ -994,7 +994,7 @@ export default function Message(props: {
               timestamp={message.timestamp * 1000}
               encrypted={message.showPadlock}
               isSavedMessage={isOrHasSavedMessage}
-              onClickError={openMessageInfo.bind(null, openDialog, message)}
+              onClickError={() => openDialog(MessageDetail, { id: message.id })}
               viewType={message.viewType}
               chatType={chat.chatType}
               tabindexForInteractiveContents={tabindexForInteractiveContents}

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -159,10 +159,6 @@ export async function openMessageHTML(messageId: number) {
   )
 }
 
-export async function downloadFullMessage(messageId: number) {
-  await BackendRemote.rpc.downloadFullMessage(selectedAccountId(), messageId)
-}
-
 export async function openWebxdc(
   message: Type.Message,
   webxdcInfo?: T.WebxdcMessageInfo

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -9,7 +9,6 @@ import ConfirmationDialog from '../dialogs/ConfirmationDialog'
 
 import type { OpenDialog } from '../../contexts/DialogContext'
 import { C, T } from '@deltachat/jsonrpc-client'
-import ConfirmDeleteMessageDialog from '../dialogs/ConfirmDeleteMessage'
 import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
 import AlertDialog from '../dialogs/AlertDialog'
 import type { msgStatus } from '../../types-app'
@@ -103,19 +102,6 @@ export async function confirmForwardMessage(
     }
   }
   return yes
-}
-
-export function confirmDeleteMessage(
-  openDialog: OpenDialog,
-  accountId: number,
-  msg: Type.Message,
-  chat: Type.FullChat
-) {
-  openDialog(ConfirmDeleteMessageDialog, {
-    accountId,
-    msg,
-    chat,
-  })
 }
 
 /**

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -6,7 +6,6 @@ import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { internalOpenWebxdc } from '../../system-integration/webxdc'
 import ConfirmationDialog from '../dialogs/ConfirmationDialog'
-import MessageDetail from '../dialogs/MessageDetail/MessageDetail'
 
 import type { OpenDialog } from '../../contexts/DialogContext'
 import { C, T } from '@deltachat/jsonrpc-client'
@@ -117,10 +116,6 @@ export function confirmDeleteMessage(
     msg,
     chat,
   })
-}
-
-export function openMessageInfo(openDialog: OpenDialog, message: Type.Message) {
-  openDialog(MessageDetail, { id: message.id })
 }
 
 /**

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -9,8 +9,6 @@ import ConfirmationDialog from '../dialogs/ConfirmationDialog'
 
 import type { OpenDialog } from '../../contexts/DialogContext'
 import { C, T } from '@deltachat/jsonrpc-client'
-import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
-import AlertDialog from '../dialogs/AlertDialog'
 import type { msgStatus } from '../../types-app'
 
 const log = getLogger('renderer/msgFunctions')
@@ -59,49 +57,6 @@ export function confirmDialog(
       },
     })
   })
-}
-
-export async function confirmForwardMessage(
-  openDialog: OpenDialog,
-  srcAccountId: number,
-  message: Type.Message,
-  chat: Pick<Type.BasicChat, 'name' | 'id'>,
-  dstAccountId?: number
-) {
-  const tx = window.static_translate
-  const yes = await confirmDialog(
-    openDialog,
-    tx('ask_forward', [chat.name]),
-    tx('forward')
-  )
-  if (yes) {
-    const targetAccountId = dstAccountId ?? srcAccountId
-    try {
-      if (targetAccountId !== srcAccountId) {
-        // Cross-account forward
-        await BackendRemote.rpc.forwardMessagesToAccount(
-          srcAccountId,
-          [message.id],
-          targetAccountId,
-          chat.id
-        )
-      } else {
-        // Same-account forward
-        await BackendRemote.rpc.forwardMessages(
-          srcAccountId,
-          [message.id],
-          chat.id
-        )
-      }
-    } catch (e) {
-      log.error('error forwarding message:', e)
-      void openDialog(AlertDialog, {
-        message: unknownErrorToString(e),
-      })
-      return false
-    }
-  }
-  return yes
 }
 
 /**

--- a/packages/frontend/src/components/message/messageFunctions.ts
+++ b/packages/frontend/src/components/message/messageFunctions.ts
@@ -5,7 +5,6 @@ import { runtime } from '@deltachat-desktop/runtime-interface'
 import { BackendRemote, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { internalOpenWebxdc } from '../../system-integration/webxdc'
-import ForwardMessage from '../dialogs/ForwardMessage'
 import ConfirmationDialog from '../dialogs/ConfirmationDialog'
 import MessageDetail from '../dialogs/MessageDetail/MessageDetail'
 
@@ -44,13 +43,6 @@ export async function openAttachmentInShell(msg: Type.Message) {
       "file couldn't be opened, try saving it in a different place and try to open it from there"
     )
   }
-}
-
-export function openForwardDialog(
-  openDialog: OpenDialog,
-  message: Type.Message
-) {
-  openDialog(ForwardMessage, { message })
 }
 
 export function confirmDialog(

--- a/packages/frontend/src/hooks/chat/useMessage.ts
+++ b/packages/frontend/src/hooks/chat/useMessage.ts
@@ -55,12 +55,6 @@ export type SendMessage = (
   message: Partial<T.MessageData>
 ) => Promise<void>
 
-export type ForwardMessage = (
-  accountId: number,
-  messageId: number,
-  chatId: number
-) => Promise<void>
-
 export type DeleteMessage = (
   accountId: number,
   messageId: number
@@ -157,13 +151,6 @@ export default function useMessage() {
     [jumpToMessage]
   )
 
-  const forwardMessage = useCallback<ForwardMessage>(
-    async (accountId: number, messageId: number, chatId: number) => {
-      await BackendRemote.rpc.forwardMessages(accountId, [messageId], chatId)
-    },
-    []
-  )
-
   const deleteMessage = useCallback<DeleteMessage>(
     async (accountId: number, messageId: number) => {
       await BackendRemote.rpc.deleteMessages(accountId, [messageId])
@@ -182,7 +169,6 @@ export default function useMessage() {
      */
     jumpToMessage,
     sendMessage,
-    forwardMessage,
     deleteMessage,
   }
 }


### PR DESCRIPTION
- **refactor: inline one-line `forwardMessage` func**
- **refactor: inline one-line `openForwardDialog` func**
- **refactor: inline one-line `openMessageInfo` func**
- **refactor: inline one-line `confirmDeleteMessage`**
- **refactor: inline one-line `downloadFullMessage` fn**
- **refactor: inline `confirmForwardMessage` function**

Most of them are one-line functions.

Looks like the mega-refactor e2f9cdb915d59ac7d718de5eb60ecf779d8289a6
(https://github.com/deltachat/deltachat-desktop/pull/3725)
introduced a bunch of these one-line abstractions
which found no use in two years.
Let's simplify things a little.

During the development of the said MR
some of these one-line abstractions have been introduced in one commit
then removed in another, such as `getChat()`
(added in https://github.com/deltachat/deltachat-desktop/pull/3725/changes/c7c8f9646a21665a7788fec7239e6995f1407d30,
then removed in https://github.com/deltachat/deltachat-desktop/pull/3725/changes/23a79b970cccd690dc2e98e7c159627be61e8652).
So one can't say that what I'm doing in this MR
goes completely against the idea of that MR.

In case you're about to get angry at me
for making another refactor MR, I'll say
that the message multiselect MR is based on this.
In cause you're still angry and don't want to review this MR
I can rebase the multiselect MR on top of main.
It's not too much work.
