### PR TITLE
feat: close (unselect) chat with Escape

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -464,6 +464,20 @@ test("closing context menu with Escape doesn't close dialog", async () => {
   await expect(page.getByRole('dialog')).not.toBeVisible()
 })
 
+test('Escape closes the chat', async () => {
+  await page.getByLabel('Chats').getByRole('tab').first().click()
+  await expect(
+    page.locator('textarea.create-or-edit-message-input')
+  ).toBeFocused()
+  await page.keyboard.press('Escape')
+  await expect(
+    page.locator('textarea.create-or-edit-message-input')
+  ).not.toBeVisible()
+  await expect(
+    page.getByLabel('Chats').getByRole('tab', { selected: true })
+  ).toHaveCount(0)
+})
+
 test('correct handling of changed profile displaynames', async () => {
   const userA = existingProfiles[0]
   const userB = existingProfiles[1]

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -102,7 +102,6 @@ const Composer = forwardRef<
   const { openDialog } = useDialog()
   const { sendMessage } = useMessage()
   const { unselectChat } = useChat()
-  const { smallScreenMode } = useContext(ScreenContext)
 
   // The philosophy of the editing mode is as follows.
   // The edit mode can be thought of as a dialog,
@@ -371,14 +370,13 @@ const Composer = forwardRef<
             regularMessageInputRef.current?.focus()
           })
         } else {
-          // No picker/edit mode/quote to close
-          if (smallScreenMode) {
-            // In small screen mode, unselect the chat to go back to chatlist
-            ActionEmitter.emitAction(KeybindAction.Chat_Unselect)
-          } else {
-            // Focus the chatlist item to enable arrow key navigation between chats
-            ActionEmitter.emitAction(KeybindAction.ChatList_FocusItems)
-          }
+          // No picker/edit mode/quote to close.
+          // Unselecting the chat goes back to chatlist in small screen mode.
+          // But it's also good in "regular" mode.
+          ActionEmitter.emitAction(KeybindAction.Chat_Unselect)
+          // Focus the chatlist item to enable arrow key navigation between chats
+          // TODO fix: doesn't work in small screen mode.
+          ActionEmitter.emitAction(KeybindAction.ChatList_FocusItems)
         }
         ev.stopPropagation()
       }
@@ -397,7 +395,6 @@ const Composer = forwardRef<
     shiftPressed,
     messageEditing,
     regularMessageInputRef,
-    smallScreenMode,
     showEmojiPicker,
     showAppPicker,
     draftState.quote,


### PR DESCRIPTION
For now only when the composer is focused.
Instead this should probably be handled by the whole "Chat" section.

Closes https://support.delta.chat/t/closing-chats-with-escape-key-show-contact-list-hide-chat-log/5068?u=wofwca.
See https://github.com/deltachat/deltachat-desktop/issues/4128#issuecomment-4267086941.
Sort of contradicts with https://github.com/deltachat/deltachat-desktop/issues/6246.

We've already been focusing the chat list on Escape since
37063985cd3d5793e18ec05d52a9bcfbe7b1546a
(https://github.com/deltachat/deltachat-desktop/pull/5920).
