### PR TITLE
fix: focus composer when user tries to type

### DIFF
--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -98,7 +98,8 @@ export default class ComposerMessageInput extends React.Component<
         // Focus on the current selection, hack for focusing on newlines
         // TODO this pretty much doesn't work,
         // because you can't focus an element that is covered by a dialog.
-        // See the comment in `onMouseUp` in `MessageListAndComposer`.
+        // See the comment added in 0c1de2505731b6fc420c8d30cc683a57606d4a4b
+        // (https://github.com/deltachat/deltachat-desktop/pull/5127).
         if (this.context.hasOpenDialogs) {
           this.textareaRef.current.blur()
           this.textareaRef.current.focus()

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect, useCallback, useEffectEvent } from 'react'
+import React, { useRef, useEffect, useEffectEvent } from 'react'
 import { join, parse, ParsedPath } from 'path'
 import { T } from '@deltachat/jsonrpc-client'
 
@@ -205,69 +205,11 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     e.stopPropagation()
   }
 
-  const onMouseUp = useCallback(
-    (e: MouseEvent) => {
-      const selection = window.getSelection()
-
-      if (selection?.type === 'Range' && selection.rangeCount > 0) {
-        return
-      }
-      const targetTagName = (e.target as unknown as any)?.tagName
-
-      if (targetTagName === 'INPUT' || targetTagName === 'TEXTAREA') {
-        return
-      }
-
-      // don't force focus on the message input as long as the emoji picker is open
-      if (
-        document.querySelector(':focus')?.tagName?.toLowerCase() ===
-        'em-emoji-picker'
-      ) {
-        return
-      }
-
-      // TODO this function pretty much never works, because of this condition.
-      // trying to focus the composer while a dialog is open
-      // is impossible, because the dialog will keep focus inside of it.
-      //
-      // The condition was probably meant to be the opposite
-      // (i.e. do nothing if a dialog is open),
-      // but it only incidentally fixed the bug that it was intended to fix
-      // (https://github.com/deltachat/deltachat-desktop/issues/3286),
-      // while at the same time breaking the function.
-      //
-      // However, we probably should not fix this function
-      // and remove it instead, for accessibility reasons, laid out here:
-      // https://github.com/deltachat/deltachat-desktop/issues/4590.
-      //
-      // The same goes for the check in
-      // `ComposerMessageInput.componentDidUpdate`.
-      if (!hasOpenDialogs) {
-        return
-      }
-
-      e.preventDefault()
-      e.stopPropagation()
-
-      // Only one of these is actually rendered at any given moment.
-      regularMessageInputRef.current?.focus()
-      editMessageInputRef.current?.focus()
-
-      return false
-    },
-    [hasOpenDialogs]
-  )
   useEffect(() => {
     // Only one of these is actually rendered at any given moment.
     regularMessageInputRef.current?.focus()
     editMessageInputRef.current?.focus()
   }, [])
-  useEffect(() => {
-    window.addEventListener('mouseup', onMouseUp)
-    return () => {
-      window.removeEventListener('mouseup', onMouseUp)
-    }
-  }, [onMouseUp])
 
   const settingsStore = useSettingsStore()[0]
   // If you want to update this, don't forget to update

--- a/packages/frontend/src/keybindings.ts
+++ b/packages/frontend/src/keybindings.ts
@@ -126,6 +126,20 @@ export function matchesNonLetterShortcut(
   const isPrintableAscii = ev.key.length === 1 && ev.key >= ' ' && ev.key <= '~'
   return !isPrintableAscii && ev.code === code
 }
+const regexIsPrintable = /\S| /
+function isPrintableCharacter(str: KeyboardEvent['key']): boolean {
+  // From https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+  return str.length === 1 && regexIsPrintable.test(str)
+}
+
+function isInput(el: HTMLElement): boolean {
+  return (
+    el.tagName === 'TEXTAREA' ||
+    el.tagName === 'INPUT' ||
+    el.tagName === 'SELECT' ||
+    el.isContentEditable
+  )
+}
 
 function haveOpenDialogs(): boolean {
   return document.querySelector('dialog:modal') != null
@@ -245,6 +259,46 @@ export function keyDownEvent2Action(
       matchesNonLetterShortcut(ev, '/', 'Slash')
     ) {
       return KeybindAction.KeybindingCheatSheet_Open
+    } else if (
+      // When the user tries to type but the composer is not focused, focus it.
+      //
+      // Accessibility-wise this should be OK, because
+      // https://www.w3.org/WAI/ARIA/apg/patterns/combobox/
+      // has similar behavior, see the "Printable Characters" part.
+      //
+      // See also similar code in Element
+      // https://github.com/element-hq/element-web/blob/c57d66bb45a89451efefc1fcb2c3131040670da6/apps/web/src/components/structures/LoggedInView.tsx#L680-L706
+      //
+      // Don't check Shift (uppercase), and apparently Alt
+      // also needs to be skipped, because it's a common accent modifier.
+      !ev.ctrlKey &&
+      !ev.metaKey &&
+      !(
+        document.activeElement instanceof HTMLElement &&
+        isInput(document.activeElement)
+      ) &&
+      // Regular keyboard "click".
+      ev.code !== 'Space' &&
+      ev.code !== 'Enter' &&
+      isPrintableCharacter(ev.key)
+    ) {
+      // Not `Composer_Focus` because that focuses the composer
+      // only after a `setTimeout`, which would not result
+      // in this keystroke getting typed.
+      const composer = document.getElementsByClassName(
+        'create-or-edit-message-input'
+      )[0]
+      if (!(composer instanceof HTMLElement)) {
+        // Could happen if the composer is not displayed,
+        // e.g. for read-only chats (e.g. channels).
+        log.info(
+          "Tried to focus composer on typing start, but it's not present",
+          composer
+        )
+        return
+      }
+
+      composer.focus()
     }
   } else {
     // fire continuesly as long as button is pressed


### PR DESCRIPTION
This is a more accessible and common-practice way to do what
8fe1381b017eec203ae5df0da5de3188129da378
(https://github.com/deltachat/deltachat-desktop/pull/2007)
did.
We sort of reverted that MR for the most part, as part of
https://github.com/deltachat/deltachat-desktop/issues/4590
("a11y: stop constantly re-focusing composer"),
which was necessary for accessibility
but was, unfortunately, mostly annoying to pointer device users.

This commit should basically fix the "composer not focused" issues
once and for all (or for 95% at least).
And this also allows us to be more liberal in focuing other stuff,
e.g. focusing a message after a click on a notification.

I have tested this with Orca Reader and NVDA,
specifically with those one-key commands that they have,
such as "u" to go to the next link in Orca Reader.
Everything works fine. I confirmed that pressing "u"
does not move the focus to the composer and does not type "u" in it.
Same for NVDA.
This, of course, changes once one enters the focus mode
("Insert + A" on Orca Reader).

Closes https://support.delta.chat/t/always-focus-the-message-field-in-a-chat/4271?u=wofwca.
I would say that this also
closes https://github.com/deltachat/deltachat-desktop/issues/6246.

This is quite a significant change, so we'd probably want to do quite some testing of this.

TODO:
- [x] Merge the base, https://github.com/deltachat/deltachat-desktop/pull/6392.
  This MR does not really depend on that one
  but they simply change the same code, the `onMouseUp` part.
- [ ] (can do later) add tests
