### PR TITLE
chore: fix CI: support pnpm@11: use pnpm@10

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,14 @@
   "engineStrict": true,
   "engines": {
     "node": "^22",
-    "pnpm": ">=9.6.0"
+    "pnpm": ">=9.6.0 <11"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": ">=9.6.0 <11",
+      "onFail": "download"
+    }
   },
   "pnpm": {
     "supportedArchitectures": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,97 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: '>=9.6.0 <11'
+        version: 10.33.4
+      pnpm:
+        specifier: '>=9.6.0 <11'
+        version: 10.33.4
+
+packages:
+
+  '@pnpm/exe@10.33.4':
+    resolution: {integrity: sha512-/kXXlHAXWHt7INYwQIWg2eQ85GaUqgfj0ltUB7T9emhA1smOgamJ8cQEhNBzc32vmKaV1bI5IxFShe1rfXMTDw==}
+    hasBin: true
+
+  '@pnpm/linux-arm64@10.33.4':
+    resolution: {integrity: sha512-VGX2CIOL/1RwOfAsQM8i4XYJXer/LUM/T2gB8eIG/g8PIxpYqJ1Fv5xjCz7x2s2Kek4mujim+3mQ0aOGnqj99Q==}
+    cpu: [arm64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/linux-x64@10.33.4':
+    resolution: {integrity: sha512-hTlGChXiJ9/NGm43d/Ai/7SQ6X7S1WQkq5+7TfNNyloB06BaKfSjlPhI9qJIEnlBKr/bkgoql1EC8zBvF2Ebxg==}
+    cpu: [x64]
+    os: [linux]
+    hasBin: true
+
+  '@pnpm/macos-arm64@10.33.4':
+    resolution: {integrity: sha512-8hfg2/6zHmptukEO8DwKCGp7OWCjDSelkBvtbcbbE1UBXwRTH5N6yCklIYK3SLfdlWfYEgHRt1SBq2AHkm90Xw==}
+    cpu: [arm64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/macos-x64@10.33.4':
+    resolution: {integrity: sha512-FuQJvHhcgJ0OMVqrbf35LUn3TAD1c8fekJL1i7gSY5ls0QtoYt49XtoDaD6beFcvrJ1GyubERlDsFe3957iXUQ==}
+    cpu: [x64]
+    os: [darwin]
+    hasBin: true
+
+  '@pnpm/win-arm64@10.33.4':
+    resolution: {integrity: sha512-13O9kR6A0AvhhGMGocxt7ujvyIzJkAir3fCVTvKFCJYHLjSANeNMrCutczxDdg3VkedZiftMWsLfCRQ64GXpQA==}
+    cpu: [arm64]
+    os: [win32]
+    hasBin: true
+
+  '@pnpm/win-x64@10.33.4':
+    resolution: {integrity: sha512-O0XumKXWdF+newAVzemkGyW/FBvGQ3t9bXG0iAYvxDxLAcTaNxUueKLNQjTCSlpgm+4s6HKw/kq6Z6i6Y+Bqeg==}
+    cpu: [x64]
+    os: [win32]
+    hasBin: true
+
+  pnpm@10.33.4:
+    resolution: {integrity: sha512-HGezs1my1AgRm6HtKJ80uPw8aHNBK+xv0mT73IJInlEPy+y5zp0i2ufzt2Jp2EQQRgFL3KU7mXnNelYa1jG4AA==}
+    engines: {node: '>=18.12'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe@10.33.4':
+    optionalDependencies:
+      '@pnpm/linux-arm64': 10.33.4
+      '@pnpm/linux-x64': 10.33.4
+      '@pnpm/macos-arm64': 10.33.4
+      '@pnpm/macos-x64': 10.33.4
+      '@pnpm/win-arm64': 10.33.4
+      '@pnpm/win-x64': 10.33.4
+
+  '@pnpm/linux-arm64@10.33.4':
+    optional: true
+
+  '@pnpm/linux-x64@10.33.4':
+    optional: true
+
+  '@pnpm/macos-arm64@10.33.4':
+    optional: true
+
+  '@pnpm/macos-x64@10.33.4':
+    optional: true
+
+  '@pnpm/win-arm64@10.33.4':
+    optional: true
+
+  '@pnpm/win-x64@10.33.4':
+    optional: true
+
+  pnpm@10.33.4: {}
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
See docs: https://pnpm.io/package_json#devenginespackagemanager

`devEngines.packageManager` is not documented for pnpm@10,
so things should keep working if the system has pnpm@10.

To make this MR I edited package.json and ran `pnpm install --frozen-lockfile` with pnpm@11.

This should be better than
https://github.com/deltachat/deltachat-desktop/pull/6354
because, according to the linked pnpm@11 docs,
the root `packageManager` is legacy and `devEngines.packageManager`
is the new thing.
