### PR TITLE
fix: use new "empty sticker folder" string, improve style

### DIFF
--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -180,7 +180,7 @@ export const StickerPicker = ({
       ) : (
         <div className='sticker-container'>
           <div className='no-stickers'>
-            <p className='description'>{tx('add_stickers_instructions')}</p>
+            <p className='description'>{tx('sticker_picker_empty_hint')}</p>
           </div>
         </div>
       )}

--- a/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
+++ b/packages/frontend/src/components/composer/EmojiAndStickerPicker.tsx
@@ -179,8 +179,8 @@ export const StickerPicker = ({
         </>
       ) : (
         <div className='sticker-container'>
-          <div className='no-stickers'>
-            <p className='description'>{tx('sticker_picker_empty_hint')}</p>
+          <div className='sticker-hint'>
+            <p>{tx('sticker_picker_empty_hint')}</p>
           </div>
         </div>
       )}


### PR DESCRIPTION
Seems like this was an unrelated change introduced by mistake in
2e2c7e6a308f6bf7969e29e6633e120d3fee34b7
(https://github.com/deltachat/deltachat-desktop/pull/6278),
was probably supposed to be a follow-up to
https://github.com/deltachat/deltachat-desktop/pull/6231#discussion_r3146871822.

The old string is deprecated:
https://github.com/deltachat/deltachat-desktop/blob/7a654e06ee533261b53315ceee2ae6b57f4dbeb8/_locales/en.xml#L184-L190

Also improve the font size and center the text, and remove an unused class name.

Before:
<img width="393" height="96" alt="image" src="https://github.com/user-attachments/assets/28e46bea-8eb3-4ab6-be6f-6c4d847e8f40" />
After:
<img width="398" height="107" alt="image" src="https://github.com/user-attachments/assets/20c1a045-c143-4927-ad52-9ac84ae30dec" />
