### PR TITLE
fix: adapt width to new MacOS traffic lights

### DIFF
--- a/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/AccountListSidebar.tsx
@@ -148,9 +148,13 @@ export default function AccountListSidebar({
     return <div></div>
   }
 
+  const isMac = runtime.getRuntimeInfo().isMac
+
   return (
-    <div className={styles.accountListSidebar}>
-      {runtime.getRuntimeInfo().isMac && !smallScreenMode && (
+    <div
+      className={`${styles.accountListSidebar}${isMac ? ` ${styles.accountListSidebarMac}` : ''}`}
+    >
+      {isMac && !smallScreenMode && (
         <div
           className={styles.macOSTrafficLightBackground}
           data-tauri-drag-region

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -44,6 +44,10 @@
   min-width: 68px;
   overflow: hidden;
 
+  &.accountListSidebarMac {
+    min-width: 76px;
+  }
+
   .accountListNav {
     flex-grow: 1;
     overflow-y: scroll;


### PR DESCRIPTION
resolves #5898
Account list sidebar is now 8px wider on MacOS

<img width="188" height="110" alt="image" src="https://github.com/user-attachments/assets/5b0e22af-96c0-4605-a5f6-341d522d1339" />
