### PR TITLE
test: add multi-Delta-Chat-instance tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,7 +26,6 @@ jobs:
       CI: true
       NODE_ENV: test
       VERSION_INFO_GIT_REF: ${{ github.ref }}
-      DC_ACCOUNTS_DIR: ../../e2e-tests/data/accounts
       DC_CHATMAIL_DOMAIN: ${{ vars.DC_CHATMAIL_DOMAIN }}
       DC_MAIL_SERVER: ${{ vars.CI_MAIL_SERVER }}
       DC_MAIL_SERVER_TOKEN: ${{ secrets.CI_MAIL_SERVER_TOKEN }}

--- a/docs/E2E-TESTING.md
+++ b/docs/E2E-TESTING.md
@@ -19,8 +19,6 @@ Be aware that the tests in each spec file are NOT isolated, so the order they ar
 This package depends on the target-browser so consider taking a look at its [README](../packages/target-browser/Readme.md),
 e.g. if you want to enable TLS.
 
-But don't run the browser at the same time, it will be started inside the test routine.
-
 ```sh
 pnpm -w e2e
 ```
@@ -55,14 +53,19 @@ pnpm -w --filter e2e-tests e2e:report
 
 to show the last report
 
-The account dir for tests is in _packages/e2e-tests/data/accounts_ (configurable in .env)
+The account dirs for tests are _packages/e2e-tests/data/app-instance-\*/accounts_
 
-It can be deleted after running tests and will be recreated in the next run.
+The whole _data/_ dir can be deleted after running tests
+and will be recreated in the next run.
+
+## Writing multi-app-instance tests
+
+Utilize `openInstancePage()`. Use the "add a second device" test as an example.
 
 ## Troubleshooting
 
 Make sure that there are no accounts left after fail.
-`rm -r packages/e2e-tests/data/accounts`
+`rm -r packages/e2e-tests/data/app-instance-*/accounts`
 
 After failing tests or stopping tests with Ctrl + C sometimes either the rpc-server process is still running or the used port is still blocked by a process
 To find the related process pid (on Linux) run:

--- a/packages/e2e-tests/_env
+++ b/packages/e2e-tests/_env
@@ -1,5 +1,6 @@
 DC_ACCOUNTS_DIR=../../e2e-tests/data/accounts
 DC_FRONTEND_NO_TLS=true
+PRIVATE_CERTIFICATE_PATH=
 NODE_ENV=test
 
 # URL of chatmail server

--- a/packages/e2e-tests/_env
+++ b/packages/e2e-tests/_env
@@ -1,4 +1,3 @@
-DC_ACCOUNTS_DIR=../../e2e-tests/data/accounts
 DC_FRONTEND_NO_TLS=true
 PRIVATE_CERTIFICATE_PATH=
 NODE_ENV=test

--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -1,4 +1,10 @@
-import { expect, test as base, Page } from '@playwright/test'
+import {
+  expect,
+  test as base,
+  Browser,
+  BrowserContext,
+  Page,
+} from '@playwright/test'
 import path from 'path'
 import { loadEnv } from './load-env'
 
@@ -7,9 +13,24 @@ loadEnv()
 export const DC_FRONTEND_NO_TLS: boolean =
   process.env.DC_FRONTEND_NO_TLS === 'true' ||
   process.env.DC_FRONTEND_NO_TLS === '1'
-const port = process.env.WEB_PORT ?? 3000
-
-export const baseURL = `${DC_FRONTEND_NO_TLS ? 'http' : 'https'}://localhost:${port}`
+export const NUM_APP_INSTANCES = 2
+type InstanceInd = 0 | 1
+export function instancePort(index: InstanceInd): number {
+  return 3000 + index
+}
+export function instanceBaseURL(index: InstanceInd): string {
+  const protocol = DC_FRONTEND_NO_TLS ? 'http' : 'https'
+  return `${protocol}://localhost:${instancePort(index)}`
+}
+export async function openInstancePage(
+  browser: Browser,
+  index: InstanceInd
+): Promise<{ context: BrowserContext; page: Page }> {
+  const context = await browser.newContext({ baseURL: instanceBaseURL(index) })
+  const page = await context.newPage()
+  await page.goto('/')
+  return { context, page }
+}
 
 export const chatmailServerDomain = process.env.DC_CHATMAIL_DOMAIN
   ? process.env.DC_CHATMAIL_DOMAIN

