### PR TITLE
chore: move ws 8.x to catalog

### DIFF
--- a/packages/target-browser/package.json
+++ b/packages/target-browser/package.json
@@ -25,13 +25,13 @@
     "express-session": "^1.18.2",
     "node-localstorage": "^3.0.5",
     "resolve-path": "^1.4.0",
-    "ws": "~8.18.0"
+    "ws": "catalog:"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.13",
     "@types/resolve-path": "^1.4.2",
-    "@types/ws": "^8.5.12",
+    "@types/ws": "catalog:",
     "error-stack-parser": "^2.1.4",
     "esbuild": "^0.25.0"
   }

--- a/packages/target-browser/src/deltachat-rpc.ts
+++ b/packages/target-browser/src/deltachat-rpc.ts
@@ -2,7 +2,8 @@ import { ChildProcessWithoutNullStreams, spawn } from 'child_process'
 import { DC_ACCOUNTS_DIR } from './config'
 import { getRPCServerPath } from '@deltachat/stdio-rpc-server'
 import { BaseDeltaChat, yerpc } from '@deltachat/jsonrpc-client'
-import { WebSocket, WebSocketServer } from 'ws'
+import ws from 'ws'
+import type { WebSocket, WebSocketServer } from 'ws'
 import { RCConfig } from './rc-config'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { join } from 'path'
@@ -200,7 +201,10 @@ export async function startDeltaChat(): Promise<
     method: 'error_other_client_stole_dc_connection',
   })
 
