### PR TITLE
fix: truncate author name in quotes

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -558,6 +558,10 @@ $info-text-max-width: 400px;
     text-overflow: ellipsis;
   }
 
+  .quote-author {
+    white-space: nowrap;
+  }
+
   .quoted-text {
     font-size: 12px;
     line-height: 12px;


### PR DESCRIPTION
resolves #5901

I see no horizontal scrolls

<img width="1045" height="339" alt="image" src="https://github.com/user-attachments/assets/2d9495d7-55d1-4998-b0cb-06ae0afdcec8" />