--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -4,6 +4,13 @@ import { loadEnv } from './load-env'
 
 loadEnv()
 
+export const DC_FRONTEND_NO_TLS: boolean =
+  process.env.DC_FRONTEND_NO_TLS === 'true' ||
+  process.env.DC_FRONTEND_NO_TLS === '1'
+const port = process.env.WEB_PORT ?? 3000
+
+export const baseURL = `${DC_FRONTEND_NO_TLS ? 'http' : 'https'}://localhost:${port}`
+
 export const chatmailServerDomain = process.env.DC_CHATMAIL_DOMAIN
   ? process.env.DC_CHATMAIL_DOMAIN
   : // Use fallback so that the tests can run on people's forks

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,8 +1,14 @@
+import path from 'node:path'
 import { defineConfig, devices } from '@playwright/test'
 
 import { loadEnv } from './load-env'
 import type { TestOptions } from './playwright-helper'
-import { baseURL, DC_FRONTEND_NO_TLS } from './playwright-helper'
+import {
+  DC_FRONTEND_NO_TLS,
+  NUM_APP_INSTANCES,
+  instanceBaseURL,
+  instancePort,
+} from './playwright-helper'
 
 loadEnv()
 
@@ -33,7 +39,8 @@ export default defineConfig<TestOptions>({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: baseURL,
+    // Instance 0 is used as the default instance for single-instance tests.
+    baseURL: instanceBaseURL(0),
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -65,16 +72,30 @@ export default defineConfig<TestOptions>({
     // },
   ],
 
-  /* Run your local dev server before starting the tests */
-  webServer: {
-    command: `node ${
-      process.env.CI ? '' : '--env-file .env'
-    } ../target-browser/dist/server.js`,
-    url: baseURL,
-    timeout: 120 * 1000,
-    ignoreHTTPSErrors: !DC_FRONTEND_NO_TLS,
-    reuseExistingServer: !process.env.CI,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  },
+  webServer: Array.from({ length: NUM_APP_INSTANCES }, (_, _index) => {
+    const index = _index as 0 | 1
+    const port = instancePort(index)
+    const url = instanceBaseURL(index)
+    return {
+      command: `node ${
+        process.env.CI ? '' : '--env-file .env'
+      } ../target-browser/dist/server.js`,
+      name: `DC instance ${port}`,
+      url,
+      timeout: 120 * 1000,
+      ignoreHTTPSErrors: !DC_FRONTEND_NO_TLS,
+      reuseExistingServer: !process.env.CI,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...(process.env as Record<string, string>),
+        WEB_PORT: port.toString(),
+        DATA_DIR: path.join(
+          import.meta.dirname,
+          'data',
+          `app-instance-${port}`
+        ),
+      },
+    }
+  }),
 })

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -1,16 +1,10 @@
 import { defineConfig, devices } from '@playwright/test'
 
 import { loadEnv } from './load-env'
-import { TestOptions } from './playwright-helper'
+import type { TestOptions } from './playwright-helper'
+import { baseURL, DC_FRONTEND_NO_TLS } from './playwright-helper'
 
 loadEnv()
