### PR TITLE
fix: settings: align bio to start

### DIFF
--- a/packages/frontend/src/components/Settings/styles.module.scss
+++ b/packages/frontend/src/components/Settings/styles.module.scss
@@ -153,6 +153,7 @@ $settingsHeight: 40px;
   width: 100%;
   border: none;
   background-color: transparent;
+  text-align: start;
 }
 
 .profileDetails {
@@ -166,7 +167,6 @@ $settingsHeight: 40px;
 .profileDisplayName {
   font-size: 18px;
   font-weight: 200;
-  text-align: start;
 }
 
 .profileBio {


### PR DESCRIPTION
It's not aligned if the name is longer than bio
(or the "Bio" placeholder).
For `<button>`s `text-align: center;` is the default,
that is what causes it.

Follow-up to https://github.com/deltachat/deltachat-desktop/pull/6349.
