### PR TITLE
fix: keep focus on old element on dialog close

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -398,6 +398,7 @@ test('add app from picker to chat', async () => {
   await page.getByTestId('add-app-to-chat').click()
   const appDraft = page.locator('.attachment-quote-section .text-part')
   await expect(appDraft).toContainText(appName)
+  await expect(page.locator('.create-or-edit-message-input')).toBeFocused()
   await page.locator('button.send-button').click()
   const webxdcMessage = page.locator('.msg-body .webxdc')
   await expect(webxdcMessage).toContainText(appName)

--- a/packages/e2e-tests/tests/file-attachments.spec.ts
+++ b/packages/e2e-tests/tests/file-attachments.spec.ts
@@ -111,6 +111,9 @@ test('send image attachment', async () => {
     '.attachment-quote-section .message-attachment-media .attachment-content'
   )
   await expect(attachmentDraftPreview).toBeVisible()
+  await expect(
+    page.locator('textarea.create-or-edit-message-input')
+  ).toBeFocused()
   // Send the message
   await page.locator('button.send-button').click()
 
@@ -164,6 +167,9 @@ test('send file attachment', async () => {
   await expect(attachmentDraftPreview).toBeVisible()
   await expect(attachmentDraftPreview).toContainText('test.zip')
 
+  await expect(
+    page.locator('textarea.create-or-edit-message-input')
+  ).toBeFocused()
   // Optionally add a message
   await page
     .locator('textarea.create-or-edit-message-input')
@@ -223,6 +229,9 @@ test('send contact as vCard', async () => {
   await expect(attachmentPreview).toBeVisible()
   await expect(attachmentPreview).toContainText(userA.name)
 
+  await expect(
+    page.locator('textarea.create-or-edit-message-input')
+  ).toBeFocused()
   // Send the message
   await page.locator('button.send-button').click()
 

--- a/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
+++ b/packages/frontend/src/components/AudioRecorder/AudioRecorder.tsx
@@ -85,11 +85,13 @@ export const AudioRecorder = ({
   recording,
   setRecording,
   saveVoiceAsDraft,
+  focusMessageInput,
   onError,
 }: {
   recording: boolean
   setRecording: (f: boolean) => void
   saveVoiceAsDraft: (blob: Blob) => void
+  focusMessageInput: () => void
   onError: (error: AudioRecorderError) => void
 }) => {
   const tx = useTranslationFunction()
@@ -149,6 +151,8 @@ export const AudioRecorder = ({
   }
   const onRecordingStop = () => {
     setRecording(false)
+    setTimeout(() => focusMessageInput())
+
     recorder.current
       ?.stop()
       .getMp3()

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -468,7 +468,10 @@ const Composer = forwardRef<
           appInfo.cache_relname,
           response.blob
         )
+
         setShowAppPicker(false)
+        setTimeout(() => focusMessageInput())
+
         await addFileToDraft(path, appInfo.cache_relname, 'File')
         await runtime.removeTempFile(path)
       }
@@ -712,6 +715,7 @@ const Composer = forwardRef<
           {!messageEditing.isEditingModeActive && !recording && (
             <MenuAttachment
               addFileToDraft={addFileToDraft}
+              focusMessageInput={focusMessageInput}
               showAppPicker={setShowAppPicker}
               selectedChat={selectedChat}
             />
@@ -803,6 +807,7 @@ const Composer = forwardRef<
               recording={recording}
               setRecording={setRecording}
               saveVoiceAsDraft={saveVoiceAsDraft}
+              focusMessageInput={focusMessageInput}
               onError={onAudioError}
             />
           )}

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -524,12 +524,15 @@ const Composer = forwardRef<
 
   const settingsStore = useSettingsStore()[0]
 
-  useLayoutEffect(() => {
-    // focus composer on chat change
+  const focusMessageInput = useCallback(() => {
     // Only one of these is actually rendered at any given moment.
     regularMessageInputRef.current?.focus()
     editMessageInputRef.current?.focus()
-  }, [chatId, editMessageInputRef, regularMessageInputRef])
+  }, [editMessageInputRef, regularMessageInputRef])
+  useLayoutEffect(() => {
+    // focus composer on chat change
+    focusMessageInput()
+  }, [chatId, focusMessageInput])
 
   const ariaSendShortcut: string = useMemo(() => {
     if (settingsStore == undefined) {

--- a/packages/frontend/src/components/composer/menuAttachment.tsx
+++ b/packages/frontend/src/components/composer/menuAttachment.tsx
@@ -24,6 +24,7 @@ import useMessage from '../../hooks/chat/useMessage'
 
 type Props = {
   addFileToDraft: (file: string, fileName: string, viewType: T.Viewtype) => void
+  focusMessageInput: () => void
   showAppPicker: (show: boolean) => void
   selectedChat: Pick<T.BasicChat, 'name' | 'id' | 'chatType'> | null
 }
@@ -31,6 +32,7 @@ type Props = {
 // Main component that creates the menu and popover
 export default function MenuAttachment({
   addFileToDraft,
+  focusMessageInput,
   showAppPicker,
   selectedChat,
 }: Props) {
@@ -56,6 +58,7 @@ export default function MenuAttachment({
           return
         }
 
+        setTimeout(() => focusMessageInput())
         for (const filePath of filePaths) {
           await sendMessage(accountId, selectedChat.id, {
             file: filePath,
@@ -104,6 +107,7 @@ export default function MenuAttachment({
         viewType = 'Vcard'
       }
       addFileToDraft(files[0], basename(files[0]), viewType)
+      focusMessageInput()
     } else if (files.length > 1) {
       confirmSendMultipleFiles(files, 'File')
     }
@@ -128,6 +132,7 @@ export default function MenuAttachment({
     if (files.length === 1) {
       setLastPath(dirname(files[0]))
       addFileToDraft(files[0], basename(files[0]), 'Image')
+      focusMessageInput()
     } else if (files.length > 1) {
       confirmSendMultipleFiles(files, 'Image')
     }
@@ -154,7 +159,9 @@ export default function MenuAttachment({
         const fileName = `VCard-${cleanAuthname}.vcf`
         const tmp_file = await runtime.writeTempFile(fileName, vCardContact)
         addFileToDraft(tmp_file, fileName, 'Vcard')
+
         closeDialog(dialogId)
+        setTimeout(() => focusMessageInput())
       }
     }
     dialogId = openDialog(SelectContactDialog, { onOk: addContactAsVcard })

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -257,14 +257,13 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     },
     [hasOpenDialogs]
   )
-
   useEffect(() => {
-    window.addEventListener('mouseup', onMouseUp)
-
     // Only one of these is actually rendered at any given moment.
     regularMessageInputRef.current?.focus()
     editMessageInputRef.current?.focus()
-
+  }, [])
+  useEffect(() => {
+    window.addEventListener('mouseup', onMouseUp)
     return () => {
       window.removeEventListener('mouseup', onMouseUp)
     }

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -310,12 +310,6 @@ export function useDraft(
         return
       }
 
-      // This is most likely not needed anymore
-      // as we try to focus the composer in more concrete places
-      // where `addFileToDraft()` is used.
-      // Related: https://github.com/deltachat/deltachat-desktop/issues/4590.
-      inputRef.current?.focus()
-
       const newDraftState: typeof draftState = {
         ...draftState,
         file,
@@ -330,7 +324,7 @@ export function useDraft(
       debouncedSaveAndRefetchDraft?.clear()
       return saveAndRefetchDraft(newDraftState)
     },
-    [draftState, inputRef, saveAndRefetchDraft, debouncedSaveAndRefetchDraft]
+    [draftState, saveAndRefetchDraft, debouncedSaveAndRefetchDraft]
   )
 
   const quoteMessage = useMemo(

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -310,7 +310,12 @@ export function useDraft(
         return
       }
 
+      // This is most likely not needed anymore
+      // as we try to focus the composer in more concrete places
+      // where `addFileToDraft()` is used.
+      // Related: https://github.com/deltachat/deltachat-desktop/issues/4590.
       inputRef.current?.focus()
+
       const newDraftState: typeof draftState = {
         ...draftState,
         file,


### PR DESCRIPTION
- **refactor: factor out `focusMessageInput` fn**
- **fix: keep focus on old element on dialog close**

...instead of always focusing the composer.
Example,
1. Focus the "Settings" button (big gear icon).
2. Press Space to open the Settings dialog.
3. Press Escape.

One would expect that the settings button would get focused again
but instead we focus the composer.
https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
also says:
> When a dialog closes, focus returns
> to the element that invoked the dialog unless...

The main change here is the `useEffect` in `MessageListAndComposer.tsx`.
The problem was that the effect focuses the composer,
but the effect's dependency, `onMouseUp`,
changes every time `hasOpenDialogs` changes.

The rest of the commit are additions of `composer.focus()`
after adding attachments in various ways,
e.g. via the WebXDC app picker or "Attach -> File".

Related:
- https://github.com/deltachat/deltachat-desktop/issues/4590.
- https://github.com/deltachat/deltachat-desktop/issues/4128.

This bug has apparently been introduced in the monster commit
584b59c1149223d04d8497f862955015248c77b7
(https://github.com/deltachat/deltachat-desktop/pull/3512).
Before that the effect had 0 dependencies, as written in
26be632de53d0b8c8f49ac1c7d51eff4aa2ccc24
(https://github.com/deltachat/deltachat-desktop/pull/2052).

Note that this MR doesn't fix _all_ the cases of focus ending up in weird places.