### PR TITLE
chore: avoid pnpm ignored build warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
       ]
     },
     "onlyBuiltDependencies": [
-      "@parcel/watcher",
       "electron",
       "esbuild"
     ],
@@ -63,14 +62,18 @@
       "minimatch@>=5.0.0 <5.1.8": "^5.1.8",
       "minimatch@>=9.0.0 <9.0.7": "^9.0.7",
       "minimatch@>=10.0.0 <10.2.3": "^10.2.3"
-    }
+    },
+    "ignoredBuiltDependencies": [
+      "@parcel/watcher",
+      "electron-winstaller"
+    ]
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.0",
     "@eslint/eslintrc": "^3.3.3",
     "@eslint/js": "^9.39.2",
-    "@types/node": "^22.19.3",
     "@types/ignore-walk": "^4.0.3",
+    "@types/node": "^22.19.3",
     "@typescript-eslint/eslint-plugin": "^8.51.0",
     "@typescript-eslint/parser": "^8.51.0",
     "chokidar": "^5.0.0",


### PR DESCRIPTION
To get rid of the:
"Warning 
Ignored build scripts: electron-winstaller@5.4.0.                           
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts."