### PR TITLE
feat: add window menu for MacOS

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -42,7 +42,7 @@ jobs:
         id: prepare
         shell: bash
         run: |
-          echo "branch=$(echo '${GITHUB_HEAD_REF}' | sed 's/[^A-Za-z0-9._-]/_/g')" >> $GITHUB_OUTPUT
+          echo "branch=$(echo "${GITHUB_HEAD_REF}" | sed 's/[^A-Za-z0-9._-]/_/g')" >> $GITHUB_OUTPUT
       - name: change build name and Product Name to branch name
         run: |
           node ./bin/github-actions/devbuild.js

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ default.nix
 target
 packages/target-tauri/src-tauri/target
 packages/target-tauri/src-tauri/gen/schemas
+
+# macOS .DS_Store files
+.DS_Store

--- a/packages/frontend/src/components/SearchInput/index.tsx
+++ b/packages/frontend/src/components/SearchInput/index.tsx
@@ -6,6 +6,7 @@ import useDialog from '../../hooks/dialog/useDialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 import { BackendRemote } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
+import { runtime } from '@deltachat-desktop/runtime-interface'
 
 import styles from './styles.module.scss'
 import { SCAN_CONTEXT_TYPE } from '../../hooks/useProcessQr'
@@ -26,6 +27,7 @@ export default function SearchInput(props: Props) {
   const tx = useTranslationFunction()
   const { openDialog } = useDialog()
   const { onChange, value, id, onClear } = props
+  const searchShortcut = runtime.getRuntimeInfo().isMac ? 'Meta+F' : 'Control+F'
 
   const handleClear = () => {
     onChange({ target: { value: '' } })
@@ -69,8 +71,8 @@ export default function SearchInput(props: Props) {
           // eslint-disable-next-line react-hooks/refs
           ref={props.inputRef}
           spellCheck={false}
-          // FYI there is also Ctrl + Shift + F to search in chat.
-          aria-keyshortcuts='Control+F'
+          // FYI there is also Ctrl/Cmd + Shift + F to search in chat.
+          aria-keyshortcuts={searchShortcut}
         />
         {hasValue && (
           <SearchInputButton

--- a/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
+++ b/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
@@ -28,27 +28,29 @@ export default function KeybindingCheatSheet(props: DialogProps) {
       <DialogBody className='shortcuts-dialog-body'>
         <div className='shortcuts-grid'>
           {settingsStore &&
-            getKeybindings(settingsStore.desktopSettings).map((entry, index) => {
-              if (entry.type === 'header') {
-                return (
-                  <div
-                    key={`header-${index}-${entry.title}`}
-                    className='shortcuts-section-title'
-                  >
-                    <h4>{entry.title}</h4>
-                  </div>
-                )
-              } else {
-                const { action } = entry
-                return (
-                  <ShortcutGroup
-                    title={action.title}
-                    keyBindings={action.keyBindings}
-                    key={`shortcut-${index}-${action.title}`}
-                  />
-                )
+            getKeybindings(settingsStore.desktopSettings).map(
+              (entry, index) => {
+                if (entry.type === 'header') {
+                  return (
+                    <div
+                      key={`header-${index}-${entry.title}`}
+                      className='shortcuts-section-title'
+                    >
+                      <h4>{entry.title}</h4>
+                    </div>
+                  )
+                } else {
+                  const { action } = entry
+                  return (
+                    <ShortcutGroup
+                      title={action.title}
+                      keyBindings={action.keyBindings}
+                      key={`shortcut-${index}-${action.title}`}
+                    />
+                  )
+                }
               }
-            })}
+            )}
         </div>
       </DialogBody>
     </Dialog>

--- a/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
+++ b/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
@@ -28,10 +28,13 @@ export default function KeybindingCheatSheet(props: DialogProps) {
       <DialogBody className='shortcuts-dialog-body'>
         <div className='shortcuts-grid'>
           {settingsStore &&
-            getKeybindings(settingsStore.desktopSettings).map(entry => {
+            getKeybindings(settingsStore.desktopSettings).map((entry, index) => {
               if (entry.type === 'header') {
                 return (
-                  <div key={entry.title} className='shortcuts-section-title'>
+                  <div
+                    key={`header-${index}-${entry.title}`}
+                    className='shortcuts-section-title'
+                  >
                     <h4>{entry.title}</h4>
                   </div>
                 )
@@ -41,7 +44,7 @@ export default function KeybindingCheatSheet(props: DialogProps) {
                   <ShortcutGroup
                     title={action.title}
                     keyBindings={action.keyBindings}
-                    key={action.title}
+                    key={`shortcut-${index}-${action.title}`}
                   />
                 )
               }

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -1,4 +1,5 @@
 import { getLogger } from '../../shared/logger'
+import { runtime } from '@deltachat-desktop/runtime-interface'
 
 const log = getLogger('renderer/keybindings')
 
@@ -129,6 +130,8 @@ export function matchesNonLetterShortcut(
 export function keyDownEvent2Action(
   ev: KeyboardEvent
 ): KeybindAction | undefined {
+  const { isMac } = runtime.getRuntimeInfo()
+
   if (window.__contextMenuActive) {
     return
   }
@@ -156,7 +159,10 @@ export function keyDownEvent2Action(
       // disabled until we find a better keycombination (see https://github.com/deltachat/deltachat-desktop/issues/1796)
       //   return KeybindAction.ChatList_ScrollToSelectedChat
       // }
-    } else if ((ev.metaKey || ev.ctrlKey) && matchesLetterShortcut(ev, 'f')) {
+    } else if (
+      (isMac ? ev.metaKey && !ev.ctrlKey : ev.ctrlKey) &&
+      matchesLetterShortcut(ev, 'f')
+    ) {
       // https://github.com/deltachat/deltachat-desktop/issues/4579
       if (ev.shiftKey) {
         return KeybindAction.ChatList_SearchInChat

--- a/packages/target-electron/src/menu.ts
+++ b/packages/target-electron/src/menu.ts
@@ -315,7 +315,6 @@ function getMenuTemplate(
     ...(isMac ? [getAppMenu(mainWindow.window)] : []),
     getFileMenu(mainWindow.window, isMac),
     getEditMenu(),
-    ...(isMac ? [getMacWindowMenu()] : []),
     {
       label: tx('global_menu_view_desktop'),
       submenu: [
@@ -385,6 +384,7 @@ function getMenuTemplate(
         },
       ],
     },
+    ...(isMac ? [getMacWindowMenu()] : []),
     getHelpMenu(isMac),
   ]
 }

--- a/packages/target-electron/src/menu.ts
+++ b/packages/target-electron/src/menu.ts
@@ -291,6 +291,22 @@ export function getHelpMenu(
   }
 }
 
+function getMacWindowMenu(): Electron.MenuItemConstructorOptions {
+  return {
+    // macOS requires a top-level menu item with role:'window' so that native
+    // window management shortcuts (Cmd+M to minimize, fn+Ctrl+Arrow tiling, …)
+    // are routed correctly to the app.
+    label: 'Window',
+    role: 'window',
+    submenu: [
+      { role: 'minimize', accelerator: 'Command+M' },
+      { role: 'zoom' },
+      { type: 'separator' },
+      { role: 'front' },
+    ],
+  }
+}
+
 function getMenuTemplate(
   logHandler: LogHandler
 ): Electron.MenuItemConstructorOptions[] {
@@ -299,6 +315,7 @@ function getMenuTemplate(
     ...(isMac ? [getAppMenu(mainWindow.window)] : []),
     getFileMenu(mainWindow.window, isMac),
     getEditMenu(),
+    ...(isMac ? [getMacWindowMenu()] : []),
     {
       label: tx('global_menu_view_desktop'),
       submenu: [

--- a/packages/target-electron/src/menu.ts
+++ b/packages/target-electron/src/menu.ts
@@ -346,6 +346,12 @@ function getMenuTemplate(
           type: 'separator',
         },
         {
+          role: 'togglefullscreen',
+        },
+        {
+          type: 'separator',
+        },
+        {
           label: tx('pref_language'),
           submenu: getAvailableLanguages(),
         },


### PR DESCRIPTION
resolves #6348

This also enables various keyboard shortcuts inherently

I tested on MacOS Tahoe 26.3.1:

With the Window menu Cmd + M minimzes the app

Not working (but also in other apps like Safari, VSCode, maybe since I don't use an original Apple keyboard)
fn+Ctrl+F / fn+Ctrl+← / fn+Ctrl+→ / fn+Ctrl+↓ → 
fn+Ctrl+C → Center window

The entries are translated automatically so we don't need to provide them

#public-preview
