### PR TITLE
fix: refocus input when send message button is pressed

### DIFF
--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -529,7 +529,7 @@ test('gets focused after clicking/touching send message button', async () => {
 
   const msg = 'Msg' + Math.random()
   await textarea.fill(msg)
-  await page.getByTestId('send-button').click()
+  await page.getByRole('button', { name: 'Send' }).click()
 
   await expect(textarea).toBeFocused()
 })

--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -524,6 +524,16 @@ test('gets focused when selecting a chat', async () => {
   await expect(textarea).toBeFocused()
 })
 
+test('gets focused after clicking/touching send message button', async () => {
+  await selectChat(1)
+
+  const msg = 'Msg' + Math.random()
+  await textarea.fill(msg)
+  await page.getByTestId('send-button').click()
+
+  await expect(textarea).toBeFocused()
+})
+
 test.describe('Ctrl + Up shortcut', () => {
   test.describe.configure({
     mode: 'serial',

--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -529,6 +529,7 @@ test('gets focused after clicking/touching send message button', async () => {
 
   const msg = 'Msg' + Math.random()
   await textarea.fill(msg)
+  await page.getByRole('button', { name: 'Send' }).focus()
   await page.getByRole('button', { name: 'Send' }).click()
 
   await expect(textarea).toBeFocused()

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -800,7 +800,6 @@ const Composer = forwardRef<
               disabled={sendButtonAction == null}
               onClick={sendButtonAction ?? (() => {})}
               aria-label={tx('menu_send')}
-              data-testid='send-button'
               aria-keyshortcuts={ariaSendShortcut}
             >
               <div className='paper-plane'></div>

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -222,6 +222,13 @@ const Composer = forwardRef<
     messageEditing.isEditingModeActive || draftIsLoading
       ? null
       : async () => {
+
+          // Focus message input in case the message was sent
+          // with the "Send" button touch / mouse click and not Ctrl + Enter.
+          setTimeout(() => {
+            regularMessageInputRef.current?.focus()
+          })
+
           if (chatId === null) {
             throw new Error('chat id is undefined')
           }
@@ -793,6 +800,7 @@ const Composer = forwardRef<
               disabled={sendButtonAction == null}
               onClick={sendButtonAction ?? (() => {})}
               aria-label={tx('menu_send')}
+              data-testid='send-button'
               aria-keyshortcuts={ariaSendShortcut}
             >
               <div className='paper-plane'></div>

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -222,7 +222,6 @@ const Composer = forwardRef<
     messageEditing.isEditingModeActive || draftIsLoading
       ? null
       : async () => {
-
           // Focus message input in case the message was sent
           // with the "Send" button touch / mouse click and not Ctrl + Enter.
           setTimeout(() => {


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6263.
Supersedes https://github.com/deltachat/deltachat-desktop/pull/6264.

If you click the paper plane button to send a message the text input is not refocused.
So you have to click again on the input each time

This behavior is ever more annoying on a touch device without a physical keyboard because not only the focus is lost but the virtual keyboard disappear

At the same time everything is fine if you press the Return button on a physical keyboard: in this case the text input does not lose focus

The paper plane button is expected to have the same behavior as the return key (or control + return depending on configuration) of the keyboard