### PR TITLE
fix: accessible "chat name is required" error msg

### DIFF
--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -534,6 +534,11 @@ export const createGroupChat = async (
   await expect(chatUserB).toBeVisible()
   await page.locator('#new-chat-button').click()
   await page.locator('#newgroup button').click()
+
+  // Name is required
+  await page.locator('.group-name-input').press('Enter')
+  await expect(page.locator('.group-name-input:invalid')).toBeVisible()
+
   await page.locator('.group-name-input').fill(groupName)
   await page.locator('#addmember button').click()
   const addMemberDialog = page.getByTestId('add-member-dialog')

--- a/packages/e2e-tests/tests/group-tests.spec.ts
+++ b/packages/e2e-tests/tests/group-tests.spec.ts
@@ -600,6 +600,11 @@ test('create channel and add members', async ({ browserName }) => {
   // Create a channel
   await page.locator('#new-chat-button').click()
   await page.locator('#newbroadcastlist button').click()
+
+  // Name is required
+  await page.locator('.group-name-input').press('Enter')
+  await expect(page.locator('.group-name-input:invalid')).toBeVisible()
+
   await page.locator('.group-name-input').fill(channelName)
   await page.getByRole('button', { name: 'Create' }).click()
 

--- a/packages/frontend/scss/dialogs/_group-styles.scss
+++ b/packages/frontend/scss/dialogs/_group-styles.scss
@@ -33,11 +33,6 @@ input.group-name-input {
 
   .group-name-input-wrapper {
     margin-inline-start: 17px;
-
-    p.input-error {
-      color: var(--colorDanger);
-      position: absolute;
-    }
   }
 }
 

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -619,8 +619,6 @@ export function CreateGroup(props: CreateGroupProps) {
     groupMembers
   )
 
-  const [errorMissingGroupName, setErrorMissingGroupName] = useState(false)
-
   const groupMemberContactListWrapperRef = useRef<HTMLDivElement>(null)
 
   const groupContactsFetch = useRpcFetch(BackendRemote.rpc.getContactsByIds, [
@@ -672,10 +670,6 @@ export function CreateGroup(props: CreateGroupProps) {
 
   const submitForm = (ev: React.FormEvent) => {
     ev.preventDefault()
-    if (groupName === '') {
-      setErrorMissingGroupName(true)
-      return
-    }
     finishCreateGroup()
       .then(groupId => {
         if (groupId) {
@@ -697,8 +691,6 @@ export function CreateGroup(props: CreateGroupProps) {
             onUnsetGroupImage={onUnsetGroupImage}
             chatName={groupName}
             setChatName={setGroupName}
-            errorMissingChatName={errorMissingGroupName}
-            setErrorMissingChatName={setErrorMissingGroupName}
             groupType={groupType}
           />
         </DialogContent>
@@ -764,15 +756,8 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
   const [broadcastName, setBroadcastName] = useState<string>('')
   const finishCreateBroadcast = useCreateBroadcast(broadcastName, onClose)
 
-  const [errorMissingChatName, setErrorMissingChatName] =
-    useState<boolean>(false)
-
   const submitForm = (ev: React.FormEvent) => {
     ev.preventDefault()
-    if (broadcastName === '') {
-      setErrorMissingChatName(true)
-      return
-    }
     finishCreateBroadcast()
   }
 
@@ -789,8 +774,6 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
             <ChatSettingsSetNameAndProfileImage
               chatName={broadcastName}
               setChatName={setBroadcastName}
-              errorMissingChatName={errorMissingChatName}
-              setErrorMissingChatName={setErrorMissingChatName}
               groupType={GroupType.BROADCAST_LIST}
             />
           </DialogContent>
@@ -816,8 +799,6 @@ export const ChatSettingsSetNameAndProfileImage = ({
   onUnsetGroupImage,
   chatName,
   setChatName,
-  errorMissingChatName,
-  setErrorMissingChatName,
   color,
   groupType,
 }: {
@@ -826,16 +807,10 @@ export const ChatSettingsSetNameAndProfileImage = ({
   onUnsetGroupImage?: () => void
   chatName: string
   setChatName: (newGroupName: string) => void
-  errorMissingChatName: boolean
-  setErrorMissingChatName: React.Dispatch<React.SetStateAction<boolean>>
   color?: string
   groupType: GroupType
 }) => {
   const tx = useTranslationFunction()
-  const onChange = ({ target }: React.ChangeEvent<HTMLInputElement>) => {
-    if (target.value.length > 0) setErrorMissingChatName(false)
-    setChatName(target.value)
-  }
   if (
     groupType === GroupType.REGULAR_GROUP &&
     !(onSetGroupImage && onUnsetGroupImage)
@@ -846,24 +821,19 @@ export const ChatSettingsSetNameAndProfileImage = ({
   }
 
   let inputLabel: string
-  let missingNameErrorText: string
   switch (groupType) {
     case GroupType.REGULAR_GROUP:
       inputLabel = tx('group_name')
-      missingNameErrorText = tx('please_enter_chat_name')
       break
     case GroupType.PLAIN_EMAIL:
       inputLabel = tx('subject')
-      missingNameErrorText = tx('please_enter_chat_name')
       break
     case GroupType.BROADCAST_LIST:
       inputLabel = tx('name_desktop')
-      missingNameErrorText = tx('please_enter_chat_name')
       break
     default: {
       const _assert: never = groupType
       inputLabel = tx('group_name')
-      missingNameErrorText = tx('please_enter_chat_name')
       break
     }
   }
@@ -889,13 +859,13 @@ export const ChatSettingsSetNameAndProfileImage = ({
             data-testid='group-name-input'
             placeholder={inputLabel}
             value={chatName}
-            onChange={onChange}
+            onChange={({ target }) => {
+              setChatName(target.value)
+            }}
+            required
             autoFocus
             spellCheck={false}
           />
-          {errorMissingChatName && (
-            <p className='input-error'>{missingNameErrorText}</p>
-          )}
         </div>
       </div>
     </>


### PR DESCRIPTION
Before:

<img width="339" height="251" alt="image" src="https://github.com/user-attachments/assets/46c2bdda-35ef-46a9-aeca-85b0510e9608" />

After:
<img width="338" height="246" alt="image" src="https://github.com/user-attachments/assets/c4b7c2e7-975b-490a-9055-a98abb70a9b4" />
<img width="338" height="305" alt="image" src="https://github.com/user-attachments/assets/a4929798-b157-483f-988f-bb47a0160b9f" />

The error appears when the user tries to submit the form.

Note that the error message is a bit more generic,
compared to "Please enter a name.".

This incidentally addresses the following point from
https://github.com/deltachat/deltachat-desktop/issues/6293
> when not entering a channel name, there is no padding
> between error message and button

Because this basically replaces the error message
with a native Chromium one.

Note that the "edit group" dialog is not affected. It requires us to add a `<form>` first. I'll do that in another MR.