### PR TITLE
fix: qr code video is flipped for back camera

### DIFF
--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -381,13 +381,13 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
           activeStream = stream
 
           const settings = videoTracks[0].getSettings()
-          let flipped = true;
-          if (settings.facingMode != undefined) {
-            flipped = !(settings.facingMode == 'environment')
+          let isFacingUser = true
+          if (settings.facingMode !== undefined) {
+            isFacingUser = settings.facingMode === 'user'
           } else {
-            flipped = !(videoTracks[0].label.toLowerCase().includes('back'))
+            isFacingUser = !(videoTracks[0].label.toLowerCase().includes('back'))
           }
-          setFlipped(flipped)
+          setFlipped(isFacingUser)
 
           if (settings.deviceId) {
             setDeviceId(settings.deviceId)

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -68,7 +68,7 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
     const [videoDevices, setVideoDevices] = useState<MediaDeviceInfo[]>([])
     const [deviceId, setDeviceId] = useState<string | undefined>(undefined)
     const [processingFile, setProcessingFile] = useState(false)
-
+    const [flipped, setFlipped] = useState(false)
     const workerRef = useRef<Worker | null>(null)
     const workerClipBoardRef = useRef<Worker | null>(null)
     // Only create the worker once per component instance.
@@ -381,6 +381,14 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
           activeStream = stream
 
           const settings = videoTracks[0].getSettings()
+          let flipped = true;
+          if (settings.facingMode != undefined) {
+            flipped = !(settings.facingMode == 'environment')
+          } else {
+            flipped = !(videoTracks[0].label.toLowerCase().includes('back'))
+          }
+          setFlipped(flipped)
+
           if (settings.deviceId) {
             setDeviceId(settings.deviceId)
           }
@@ -508,6 +516,7 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
         <video
           className={classNames(styles.qrReaderVideo, {
             [styles.visible]: ready && !cameraAccessError && !processingFile,
+            [styles.flipped]: flipped,
           })}
           autoPlay
           muted

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -383,7 +383,7 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
           const settings = videoTracks[0].getSettings()
           let isFacingUser = true
           if (settings.facingMode !== undefined) {
-            isFacingUser = settings.facingMode === 'user'
+            isFacingUser = settings.facingMode !== 'environment'
           } else {
             isFacingUser = !videoTracks[0].label.toLowerCase().includes('back')
           }

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -385,7 +385,7 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
           if (settings.facingMode !== undefined) {
             isFacingUser = settings.facingMode === 'user'
           } else {
-            isFacingUser = !(videoTracks[0].label.toLowerCase().includes('back'))
+            isFacingUser = !videoTracks[0].label.toLowerCase().includes('back')
           }
           setFlipped(isFacingUser)
 

--- a/packages/frontend/src/components/QrReader/index.tsx
+++ b/packages/frontend/src/components/QrReader/index.tsx
@@ -69,6 +69,7 @@ export const QrReader = forwardRef<QrCodeScanRef, Props>(
     const [deviceId, setDeviceId] = useState<string | undefined>(undefined)
     const [processingFile, setProcessingFile] = useState(false)
     const [flipped, setFlipped] = useState(false)
+
     const workerRef = useRef<Worker | null>(null)
     const workerClipBoardRef = useRef<Worker | null>(null)
     // Only create the worker once per component instance.

--- a/packages/frontend/src/components/QrReader/styles.module.scss
+++ b/packages/frontend/src/components/QrReader/styles.module.scss
@@ -19,7 +19,6 @@
   &.flipped {
     transform: scale(-1, 1); // Mirror video by flipping it horizontally
   }
-
 }
 
 .qrReaderButton {

--- a/packages/frontend/src/components/QrReader/styles.module.scss
+++ b/packages/frontend/src/components/QrReader/styles.module.scss
@@ -11,11 +11,15 @@
   position: absolute;
   right: 0;
   top: 0;
-  transform: scale(-1, 1); // Mirror video by flipping it horizontally
 
   &.visible {
     display: block;
   }
+
+  &.flipped {
+    transform: scale(-1, 1); // Mirror video by flipping it horizontally
+  }
+
 }
 
 .qrReaderButton {


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6269.

The qr code video is flipped horizontally to have a correct behaviour for front cameras

The problem is that when selecting a back camera (instead of a front camera) the horizontal flip has not to be performed
