### PR TITLE
fix: don't faint text select color if <2 msgs selected

### DIFF
--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -105,6 +105,22 @@
     &::-webkit-scrollbar-track {
       background: transparent;
     }
+
+    // If you Shift+Click some messages then their text
+    // also gets selected, which looks pretty ugly.
+    // However, some people might still want to select text this way,
+    // so let's keep a really faint color for them.
+    //
+    // We apply this to the whole `<ol>` and not `<li>`
+    // because otherwise daymarkers are not affected by this
+    // (because they're not selectable).
+    &.multiselected-one-or-more::selection {
+      background-color: color-mix(
+        in srgb,
+        var(--messageHightlightColor) 5%,
+        transparent
+      );
+    }
   }
 
   ol {
@@ -183,22 +199,6 @@
         -webkit-animation: none;
         -moz-animation: none;
       }
-    }
-
-    // If you Shift+Click some messages then their text
-    // also gets selected, which looks pretty ugly.
-    // However, some people might still want to select text this way,
-    // so let's keep a really faint color for them.
-    //
-    // We apply this to the whole `<ol>` and not `<li>`
-    // because otherwise daymarkers are not affected by this
-    // (because they're not selectable).
-    &:has(.multiselectable-message[aria-selected='true'])::selection {
-      background-color: color-mix(
-        in srgb,
-        var(--messageHightlightColor) 5%,
-        transparent
-      );
     }
   }
 }

--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -114,7 +114,12 @@
     // We apply this to the whole `<ol>` and not `<li>`
     // because otherwise daymarkers are not affected by this
     // (because they're not selectable).
-    &.multiselected-one-or-more::selection {
+    //
+    // Only apply this if two or more are selected because if the user
+    // tries to simply select text in a message with Shift + Click
+    // then that will select the message,
+    // in which case we should not faint the color.
+    &.multiselected-two-or-more::selection {
       background-color: color-mix(
         in srgb,
         var(--messageHightlightColor) 5%,

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -904,6 +904,10 @@ export const MessageListInner = React.memo(
 
           focusAndMultiselectContextValue.resetSelection()
         }}
+        className={classNames({
+          'multiselected-one-or-more':
+            focusAndMultiselectContextValue.selectedItems.size >= 1,
+        })}
       >
         <ol aria-label={tx('messages')}>
           <RovingTabindexProvider wrapperElementRef={messageListRef}>

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -907,6 +907,8 @@ export const MessageListInner = React.memo(
         className={classNames({
           'multiselected-one-or-more':
             focusAndMultiselectContextValue.selectedItems.size >= 1,
+          'multiselected-two-or-more':
+            focusAndMultiselectContextValue.selectedItems.size >= 2,
         })}
       >
         <ol aria-label={tx('messages')}>


### PR DESCRIPTION
- **refactor: msg multiselect: `:has()` -> class name**
- **fix: faint text select color if <2 msgs selected**

Before / after:

<img width="406" height="272" alt="image" src="https://github.com/user-attachments/assets/e9845dd2-03c4-4c70-b650-21ac8ef0387b" /> <img width="397" height="267" alt="image" src="https://github.com/user-attachments/assets/5c1b6603-71dd-4981-90ce-5f5fdbbc7f87" />
