### PR TITLE
fix: Ctrl+Click on msg image to multiselect

### DIFF
--- a/packages/e2e-tests/tests/message-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/message-list-multiselect.spec.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from '@playwright/test'
+import path from 'path'
 
 import {
   createProfiles,
@@ -38,7 +39,9 @@ const getMessage = (messageNum: number) =>
   page
     .getByRole('list', { name: 'Messages' })
     .getByRole('listitem')
-    .getByText(new RegExp(`Some message ${messageNum}(?!\\d)`))
+    .locator('.message', {
+      hasText: new RegExp(`Some message ${messageNum}(?!\\d)`),
+    })
 const expectSelectedMessages = async (messageNums: number[]) => {
   await expect(
     page
@@ -55,6 +58,9 @@ const expectMessages = async (messageNums: number[]) => {
       .filter({ hasText: 'Some message' })
   ).toHaveText(messageNums.map(n => makeMessageRegex(n)))
 }
+
+const fixturesPath = path.join(import.meta.dirname, '..', 'fixtures')
+const imagePath = path.join(fixturesPath, 'Deltachat-Logo.png')
 
 test.beforeAll(async ({ browser, isChatmail }) => {
   const contextForProfileCreation = await browser.newContext()
@@ -146,6 +152,75 @@ test.describe('Ctrl + Click', () => {
     await page.keyboard.press('ControlOrMeta+Space')
     await expectSelectedMessages([4, 6])
   })
+})
+
+test('interactive elements inside a message are not clickable in multiselect mode', async () => {
+  await getMessage(4).click()
+  await expectSelectedMessages([])
+
+  const fileChooserPromise = page.waitForEvent('filechooser')
+  await page.getByRole('button', { name: 'Attach' }).click()
+  await page.getByRole('menuitem', { name: 'Image' }).click()
+  const fileChooser = await fileChooserPromise
+  await fileChooser.setFiles(imagePath)
+  await textarea().fill(
+    getMessageText(42) + '\nhttps://localhost/somepage.html'
+  )
+  await textarea().press('ControlOrMeta+Enter')
+
+  // Normally clicking the image opens the "View Image" dialog
+  const image = getMessage(42).getByRole('img')
+  const link = getMessage(42).getByRole('link', {
+    name: 'https://localhost/somepage.html',
+  })
+  await image.click()
+  const closeButton = page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Close' })
+  await closeButton.click()
+
+  await getMessage(2).click({
+    modifiers: ['ControlOrMeta'],
+  })
+  await expectSelectedMessages([2])
+
+  await image.click({
+    modifiers: ['ControlOrMeta'],
+    // The wrapper is `inert`, so withour `force` the click would fail.
+    force: true,
+  })
+  await expectSelectedMessages([2, 42])
+  // If a dialog has been opened then the rest should not work,
+  // because the dialog makes outside content inert.
+  await image.click({
+    modifiers: ['ControlOrMeta'],
+    force: true,
+  })
+  await expectSelectedMessages([2])
+
+  await link.click({
+    modifiers: ['ControlOrMeta'],
+    force: true,
+  })
+  await expectSelectedMessages([2, 42])
+
+  await link.click({ force: true })
+  await expectSelectedMessages([])
+  await expect(closeButton).not.toBeVisible()
+
+  await image.click()
+  await closeButton.click()
+
+  // Clean up.
+  await image.click({
+    button: 'right',
+  })
+  await page.getByRole('menuitem', { name: 'Delete' }).click()
+  await page
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Delete' })
+    .last()
+    .click()
 })
 
 test('delete several', async () => {

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -21,7 +21,7 @@ $info-text-max-width: 400px;
   align-items: stretch;
   max-width: 75%;
 
-  & > .author-avatar {
+  .author-avatar {
     @include mixins.button-reset;
 
     align-self: flex-end;

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -523,6 +523,7 @@ export default function Message(props: {
   const isMultiselectMember =
     focusAndMultiselect.selectedItems.size > 1 &&
     focusAndMultiselect.selectedItems.has(message.id)
+  const isMultiselectMode = focusAndMultiselect.selectedItems.size > 0
 
   const showContextMenu = useCallback(
     (
@@ -985,141 +986,152 @@ export default function Message(props: {
       }}
       {...commonAttrs}
     >
-      {showAuthor && direction === 'incoming' && (
-        <Avatar
-          contact={message.sender}
-          onContactClick={onContactClick}
-          // The avatar doesn't need to be a tab stop, because
-          // the author name is a tab stop and clicking on it does the same.
-          tabIndex={-1}
-        />
-      )}
       <div
-        className='msg-container'
-        style={{ borderColor: message.sender.color }}
-        ref={messageContainerRef}
+        // Make links, images, etc, unclickable
+        // so that it's harder to accidentally activate them
+        // while actually trying to simply Ctrl + Click the message.
+        // Especially usefult for images, which occupy the majority
+        // of the message bubble's area.
+        inert={isMultiselectMode}
+        style={{ display: 'contents' }}
       >
-        {message.isForwarded && (
-          <ForwardedTitle
+        {showAuthor && direction === 'incoming' && (
+          <Avatar
             contact={message.sender}
             onContactClick={onContactClick}
-            direction={direction}
-            conversationType={conversationType}
-            overrideSenderName={message.overrideSenderName}
-            tabIndex={tabindexForInteractiveContents}
+            // The avatar doesn't need to be a tab stop, because
+            // the author name is a tab stop and clicking on it does the same.
+            tabIndex={-1}
           />
         )}
-        {!message.isForwarded && (
-          <div
-            className={classNames('author-wrapper', {
-              'can-hide':
-                (!message.overrideSenderName && direction === 'outgoing') ||
-                !showAuthor,
-            })}
-          >
-            <AuthorName
+        <div
+          className='msg-container'
+          style={{ borderColor: message.sender.color }}
+          ref={messageContainerRef}
+        >
+          {message.isForwarded && (
+            <ForwardedTitle
               contact={message.sender}
               onContactClick={onContactClick}
+              direction={direction}
+              conversationType={conversationType}
               overrideSenderName={message.overrideSenderName}
               tabIndex={tabindexForInteractiveContents}
             />
-          </div>
-        )}
-        <div
-          className={classNames('msg-body', {
-            call: message.viewType === 'Call',
-          })}
-        >
-          {message.quote !== null && (
-            <Quote
-              quote={message.quote}
-              msgParentId={message.id}
-              // FYI the quote is not always interactive,
-              // e.g. when `quote.kind === 'JustText'`.
-              tabIndex={tabindexForInteractiveContents}
-            />
           )}
-          {showAttachment(message) && (
-            <Attachment
-              text={text || undefined}
-              message={message}
-              tabindexForInteractiveContents={tabindexForInteractiveContents}
-            />
-          )}
-          {message.viewType === 'Webxdc' && (
-            <WebxdcMessageContent
-              tabindexForInteractiveContents={tabindexForInteractiveContents}
-              message={message}
-            ></WebxdcMessageContent>
-          )}
-          {message.viewType === 'Vcard' && (
-            <VCardComponent
-              message={message}
-              tabindexForInteractiveContents={tabindexForInteractiveContents}
-            ></VCardComponent>
-          )}
-          {content}
-          {hasHtml && (
-            <button
-              type='button'
-              onClick={openMessageHTML.bind(null, message.id)}
-              className='show-html'
-              tabIndex={tabindexForInteractiveContents}
+          {!message.isForwarded && (
+            <div
+              className={classNames('author-wrapper', {
+                'can-hide':
+                  (!message.overrideSenderName && direction === 'outgoing') ||
+                  !showAuthor,
+              })}
             >
-              {tx('show_full_message')}
-            </button>
+              <AuthorName
+                contact={message.sender}
+                onContactClick={onContactClick}
+                overrideSenderName={message.overrideSenderName}
+                tabIndex={tabindexForInteractiveContents}
+              />
+            </div>
           )}
-          <footer
-            className={classNames(styles.messageFooter, {
-              [styles.onlyMedia]: isWithoutText,
-              [styles.withReactionsNoText]: isWithoutText && message.reactions,
+          <div
+            className={classNames('msg-body', {
+              call: message.viewType === 'Call',
             })}
           >
-            <MessageMetaData
-              messageId={message.id}
-              fileMime={fileMime}
-              direction={direction}
-              status={status}
-              error={message.error || null}
-              downloadState={downloadState}
-              isEdited={message.isEdited}
-              hasText={hasText}
-              hasLocation={hasLocation}
-              timestamp={message.timestamp * 1000}
-              encrypted={message.showPadlock}
-              isSavedMessage={isOrHasSavedMessage}
-              onClickError={() =>
-                openDialog(AlertDialog, {
-                  message: message.error
-                    ? tx('error_x', message.error)
-                    : tx('ok'),
-                  dialogComponentProps: {
-                    width: 600,
-                  },
-                })
-              }
-              viewType={message.viewType}
-              chatType={chat.chatType}
-              tabindexForInteractiveContents={tabindexForInteractiveContents}
-            />
-            <div
-              // TODO the "+1" count aria-live announcment is perhaps not great
-              // out of context.
-              // Also the "show ReactionsDialog" button gets announced.
-              aria-live='polite'
-              aria-relevant='all'
+            {message.quote !== null && (
+              <Quote
+                quote={message.quote}
+                msgParentId={message.id}
+                // FYI the quote is not always interactive,
+                // e.g. when `quote.kind === 'JustText'`.
+                tabIndex={tabindexForInteractiveContents}
+              />
+            )}
+            {showAttachment(message) && (
+              <Attachment
+                text={text || undefined}
+                message={message}
+                tabindexForInteractiveContents={tabindexForInteractiveContents}
+              />
+            )}
+            {message.viewType === 'Webxdc' && (
+              <WebxdcMessageContent
+                tabindexForInteractiveContents={tabindexForInteractiveContents}
+                message={message}
+              ></WebxdcMessageContent>
+            )}
+            {message.viewType === 'Vcard' && (
+              <VCardComponent
+                message={message}
+                tabindexForInteractiveContents={tabindexForInteractiveContents}
+              ></VCardComponent>
+            )}
+            {content}
+            {hasHtml && (
+              <button
+                type='button'
+                onClick={openMessageHTML.bind(null, message.id)}
+                className='show-html'
+                tabIndex={tabindexForInteractiveContents}
+              >
+                {tx('show_full_message')}
+              </button>
+            )}
+            <footer
+              className={classNames(styles.messageFooter, {
+                [styles.onlyMedia]: isWithoutText,
+                [styles.withReactionsNoText]:
+                  isWithoutText && message.reactions,
+              })}
             >
-              {message.reactions && (
-                <Reactions
-                  reactions={message.reactions}
-                  tabindexForInteractiveContents={
-                    tabindexForInteractiveContents
-                  }
-                  messageWidth={messageWidth}
-                />
-              )}
-            </div>
-          </footer>
+              <MessageMetaData
+                messageId={message.id}
+                fileMime={fileMime}
+                direction={direction}
+                status={status}
+                error={message.error || null}
+                downloadState={downloadState}
+                isEdited={message.isEdited}
+                hasText={hasText}
+                hasLocation={hasLocation}
+                timestamp={message.timestamp * 1000}
+                encrypted={message.showPadlock}
+                isSavedMessage={isOrHasSavedMessage}
+                onClickError={() =>
+                  openDialog(AlertDialog, {
+                    message: message.error
+                      ? tx('error_x', message.error)
+                      : tx('ok'),
+                    dialogComponentProps: {
+                      width: 600,
+                    },
+                  })
+                }
+                viewType={message.viewType}
+                chatType={chat.chatType}
+                tabindexForInteractiveContents={tabindexForInteractiveContents}
+              />
+              <div
+                // TODO the "+1" count aria-live announcment is perhaps not great
+                // out of context.
+                // Also the "show ReactionsDialog" button gets announced.
+                aria-live='polite'
+                aria-relevant='all'
+              >
+                {message.reactions && (
+                  <Reactions
+                    reactions={message.reactions}
+                    tabindexForInteractiveContents={
+                      tabindexForInteractiveContents
+                    }
+                    messageWidth={messageWidth}
+                  />
+                )}
+              </div>
+            </footer>
+          </div>
         </div>
       </div>
       <ShortcutMenu

--- a/packages/frontend/themes/dev_minimal.scss
+++ b/packages/frontend/themes/dev_minimal.scss
@@ -194,7 +194,7 @@ $navbarBgLight: $borderColor;
   display: none;
 }
 
-.message > .author-avatar {
+.message .author-avatar {
   display: none;
 }
 .message .msg-container .msg-body > .text {

--- a/packages/frontend/themes/dev_rocket.scss
+++ b/packages/frontend/themes/dev_rocket.scss
@@ -232,7 +232,7 @@ $navbarBgLight: $borderColor;
   background-color: var(--messageMetadataIconColorIncoming);
 }
 
-.message > .author-avatar {
+.message .author-avatar {
   display: none;
 }
 .message .msg-container .msg-body > .text {


### PR DESCRIPTION
Make the interactive elements inside a message inert (unclickable)
when multiselect "mode" is active.

I had to change `getMessage` in tests
because originally it was pointing to the message text,
and clicking it without `force` would not work in Playwrtight,
so I had to select some element outside of `inert`.

The CSS change should not break anything,
because `.author-avatar` is only used as "message author avatar",
and not e.g. also in VCards.

WIP because I want to take time to consider alternative solutions. But yep, this works.
- [ ] Hmmmm, but https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert#accessibility_concerns says
  > hidden from assistive technologies as they are excluded from the accessibility tree
  
  I believe we don't want this, because we want to read the message contents when it gets focused.
  Edit: just confirmed with Orca reader. It only announces "opens menu" when you switch between messages if at least one message is selected.
- [ ] If we go for this then the selection text color CSS is not needed?