### PR TITLE
refactor: remove unnecessary check

### DIFF
--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -208,7 +208,7 @@ export default function Settings({ onClose }: DialogProps) {
             dataTestid='settings-advanced'
           />
           <DialogBody>
-            {settingsStore != null && <Advanced onClose={onClose} />}
+            <Advanced onClose={onClose} />
             <SettingsEndSeparator />
           </DialogBody>
         </>


### PR DESCRIPTION
The wrapped component used to take `settingsStore` as a prop,
and that was the reason for the check.
Now it doesn't, so the check is not needed.