-  const wssDC = new WebSocketServer({ noServer: true, perMessageDeflate: true })
+  const wssDC = new ws.WebSocketServer({
+    noServer: true,
+    perMessageDeflate: true,
+  })
   wssDC.on('connection', function connection(ws) {
     // eslint-disable-next-line no-console
     ws.on('error', console.error)

--- a/packages/target-browser/src/index.ts
+++ b/packages/target-browser/src/index.ts
@@ -7,7 +7,8 @@ import session from 'express-session'
 import { FileStore } from './session-store'
 import { authMiddleWare, CORSMiddleWare } from './middlewares'
 import resolvePath from 'resolve-path'
-import { WebSocketServer } from 'ws'
+import ws from 'ws'
+import type { WebSocket } from 'ws'
 import { BackendApiRoute } from './backendApi'
 import { MessageToBackend } from './runtime-ws-protocol'
 
@@ -234,7 +235,7 @@ if (DC_FRONTEND_NO_TLS) {
   )
 }
 
-const wssBackend = new WebSocketServer({
+const wssBackend = new ws.WebSocketServer({
   noServer: true,
   perMessageDeflate: true,
 })
@@ -275,13 +276,18 @@ server.on('upgrade', (request, socket, head) => {
     }
     const { pathname } = new URL(request.url || '', 'wss://base.url')
     if (pathname === '/ws/dc') {
-      wssDC.handleUpgrade(request, socket, head, function (ws) {
-        wssDC.emit('connection', ws, request)
+      wssDC.handleUpgrade(request, socket, head, function (socket: WebSocket) {
+        wssDC.emit('connection', socket, request)
       })
     } else if (pathname === '/ws/backend') {
-      wssBackend.handleUpgrade(request, socket, head, function (ws) {
-        wssBackend.emit('connection', ws, request)
-      })
+      wssBackend.handleUpgrade(
+        request,
+        socket,
+        head,
+        function (socket: WebSocket) {
+          wssBackend.emit('connection', socket, request)
+        }
+      )
     }
   })
 })

--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -61,7 +61,7 @@
     "escape-html": "^1.0.3",
     "mime-types": "catalog:",
     "sass": "catalog:",
-    "ws": "7.5.10"
+    "ws": "catalog:"
   },
   "devDependencies": {
     "@deltachat-desktop/runtime-interface": "link:../runtime",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@types/node':
       specifier: ^22.15.33
       version: 22.15.33
+    '@types/ws':
+      specifier: ^8.5.12
+      version: 8.18.1
     '@webxdc/types':
       specifier: ^2.1.2
       version: 2.1.2
@@ -51,6 +54,9 @@ catalogs:
     typescript-plugin-css-modules:
       specifier: ^5.2.0
       version: 5.2.0
+    ws:
+      specifier: ^8.18.0
+      version: 8.21.0
 
 overrides:
   stylus: npm:empty-npm-package@1.0.0
@@ -141,7 +147,7 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 2.50.0(ws@8.18.2)
+        version: 2.50.0(ws@8.21.0)
       '@emoji-mart-awesome/react':
         specifier: 1.0.0
         version: 1.0.0(emoji-mart-awesome@3.0.0)(react@19.2.0)
@@ -274,7 +280,7 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 2.50.0(ws@8.18.2)
+        version: 2.50.0(ws@8.21.0)
       '@types/node':
         specifier: 'catalog:'
         version: 22.15.33
@@ -283,7 +289,7 @@ importers:
     dependencies:
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 2.50.0(ws@8.18.2)
+        version: 2.50.0(ws@8.21.0)
       error-stack-parser:
         specifier: ^2.1.4
         version: 2.1.4
@@ -320,10 +326,10 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 2.50.0(ws@8.18.2)
+        version: 2.50.0(ws@8.21.0)
       '@deltachat/stdio-rpc-server':
         specifier: 'catalog:'
-        version: 2.50.0(@deltachat/jsonrpc-client@2.50.0(ws@8.18.2))
+        version: 2.50.0(@deltachat/jsonrpc-client@2.50.0(ws@8.21.0))
       '@types/express-session':
         specifier: ^1.18.0
         version: 1.18.1
@@ -343,8 +349,8 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       ws:
-        specifier: ~8.18.0
-        version: 8.18.2
+        specifier: 'catalog:'
+        version: 8.21.0
     devDependencies:
       '@types/express':
         specifier: ^4.17.21
@@ -356,7 +362,7 @@ importers:
         specifier: ^1.4.2
         version: 1.4.3
       '@types/ws':
-        specifier: ^8.5.12
+        specifier: 'catalog:'
         version: 8.18.1
       error-stack-parser:
         specifier: ^2.1.4
@@ -372,10 +378,10 @@ importers:
         version: 0.12.1-beta-debug
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 2.50.0(ws@7.5.10)
+        version: 2.50.0(ws@8.21.0)
       '@deltachat/stdio-rpc-server':
         specifier: 'catalog:'
-        version: 2.50.0(@deltachat/jsonrpc-client@2.50.0(ws@7.5.10))
+        version: 2.50.0(@deltachat/jsonrpc-client@2.50.0(ws@8.21.0))
       escape-html:
         specifier: ^1.0.3
         version: 1.0.3
@@ -386,8 +392,8 @@ importers:
         specifier: 'catalog:'
         version: 1.86.3
       ws:
-        specifier: 7.5.10
-        version: 7.5.10
+        specifier: 'catalog:'
+        version: 8.21.0
     devDependencies:
       '@deltachat-desktop/runtime-interface':
         specifier: link:../runtime
@@ -482,7 +488,7 @@ importers:
         version: link:../shared
       '@deltachat/jsonrpc-client':
         specifier: 'catalog:'
-        version: 2.50.0(ws@8.18.2)
+        version: 2.50.0(ws@8.21.0)
       '@tauri-apps/cli':
         specifier: ^2.8.4
         version: 2.9.4
@@ -4169,20 +4175,8 @@ packages:
     resolution: {integrity: sha512-ddSsCLa4aQ3kI21BthINo4q905/wfhvQ3JL3774AcRjBaiQmfn5v4rw77jQ7T6CmAit9VOQO+FsLyPkwxoB1fw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.2:
-    resolution: {integrity: sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4387,20 +4381,10 @@ snapshots:
     dependencies:
       preact: 10.28.3
 
-  '@deltachat/jsonrpc-client@2.50.0(ws@7.5.10)':
+  '@deltachat/jsonrpc-client@2.50.0(ws@8.21.0)':
     dependencies:
       '@deltachat/tiny-emitter': 3.0.0
-      isomorphic-ws: 5.0.0(ws@7.5.10)
-      yerpc: 0.6.2
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-      - ws
-
-  '@deltachat/jsonrpc-client@2.50.0(ws@8.18.2)':
-    dependencies:
-      '@deltachat/tiny-emitter': 3.0.0
-      isomorphic-ws: 5.0.0(ws@8.18.2)
+      isomorphic-ws: 5.0.0(ws@8.21.0)
       yerpc: 0.6.2
     transitivePeerDependencies:
       - bufferutil
@@ -4437,24 +4421,9 @@ snapshots:
   '@deltachat/stdio-rpc-server-win32-x64@2.50.0':
     optional: true
 
-  '@deltachat/stdio-rpc-server@2.50.0(@deltachat/jsonrpc-client@2.50.0(ws@7.5.10))':
+  '@deltachat/stdio-rpc-server@2.50.0(@deltachat/jsonrpc-client@2.50.0(ws@8.21.0))':
     dependencies:
-      '@deltachat/jsonrpc-client': 2.50.0(ws@7.5.10)
-    optionalDependencies:
-      '@deltachat/stdio-rpc-server-android-arm': 2.50.0
-      '@deltachat/stdio-rpc-server-android-arm64': 2.50.0
-      '@deltachat/stdio-rpc-server-darwin-arm64': 2.50.0
-      '@deltachat/stdio-rpc-server-darwin-x64': 2.50.0
-      '@deltachat/stdio-rpc-server-linux-arm': 2.50.0
-      '@deltachat/stdio-rpc-server-linux-arm64': 2.50.0
-      '@deltachat/stdio-rpc-server-linux-ia32': 2.50.0
-      '@deltachat/stdio-rpc-server-linux-x64': 2.50.0
-      '@deltachat/stdio-rpc-server-win32-ia32': 2.50.0
-      '@deltachat/stdio-rpc-server-win32-x64': 2.50.0
-
-  '@deltachat/stdio-rpc-server@2.50.0(@deltachat/jsonrpc-client@2.50.0(ws@8.18.2))':
-    dependencies:
-      '@deltachat/jsonrpc-client': 2.50.0(ws@8.18.2)
+      '@deltachat/jsonrpc-client': 2.50.0(ws@8.21.0)
     optionalDependencies:
       '@deltachat/stdio-rpc-server-android-arm': 2.50.0
       '@deltachat/stdio-rpc-server-android-arm64': 2.50.0
@@ -5192,7 +5161,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.17.50
+      '@types/node': 22.19.3
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -6932,17 +6901,13 @@ snapshots:
 
   isexe@3.1.5: {}
 
-  isomorphic-ws@4.0.1(ws@8.18.2):
+  isomorphic-ws@4.0.1(ws@8.21.0):
     dependencies:
-      ws: 8.18.2
+      ws: 8.21.0
 
-  isomorphic-ws@5.0.0(ws@7.5.10):
+  isomorphic-ws@5.0.0(ws@8.21.0):
     dependencies:
-      ws: 7.5.10
-
-  isomorphic-ws@5.0.0(ws@8.18.2):
-    dependencies:
-      ws: 8.18.2
+      ws: 8.21.0
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -8362,9 +8327,7 @@ snapshots:
       sort-keys: 5.1.0
       write-file-atomic: 3.0.3
 
-  ws@7.5.10: {}
-
-  ws@8.18.2: {}
+  ws@8.21.0: {}
 
   xml-js@1.6.11:
     dependencies:
@@ -8423,10 +8386,10 @@ snapshots:
   yerpc@0.6.2:
     dependencies:
       '@types/ws': 8.18.1
-      isomorphic-ws: 4.0.1(ws@8.18.2)
+      isomorphic-ws: 4.0.1(ws@8.21.0)
       typescript: 4.9.5
     optionalDependencies:
-      ws: 8.18.2
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,9 @@ catalog:
 
   # dependencies
   '@types/mime-types': ^2.1.4
+  '@types/ws': ^8.5.12
   mime-types: ^2.1.35
+  ws: ^8.18.0
 
   # tools / dev dependencies
   sass: ^1.86.3


### PR DESCRIPTION
The failing test in https://github.com/deltachat/deltachat-desktop/pull/6408 revealed the fact that browser and electron use different versions of ws. So let's see if we can't use ws 8.x throughout.