### PR TITLE
fix: Shift + Tab sometimes selecting chats

### DIFF
--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -240,8 +240,8 @@ export const ChatListItemRowChat = React.memo<{
 
   const multiselectOnFocus = multiselect?.onFocus
   const onFocus = useCallback(
-    (_e: React.FocusEvent) => {
-      multiselectOnFocus?.(chatId)
+    (e: React.FocusEvent) => {
+      multiselectOnFocus?.(e, chatId)
     },
     [chatId, multiselectOnFocus]
   )

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -46,7 +46,7 @@ const none = Symbol()
  *             // The "regular", non-multiselect click action.
  *             myOnClick(id)
  *           }}
- *           onFocus={() => multiselect.onFocus(id)}
+ *           onFocus={(event) => multiselect.onFocus(event, id)}
  *         >
  *           Item {id}
  *         </button>
@@ -289,9 +289,25 @@ export function useMultiselect<T>(
     [onClickOrKeyDown]
   )
 
+  const prevFocusedListMemberElRef = useRef<Element>(null)
   // Handle Shift + ArrowDown, Shift + End.
   const onFocus = useCallback(
-    (item: T) => {
+    (event: React.FocusEvent, item: T) => {
+      const prevFocusedEl = prevFocusedListMemberElRef.current
+      prevFocusedListMemberElRef.current = event.target
+
+      const elLosingFocus = event.relatedTarget
+      // Without this, pressing Shift + Tab, which is usually supposed to
+      // only change focus, could also change selection.
+      //
+      // Just FYI, instead of comparing to `prevFocusedEl`
+      // we could have checked whether the element is a member of the list,
+      // but that would require the user of this hook
+      // to specify the checking function.
+      if (elLosingFocus == null || elLosingFocus !== prevFocusedEl) {
+        return
+      }
+
       if (shiftPressed.current) {
         onSelectContiguous(item)
       } else {


### PR DESCRIPTION
Reproduction:
1. Activate (open) a chat.
2. Move focus to that chat list item.
3. Press ArrowDown a couple of times (so that the focused chat
   is not the active chat).
4. Press Tab (to move focus ouf of the chat list).
5. Press Shift + Tab (to move the focus back in the chat list).

This will unexpectedly perform a contiguous selection
between the active chat and the focused chat.
This commit fixes that.

This is also gonna be useful for the message list multiselect,
where this bug is more annoying.
