### PR TITLE
fix: warn before sending large image

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -64,5 +64,8 @@
   },
   "paste_in_qr_scanner": {
     "message": "Click to paste it in QR scanner"
+  },
+  "large_image_warning_body": {
+    "message": "Warning: this image is very large (%1$s × %2$s pixels). It cannot be compressed for sending and will not be rendered as an image in the chat."
   }
 }

--- a/packages/frontend/src/components/attachment/Attachment.tsx
+++ b/packages/frontend/src/components/attachment/Attachment.tsx
@@ -6,6 +6,13 @@ export function isImage(viewType: Type.Viewtype | null) {
   return viewType === 'Image' || viewType === 'Gif'
 }
 
+/**
+ * Images whose uncompressed pixel count exceeds this threshold are not rendered
+ * inline since they cause severe UI slowness.
+ * Let's set 50 MP as limit, which should be fine in most cases
+ */
+export const LARGE_IMAGE_PIXEL_THRESHOLD = 50_000_000
+
 export function hasAttachment(attachment: MessageTypeAttachmentSubset | null) {
   return attachment && attachment.file
 }

--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -9,6 +9,7 @@ import {
   getExtension,
   dragAttachmentOut,
   MessageTypeAttachmentSubset,
+  LARGE_IMAGE_PIXEL_THRESHOLD,
 } from './Attachment'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { Type } from '../../backend-com'
