### PR TITLE
fix: Escape in Create Group goes back to New Chat

### DIFF
--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -545,7 +545,7 @@ export const createGroupChat = async (
   await page.getByPlaceholder('Description').fill('Test group description')
   await page.locator('#addmember button').click()
   const addMemberDialog = page.getByTestId('add-member-dialog')
-  await page
+  await addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: member.name })
     .click()

--- a/packages/e2e-tests/tests/reactions-image-collapse.spec.ts
+++ b/packages/e2e-tests/tests/reactions-image-collapse.spec.ts
@@ -62,11 +62,11 @@ test.beforeAll(async ({ browser, isChatmail }) => {
   await setupPage.locator('.group-name-input').fill(testGroupName)
   await setupPage.locator('#addmember button').click()
   const addMemberDialog = setupPage.getByTestId('add-member-dialog')
-  await setupPage
+  await addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: userB.name })
     .click()
-  await setupPage
+  await addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: userC.name })
     .click()

--- a/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
+++ b/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
@@ -148,11 +148,11 @@ test('check appropriate members are shown for new encrypted group', async () => 
   await expect(contactList).toHaveCount(2)
   // TODO: this should show the contact by name but it fails with a
   // screenshot showing the mail address instead of the name ??
-  await page
+  await addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: userD.address })
     .click()
-  const contactShouldNotBeListed = page
+  const contactShouldNotBeListed = addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: userB.name })
   await expect(contactShouldNotBeListed).not.toBeVisible()
@@ -177,15 +177,15 @@ test('check appropriate members are shown for new unencrypted group', async () =
   const contactList = page.getByTestId('add-member-dialog').locator('li button')
   // only self and the non verified users should be visible
   await expect(contactList).toHaveCount(3)
-  await page
+  await addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: userB.address })
     .click()
-  const contactShouldNotBeListedByName = page
+  const contactShouldNotBeListedByName = addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: userD.name })
   await expect(contactShouldNotBeListedByName).not.toBeVisible()
-  const contactShouldNotBeListedByAddress = page
+  const contactShouldNotBeListedByAddress = addMemberDialog
     .locator('.contact-list-item')
     .filter({ hasText: userD.address })
   await expect(contactShouldNotBeListedByAddress).not.toBeVisible()

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -84,46 +84,12 @@ const enum GroupType {
   BROADCAST_LIST = 'broadcast_list',
 }
 
-type ViewMode = 'main_' | GroupType
-
 export default function CreateChat(props: DialogProps) {
   const { onClose } = props
-  const tx = useTranslationFunction()
-
-  const [viewMode, setViewMode] = useState<ViewMode>('main_')
 
   return (
-    <Dialog
-      width={400}
-      onClose={onClose}
-      canOutsideClickClose={viewMode === 'main_'}
-      fixed
-      dataTestid='create-chat-dialog'
-    >
-      {viewMode == 'main_' && <CreateChatMain {...{ setViewMode, onClose }} />}
-      {viewMode == GroupType.REGULAR_GROUP && (
-        <>
-          <DialogHeader title={tx('menu_new_group')} />
-          <CreateGroup
-            {...{
-              groupType: GroupType.REGULAR_GROUP,
-              setViewMode,
-              onClose,
-            }}
-          />
-        </>
-      )}
-      {viewMode == GroupType.PLAIN_EMAIL && (
-        <>
-          <DialogHeader title={tx('new_email')} />
-          <CreateGroup
-            {...{ groupType: GroupType.PLAIN_EMAIL, setViewMode, onClose }}
-          />
-        </>
-      )}
-      {viewMode == GroupType.BROADCAST_LIST && (
-        <CreateBroadcastList {...{ setViewMode, onClose }} />
-      )}
+    <Dialog width={400} onClose={onClose} fixed dataTestid='create-chat-dialog'>
+      <CreateChatMain onClose={onClose} />
     </Dialog>
   )
 }
