### PR TITLE
chore: fix "Build preview" workflow

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -24,7 +24,6 @@ jobs:
     name: Upload Preview
     env:
       IS_PREVIEW: true
-      BRANCH: ${{ steps.prepare.outputs.branch }}
     steps:
       # Preperation
       - uses: actions/checkout@v6
@@ -64,6 +63,8 @@ jobs:
       - name: LINUX renaming / upload Preperation
         if: runner.os == 'Linux'
         working-directory: packages/target-electron
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
         run: |
           cd dist
           mkdir preview
@@ -86,6 +87,8 @@ jobs:
       - name: MAC renaming / upload Preperation
         if: runner.os == 'macOS'
         working-directory: packages/target-electron
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
         run: |
           ls -lah dist
           mkdir -p dist/preview
@@ -96,6 +99,8 @@ jobs:
           ls dist/preview
       - name: WINDOWS electron builder
         if: runner.os == 'Windows'
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
         run: |
           cd packages/target-electron
           set DEBUG=electron-builder
@@ -103,6 +108,8 @@ jobs:
       - name: WINDOWS renaming / upload Preperation
         if: runner.os == 'Windows'
         working-directory: packages/target-electron/dist
+        env:
+          BRANCH: ${{ steps.prepare.outputs.branch }}
         run: |
           dir
           mkdir preview


### PR DESCRIPTION
Issue introduced in https://github.com/deltachat/deltachat-desktop/pull/6308.
When I suggested to unify the declaration I didn't realize
that it's from a workflow step and is not just the raw branch name.
