### PR TITLE
style: don't change acc list item position on msg

### DIFF
--- a/packages/frontend/src/components/AccountListSidebar/styles.module.scss
+++ b/packages/frontend/src/components/AccountListSidebar/styles.module.scss
@@ -68,8 +68,8 @@
       li:has(.accountWrapper.isSticky) {
         // Styles for the li element when it contains a sticky account
         position: sticky;
-        bottom: var(--als-avatar-margin);
-        top: var(--als-avatar-margin);
+        bottom: 0;
+        top: 0;
         // Only needed when this account is scrolled _above_ the visible region.
         z-index: map.get(
           variables.$z-index,
@@ -108,7 +108,7 @@
     // to the margins so that
     // if there is another `.isSticky` account, then that account does not
     // cover the account that we want to scroll into view.
-    // And another extra `2 * var(--als-avatar-margin)` so that it's obvious that
+    // And another extra `var(--als-avatar-margin)` so that it's obvious that
     // the other sticky account really is sticky, to make it obviously overlay
     // on top of another account, and be positioned perfectly on top of it.
     //
@@ -116,10 +116,10 @@
     // `var(--als-avatar-margin)` in case there is no sticky account above.
     // This should be achievable with CSS.
     scroll-margin-bottom: calc(
-      5 * var(--als-avatar-margin) + var(--als-avatar-size)
+      3 * var(--als-avatar-margin) + var(--als-avatar-size)
     );
     scroll-margin-top: calc(
-      5 * var(--als-avatar-margin) + var(--als-avatar-size)
+      3 * var(--als-avatar-margin) + var(--als-avatar-size)
     );
 
     position: relative;


### PR DESCRIPTION
1. Have > 1 accounts, have no unread messages on the first account
   (no "unread" badge).
2. Receive a message on the first account.

When a badge appears on the account, it also gets shifted down a little.

The bug has apparently been introduced in
ede71ccfec586adbce746eb63f3c24d0dcb17319
(https://github.com/deltachat/deltachat-desktop/pull/5590),
due to some markup changes.
Now the items already include the margin (or rather padding).

Also adjust the `scroll-margin` accordingly.

The "sticky" behavior has been added in
aa7cafcb84e7f688bc85621b9dbedd4e7eea5e87
(https://github.com/deltachat/deltachat-desktop/pull/4536).
