### PR TITLE
fix: undismissable context menu in fullscreen media

### DIFF
--- a/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
+++ b/packages/frontend/src/components/dialogs/FullscreenMedia.tsx
@@ -13,7 +13,7 @@ import { useInitEffect } from '../helpers/hooks'
 import { BackendRemote, onDCEvent, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
-import { useContextMenuWithActiveState } from '../ContextMenu'
+import useContextMenu from '../../hooks/useContextMenu'
 import useMessage from '../../hooks/chat/useMessage'
 import { useZoomKeyboardShortcuts } from '../../hooks/useZoomKeyboardShortcuts'
 
@@ -100,7 +100,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
     throw new Error('file attribute not set')
   }
 
-  const { isContextMenuActive, onContextMenu } = useContextMenuWithActiveState([
+  const onContextMenu = useContextMenu([
     {
       label: tx('menu_copy_image_to_clipboard'),
       action: () => {
@@ -263,12 +263,6 @@ export default function FullscreenMedia(props: Props & DialogProps) {
       if (ev.repeat) {
         return
       }
-      if (ev.code === 'Escape' && isContextMenuActive) {
-        // Only close the context menu, instead of closing both
-        // the context menu and the whole FullscreenMedia dialog.
-        ev.preventDefault()
-        return
-      }
       const left = ev.code === 'ArrowLeft'
       const right = ev.code === 'ArrowRight'
       if (!left && !right) {
@@ -284,7 +278,7 @@ export default function FullscreenMedia(props: Props & DialogProps) {
     }
     document.addEventListener('keydown', listener)
     return () => document.removeEventListener('keydown', listener)
-  }, [previousImage, nextImage, isContextMenuActive])
+  }, [previousImage, nextImage])
 
   if (!msg || !msg.file) return elm
 


### PR DESCRIPTION
Unclosable for keyboard users without activating a menu item.

1. Click on a photo in a chat to start viewing it in full screen.
2. Tab-focus the image element.
3. Invoke the context menu.
4. Press Escape.

Nothing will happen, whereas the context menu should close.

The problem is `preventDefault()` prevents the default action
which is to close the context menu dialog.

This partially reverts 6ce4d78f30cce9dfabe8288876f690c8a134ec42
(https://github.com/deltachat/deltachat-desktop/pull/5191),
which introduced this hack.
The hack became a bug apparently after
0795308eaeac0e3f9084339695926cdbf8857dab
(https://github.com/deltachat/deltachat-desktop/pull/6226).

Related:
- https://github.com/deltachat/deltachat-desktop/issues/4128.
