### PR TITLE
chore: upgrade Electron

### DIFF
--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -81,7 +81,7 @@
     "application-config": "^3.0.0",
     "chai": "^5.1.1",
     "debounce": "^1.2.0",
-    "electron": "^41.6.0",
+    "electron": "^41.7.1",
     "electron-builder": "^26.7.0",
     "esbuild": "^0.25.0",
     "mocha": "^10.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,8 +441,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.1
       electron:
-        specifier: ^41.6.0
-        version: 41.6.0
+        specifier: ^41.7.1
+        version: 41.7.1
       electron-builder:
         specifier: ^26.7.0
         version: 26.7.0(electron-builder-squirrel-windows@26.7.0)
@@ -2139,8 +2139,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@41.6.0:
-    resolution: {integrity: sha512-5UWV5FXkYMzCDV6FvLCa5mzlCBtlX/H1Af27TD5di+4CUCPi0/ZmWPBdSBlYrunsBlUvlcpW8X0NurW4zesQ6g==}
+  electron@41.7.1:
+    resolution: {integrity: sha512-pdRvNNP99Qfvs1lyIxo/sfIGAwJP0CrJFNCE3goFKc7/fV+kjK3EPxx5Nt6sLTkzqTyeRYylpwPUfpeGojiyyw==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5966,7 +5966,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@41.6.0:
+  electron@41.7.1:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 24.10.9


### PR DESCRIPTION
Some memory safety fixes
https://releases.electronjs.org/release/compare/v41.6.1/v41.7.1.
