### PR TITLE
fix: adapt accountlist sidebar

### DIFF
--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -41,8 +41,9 @@
   background-color: var(--accountSidebarBg);
   display: flex;
   flex-direction: column;
-  min-width: 68px;
+  min-width: 76px;
   overflow: hidden;
+  padding-top: 4px;
 
   .accountListNav {
     flex-grow: 1;
@@ -53,8 +54,8 @@
     }
 
     .accountList {
-      --als-avatar-size: 42px;
-      --als-avatar-margin: 5px;
+      --als-avatar-size: 48px;
+      --als-avatar-margin: 8px;
       --als-active-indicator-color: white;
 
       margin: 0;
@@ -142,7 +143,7 @@
     &:hover,
     &.context-menu-active {
       .avatar::before {
-        --als-active-indicator-height: 32px;
+        --als-active-indicator-height: 15px;
 
         background: var(--als-active-indicator-color);
         border-radius: 20px;
@@ -157,7 +158,7 @@
               var(--als-active-indicator-height) / 2
             )
         );
-        width: 8px;
+        width: 10px;
       }
 
       .avatar {
@@ -165,9 +166,10 @@
       }
     }
 
-    &:hover {
+    &.active,
+    &.context-menu-active {
       .avatar::before {
-        --als-active-indicator-height: 15px;
+        --als-active-indicator-height: 36px;
       }
     }
 

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -149,7 +149,7 @@
         border-radius: 20px;
         content: ' ';
         height: var(--als-active-indicator-height);
-        margin-inline-start: -16.5px;
+        margin-inline-start: -18px;
         overflow: hidden;
         pointer-events: none;
         position: absolute;

--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -55,7 +55,7 @@
 
     .accountList {
       --als-avatar-size: 48px;
-      --als-avatar-margin: 8px;
+      --als-avatar-margin: 7px;
       --als-active-indicator-color: white;
 
       margin: 0;


### PR DESCRIPTION
Apply suggestions from https://github.com/deltachat/deltachat-desktop/pull/6358#pullrequestreview-4264876403

resolves #5898 

Before

<img width="100" height="453" alt="image" src="https://github.com/user-attachments/assets/8ed3d4e2-0cb8-45b8-a7ee-f9b477f6d30b" />


After

<img width="114" height="537" alt="image" src="https://github.com/user-attachments/assets/27007467-d42d-43d2-b3b2-005f095948f2" />



MacOS Tahoe

<img height="300" alt="image" src="https://github.com/user-attachments/assets/97f6da81-69a2-4d48-8b2b-4a358d7ac455" />
