### PR TITLE
improvement: a11y: `alt=""` where img is redundant

### DIFF
--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -272,7 +272,7 @@ export function AppPicker({ onAppSelected }: Props) {
       <div className={styles.appItem}>
         <img
           src={icons[app.app_id] ?? './images/icons/image_outline.svg'}
-          alt={`${app.name} icon`}
+          alt=''
           className={styles.appIcon}
         />
         <div className={styles.appInfo}>
@@ -377,7 +377,7 @@ export function AppPicker({ onAppSelected }: Props) {
                 <img
                   className={styles.categoryIcon}
                   src={`./images/${category}.svg`}
-                  alt={category}
+                  alt=''
                 />
                 <div className={styles.categoryTitle}>
                   {categoryTitle(category)}

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -324,7 +324,7 @@ export function DraftAttachment({
     const iconUrl = runtime.getWebxdcIconURL(selectedAccountId(), attachment.id)
     return (
       <div className='media-attachment-webxdc'>
-        <img className='icon' src={iconUrl} alt='app icon' />
+        <img className='icon' src={iconUrl} alt='' />
         <div className='text-part'>
           <div className='name'>
             {/* `webxdcInfoFetch` is never `null` here, but TypeScript

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1229,7 +1229,7 @@ function WebxdcMessageContent({
     <div className='webxdc'>
       <img
         src={runtime.getWebxdcIconURL(selectedAccountId(), message.id)}
-        alt={`icon of ${info.name}`}
+        alt=''
         // No need to turn this element into a `<button>` for a11y,
         // because there is a button below that does the same.
         onClick={() => openWebxdc(message, webxdcInfo ?? undefined)}

--- a/packages/frontend/src/components/message/VCard.tsx
+++ b/packages/frontend/src/components/message/VCard.tsx
@@ -83,7 +83,7 @@ export function VisualVCardComponent({
       >
         {profileImage ? (
           <img
-            alt={displayName}
+            alt=''
             className='content'
             src={'data:image/jpeg;base64,' + profileImage}
           />


### PR DESCRIPTION
Disclaimer: In light of the recent
"let's not work endlessly on accessibility" discussion:
nobody has asked me to make this change.
I'm making this contribution as an individual
and not as a Delta Chat team member.

See https://www.w3.org/WAI/tutorials/images/decision-tree/
These are either decorative or redundant.
