### PR TITLE
chore: bump required Node version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "engineStrict": true,
   "engines": {
-    "node": "^22",
+    "node": ">=22 <27",
     "pnpm": ">=9.6.0"
   },
   "pnpm": {


### PR DESCRIPTION
To make pnpm stop warning about unsupported engine.
I have tested `pnpm dev` on Node 26. Works fine.
