### PR TITLE
fix: disable keyboard shortcuts when have dialog

### DIFF
--- a/packages/e2e-tests/tests/keyboard.spec.ts
+++ b/packages/e2e-tests/tests/keyboard.spec.ts
@@ -1,0 +1,109 @@
+import { expect, type Page } from '@playwright/test'
+
+import {
+  createProfiles,
+  User,
+  loadExistingProfiles,
+  deleteAllProfiles,
+  reloadPage,
+  test,
+} from '../playwright-helper'
+
+test.describe.configure({
+  mode: 'serial',
+})
+
+expect.configure({ timeout: 5_000 })
+
+let existingProfiles: User[] = []
+
+const numberOfProfiles = 1
+
+// https://playwright.dev/docs/next/test-retries#reuse-single-page-between-tests
+let page: Page
+
+test.beforeAll(async ({ browser, isChatmail }) => {
+  const contextForProfileCreation = await browser.newContext()
+  const pageForProfileCreation = await contextForProfileCreation.newPage()
+
+  await reloadPage(pageForProfileCreation)
+
+  existingProfiles =
+    (await loadExistingProfiles(pageForProfileCreation)) ?? existingProfiles
+
+  await createProfiles(
+    numberOfProfiles,
+    existingProfiles,
+    pageForProfileCreation,
+    browser.browserType().name(),
+    isChatmail
+  )
+
+  await contextForProfileCreation.close()
+  page = await browser.newPage()
+  await reloadPage(page)
+
+  // Shortcuts don't seem to work otherwise. Maybe a Playwright issue.
+  await page.locator('body').click()
+})
+
+test.afterEach(async () => {
+  // Pressing Escape a bunch of times should reset the UI state,
+  // so there is no need to reload the page.
+  for (let i = 0; i < 5; i++) {
+    await page.keyboard.press('Escape')
+  }
+})
+
+test.afterAll(async ({ browser }) => {
+  await page?.close()
+
+  const context = await browser.newContext()
+  const pageForProfileDeletion = await context.newPage()
+  await reloadPage(pageForProfileDeletion)
+  await deleteAllProfiles(pageForProfileDeletion, existingProfiles)
+  await context.close()
+})
+
+test.describe('keyboard shortcuts', () => {
+  test("don't work when a dialog is open", async () => {
+    const dialogs = page.getByRole('dialog')
+
+    // Ensure that normally it opens
+    await expect(dialogs).toHaveCount(0)
+    await page.keyboard.press('ControlOrMeta+N')
+    await expect(dialogs).toHaveCount(1)
+    await page.keyboard.press('ControlOrMeta+N')
+    await expect(dialogs).toHaveCount(1)
+    await page.keyboard.press('Escape')
+    await expect(dialogs).toHaveCount(0)
+
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await expect(dialogs).toHaveCount(1)
+    await page.keyboard.press('ControlOrMeta+N')
+    await expect(dialogs).toHaveCount(1)
+  })
+  test("don't work when a context menu is open", async () => {
+    const dialogs = page.getByRole('dialog')
+
+    await expect(page.getByRole('menu')).not.toBeVisible()
+    await page
+      .getByLabel('Chats')
+      .getByRole('tab')
+      .first()
+      .click({ button: 'right' })
+    await expect(page.getByRole('menu')).toBeVisible()
+
+    await expect(dialogs).toHaveCount(0)
+    await page.keyboard.press('ControlOrMeta+N')
+    await expect(dialogs).toHaveCount(0)
+    await page.keyboard.press('ControlOrMeta+N')
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByRole('menu')).not.toBeVisible()
+    await page.keyboard.press('ControlOrMeta+N')
+    await expect(dialogs).toHaveCount(1)
+
+    await page.keyboard.press('Escape')
+  })
+})

--- a/packages/frontend/src/components/ContextMenu.tsx
+++ b/packages/frontend/src/components/ContextMenu.tsx
@@ -114,7 +114,6 @@ export function ContextMenuLayer({
 
       // Get required information
       setCurrentItems(items)
-      window.__setContextMenuActive(true)
       setCurrentAriaAttrs(ariaAttrs)
 
       await new Promise<void>((resolve, _reject) => {
@@ -180,7 +179,6 @@ export function ContextMenuLayer({
       className='dc-context-menu-layer'
       onClick={cancel}
       onClose={() => {
-        window.__setContextMenuActive(false)
         setCurrentItems([])
         endPromiseRef.current?.()
       }}
@@ -502,11 +500,4 @@ export function useContextMenuWithActiveState(
       setIsContextMenuActive(false)
     },
   }
-}
-
-window.__setContextMenuActive = (newVal: boolean): void => {
-  type Writable<T> = {
-    -readonly [P in keyof T]: T[P]
-  }
-  ;(window as Writable<typeof window>).__contextMenuActive = newVal
 }

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -13,8 +13,6 @@ declare global {
     readonly __selectedAccountId: number | undefined
     __selectedChatId: number | undefined
     __screen: Screens
-    readonly __contextMenuActive: boolean
-    __setContextMenuActive: (newVal: boolean) => void
     __settingsOpened: boolean
     __keybindingsDialogOpened: boolean
     __aboutDialogOpened: boolean

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -127,12 +127,30 @@ export function matchesNonLetterShortcut(
   return !isPrintableAscii && ev.code === code
 }
 
+function haveOpenDialogs(): boolean {
+  return document.querySelector('dialog:modal') != null
+}
+
 export function keyDownEvent2Action(
   ev: KeyboardEvent
 ): KeybindAction | undefined {
   const { isMac } = runtime.getRuntimeInfo()
 
-  if (window.__contextMenuActive) {
+  // If a dialog is open, disable shortcuts.
+  // This also applies to a context menu being open.
+  //
+  // Perhaps there are some shortcuts that we don't strictly need to disable
+  // when a dialog is open, such as `Settings_Open` and `Debug_MaybeNetwork`,
+  // but it's probably not important to support that,
+  // so let's not complicate things yet.
+  if (
+    (ev.target instanceof HTMLElement && ev.target.closest('dialog') != null) ||
+    // `ev.target.closest('dialog')` doesn't always work as of writing
+    // because of `allowDefaultFocus` in `Dialog.tsx`,
+    // which `.blur()`s the element inside the dialog
+    // and thus makes `<body>` the event target.
+    haveOpenDialogs()
+  ) {
     return
   }
   // Don't capture keys during IME composition (Chinese, Japanese, Korean input)


### PR DESCRIPTION
For example, don't open multiple "New Chat" dialogs,
don't switch chats while a "View Chat" dialog is open.

However this commit is primarily for
https://github.com/deltachat/deltachat-desktop/pull/6223
where this is much more important.
