### PR TITLE
fix: contiguous multiselect: handle item removal

### DIFF
--- a/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
@@ -194,7 +194,7 @@ test.describe('Shift + Click', () => {
     await expectSelectedChats([9, 8, 7])
   })
 
-  test('handles selection start chat getting removed', async () => {
+  test("doesn't break if the item at the start of the selection gets removed", async () => {
     const chatName = 'Chat to be removed'
     await createDummyChat(page, chatName)
     const chat = chatList.getByRole('tab', { name: chatName })

--- a/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
@@ -8,6 +8,7 @@ import {
   reloadPage,
   test,
   createNDummyChats,
+  createDummyChat,
 } from '../playwright-helper'
 
 test.describe.configure({
@@ -191,6 +192,25 @@ test.describe('Shift + Click', () => {
     await page.keyboard.press('Shift+ArrowUp')
     // This is the topmost chat: do nothing.
     await expectSelectedChats([9, 8, 7])
+  })
+
+  test('handles selection start chat getting removed', async () => {
+    const chatName = 'Chat to be removed'
+    await createDummyChat(page, chatName)
+    const chat = chatList.getByRole('tab', { name: chatName })
+    await chat.click()
+    await expect(selectedChats).toContainText([chatName])
+
+    await chat.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Leave' }).click()
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Delete' })
+      .click()
+    await expectSelectedChats([])
+
+    await getChat(3).click({ modifiers: ['Shift'] })
+    await expectSelectedChats([3])
   })
 })
 

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -155,14 +155,6 @@ export function useMultiselect<T>(
       const from = prevLastActivatedItem
       const to = toItem
 
-      let fromInd = availableItemsRef.current.indexOf(from)
-      if (fromInd === -1) {
-        // This could happen if `availableItems` got updated
-        // such that `prevLastActivatedItem` is no longer a member of it.
-        // Maybe there is a more graceful way to handle this.
-        onSelectionChange(new Set([from]))
-        return
-      }
       // `lastIndexOf` is functionally equivalent to `indexOf`
       // given that all items are unique,
       // but this has higher performance when selecting down,
@@ -175,7 +167,15 @@ export function useMultiselect<T>(
           'is not a member of availableItems',
           availableItemsRef.current
         )
-        onSelectionChange(new Set([from]))
+        return
+      }
+      let fromInd = availableItemsRef.current.indexOf(from)
+      if (fromInd === -1) {
+        // This could happen if `availableItems` got updated
+        // such that `prevLastActivatedItem` is no longer a member of it.
+        // Maybe there is a more graceful way to handle this.
+        onSelectionChange(new Set([to]))
+        return
       }
 
       ;[fromInd, toInd] = [Math.min(fromInd, toInd), Math.max(fromInd, toInd)]


### PR DESCRIPTION
This changes a couple of things:
1. When the "from" item has been removed,
   Shift + Click will only select the "to" item.
2. Handle the absence of the "to" item before handling the absence
   of the "from" item (move that piece of code).
3. When the "to" item is absent, return and do nothing.

This will be useful for the upcoming message multiselect,
where item deletion and contiguous selection
is perhaps more common than that for chats.
