### PR TITLE
fix: Log dialog overflowing screen

### DIFF
--- a/packages/frontend/scss/_variables.scss
+++ b/packages/frontend/scss/_variables.scss
@@ -55,4 +55,4 @@ $z-index: (
 // setting z-index to 0 creates a new scope for children without changing the ordering of the parent element
 $z-index-new-local-scope: 0;
 
-$default-dialog-width: 500px;
+$dialog-breakpoint: 500px;

--- a/packages/frontend/src/components/Dialog/Dialog.tsx
+++ b/packages/frontend/src/components/Dialog/Dialog.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useRef } from 'react'
 import styles from './styles.module.scss'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 
-// same as $default-dialog-width variable in styles
 const DEFAULT_WIDTH = 500
 
 type Props = React.PropsWithChildren<{

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -6,10 +6,6 @@ $paddingVertical: 20px;
 
 .dialog {
   padding: 0;
-  @media (width < variables.$default-dialog-width) {
-    max-width: calc(100vw - 1rem) !important;
-    min-width: 0 !important;
-  }
 
   &.unstyled {
     background: none;
@@ -33,8 +29,8 @@ $paddingVertical: 20px;
     // display: flex;
     flex-direction: column;
     max-height: calc(100% - 50px);
-    max-width: 733px;
-    min-width: 350px;
+    max-width: min(733px, calc(100vw - 1rem));
+    min-width: min(350px, calc(100vw - 1rem));
     width: unset;
 
     justify-content: center;

--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -143,7 +143,7 @@ $paddingVertical: 20px;
 
 .footerActions {
   display: flex;
-  @media (width <= variables.$default-dialog-width) {
+  @media (width <= variables.$dialog-breakpoint) {
     flex-direction: column;
   }
 
@@ -172,7 +172,7 @@ $paddingVertical: 20px;
   & + & {
     margin-inline-start: 20px;
   }
-  @media (width <= variables.$default-dialog-width) {
+  @media (width <= variables.$dialog-breakpoint) {
     & + & {
       margin-inline-start: 10px;
     }


### PR DESCRIPTION
The problem was that if the screen width is more than 500px
(`$default-dialog-width`) but is less than `width` prop
of the Log dialog (which is 800) then the dialog would be 800px wide.

This also should fix it for all future dialogs,
and IMO also simplifies the code a little.

Related:
- 68ac03bc9da067d6a65bddd5f244b4f98221d032
  (https://github.com/deltachat/deltachat-desktop/pull/4806).
