### PR TITLE
fix: chat list: Ctrl + Space multiselect on Linux

### DIFF
--- a/packages/frontend/src/components/chat/ChatListItem.tsx
+++ b/packages/frontend/src/components/chat/ChatListItem.tsx
@@ -141,11 +141,13 @@ export const PlaceholderChatListItem = React.memo(
 
 function ChatListItemArchiveLink({
   onClick,
+  onKeyDown,
   onFocus,
   chatListItem,
   ...rest
 }: {
   onClick: (event: React.MouseEvent) => void
+  onKeyDown?: React.KeyboardEventHandler
   onFocus?: (event: React.FocusEvent) => void
   chatListItem: Type.ChatListItemFetchResult & {
     kind: 'ArchiveLink'
@@ -179,7 +181,10 @@ function ChatListItemArchiveLink({
       {...rest}
       tabIndex={tabIndex}
       onClick={onClick}
-      onKeyDown={tabindexOnKeydown}
+      onKeyDown={e => {
+        onKeyDown?.(e)
+        tabindexOnKeydown(e)
+      }}
       onFocus={e => {
         tabindexSetAsActiveElement()
         onFocus?.(e)
@@ -204,6 +209,7 @@ function ChatListItemArchiveLink({
 function ChatListItemError({
   chatListItem,
   onClick,
+  onKeyDown,
   roleTab,
   onFocus,
   isSelected,
@@ -214,6 +220,7 @@ function ChatListItemError({
     kind: 'Error'
   }
   onClick: (event: React.MouseEvent) => void
+  onKeyDown?: React.KeyboardEventHandler
   onFocus?: (event: React.FocusEvent) => void
   onContextMenu?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -241,7 +248,10 @@ function ChatListItemError({
       {...rest}
       tabIndex={tabIndex}
       onClick={onClick}
-      onKeyDown={tabindexOnKeydown}
+      onKeyDown={e => {
+        onKeyDown?.(e)
+        tabindexOnKeydown(e)
+      }}
       onFocus={e => {
         onFocus?.(e)
         tabindexSetAsActiveElement()
@@ -287,6 +297,7 @@ function RegularChatListItem({
   // simply remove it from `rest`.
   chatListItem: _chatListItem,
   onClick,
+  onKeyDown,
   onFocus,
   isSelected,
   roleTab,
@@ -299,6 +310,7 @@ function RegularChatListItem({
   }
   chatListItem?: Type.ChatListItemFetchResult
   onClick: (event: React.MouseEvent) => void
+  onKeyDown?: React.KeyboardEventHandler
   onFocus?: (event: React.FocusEvent) => void
   onContextMenu?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -332,7 +344,10 @@ function RegularChatListItem({
       {...rest}
       tabIndex={tabIndex}
       onClick={onClick}
-      onKeyDown={tabindexOnKeydown}
+      onKeyDown={e => {
+        onKeyDown?.(e)
+        tabindexOnKeydown(e)
+      }}
       onFocus={e => {
         onFocus?.(e)
         tabindexSetAsActiveElement()
@@ -388,6 +403,7 @@ function RegularChatListItem({
 type ChatListItemProps = {
   chatListItem: Type.ChatListItemFetchResult | undefined
   onClick: (event: React.MouseEvent) => void
+  onKeyDown: React.KeyboardEventHandler
   onFocus?: (event: React.FocusEvent) => void
   onContextMenu?: (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -427,6 +443,7 @@ const ChatListItem = React.memo<ChatListItemProps>(props => {
         chatListItem={chatListItem}
         onClick={props.onClick}
         onFocus={props.onFocus}
+        onKeyDown={props.onKeyDown}
         aria-posinset={props['aria-posinset']}
         aria-setsize={props['aria-setsize']}
       />

--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -126,6 +126,24 @@ export const ChatListItemRowChat = React.memo<{
   // eslint-disable-next-line react-hooks/refs
   onChatClick2Ref.current = onChatClick2
 
+  const multiselectOnKeyDown = multiselect?.onKeyDown
+  const onKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      let shouldPreventDefault = false
+      if (multiselectOnKeyDown) {
+        shouldPreventDefault = multiselectOnKeyDown?.(e, chatId)
+      }
+      if (shouldPreventDefault) {
+        e.preventDefault()
+        return
+      }
+    },
+    [chatId, multiselectOnKeyDown]
+  )
+  const onKeyDownRef = useRef(onKeyDown)
+  // eslint-disable-next-line react-hooks/refs
+  onKeyDownRef.current = onKeyDown
+
   const onContextMenu = useCallback(
     (event: React.MouseEvent) => {
       // So, do we handle archive link multiselect here?
@@ -253,6 +271,7 @@ export const ChatListItemRowChat = React.memo<{
         }
         chatListItem={chat}
         onClick={useCallback(event => onChatClick2Ref.current(event), [])}
+        onKeyDown={useCallback(event => onKeyDownRef.current(event), [])}
         onFocus={useCallback(
           (event: React.FocusEvent) => onFocusRef.current(event),
           []

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -229,9 +229,18 @@ export function useMultiselect<T>(
     }
   }, [])
 
-  // This handles the "Space" keydown event, as well as clicks.
-  const onClick = useCallback(
-    (event: React.MouseEvent, item: T): boolean => {
+  // Note that `keydown` and `click` events both fire
+  // for a single press of "Space" for `<button>`s
+  // https://w3c.github.io/uievents/#event-type-keydown
+  // > If the key is the Enter or Space key and the current focus
+  // > is on a state-changing element, the default action MUST be
+  // > to dispatch a click event
+  //
+  // This is important for the Ctrl + Space handler
+  // which would basically have no effect (toggle selection twice)
+  // if `preventDefault()` is not called for the `keydown` event.
+  const onClickOrKeyDown = useCallback(
+    (event: React.MouseEvent | React.KeyboardEvent, item: T): boolean => {
       // Note that we use `event.ctrlKey` and not `ctrlPressed.current`.
       // We could get rid of the `event` argument,
       // but let's not do that, e.g. in case we later actually need it,
@@ -262,6 +271,22 @@ export function useMultiselect<T>(
       return false
     },
     [onSelectContiguous, onSelectionChange, toggleItemSelection]
+  )
+  const onClick = useCallback(
+    (event: React.MouseEvent, item: T) => {
+      return onClickOrKeyDown(event, item)
+    },
+    [onClickOrKeyDown]
+  )
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent, item: T) => {
+      if (event.code !== 'Space') {
+        return false
+      }
+
+      return onClickOrKeyDown(event, item)
+    },
+    [onClickOrKeyDown]
   )
 
   // Handle Shift + ArrowDown, Shift + End.
@@ -316,6 +341,10 @@ export function useMultiselect<T>(
        */
       onClick,
       /**
+       * @see {@linkcode onClick}
+       */
+      onKeyDown,
+      /**
        * This must be invoked when an item is focused,
        * i.e. on `focus` events.
        *
@@ -325,6 +354,6 @@ export function useMultiselect<T>(
        */
       onFocus,
     }),
-    [onClick, onFocus, selectedItems]
+    [onClick, onKeyDown, onFocus, selectedItems]
   )
 }


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6209.

Apparently in Chromium on Linux the "click" event doesn't fire
for the Ctrl + Space combination.
Might be because there is such a native shortcut in Chrome.

It's not entirely clear though why the E2E tests are passing then.

Regardless, we want to be handling the `keydown` event anyway
in order for multiselect to be able to work
with non-`<button>` elements,
because such elements don't fire the `click` event on Space press.
We'll need this when we add multiselect to the message list
(https://github.com/deltachat/deltachat-desktop/pull/6268).
