### PR TITLE
streamline notification settings

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -53,9 +53,6 @@
   "prevent_dialog_spam_checkbox": {
     "message": "Don't allow the app to open this dialog again"
   },
-  "who_can_call_me_toggle": {
-    "message": "Show call screen on incoming calls"
-  },
   "react_more_emojis" : {
     "message": "More emojis..."
   },

--- a/packages/frontend/src/components/Settings/Notifications.tsx
+++ b/packages/frontend/src/components/Settings/Notifications.tsx
@@ -93,7 +93,8 @@ export default function Notifications({ desktopSettings }: Props) {
         // Calls are only implemented on Electron.
         // https://github.com/deltachat/deltachat-desktop/pull/6044#issuecomment-3977395069
         <SettingsSwitch
-          label={tx('who_can_call_me_toggle')}
+          label={tx('pref_calls')}
+          description={tx('pref_calls_explain')}
           value={
             settingsStore?.settings.who_can_call_me !== WhoCanCallMe.Nobody
           }

--- a/packages/frontend/src/components/Settings/Notifications.tsx
+++ b/packages/frontend/src/components/Settings/Notifications.tsx
@@ -71,24 +71,21 @@ export default function Notifications({ desktopSettings }: Props) {
 
   return (
     <>
-      <SettingsHeading>{tx('all_profiles')}</SettingsHeading>
-      <DesktopSettingsSwitch
-        settingsKey='notifications'
-        label={tx('pref_notifications_explain')}
-      />
-      <DesktopSettingsSwitch
-        settingsKey='showNotificationContent'
-        label={tx('pref_show_notification_content_explain')}
+      <SettingsSwitch
+        label={tx('menu_mute')}
+        value={isMuted}
         disabled={!desktopSettings['notifications']}
+        onChange={() => {
+          AccountNotificationStoreInstance.effect.setMuted(accountId, !isMuted)
+        }}
       />
-      <SettingsSelector
-        onClick={onOpenInChatSoundsVolumeDialog.bind(null)}
-        currentValue={volumeNumberToString(desktopSettings.inChatSoundsVolume)}
-      >
-        {tx('pref_in_chat_sounds')}
-      </SettingsSelector>
-      <SettingsSeparator></SettingsSeparator>
-      <SettingsHeading>{tx('current_profile')}</SettingsHeading>
+      <CoreSettingsSwitch
+        settingsKey='ui.mentions_enabled'
+        label={tx('pref_mention_notifications')}
+        description={tx('pref_mention_notifications_explain')}
+        disabled={isMuted || !desktopSettings['notifications']}
+        disabledValue={false}
+      />
       {runtime.getRuntimeInfo().target === 'electron' && (
         // Calls are only implemented on Electron.
         // https://github.com/deltachat/deltachat-desktop/pull/6044#issuecomment-3977395069
@@ -107,20 +104,21 @@ export default function Notifications({ desktopSettings }: Props) {
           }}
         />
       )}
-      <SettingsSwitch
-        label={tx('menu_mute')}
-        value={isMuted}
+      <SettingsSeparator></SettingsSeparator>
+      <SettingsSelector
+        onClick={onOpenInChatSoundsVolumeDialog.bind(null)}
+        currentValue={volumeNumberToString(desktopSettings.inChatSoundsVolume)}
+      >
+        {tx('pref_in_chat_sounds')}
+      </SettingsSelector>
+      <DesktopSettingsSwitch
+        settingsKey='showNotificationContent'
+        label={tx('pref_show_notification_content')}
         disabled={!desktopSettings['notifications']}
-        onChange={() => {
-          AccountNotificationStoreInstance.effect.setMuted(accountId, !isMuted)
-        }}
       />
-      <CoreSettingsSwitch
-        settingsKey='ui.mentions_enabled'
-        label={tx('pref_mention_notifications')}
-        description={tx('pref_mention_notifications_explain')}
-        disabled={isMuted || !desktopSettings['notifications']}
-        disabledValue={false}
+      <DesktopSettingsSwitch
+        settingsKey='notifications'
+        label={tx('pref_notifications_explain')}
       />
     </>
   )

--- a/packages/frontend/src/components/Settings/Notifications.tsx
+++ b/packages/frontend/src/components/Settings/Notifications.tsx
@@ -72,8 +72,8 @@ export default function Notifications({ desktopSettings }: Props) {
   return (
     <>
       <SettingsSwitch
-        label={tx('menu_mute')}
-        value={isMuted}
+        label={tx('pref_notifications')}
+        value={!isMuted}
         disabled={!desktopSettings['notifications']}
         onChange={() => {
           AccountNotificationStoreInstance.effect.setMuted(accountId, !isMuted)

--- a/packages/frontend/src/components/Settings/Notifications.tsx
+++ b/packages/frontend/src/components/Settings/Notifications.tsx
@@ -9,7 +9,6 @@ import AccountNotificationStoreInstance, {
 } from '../../stores/accountNotifications'
 import { selectedAccountId } from '../../ScreenController'
 import SettingsSwitch from './SettingsSwitch'
-import SettingsHeading from './SettingsHeading'
 import SettingsSelector from './SettingsSelector'
 import SmallSelectDialog from '../SmallSelectDialog'
 import SettingsStoreInstance, {


### PR DESCRIPTION
this PR:

- uses correct translation for "Calls" option
- moves most interesting options atop, advanced options down
- all options are now same "uncheck to get less disturbance"
- very first option is now to disable/mute notifications for the profile; even if it is not called "mute" any longer, but got a clear name, it clearly shows the relationship with "mute" used elsewhere, and is no longer hidden in some other option
- streamlines options with other clients
- removes the current/all profile notion [^1]

## before / after:

<img width="370" src="https://github.com/user-attachments/assets/e617505d-9abc-4905-92bb-fc1490f0bf13" />
<img width="370" src="https://github.com/user-attachments/assets/aacdcea7-c1e8-4203-ae8a-867fc184c642" />

[^1]: i known, this has some fans, some even want to have separated settings dialogs or use that notion also elsewhere. but most non-advanced user just do not care, so that adds questions, and does not answer much. as a rule of thumb, most options are per-profile, or should be. the ones who are not usually do not raise this question