### PR TITLE
chore: pin pnpm version with packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,5 +87,6 @@
     "typescript-eslint": "^8.51.0",
     "xml-js": "^1.6.11",
     "yaml": "^2.8.3"
-  }
+  },
+  "packageManager": "pnpm@10.33.2"
 }


### PR DESCRIPTION
To avoid failures in CI like today after a new pnpm release.

Means also we have to upgrade manually from time to time