### PR TITLE
feat: click on call messages opens/focus call window

### DIFF
--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1285,31 +1285,40 @@ function CallIconButton({
   const refresh = useEffectEvent(callInfoFetch.refresh)
   useEffect(() => {
     return onDCEvent(accountId, 'MsgsChanged', event => {
+      // MsgsChanged event is fired when the call state changes
       if (event.msgId !== messageId) {
         return
       }
+      // update the call info
       refresh()
     })
   }, [accountId, messageId])
 
-  const onClickParams:
-    | undefined
-    | Parameters<typeof runtime.openIncomingVideoCallWindow>[0] =
-    callInfoFetch.result?.ok &&
-    callInfoFetch.result.value.state.kind === 'Alerting'
-      ? {
-          accountId,
-          chatId,
-          callMessageId: messageId,
-          callerWebrtcOffer: callInfoFetch.result.value.sdpOffer,
-          startWithCameraEnabled: callInfoFetch.result.value.hasVideo,
-        }
-      : undefined
-  // TODO fix: don't open a second window if one is already open
-  // for this message (this should be done in the main process).
-  const onClick = onClickParams
-    ? () => runtime.openIncomingVideoCallWindow(onClickParams)
+  const callInfo = callInfoFetch.result?.ok
+    ? callInfoFetch.result.value
     : undefined
+
+  const callWindowParams = callInfo
+    ? {
+        accountId,
+        chatId,
+        callMessageId: messageId,
+        callerWebrtcOffer: callInfo.sdpOffer,
+        startWithCameraEnabled: callInfo.hasVideo,
+      }
+    : undefined
+
+  const onClick =
+    callInfo == undefined
+      ? undefined
+      : callInfo.state.kind === 'Alerting' || callInfo.state.kind === 'Active'
+        ? // Focus the existing window (if any) or open the incoming call dialog.
+          () => runtime.openIncomingVideoCallWindow(callWindowParams!)
+        : // Terminated state (Completed, Missed, Declined, Canceled): start a new outgoing call.
+          () =>
+            runtime.startOutgoingVideoCall(accountId, chatId, {
+              startWithCameraEnabled: callInfo.hasVideo,
+            })
 
   return (
     <IconButton

--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -22,12 +22,33 @@ import { setContentProtection } from '../content-protection'
 
 const log = getLogger('windows/video-call')
 
+/**
+ * Tracks open call windows by "accountId-chatId" key.
+ * Used to focus an existing call window when the user clicks a call bubble.
+ */
+const openCallWindows = new Map<string, BrowserWindow>()
+
+function callWindowKey(accountId: number, chatId: number): string {
+  return `${accountId}-${chatId}`
+}
+
 export function startOutgoingVideoCall(
   accountId: number,
   chatId: number,
   param: { startWithCameraEnabled: boolean }
 ) {
   log.info('starting outgoing video call', { accountId, chatId })
+
+  // If a call window for this chat is already open (e.g. a call is active),
+  // raise it instead of starting a new call.
+  const existingWin = openCallWindows.get(callWindowKey(accountId, chatId))
+  if (existingWin && !existingWin.isDestroyed()) {
+    if (existingWin.isMinimized()) {
+      existingWin.restore()
+    }
+    existingWin.focus()
+    return
+  }
 
   const { offerPromise, windowClosed, closeWindow } = openVideoCallWindow(
     accountId,
@@ -136,6 +157,17 @@ export function openIncomingVideoCallWindow({
     callMessageId,
     startWithCameraEnabled,
   })
+
+  // If a call window for this chat is already open bring it to the
+  // foreground instead of opening a second window.
+  const existingWin = openCallWindows.get(callWindowKey(accountId, chatId))
+  if (existingWin && !existingWin.isDestroyed()) {
+    if (existingWin.isMinimized()) {
+      existingWin.restore()
+    }
+    existingWin.focus()
+    return
+  }
 
   const { answerPromise, windowClosed, closeWindow } = openVideoCallWindow(
     accountId,
@@ -259,8 +291,14 @@ function openVideoCallWindow<D extends CallDirection>(
   // Maybe we could add a setting for this, i.e. "Allow calls to bypass VPN".
   // win.webContents.setWebRTCIPHandlingPolicy()
 
+  const windowKey = callWindowKey(accountId, chatId)
+  openCallWindows.set(windowKey, win)
+
   const abortController = new AbortController()
-  win.once('closed', () => abortController.abort('window closed'))
+  win.once('closed', () => {
+    openCallWindows.delete(windowKey)
+    abortController.abort('window closed')
+  })
 
   chatInfoPromise.then(chat => {
     if (win.isDestroyed()) {


### PR DESCRIPTION
resolves #6081 

tbd: currently only a click on the phone icon triggers that behaviour - should we extend that to the whole message bubble as stated in the issue?