@@ -147,38 +113,35 @@ export function CloneChat(props: { chatTemplateId: number } & DialogProps) {
     ? descriptionFetch.result.value
     : undefined
 
-  return (
-    <Dialog width={400} onClose={onClose} fixed>
-      {chat && description !== undefined && (
-        <>
-          <DialogHeader title={tx('clone_chat')} />
-          <CreateGroup
-            {...{
-              // See https://github.com/deltachat/deltachat-desktop/issues/5059.
-              groupType: chat.isEncrypted
-                ? GroupType.REGULAR_GROUP
-                : GroupType.PLAIN_EMAIL,
+  if (!chat || description === undefined) {
+    return <Dialog width={400} onClose={onClose} fixed />
+  }
 
-              setViewMode: onClose,
-              onClose,
-              groupMembers: chat.contactIds,
-              groupImage: chat.profileImage,
-              groupDescription: description,
-            }}
-          />
-        </>
-      )}
-    </Dialog>
+  return (
+    <CreateGroup
+      {...{
+        titleOverride: tx('clone_chat'),
+        // See https://github.com/deltachat/deltachat-desktop/issues/5059.
+        groupType: chat.isEncrypted
+          ? GroupType.REGULAR_GROUP
+          : GroupType.PLAIN_EMAIL,
+
+        onFinish: onClose,
+        onClose,
+        groupMembers: chat.contactIds,
+        groupImage: chat.profileImage,
+        groupDescription: description,
+      }}
+    />
   )
 }
 
 type CreateChatMainProps = {
-  setViewMode: (newViewMode: ViewMode) => void
   onClose: DialogProps['onClose']
 }
 
 function CreateChatMain(props: CreateChatMainProps) {
-  const { setViewMode, onClose } = props
+  const { onClose } = props
   const { tx, writingDirection } = useContext(I18nContext)
   const openConfirmationDialog = useConfirmationDialog()
   const accountId = selectedAccountId()
@@ -412,7 +375,6 @@ function CreateChatMain(props: CreateChatMainProps) {
                       onContactClick: chooseContact,
                       addContactOnClick,
                       onContactContextMenu,
-                      setViewMode,
                       openQRScan,
                       queryStrIsValidEmail,
                       queryStr,
@@ -461,7 +423,6 @@ function CreateChatMainRow({
     onContactClick: (contact: Type.Contact) => void
     addContactOnClick: () => void
     onContactContextMenu: (contact: Type.Contact, ev: MouseEvent) => void
-    setViewMode: (viewMode: ViewMode) => void
     openQRScan: () => Promise<void>
     queryStrIsValidEmail: boolean
     queryStr: string
@@ -474,7 +435,6 @@ function CreateChatMainRow({
     onContactClick,
     addContactOnClick,
     onContactContextMenu,
-    setViewMode,
     openQRScan,
     queryStrIsValidEmail,
     queryStr,
@@ -484,6 +444,7 @@ function CreateChatMainRow({
 
   const tx = useTranslationFunction()
   const accountId = selectedAccountId()
+  const { openDialog } = useDialog()
 
   const el = (() => {
     switch (item) {
@@ -493,7 +454,12 @@ function CreateChatMainRow({
             id='newgroup'
             cutoff='+'
             text={tx('menu_new_group')}
-            onClick={() => setViewMode(GroupType.REGULAR_GROUP)}
+            onClick={() =>
+              openDialog(CreateGroup, {
+                groupType: GroupType.REGULAR_GROUP as const,
+                onFinish: onClose,
+              })
+            }
           />
         )
       }
@@ -503,7 +469,11 @@ function CreateChatMainRow({
             id='newbroadcastlist'
             cutoff='+'
             text={tx('new_channel')}
-            onClick={() => setViewMode(GroupType.BROADCAST_LIST)}
+            onClick={() => {
+              openDialog(CreateBroadcastList, {
+                onFinish: onClose,
+              })
+            }}
           />
         )
       }
@@ -513,7 +483,12 @@ function CreateChatMainRow({
             id='newemail'
             cutoff='+'
             text={tx('new_email')}
-            onClick={() => setViewMode(GroupType.PLAIN_EMAIL)}
+            onClick={() =>
+              openDialog(CreateGroup, {
+                groupType: GroupType.PLAIN_EMAIL as const,
+                onFinish: onClose,
+              })
+            }
           />
         )
       }
@@ -585,7 +560,8 @@ const enum CreateChatExtraItemType {
 }
 
 type CreateGroupProps = {
-  setViewMode: (newViewMode: ViewMode) => void
+  onFinish: () => void
+  titleOverride?: string
   // `GroupType.BROADCAST_LIST` type is handled
   // in the `CreateBroadcastList` component.
   groupType: GroupType.REGULAR_GROUP | GroupType.PLAIN_EMAIL
@@ -605,7 +581,7 @@ type CreateGroupProps = {
 export function CreateGroup(props: CreateGroupProps) {
   const { selectChat } = useChat()
   const { openDialog } = useDialog()
-  const { setViewMode, onClose, groupType } = props
+  const { titleOverride, onFinish, onClose, groupType } = props
   const tx = useTranslationFunction()
   const accountId = selectedAccountId()
 
@@ -697,89 +673,102 @@ export function CreateGroup(props: CreateGroupProps) {
           // TODO: handle error
         }
       })
-      .finally(onClose)
+      .finally(() => {
+        onFinish()
+        onClose()
+      })
   }
 
   return (
-    <form onSubmit={submitForm}>
-      <DialogBody>
-        <DialogContent>
-          <ChatSettingsSetNameAndProfileImage
-            chatName={groupName}
-            setChatName={setGroupName}
-            errorMissingChatName={errorMissingGroupName}
-            setErrorMissingChatName={setErrorMissingGroupName}
-            {...((groupType === GroupType.PLAIN_EMAIL
-              ? { groupType }
-              : {
-                  groupType,
-                  groupImage,
-                  onSetGroupImage: onSetGroupImage!,
-                  onUnsetGroupImage: onUnsetGroupImage!,
-                  description: groupDescription,
-                  setDescription: setGroupDescription,
-                }) satisfies Partial<
-              Parameters<typeof ChatSettingsSetNameAndProfileImage>[0]
-            >)}
-          />
-        </DialogContent>
-        <div id='create-group-members-title' className='group-separator'>
-          {tx(
-            membersOrRecipients === 'members' ? 'n_members' : 'n_recipients',
-            groupMembers.length.toString(),
-            {
-              quantity: groupMembers.length,
-            }
-          )}
-        </div>
-        <div
-          className='group-member-contact-list-wrapper'
-          ref={groupMemberContactListWrapperRef}
-        >
-          <RovingTabindexProvider
-            wrapperElementRef={groupMemberContactListWrapperRef}
-          >
-            <PseudoListItemAddMember onClick={showAddMemberDialog} />
-            <ContactList
-              contacts={groupContacts}
-              showRemove
-              onRemoveClick={c => {
-                removeGroupMember(c)
-              }}
-              olElementAttrs={{
-                'aria-labelledby': 'create-group-members-title',
-              }}
+    <Dialog width={400} onClose={onClose} canOutsideClickClose={false} fixed>
+      <DialogHeader
+        title={
+          titleOverride ??
+          (groupType === GroupType.REGULAR_GROUP
+            ? tx('menu_new_group')
+            : tx('new_email'))
+        }
+      />
+      <form onSubmit={submitForm}>
+        <DialogBody>
+          <DialogContent>
+            <ChatSettingsSetNameAndProfileImage
+              chatName={groupName}
+              setChatName={setGroupName}
+              errorMissingChatName={errorMissingGroupName}
+              setErrorMissingChatName={setErrorMissingGroupName}
+              {...((groupType === GroupType.PLAIN_EMAIL
+                ? { groupType }
+                : {
+                    groupType,
+                    groupImage,
+                    onSetGroupImage: onSetGroupImage!,
+                    onUnsetGroupImage: onUnsetGroupImage!,
+                    description: groupDescription,
+                    setDescription: setGroupDescription,
+                  }) satisfies Partial<
+                Parameters<typeof ChatSettingsSetNameAndProfileImage>[0]
+              >)}
             />
-          </RovingTabindexProvider>
-        </div>
-      </DialogBody>
-      <DialogFooter>
-        <FooterActions align='spaceBetween'>
-          <FooterActionButton onClick={() => setViewMode('main_')}>
-            {tx('cancel')}
-          </FooterActionButton>
-          <FooterActionButton
-            type='submit'
-            data-testid='group-create-button'
-            styling='primary'
+          </DialogContent>
+          <div id='create-group-members-title' className='group-separator'>
+            {tx(
+              membersOrRecipients === 'members' ? 'n_members' : 'n_recipients',
+              groupMembers.length.toString(),
+              {
+                quantity: groupMembers.length,
+              }
+            )}
+          </div>
+          <div
+            className='group-member-contact-list-wrapper'
+            ref={groupMemberContactListWrapperRef}
           >
-            {groupType === GroupType.PLAIN_EMAIL
-              ? tx('perm_continue')
-              : tx('group_create_button')}
-          </FooterActionButton>
-        </FooterActions>
-      </DialogFooter>
-    </form>
+            <RovingTabindexProvider
+              wrapperElementRef={groupMemberContactListWrapperRef}
+            >
+              <PseudoListItemAddMember onClick={showAddMemberDialog} />
+              <ContactList
+                contacts={groupContacts}
+                showRemove
+                onRemoveClick={c => {
+                  removeGroupMember(c)
+                }}
+                olElementAttrs={{
+                  'aria-labelledby': 'create-group-members-title',
+                }}
+              />
+            </RovingTabindexProvider>
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <FooterActions align='spaceBetween'>
+            <FooterActionButton onClick={onClose}>
+              {tx('cancel')}
+            </FooterActionButton>
+            <FooterActionButton
+              type='submit'
+              data-testid='group-create-button'
+              styling='primary'
+            >
+              {groupType === GroupType.PLAIN_EMAIL
+                ? tx('perm_continue')
+                : tx('group_create_button')}
+            </FooterActionButton>
+          </FooterActions>
+        </DialogFooter>
+      </form>
+    </Dialog>
   )
 }
 
 type CreateBroadcastListProps = {
-  setViewMode: (newViewMode: ViewMode) => void
+  onFinish: () => void
   onClose: DialogProps['onClose']
 }
 
 function CreateBroadcastList(props: CreateBroadcastListProps) {
-  const { setViewMode, onClose } = props
+  const { onFinish, onClose } = props
   const tx = useTranslationFunction()
 
   const [broadcastName, setBroadcastName] = useState<string>('')
@@ -790,7 +779,10 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
     broadcastName,
     broadcastImage,
     broadcastDescription,
-    onClose
+    () => {
+      onClose()
+      onFinish()
+    }
   )
 
   const [errorMissingChatName, setErrorMissingChatName] =
@@ -806,7 +798,7 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
   }
 
   return (
-    <>
+    <Dialog width={400} onClose={onClose} canOutsideClickClose={false} fixed>
       <DialogHeader title={tx('new_channel')} />
       <form onSubmit={submitForm}>
         <DialogBody>
@@ -831,7 +823,7 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
         </DialogBody>
         <DialogFooter>
           <FooterActions align='spaceBetween'>
-            <FooterActionButton onClick={() => setViewMode('main_')}>
+            <FooterActionButton onClick={onClose}>
               {tx('cancel')}
             </FooterActionButton>
             <FooterActionButton type='submit' styling='primary'>
@@ -840,7 +832,7 @@ function CreateBroadcastList(props: CreateBroadcastListProps) {
           </FooterActions>
         </DialogFooter>
       </form>
-    </>
+    </Dialog>
   )
 }
 
@@ -1023,7 +1015,7 @@ const useCreateBroadcast = (
   groupName: string,
   groupImage: string | null,
   description: string,
-  onClose: DialogProps['onClose']
+  onFinish: () => void
 ) => {
   const accountId = selectedAccountId()
   const { selectChat } = useChat()
@@ -1045,7 +1037,7 @@ const useCreateBroadcast = (
 
   return async () => {
     const chatId = await createBroadcastList()
-    onClose()
+    onFinish()
     selectChat(accountId, chatId)
   }
 }


### PR DESCRIPTION
Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/4128.

Note that this changes how things look a bit:
now the "Create Group" / "Create Channel" dialog is displayed
on top of the "New Chat" dialog, instead of basically replacing it.

When group / channel creation finishes, we still close
both of the dialogs.

Hide whitespace for easier review

This is mostly AI-generated, with adjustments from me. Let me know if you'd like me to rewrite this by hand.
The prompts were:
> In `CreateChat` move the sub-sections into their own dialogs.
> Replace `setViewMode` with `onDone` which we'll call
> when chat creation is done, which will close the parent dialog.

> There is no need to have thin wrappers like
> `CreateBroadcastListDialog`.
> Remove them and do the changes on `CreateBroadcastList` directly.
> Let's also keep the name `CreateBroadcastList` for now,
> don't append `Dialog`.

Related:
- https://github.com/deltachat/deltachat-desktop/pull/6404
