### PR TITLE
style: fix ugly dialog buttons margin-inline-start

### DIFF
--- a/packages/frontend/src/components/Dialog/styles.module.scss
+++ b/packages/frontend/src/components/Dialog/styles.module.scss
@@ -178,7 +178,7 @@ $paddingVertical: 20px;
   }
   @media (width <= variables.$default-dialog-width) {
     & + & {
-      margin-inline-start: 10px;
+      margin-inline-start: 0;
     }
   }
 }


### PR DESCRIPTION
At screen sizes < 500px where the dialog has 2 or more
`FooterActionButton`s.

Before:
<img width="412" height="142" alt="image" src="https://github.com/user-attachments/assets/4e703733-7cdd-479a-bd74-583d243fb2dc" />


This basically reverts ac56e2788f4764ea925ec68db2068e6ac09142da
(https://github.com/deltachat/deltachat-desktop/pull/5395).
That MR was made to handle the `SendBackupDialog`,
which back when the MR was created had 3 footer buttons
with this weird `.buttonGroup` wrapper
which made the buttons be arranged side by side even on narrow screens
where we have `.footerActions { flex-direction: column; }`.
However it made all other dialogs uglier.
Now the `SendBackupDialog` doesn't have those 3 buttons anymore,
so we can revert that.
