### PR TITLE
test: don't ignore TLS errors if `!DC_FRONTEND_NO_TLS`

### DIFF
--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -46,10 +46,9 @@ export default defineConfig<TestOptions>({
     video: 'retain-on-failure',
     screenshot: 'only-on-failure',
     permissions: ['notifications'],
-    ignoreHTTPSErrors: true,
+    ignoreHTTPSErrors: !DC_FRONTEND_NO_TLS,
     launchOptions: {
-      // Only relevant with TLS.
-      args: ['--ignore-certificate-errors'],
+      args: DC_FRONTEND_NO_TLS ? undefined : ['--ignore-certificate-errors'],
     },
   },
 
@@ -79,7 +78,7 @@ export default defineConfig<TestOptions>({
     } ../target-browser/dist/server.js`,
     url: baseURL,
     timeout: 120 * 1000,
-    ignoreHTTPSErrors: true,
+    ignoreHTTPSErrors: !DC_FRONTEND_NO_TLS,
     reuseExistingServer: !process.env.CI,
     stdout: 'pipe',
     stderr: 'pipe',


### PR DESCRIPTION
This is foremost just a refactor,
to clarify why we needed to ignore TLS errors.

Follow-up to 52161eac22be3e682693d3651d8916160e86fcc4
(https://github.com/deltachat/deltachat-desktop/pull/6235).

I have ran the tests locally, they still work.
