### PR TITLE
fix: detect images dropped with uppercase extensions (e.g. .JPG)

### DIFF
--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -90,7 +90,7 @@ export function getBackgroundImageStyle(
 }
 
 function isImage(file: ParsedPath) {
-  return IMAGE_EXTENSIONS.map(ext => '.' + ext).includes(file.ext)
+  return IMAGE_EXTENSIONS.map(ext => '.' + ext).includes(file.ext.toLowerCase())
 }
 
 export default function MessageListAndComposer({ accountId, chat }: Props) {


### PR DESCRIPTION
Closes #6323.

## What

The drag-and-drop handler in `MessageListAndComposer.tsx` compares `file.ext` against a lowercase `IMAGE_EXTENSIONS` list. If a user drops a file with an uppercase extension like \`photo.JPG\`, the \`includes\` check fails and the file is sent as a raw \`DC_MSG_FILE\` instead of a compressed \`DC_MSG_IMAGE\`.

## Why

Per [@WofWca's diagnosis on the issue](https://github.com/deltachat/deltachat-desktop/issues/6323), the comparison is case-sensitive. Most operating systems treat file extensions case-insensitively for typing/identification purposes, so \`.JPG\`, \`.Jpg\`, and \`.jpg\` should all be detected as images.

## Fix

Lowercase \`file.ext\` before the \`includes\` check:

\`\`\`diff
 function isImage(file: ParsedPath) {
-  return IMAGE_EXTENSIONS.map(ext => '.' + ext).includes(file.ext)
+  return IMAGE_EXTENSIONS.map(ext => '.' + ext).includes(file.ext.toLowerCase())
 }
\`\`\`

The \`IMAGE_EXTENSIONS\` constant in \`packages/shared/constants.ts\` is already lowercase (\`['jpg', 'jpeg', 'png', 'apng', 'gif', 'webp']\`), so normalizing the input side is the minimal fix.