### PR TITLE
refactor: remove unused `top: -121px;` CSS

### DIFF
--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -48,8 +48,6 @@ $info-text-max-width: 400px;
         --local-avatar-color: #bcbac9;
         background-color: var(--local-avatar-color);
 
-        top: -121px;
-        left: -10px;
         border-radius: 50%;
         width: 36px;
         height: 36px;


### PR DESCRIPTION
The element has `position: static;` so it has no effect.
And it's anyway not good to specify position like this.
This line is lingering around since over 7 years,
I have not investigated when it stopped having an effect.

<img width="320" height="220" alt="image" src="https://github.com/user-attachments/assets/080a9393-f8df-4df0-babd-835b4da46a42" />
