### PR TITLE
fix: show appropriate buttons when qr code is pasted

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -61,5 +61,11 @@
   },
   "edit_channel": {
     "message": "Edit Channel"
+  },
+  "qr_link_pasted": {
+    "message": "QR link detected"
+  },
+  "paste_in_qr_scanner": {
+    "message": "Click to paste it in QR scanner"
   }
 }

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -361,6 +361,13 @@ export default function ChatList(props: {
   // Render --------------------
   const tx = useTranslationFunction()
 
+  let showChatResults = true
+
+  if (chatListIds.length === 0 && queryStr && isInviteLink(queryStr)) {
+    // Don't show "0 chats" when the query is an invite link
+    showChatResults = false
+  }
+
   if (queryChatId) {
     return (
       <SearchInChatResults
@@ -379,7 +386,7 @@ export default function ChatList(props: {
       <AutoSizer disableWidth>
         {({ height }) => (
           <>
-            {isSearchActive && (
+            {isSearchActive && showChatResults && (
               <div
                 id='search-result-divider-chats'
                 className='search-result-divider'
@@ -648,6 +655,19 @@ function ContactAndMessageSearchResults({
       isSingleChatSearch: queryChatId != null, // `false`
     }
   }, [messageResultIds, messageCache, queryStr, queryChatId])
+
+  if (
+    showPseudoListItemAddContactFromInviteLink &&
+    contactIds.length === 0 &&
+    messageResultIds.length === 0
+  ) {
+    return (
+      <PseudoListItemAddContactOrGroupFromInviteLink
+        inviteLink={queryStr!}
+        accountId={accountId}
+      />
+    )
+  }
 
   return (
     <>

--- a/packages/frontend/src/components/helpers/PseudoListItem.tsx
+++ b/packages/frontend/src/components/helpers/PseudoListItem.tsx
@@ -177,11 +177,28 @@ export const PseudoListItemAddContactOrGroupFromInviteLink = ({
       subText={tx('join_group')}
       onClick={onClick}
     />
+  ) : parsedQr?.kind === 'askJoinBroadcast' ? (
+    <PseudoListItem
+      id='newbroadcastfrominvitelink'
+      cutoff='+'
+      text={parsedQr.name}
+      subText={tx('join_channel')}
+      onClick={onClick}
+    />
+  ) : parsedQr !== null ? (
+    // Other valid QR kinds (e.g. account, login, backup2):
+    // hint the user to paste the URL in the scanner dialog.
+    <PseudoListItem
+      id='otherinvitelinkaction'
+      cutoff='+'
+      text={tx('qr_link_pasted')}
+      subText={tx('paste_in_qr_scanner')}
+      onClick={onClick}
+    >
+      <QRAvatar />
+    </PseudoListItem>
   ) : (
-    // There are many kinds of QRs. For example, if you paste an invite link
-    // of a group that you created yourself, you'll get
-    // `parsedQr.kind === "withdrawVerifyGroup"`.
-    // TODO we probably want to better handle such cases.
+    // parsedQr is null: still loading or unrecognised content.
     <PseudoListItem
       id='otherinvitelinkaction'
       cutoff='+'


### PR DESCRIPTION
resolves #6294

<img width="448" height="253" alt="image" src="https://github.com/user-attachments/assets/79e26afc-ff1b-4a55-8ecb-b64f6763d4f4" />


<img width="442" height="261" alt="image" src="https://github.com/user-attachments/assets/500adb02-883c-472b-b5b4-98c629bd4302" />
