### PR TITLE
Button cleanup

### DIFF
--- a/packages/frontend/src/components/Button/style.module.scss
+++ b/packages/frontend/src/components/Button/style.module.scss
@@ -9,7 +9,7 @@
   font-size: 16px;
   font-weight: bold;
   justify-content: center;
-  padding: 12px 15px;
+  padding: 8px 12px;
   text-align: center;
   user-select: none;
 

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -168,5 +168,4 @@ $paddingVertical: 20px;
   min-width: 100px;
   flex: 0 1 auto;
   margin: 0;
-  white-space: nowrap;
 }

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -143,9 +143,8 @@ $paddingVertical: 20px;
 
 .footerActions {
   display: flex;
-  @media (width <= variables.$dialog-breakpoint) {
-    flex-direction: column;
-  }
+  flex-wrap: wrap;
+  gap: 10px;
 
   &.spaceBetween {
     justify-content: space-between;
@@ -167,13 +166,7 @@ $paddingVertical: 20px;
 .footerActionButton {
   // `.appDownloadingStatus` copy-pated these styles.
   min-width: 100px;
-  margin: 10px 0;
-  & + & {
-    margin-inline-start: 20px;
-  }
-  @media (width <= variables.$dialog-breakpoint) {
-    & + & {
-      margin-inline-start: 0;
-    }
-  }
+  flex: 0 1 auto;
+  margin: 0;
+  white-space: nowrap;
 }

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -167,7 +167,6 @@ $paddingVertical: 20px;
 .footerActionButton {
   // `.appDownloadingStatus` copy-pated these styles.
   min-width: 100px;
-  padding: 8px 12px !important;
   margin: 10px 0;
   & + & {
     margin-inline-start: 20px;


### PR DESCRIPTION
fixes #5887
Set consistent button heights, use flex layout for dialog footer buttons


Before 

<img width="454" height="204" alt="image" src="https://github.com/user-attachments/assets/a59b9687-6d7c-4673-91e3-aba02b67e95a" />

<img width="412" height="142" alt="image" src="https://github.com/user-attachments/assets/5f663ff9-762b-45ff-bdcd-96047b14d737" />

After

<img width="349" height="190" alt="image" src="https://github.com/user-attachments/assets/a8bc169e-5a8a-4e1f-9970-1f440cb17650" />



<img width="414" height="91" alt="image" src="https://github.com/user-attachments/assets/abaa4418-4c6e-4250-ae99-a91b11eac8fb" />

