### PR TITLE
style: increase msg error dialog width

### DIFF
--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1005,7 +1005,7 @@ export default function Message(props: {
                     ? tx('error_x', message.error)
                     : tx('ok'),
                   dialogComponentProps: {
-                    width: 500,
+                    width: 600,
                   },
                 })
               }


### PR DESCRIPTION
As requested in https://github.com/deltachat/deltachat-desktop/pull/6302#pullrequestreview-4168499170.
Before 4cc0a7aae this would cause overflow, but now it doesn't.
