### PR TITLE
fix: add `type="button"`: accidental form submission

### DIFF
--- a/packages/frontend/src/components/GroupImage.tsx
+++ b/packages/frontend/src/components/GroupImage.tsx
@@ -47,6 +47,7 @@ export default function GroupImage(props: Props) {
   return (
     <div className='group-image-wrapper'>
       <AvatarTag
+        type='button'
         className='group-image'
         onClick={() => groupImage && showAvatarFullscreen()}
         {...(groupImage ? { 'aria-label': tx('group_avatar') } : {})}

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -355,6 +355,7 @@ export function ViewProfileInner({
             <div className={styles.contactAttributesBottom}>
               {verifier && (
                 <VerificationTag
+                  type='button'
                   className={styles.verification}
                   onClick={verifier.action}
                   style={{ display: 'flex' }}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -777,6 +777,7 @@ export default function Message(props: {
         onContextMenu={showContextMenu}
       >
         <TagName
+          type='button'
           className={'bubble ' + rovingTabindex.className}
           onClick={onClick}
           {...commonAttrs}
@@ -1094,7 +1095,12 @@ export const Quote = ({
   const Tag = onClick ? 'button' : 'div'
 
   return (
-    <Tag className='quote-background' onClick={onClick} tabIndex={tabIndex}>
+    <Tag
+      type='button'
+      className='quote-background'
+      onClick={onClick}
+      tabIndex={tabIndex}
+    >
       <div
         className={`quote ${hasMessage && 'has-message'}`}
         style={borderStyle}

--- a/packages/frontend/src/components/message/VCard.tsx
+++ b/packages/frontend/src/components/message/VCard.tsx
@@ -73,6 +73,7 @@ export function VisualVCardComponent({
   const Tag = onClick ? 'button' : 'div'
   return (
     <Tag
+      type='button'
       onClick={onClick}
       tabIndex={tabindexForInteractiveContents}
       className={styles.vcard}


### PR DESCRIPTION
Follow-up to 10912f1978edd90416a5a8461cd457b5e91c7a8d
(https://github.com/deltachat/deltachat-desktop/pull/5811).

This resulted in a bug at least in the "Create Group" dialog
where clicking on the avatar would submit the form.

Unfortunately the `react/button-has-type` linter rule
can't handle such cases where a dynamic tag is used.
