### PR TITLE
improvement: error dialog: pretty-print err stack

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -125,8 +125,10 @@ process.on('uncaughtException', err => {
   }
   dialog.showErrorBox(
     'Error - uncaughtException',
-    `See the logfile (${logHandler.logFilePath()}) for details and contact the developers about this issue:\n` +
-      JSON.stringify(error)
+    `See the logfile (${logHandler.logFilePath()}) for details and contact the developers about this issue:\n\n` +
+      error.message +
+      '\n\n' +
+      error.stack
   )
 })
 


### PR DESCRIPTION
With JSON.stringify all the line breaks are displayed
not as line breaks but as `\n`,
making the error barely readable.
