### PR TITLE
Fix double group image

### DIFF
--- a/packages/frontend/src/components/ImageCropper/styles.module.scss
+++ b/packages/frontend/src/components/ImageCropper/styles.module.scss
@@ -6,6 +6,7 @@
   background-color: #000;
   padding-inline-start: 0;
   padding-inline-end: 0;
+  margin-bottom: 20px;
 }
 
 .imageCropperWrapper {

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -906,19 +906,6 @@ export const ChatSettingsSetNameAndProfileImage = ({
     <>
       <div className='group-settings-container'>
         {(groupType === GroupType.REGULAR_GROUP ||
-          groupType === GroupType.BROADCAST_LIST) &&
-          onUnsetGroupImage &&
-          onSetGroupImage && (
-            <GroupImage
-              style={{ float: 'left' }}
-              groupImage={groupImage}
-              onSetGroupImage={onSetGroupImage}
-              onUnsetGroupImage={onUnsetGroupImage}
-              groupName={chatName}
-              color={color}
-            />
-          )}
-        {(groupType === GroupType.REGULAR_GROUP ||
           groupType === GroupType.BROADCAST_LIST) && (
           <GroupImage
             style={{ float: 'left' }}


### PR DESCRIPTION
The duplicate code was inserted using githubs "apply suggestion" function.

The second commit fixes a missing margin in the ImageCropper dialog