@@ -137,7 +138,18 @@ export default function Attachment({
   const withCaption = Boolean(text)
   // For attachments which aren't full-frame
   const withContentBelow = withCaption
-  if (isImage(message.viewType) || message.viewType === 'Sticker') {
+
+  const isOversizedImage =
+    isImage(message.viewType) &&
+    message.dimensionsWidth > 0 &&
+    message.dimensionsHeight > 0 &&
+    message.dimensionsWidth * message.dimensionsHeight >
+      LARGE_IMAGE_PIXEL_THRESHOLD
+
+  if (
+    (isImage(message.viewType) || message.viewType === 'Sticker') &&
+    !isOversizedImage
+  ) {
     return (
       <button
         type='button'
@@ -195,38 +207,39 @@ export default function Attachment({
         />
       </div>
     )
-  } else {
-    const { fileName, fileBytes, fileMime, file } = message
-    const extension = getExtension(message)
-    return (
-      <button
-        type='button'
-        className={classNames(
-          'message-attachment-generic',
-          withContentBelow ? 'content-below' : null
-        )}
-        onClick={onClickAttachment}
-        tabIndex={tabindexForInteractiveContents}
-      >
-        <div
-          className='file-icon'
-          draggable='true'
-          onDragStart={ev => dragAttachmentOut(file, fileName, ev)}
-          title={fileMime || 'null'}
-        >
-          {extension ? (
-            <div className='file-extension'>
-              {fileMime === 'application/octet-stream' ? '' : extension}
-            </div>
-          ) : null}
-        </div>
-        <div className='text-part'>
-          <div className='name'>{fileName}</div>
-          <div className='size'>{filesize(fileBytes ?? 0)}</div>
-        </div>
-      </button>
-    )
   }
+
+  // Generic file renderer - (also used for oversized images)
+  const { fileName, fileBytes, fileMime, file } = message
+  const extension = getExtension(message)
+  return (
+    <button
+      type='button'
+      className={classNames(
+        'message-attachment-generic',
+        withContentBelow ? 'content-below' : null
+      )}
+      onClick={onClickAttachment}
+      tabIndex={tabindexForInteractiveContents}
+    >
+      <div
+        className='file-icon'
+        draggable='true'
+        onDragStart={ev => dragAttachmentOut(file, fileName, ev)}
+        title={fileMime || 'null'}
+      >
+        {extension ? (
+          <div className='file-extension'>
+            {fileMime === 'application/octet-stream' ? '' : extension}
+          </div>
+        ) : null}
+      </div>
+      <div className='text-part'>
+        <div className='name'>{fileName}</div>
+        <div className='size'>{filesize(fileBytes ?? 0)}</div>
+      </div>
+    </button>
+  )
 }
 /**
  * @see also {@linkcode GalleryAudioAttachment}.

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -10,6 +10,7 @@ import { T } from '@deltachat/jsonrpc-client'
 
 import { getLogger } from '../../../../shared/logger'
 import { BackendRemote, Type } from '../../backend-com'
+import { LARGE_IMAGE_PIXEL_THRESHOLD } from '../../components/attachment/Attachment'
 import { MessageTypeAttachmentSubset } from '../../components/attachment/Attachment'
 import { KeybindAction } from '../../keybindings'
 import useMessage from './useMessage'
@@ -22,6 +23,35 @@ import useConfirmationDialog from '../dialog/useConfirmationDialog'
 import useAlertDialog from '../dialog/useAlertDialog'
 
 const log = getLogger('renderer/composer')
+
+/**
+ * Returns the pixel dimensions of an image file using the browser's native
+ * image decoder, or `null` if the file cannot be read or is not a recognised
+ * image format.
+ */
+function getImageDimensions(
+  filePath: string
+): Promise<{ width: number; height: number } | null> {
+  return new Promise(resolve => {
+    const img = new Image()
+    // 5 s timeout guards against hanging on malformed files.
+    const timer = setTimeout(() => resolve(null), 5000)
+    const done = (result: { width: number; height: number } | null) => {
+      clearTimeout(timer)
+      resolve(result)
+    }
+    img.onload = () =>
+      done({ width: img.naturalWidth, height: img.naturalHeight })
+    img.onerror = () => done(null)
+    // Build a file:// URL.  On Unix the path already starts with '/' so we
+    // get exactly three slashes: file:// + /path = file:///path.
+    // On Windows paths look like C:/... so we prepend an extra slash.
+    const normalized = filePath.replace(/\\/g, '/')
+    img.src = normalized.startsWith('/')
+      ? `file://${normalized}`
+      : `file:///${normalized}`
+  })
+}
 
 export type DraftObject = { chatId: number } & Pick<
   Type.Message,
@@ -309,6 +339,27 @@ export function useDraft(
       if (debouncedSaveAndRefetchDraft == null || saveAndRefetchDraft == null) {
         return
       }
+
+      // Warn the user when attaching a very large image: core cannot compress
+      // it (OOM) and the image will be displayed without scaling, which may
+      // cause UI slowness on the recipient's side.
+      // TODO: when the core issue is fixed, we could propose to send the image
+      // as a file instead or show no warning at all if core can handle it well.
+      if (viewType === 'Image') {
+        const dims = await getImageDimensions(file)
+        if (
+          dims !== null &&
+          dims.width * dims.height > LARGE_IMAGE_PIXEL_THRESHOLD
+        ) {
+          await openAlertDialog({
+            message: tx('large_image_warning_body', [
+              String(dims.width),
+              String(dims.height),
+            ]),
+          })
+        }
+      }
+
       inputRef.current?.focus()
       const newDraftState: typeof draftState = {
         ...draftState,
@@ -324,7 +375,14 @@ export function useDraft(
       debouncedSaveAndRefetchDraft?.clear()
       return saveAndRefetchDraft(newDraftState)
     },
-    [draftState, inputRef, saveAndRefetchDraft, debouncedSaveAndRefetchDraft]
+    [
+      draftState,
+      inputRef,
+      saveAndRefetchDraft,
+      debouncedSaveAndRefetchDraft,
+      openAlertDialog,
+      tx,
+    ]
   )
 
   const quoteMessage = useMemo(


### PR DESCRIPTION
fixes #5053 

Current behaviour:

<img width="630" alt="Large-Image" src="https://github.com/user-attachments/assets/0b97a5a0-af1a-4bbe-a049-2170fd34e955" />

Desktop shows a core error if the image is sent as Image (in the old deprecated "user feedback" way) and renders the image only if it is sent as File.

The reason is in core:

1. core runs out of memory when img reader decodes the image https://github.com/chatmail/core/blob/main/src/blob.rs#L360 which results in the fallback to viewType File
2. when the image is sent as file core converts it to an image based on the mime type and "converts" it to viewType Image but does NOT run imgreader.decode() 

In the latter case desktop displays the uncompressed image which causes delays in Chrome.

So the fix in desktop is:  show a warning when an Image is too large to be rendered in the UI.

<img width="337"  alt="image" src="https://github.com/user-attachments/assets/4324a141-7ad1-482a-b9c2-40a1ddf3438b" />

And don't render images that are larger than LARGE_IMAGE_PIXEL_THRESHOLD anymore.

In Android the large image results in a grey empty "image like" message. So the same behaviour from core results in a viewType Image that the webview can't display.

<img width="380" alt="android-large-image" src="https://github.com/user-attachments/assets/e63d5ec1-0928-4d78-95a6-b8e2691acb78" />

I also checked how Signal treats large images: it turned out, the images are resized already on the client side (see https://github.com/signalapp/Signal-Desktop/blob/main/ts/util/Attachment.std.ts#L51 and https://github.com/signalapp/Signal-Desktop/blob/main/ts/util/Attachment.std.ts#L235 ) 

So it is not possible at all to send large images. Neither as Image nor as File.