-
-export const DC_FRONTEND_NO_TLS: boolean =
-  process.env.DC_FRONTEND_NO_TLS === 'true' ||
-  process.env.DC_FRONTEND_NO_TLS === '1'
-const port = process.env.WEB_PORT ?? 3000
-
-const baseURL = `${DC_FRONTEND_NO_TLS ? 'http' : 'https'}://localhost:${port}`
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/packages/e2e-tests/tests/add-second-device.spec.ts
+++ b/packages/e2e-tests/tests/add-second-device.spec.ts
@@ -1,0 +1,75 @@
+import { expect, type BrowserContext, type Page } from '@playwright/test'
+
+import {
+  deleteSelectedProfile,
+  importDummyProfileFromBackup,
+  openInstancePage,
+  reloadPage,
+  test,
+} from '../playwright-helper'
+
+test.describe.configure({
+  mode: 'serial',
+})
+
+let contextA: BrowserContext
+let contextB: BrowserContext
+let pageA: Page
+let pageB: Page
+
+test.beforeAll(async ({ browser }) => {
+  ;[{ context: contextA, page: pageA }, { context: contextB, page: pageB }] =
+    await Promise.all([
+      openInstancePage(browser, 0),
+      openInstancePage(browser, 1),
+    ])
+
+  await importDummyProfileFromBackup(pageA)
+})
+
+test.afterAll(async () => {
+  await Promise.all(
+    [pageA, pageB].map(async page => {
+      await reloadPage(page)
+      await deleteSelectedProfile(page)
+    })
+  )
+  await contextA.close()
+  await contextB.close()
+})
+
+test('add a second device', async ({ browserName }) => {
+  await pageB.getByRole('button', { name: 'I Already Have a Profile' }).click()
+  await pageB.getByRole('button', { name: 'Add as Second Device' }).click()
+
+  await pageA.getByRole('button', { name: 'Settings' }).click()
+  await pageA.getByRole('button', { name: 'Add Second Device' }).click()
+  await pageA
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Continue' })
+    .click()
+  await expect(pageA.getByRole('dialog').getByRole('img')).toBeVisible()
+  await pageA.getByRole('dialog').getByRole('button', { name: 'More' }).click()
+  if (browserName.toLowerCase().indexOf('chrom') > -1) {
+    await pageA.context().grantPermissions(['clipboard-write'])
+  }
+  await pageA.getByRole('menuitem', { name: 'Copy' }).click()
+  await pageA.getByRole('dialog').getByRole('button', { name: 'Ok' }).click()
+
+  await pageB
+    .getByRole('dialog')
+    .getByRole('button', { name: 'Settings' })
+    .click()
+  if (browserName.toLowerCase().indexOf('chrom') > -1) {
+    await pageB.context().grantPermissions(['clipboard-read'])
+  }
+  await pageB.getByRole('menuitem', { name: 'Paste from Clipboard' }).click()
+
+  await expect(pageB.getByRole('dialog')).toHaveCount(0)
+  await expect(
+    pageB.getByLabel('Chats').getByRole('tab', { name: 'Saved Messages' })
+  ).toBeVisible()
+  await expect(
+    pageA.getByLabel('Chats').getByRole('tab', { name: 'Device Messages' })
+  ).toContainText('Profile transferred to your second device')
+})

