### PR TITLE
fix: don't show description input in "New Email"

### DIFF
--- a/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
+++ b/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
@@ -93,6 +93,9 @@ test('check "New E-Mail" option is shown and a chat can be created', async () =>
   await newEmailButton.click()
 
   await page.getByTestId('group-name-input').fill(unencryptedGroupSubject1)
+  await expect(
+    page.getByRole('dialog').getByRole('textbox', { name: 'description' })
+  ).not.toBeVisible()
   await page.locator('#addmember').click()
 
   await page.getByTestId('add-member-search').fill(emailUserB)

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -709,16 +709,18 @@ export function CreateGroup(props: CreateGroupProps) {
             setChatName={setGroupName}
             errorMissingChatName={errorMissingGroupName}
             setErrorMissingChatName={setErrorMissingGroupName}
-            description={groupDescription}
-            setDescription={setGroupDescription}
-            {...(groupType === GroupType.PLAIN_EMAIL
+            {...((groupType === GroupType.PLAIN_EMAIL
               ? { groupType }
               : {
                   groupType,
                   groupImage,
                   onSetGroupImage: onSetGroupImage!,
                   onUnsetGroupImage: onUnsetGroupImage!,
-                })}
+                  description: groupDescription,
+                  setDescription: setGroupDescription,
+                }) satisfies Partial<
+              Parameters<typeof ChatSettingsSetNameAndProfileImage>[0]
+            >)}
           />
         </DialogContent>
         <div id='create-group-members-title' className='group-separator'>


### PR DESCRIPTION
Edit: settings a description on an unencrypted chat doesn't work.
And Android also doesn't show this input.