### PR TITLE
chore: fix workflow `postLinksToDetails.js`

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -12,7 +12,9 @@ on:
       - '.prettierrc.yml'
       - '.vscode/**'
 
-permissions: {}
+permissions:
+  # For `postLinksToDetails.js`.
+  statuses: write
 
 jobs:
   upload-preview:


### PR DESCRIPTION
It has been broken in #6307.

https://docs.github.com/en/rest/commits/statuses?apiVersion=2026-03-10#create-a-commit-status

Supersedes https://github.com/deltachat/deltachat-desktop/pull/6310.