--- a/packages/e2e-tests/tests/backup-tests.spec.ts
+++ b/packages/e2e-tests/tests/backup-tests.spec.ts
@@ -1,11 +1,15 @@
-import { expect, type Page } from '@playwright/test'
+import { expect, type Page, type BrowserContext } from '@playwright/test'
 import path from 'path'
 
 import {
   clickThroughTestIds,
+  createDummyChat,
   deleteAllProfiles,
+  deleteSelectedProfile,
   getUser,
+  importDummyProfileFromBackup,
   loadExistingProfiles,
+  openInstancePage,
   reloadPage,
   switchToProfile,
   test,
@@ -63,6 +67,81 @@ test('import backup from file', async () => {
   await expect(profileButtons.last()).toContainText('Alice'[0])
   await expect(page.getByRole('dialog')).toHaveCount(0)
   await expect(page.getByRole('button', { name: 'New Chat' })).toBeVisible()
+})
+
+test.describe('export then import backup', () => {
+  // let contextA: BrowserContext
+  let contextB: BrowserContext
+  let pageA: Page
+  let pageB: Page
+  let backupPath: Promise<string>
+
+  test.beforeAll(async ({ browser }) => {
+    pageA = page
+    ;({ context: contextB, page: pageB } = await openInstancePage(browser, 1))
+
+    await pageA.getByRole('button', { name: 'Add Profile' }).click()
+    await importDummyProfileFromBackup(pageA)
+    await createDummyChat(pageA, "I'm a chat, backup me!")
+  })
+  test.afterAll(async () => {
+    await Promise.all(
+      [pageA, pageB].map(async page => {
+        await reloadPage(page)
+        await deleteSelectedProfile(page)
+      })
+    )
+    // await contextA.close()
+    await contextB.close()
+  })
+
+  test('export', async () => {
+    await pageA.getByRole('button', { name: 'Settings' }).click()
+    await pageA.getByRole('button', { name: 'Chats' }).click()
+    await pageA.getByRole('button', { name: 'Export Backup' }).click()
+
+    await expect(pageA.getByRole('dialog').last()).toContainText(
+      'Keep the backup file in a safe place or delete it as soon as possible'
+    )
+    await expect(
+      pageA.getByRole('dialog').last().getByRole('button')
+    ).toHaveText(['Cancel', 'Start Backup'])
+
+    // In Electron we would show a directory picker dialog,
+    // but in the browser version it's a download.
+    const downloadPromise = pageA.waitForEvent('download')
+    await pageA.getByRole('button', { name: 'Start Backup' }).click()
+    // This dialog is also not present on Electron.
+    await pageA
+      .getByRole('dialog')
+      .filter({ hasText: 'Backup written successfully' })
+      .getByRole('button', { name: 'Open' })
+      .click()
+    const download = await downloadPromise
+    backupPath = download.path()
+
+    await expect(
+      pageA.getByRole('button', { name: 'Start Backup' })
+    ).not.toBeVisible()
+  })
+
+  test('import', async () => {
+    await pageB
+      .getByRole('button', { name: 'I Already Have a Profile' })
+      .click()
+
+    const fileChooserPromise = pageB.waitForEvent('filechooser')
+    await pageB.getByRole('button', { name: 'Restore from Backup' }).click()
+    const fileChooser = await fileChooserPromise
+    await fileChooser.setFiles(await backupPath)
+
+    await expect(
+      pageB
+        .getByLabel('Chats')
+        .getByRole('tab', { name: "I'm a chat, backup me!" })
+    ).toBeVisible()
+    await expect(pageB.getByRole('dialog')).toHaveCount(0)
+  })
 })
 
 test('shows warning when scanning backups that are newer than supported', async ({

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -21,7 +21,9 @@ function resolvePath(path: string): string {
 
 // Directories & Files
 export const DIST_DIR = join(__dirname)
-export const DATA_DIR = join(__dirname, '../data')
+export const DATA_DIR = process.env['DATA_DIR']
+  ? resolvePath(process.env['DATA_DIR'])
+  : join(__dirname, '../data')
 export const LOGS_DIR = join(DATA_DIR, 'logs')
 const privateCertPath = process.env['PRIVATE_CERTIFICATE_PATH']
   ? resolvePath(process.env['PRIVATE_CERTIFICATE_PATH'])
@@ -47,13 +49,7 @@ export const ENV_WEB_TRUST_FIRST_PROXY = Boolean(
 
 export const NODE_ENV = (process.env['NODE_ENV'] ?? 'production').toLowerCase()
 
-try {
-  mkdirSync(DATA_DIR)
-} catch (err: any) {
-  if (err.code !== 'EEXIST') {
-    throw err
-  }
-}
+mkdirSync(DATA_DIR, { recursive: true })
 mkdirSync(LOGS_DIR, { recursive: true })
 
 if (

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -15,6 +15,10 @@ try {
   console.error(`Failed to load ${envPath}`, error)
 }
 
+function resolvePath(path: string): string {
+  return isAbsolute(path) ? path : join(__dirname, path)
+}
+
 // Directories & Files
 export const DIST_DIR = join(__dirname)
 export const DATA_DIR = join(__dirname, '../data')
@@ -40,11 +44,7 @@ export const ENV_WEB_TRUST_FIRST_PROXY = Boolean(
 )
 
 if (process.env['DC_ACCOUNTS_DIR']) {
-  if (isAbsolute(process.env['DC_ACCOUNTS_DIR'])) {
-    DC_ACCOUNTS_DIR = process.env['DC_ACCOUNTS_DIR']
-  } else {
-    DC_ACCOUNTS_DIR = join(__dirname, process.env['DC_ACCOUNTS_DIR'])
-  }
+  DC_ACCOUNTS_DIR = resolvePath(process.env['DC_ACCOUNTS_DIR'])
 }
 
 export const NODE_ENV = (process.env['NODE_ENV'] ?? 'production').toLowerCase()

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -23,11 +23,11 @@ function resolvePath(path: string): string {
 export const DIST_DIR = join(__dirname)
 export const DATA_DIR = join(__dirname, '../data')
 export const LOGS_DIR = join(DATA_DIR, 'logs')
-export const PRIVATE_CERTIFICATE_KEY = join(
-  DATA_DIR,
-  'certificate/cert.key.pem'
-)
-export const PRIVATE_CERTIFICATE_CERT = join(DATA_DIR, 'certificate/cert.pem')
+const privateCertPath = process.env['PRIVATE_CERTIFICATE_PATH']
+  ? resolvePath(process.env['PRIVATE_CERTIFICATE_PATH'])
+  : join(DATA_DIR, 'certificate')
+export const PRIVATE_CERTIFICATE_KEY = join(privateCertPath, 'cert.key.pem')
+export const PRIVATE_CERTIFICATE_CERT = join(privateCertPath, 'cert.pem')
 export const DC_ACCOUNTS_DIR = process.env['DC_ACCOUNTS_DIR']
   ? resolvePath(process.env['DC_ACCOUNTS_DIR'])
   : join(DATA_DIR, 'accounts')

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -28,7 +28,9 @@ export const PRIVATE_CERTIFICATE_KEY = join(
   'certificate/cert.key.pem'
 )
 export const PRIVATE_CERTIFICATE_CERT = join(DATA_DIR, 'certificate/cert.pem')
-export let DC_ACCOUNTS_DIR = join(DATA_DIR, 'accounts')
+export const DC_ACCOUNTS_DIR = process.env['DC_ACCOUNTS_DIR']
+  ? resolvePath(process.env['DC_ACCOUNTS_DIR'])
+  : join(DATA_DIR, 'accounts')
 
 export const LOCALES_DIR = join(__dirname, '../../../_locales')
 
@@ -42,10 +44,6 @@ export const ENV_WEB_PORT = process.env['WEB_PORT'] || 3000
 export const ENV_WEB_TRUST_FIRST_PROXY = Boolean(
   process.env['WEB_TRUST_FIRST_PROXY']
 )
-
-if (process.env['DC_ACCOUNTS_DIR']) {
-  DC_ACCOUNTS_DIR = resolvePath(process.env['DC_ACCOUNTS_DIR'])
-}
 
 export const NODE_ENV = (process.env['NODE_ENV'] ?? 'production').toLowerCase()
 


### PR DESCRIPTION
- **refactor: test: factor out `resolvePath()`**
- **refactor: test: simplify `DC_ACCOUNTS_DIR`**
- **test: add `PRIVATE_CERTIFICATE_PATH` support**
- **refactor: test: move some consts to another file**
- **test: support `DATA_DIR` env var**
- **test: add multi-Delta-Chat-instance tests**

test: add multi-Delta-Chat-instance tests

This starts multiple Delta Chat instances,
available on different ports,
each having their own data directory (for accounts and stuff).

And add tests for "Add Second Device".

This will also allow us to test things
that we previously weren't able to test,
due to the fact that we can only have one page open
(see `error_other_client_stole_dc_connection`).
For example, we can now add tests
for receiving a message while a chat is open.
Also this might allow to simplify other multi-account tests,
because now explicitly switching between accounts is not required.

Those developers who have an existing `e2e-tests/.env` file
should remove `DC_ACCOUNTS_DIR` from it,
because the accounts dir is now specified per-instance.

The initial version of this MR has been AI-generated,
then within a couple of hours I rewrote ~75% of it.
The idea itself, i.e. using multiple ports and data dirs, is mine.
The `test()` is also 100% mine.
The prompt was something along the lines of
> Add support for running multiple app instances
> on separate ports in `e2e-tests`.
> Keep existing tests as is.

TODO:
- [x] Merge the base https://github.com/deltachat/deltachat-desktop/pull/6398 into main, such that only 6 commits remain.