### PR TITLE
chore: fix Tauri build workflow

### DIFF
--- a/.github/workflows/build-tauri-preview.yml
+++ b/.github/workflows/build-tauri-preview.yml
@@ -97,7 +97,7 @@ jobs:
         id: pathsWin
         run: |
           mkdir out
-          $jsonString = '$env:STEPS_BUILD_OUTPUTS_ARTIFACTPATHS'
+          $jsonString = $env:STEPS_BUILD_OUTPUTS_ARTIFACTPATHS
           $filePaths = ConvertFrom-Json $jsonString
           foreach ($path in $filePaths) {
             if (Test-Path $path -PathType Leaf) {


### PR DESCRIPTION
You can see it failed in https://github.com/deltachat/deltachat-desktop/pull/6335.

I ran the workflow in this MR. It's at least green.