### PR TITLE
feat: WebXDC: add `isAppSender`, `isBroadcast`

### DIFF
--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -48,11 +48,15 @@ type AppInstance = {
   msgId: number
   accountId: number
   internet_access: boolean
-  selfAddr: string
   displayName: string
-  sendUpdateInterval: number
-  sendUpdateMaxSize: number
-}
+} & Pick<
+  T.WebxdcMessageInfo,
+  | 'selfAddr'
+  | 'sendUpdateInterval'
+  | 'sendUpdateMaxSize'
+  | 'isAppSender'
+  | 'isBroadcast'
+>
 const open_apps: {
   [instanceId: string]: AppInstance
 } = {}
@@ -384,6 +388,8 @@ export default class DCWebxdc {
         displayName: p.displayname || webxdcInfo.selfAddr || 'unknown',
         sendUpdateInterval: webxdcInfo.sendUpdateInterval,
         sendUpdateMaxSize: webxdcInfo.sendUpdateMaxSize,
+        isAppSender: webxdcInfo.isAppSender,
+        isBroadcast: webxdcInfo.isBroadcast,
       }
 
       const isMac = platform() === 'darwin'
@@ -1188,7 +1194,10 @@ async function webxdcProtocolHandler(
       body: Buffer.from(
         `window.webxdc_internal.setup("${selfAddr}","${displayName}", ${Number(
           open_apps[id].sendUpdateInterval
-        )}, ${Number(open_apps[id].sendUpdateMaxSize)})`
+        )}, ${Number(open_apps[id].sendUpdateMaxSize)},
+          ${Boolean(open_apps[id].isAppSender)},
+          ${Boolean(open_apps[id].isBroadcast)},
+        )`
       ),
       responseInit: {},
       mime_type: mimeType,

--- a/packages/target-electron/static/webxdc-preload.js
+++ b/packages/target-electron/static/webxdc-preload.js
@@ -239,7 +239,14 @@ class RealtimeListener {
   }
 
   contextBridge.exposeInMainWorld('webxdc_internal', {
-    setup: (selfAddr, selfName, sendUpdateInterval, sendUpdateMaxSize) => {
+    setup: (
+      selfAddr,
+      selfName,
+      sendUpdateInterval,
+      sendUpdateMaxSize,
+      isAppSender,
+      isBroadcast
+    ) => {
       if (is_ready) {
         return
       }
@@ -247,6 +254,8 @@ class RealtimeListener {
       api.selfName = Buffer.from(selfName, 'base64').toString('utf-8')
       api.sendUpdateInterval = sendUpdateInterval
       api.sendUpdateMaxSize = sendUpdateMaxSize
+      api.isAppSender = isAppSender
+      api.isBroadcast = isBroadcast
 
       // be sure that webxdc.js was included
       contextBridge.exposeInMainWorld('webxdc', api)


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6414.
The API has been added to Core in
https://github.com/chatmail/core/pull/8138.

I tested it, works fine:

<img width="463" height="51" alt="image" src="https://github.com/user-attachments/assets/1e3d0d35-c296-4998-aa52-0a393cccdcf9" />
<img width="192" height="51" alt="image" src="https://github.com/user-attachments/assets/b3543152-7b7a-4cc0-b0f0-a3ba998588d2" />
