### PR TITLE
feat: show imap folder if set

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -64,8 +64,5 @@
   },
   "paste_in_qr_scanner": {
     "message": "Click to paste it in QR scanner"
-  },
-  "imap_folder": {
-    "message": "IMAP Folder"
   }
 }

--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -64,5 +64,8 @@
   },
   "paste_in_qr_scanner": {
     "message": "Click to paste it in QR scanner"
+  },
+  "imap_folder": {
+    "message": "IMAP Folder"
   }
 }

--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -210,15 +210,15 @@ export default function LoginForm({
             />
             {imapFolder !== null && (
               <>
-                <p>{tx('pref_imap_folder_warn_disable_defaults')}</p>
                 <DeltaInput
                   key='imapFolder'
                   id='imapFolder'
                   placeholder={tx('automatic')}
-                  label={tx('imap_folder')}
+                  label='IMAP Folder'
                   type='text'
                   value={imapFolder}
                   onChange={handleCredentialsChange}
+                  disabled
                 />
               </>
             )}

--- a/packages/frontend/src/components/LoginForm.tsx
+++ b/packages/frontend/src/components/LoginForm.tsx
@@ -115,6 +115,7 @@ export default function LoginForm({
     password,
     imapServer,
     imapPort,
+    imapFolder,
     imapSecurity,
     certificateChecks,
     smtpUser,
@@ -207,6 +208,20 @@ export default function LoginForm({
               value={imapPort}
               onChange={handleCredentialsChange}
             />
+            {imapFolder !== null && (
+              <>
+                <p>{tx('pref_imap_folder_warn_disable_defaults')}</p>
+                <DeltaInput
+                  key='imapFolder'
+                  id='imapFolder'
+                  placeholder={tx('automatic')}
+                  label={tx('imap_folder')}
+                  type='text'
+                  value={imapFolder}
+                  onChange={handleCredentialsChange}
+                />
+              </>
+            )}
 
             <DeltaSelect
               id='imapSecurity'


### PR DESCRIPTION
Resolves #6422 

<img height="250" alt="image" src="https://github.com/user-attachments/assets/15ab6068-b3cb-4ecd-9792-b0fa8148faaf" />

Field is only shown if imap_folder is not empty.

tbd: 
1. do we need the hint?
2. should we add a translation for "IMAP Folder"?