### PR TITLE
test: fail faster in non-CI

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -31,9 +31,9 @@ export default defineConfig<TestOptions>({
   // Our tests involve network interaction, so we want a higher timeout
   // for assertions, such as receiving an invitation to a group,
   // as well as whole tests.
-  timeout: 5 * 60 * 1000,
+  timeout: (process.env.CI ? 5 : 1) * 60 * 1000,
   expect: {
-    timeout: 60_000,
+    timeout: process.env.CI ? 60_000 : 20_000,
   },
 
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
When running tests locally you don't want to wait
for 5 minutes in order to be able to read the error report.

Our longest test is
"instant onboarding with withdrawn and revived invite link"
and it takes ~10 seconds, so these new values should still be enough.
