### PR TITLE
improvement: on msg error click show `msg.error`

### DIFF
--- a/packages/frontend/src/components/dialogs/AlertDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AlertDialog.tsx
@@ -16,6 +16,10 @@ export type Props = {
   message: string
   okBtnLabel?: string
   dataTestid?: string
+  dialogComponentProps?: Omit<
+    Parameters<typeof Dialog>[0],
+    'dataTestid' | 'onClose'
+  >
 } & DialogProps
 
 export default function AlertDialog({
@@ -24,6 +28,7 @@ export default function AlertDialog({
   cb,
   okBtnLabel,
   dataTestid,
+  dialogComponentProps,
 }: Props) {
   const tx = useTranslationFunction()
 
@@ -34,7 +39,8 @@ export default function AlertDialog({
 
   return (
     <Dialog
-      width={350}
+      {...dialogComponentProps}
+      width={dialogComponentProps?.width ?? 350}
       onClose={() => {
         cb && cb()
         onClose()

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -67,6 +67,7 @@ import { useRpcFetch } from '../../hooks/useFetch'
 import ForwardMessage from '../dialogs/ForwardMessage'
 import MessageDetail from '../dialogs/MessageDetail/MessageDetail'
 import ConfirmDeleteMessageDialog from '../dialogs/ConfirmDeleteMessage'
+import AlertDialog from '../dialogs/AlertDialog'
 
 const log = getLogger('Message')
 
@@ -998,7 +999,13 @@ export default function Message(props: {
               timestamp={message.timestamp * 1000}
               encrypted={message.showPadlock}
               isSavedMessage={isOrHasSavedMessage}
-              onClickError={() => openDialog(MessageDetail, { id: message.id })}
+              onClickError={() =>
+                openDialog(AlertDialog, {
+                  message: message.error
+                    ? tx('error_x', message.error)
+                    : tx('ok'),
+                })
+              }
               viewType={message.viewType}
               chatType={chat.chatType}
               tabindexForInteractiveContents={tabindexForInteractiveContents}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1004,6 +1004,9 @@ export default function Message(props: {
                   message: message.error
                     ? tx('error_x', message.error)
                     : tx('ok'),
+                  dialogComponentProps: {
+                    width: 500,
+                  },
                 })
               }
               viewType={message.viewType}


### PR DESCRIPTION
...instead of opening the "message details" dialog,
which has the error hidden behind "three-dot menu -> Developer",
since 08199e00767f82ce860ad93b10006d700aa1f68a
(https://github.com/deltachat/deltachat-desktop/pull/6156).

Closes https://github.com/deltachat/deltachat-desktop/issues/6290.

<img width="325" height="470" alt="image" src="https://github.com/user-attachments/assets/0a45f85f-412b-4c8c-b978-bb39063a773a" />
