### PR TITLE
fix: Edit Group dialog a11y and small bugs

### DIFF
--- a/packages/e2e-tests/tests/group-tests.spec.ts
+++ b/packages/e2e-tests/tests/group-tests.spec.ts
@@ -397,7 +397,15 @@ test('Edit group profile from context menu and rename group', async () => {
   await page.getByTestId('edit-group').click({ force: true })
   // open edit group profile dialog
   await page.getByTestId('view-group-dialog-header-edit').click()
+
+  // Group name is required
+  await expect(page.locator('#groupname:invalid')).not.toBeVisible()
+  await page.locator('#groupname').clear()
+  await page.locator('#groupname').press('Enter')
+  await expect(page.locator('#groupname:invalid')).toBeVisible()
+
   await page.locator('#groupname').fill(groupName + ' edited')
+  await expect(page.locator('#groupname:invalid')).not.toBeVisible()
   await page.getByTestId('ok').click()
   await expect(page.locator('.styles_module_displayName')).toHaveText(
     groupName + ' edited'

--- a/packages/frontend/src/components/Dialog/OkCancelFooterAction.tsx
+++ b/packages/frontend/src/components/Dialog/OkCancelFooterAction.tsx
@@ -10,7 +10,7 @@ type Props = {
   confirmLabel?: string
   disableOK?: boolean
   onCancel: () => void
-  onOk: () => void
+  onOk: (() => void) | 'submit'
 }
 
 export default function OkCancelFooterAction({
@@ -35,7 +35,8 @@ export default function OkCancelFooterAction({
           styling='primary'
           disabled={disableOK}
           data-testid='ok'
-          onClick={onOk}
+          onClick={onOk === 'submit' ? undefined : onOk}
+          type={onOk === 'submit' ? 'submit' : undefined}
         >
           {confirmLabel}
         </FooterActionButton>

--- a/packages/frontend/src/components/Login-Styles.tsx
+++ b/packages/frontend/src/components/Login-Styles.tsx
@@ -94,7 +94,8 @@ export const DeltaInput = React.memo(
         event: React.FormEvent<HTMLElement> & React.FocusEvent<HTMLInputElement>
       ) => void
       dataTestId?: string
-    }>
+    }> &
+      Pick<React.ComponentProps<'input'>, 'required'>
   ) => {
     const defaultId = useId()
     const id = props.id ?? `delta-input-${defaultId}`
@@ -117,6 +118,7 @@ export const DeltaInput = React.memo(
           value={props.value === null ? '' : props.value}
           onChange={props.onChange}
           placeholder={props.placeholder}
+          required={props.required}
           min={props.min}
           max={props.max}
           disabled={props.disabled}

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -580,57 +580,59 @@ export function EditGroupNameDialog({
           !isBroadcast ? tx('menu_group_name_and_image') : tx('channel_name')
         }
       />
-      <DialogBody>
-        <DialogContent>
-          <div
-            className='profile-image-username center'
-            style={{ marginBottom: '30px' }}
-          >
-            <GroupImageSelector
-              groupName={groupName}
-              groupColor={groupColor}
-              groupImage={groupImage}
-              setGroupImage={setGroupImage}
-            />
-          </div>
-          <DeltaInput
-            id='groupname'
-            placeholder={!isBroadcast ? tx('group_name') : tx('channel_name')}
-            value={groupName}
-            onChange={(
-              event: React.FormEvent<HTMLElement> &
-                React.ChangeEvent<HTMLInputElement>
-            ) => {
-              setGroupName(event.target.value)
-            }}
-          />
-          {groupName === '' && (
-            <p
-              style={{
-                color: 'var(--colorDanger)',
-                marginLeft: '80px',
-                position: 'relative',
-                top: '-10px',
-                marginBottom: '-18px',
-              }}
+      <form action={onClickOk}>
+        <DialogBody>
+          <DialogContent>
+            <div
+              className='profile-image-username center'
+              style={{ marginBottom: '30px' }}
             >
-              {!tx('please_enter_chat_name')}
-            </p>
-          )}
-          <DeltaTextarea
-            id='description'
-            placeholder={tx('chat_description')}
-            value={groupDescription}
-            onChange={(
-              event: React.FormEvent<HTMLElement> &
-                React.ChangeEvent<HTMLTextAreaElement>
-            ) => {
-              setGroupDescription(event.target.value)
-            }}
-          />
-        </DialogContent>
-      </DialogBody>
-      <OkCancelFooterAction onCancel={onClickCancel} onOk={onClickOk} />
+              <GroupImageSelector
+                groupName={groupName}
+                groupColor={groupColor}
+                groupImage={groupImage}
+                setGroupImage={setGroupImage}
+              />
+            </div>
+            <DeltaInput
+              id='groupname'
+              placeholder={!isBroadcast ? tx('group_name') : tx('channel_name')}
+              value={groupName}
+              onChange={(
+                event: React.FormEvent<HTMLElement> &
+                  React.ChangeEvent<HTMLInputElement>
+              ) => {
+                setGroupName(event.target.value)
+              }}
+            />
+            {groupName === '' && (
+              <p
+                style={{
+                  color: 'var(--colorDanger)',
+                  marginLeft: '80px',
+                  position: 'relative',
+                  top: '-10px',
+                  marginBottom: '-18px',
+                }}
+              >
+                {!tx('please_enter_chat_name')}
+              </p>
+            )}
+            <DeltaTextarea
+              id='description'
+              placeholder={tx('chat_description')}
+              value={groupDescription}
+              onChange={(
+                event: React.FormEvent<HTMLElement> &
+                  React.ChangeEvent<HTMLTextAreaElement>
+              ) => {
+                setGroupDescription(event.target.value)
+              }}
+            />
+          </DialogContent>
+        </DialogBody>
+        <OkCancelFooterAction onCancel={onClickCancel} onOk='submit' />
+      </form>
     </Dialog>
   )
 }

--- a/packages/frontend/src/components/dialogs/ViewGroup.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup.tsx
@@ -317,10 +317,7 @@ function ViewGroupInner(
         groupDescription: string,
         groupImage: string | null
       ) => {
-        // TODO this check should be way earlier, you should not be able to "OK" the dialog if there is no group name
-        if (groupName.length > 1) {
-          setGroupName(groupName)
-        }
+        setGroupName(groupName)
         // Description can be empty, so always set it
         setGroupDescription(groupDescription)
         setGroupImage(groupImage)
@@ -604,20 +601,8 @@ export function EditGroupNameDialog({
               ) => {
                 setGroupName(event.target.value)
               }}
+              required
             />
-            {groupName === '' && (
-              <p
-                style={{
-                  color: 'var(--colorDanger)',
-                  marginLeft: '80px',
-                  position: 'relative',
-                  top: '-10px',
-                  marginBottom: '-18px',
-                }}
-              >
-                {!tx('please_enter_chat_name')}
-              </p>
-            )}
             <DeltaTextarea
               id='description'
               placeholder={tx('chat_description')}


### PR DESCRIPTION
- **feat: allow to submit "Edit Group" with "Enter"**
- **refactor: make `DeltaInput` support more props**
- **fix: broken "Group name is required" error msg**

Hide whitespace for easier review.

<img width="338" height="386" alt="image" src="https://github.com/user-attachments/assets/33b0825f-f810-4d0f-950a-4b0a354f6015" />

- The error message was invisible.
  Edit: ah I just realized that this is only the case since https://github.com/deltachat/deltachat-desktop/pull/6289.
  
  In the release version of DC it looks OK:
  <img width="232" height="108" alt="image" src="https://github.com/user-attachments/assets/81b97388-0d44-463a-99e7-4bb7bf8a2464" />

- The error message was not accessible.
- Let's address the TODO comment:
  can't submit the form if the user emptied the group name input.
- Make it possible to submit the form with "Enter".

TODO:
- [ ] When / if this and https://github.com/deltachat/deltachat-desktop/pull/6298 gets approved and merged then we can remove the `please_enter_chat_name` string which was recently added. https://github.com/deltachat/deltachat-android/blob/af49018911ff296a11337a7c945dc14cb8364d89/src/main/res/values/strings.xml#L548

Related:
- https://github.com/deltachat/deltachat-desktop/pull/6298.
- 125fdd62a45c841f3cae3d48cb81262cf302fd82
  (https://github.com/deltachat/deltachat-desktop/pull/5805).
