### PR TITLE
feat: show num selected messages

### DIFF
--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -206,4 +206,18 @@
       }
     }
   }
+
+  .num-selected-messages-status {
+    position: absolute;
+    bottom: 0;
+    inset-inline-start: 0;
+    border-start-end-radius: 0.25rem;
+    $borderColor: color-mix(in srgb, var(--contextMenuBorder) 50%, transparent);
+    border-block-start: 1px solid $borderColor;
+    border-inline-end: 1px solid $borderColor;
+
+    background: var(--composerBg);
+    padding: 0.5rem 0.625rem;
+    line-height: 1;
+  }
 }

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -882,87 +882,103 @@ export const MessageListInner = React.memo(
     }
 
     return (
-      <div
-        id='message-list'
-        ref={messageListRef}
-        onScroll={onScroll2}
-        onWheel={onWheel}
-        className={classNames({
-          'multiselected-one-or-more':
-            focusAndMultiselectContextValue.selectedItems.size >= 1,
-          'multiselected-two-or-more':
-            focusAndMultiselectContextValue.selectedItems.size >= 2,
-        })}
-        onClick={e => {
-          // If clicked on dead space, reset selection.
+      <>
+        <div
+          id='message-list'
+          ref={messageListRef}
+          onScroll={onScroll2}
+          onWheel={onWheel}
+          className={classNames({
+            'multiselected-one-or-more':
+              focusAndMultiselectContextValue.selectedItems.size >= 1,
+            'multiselected-two-or-more':
+              focusAndMultiselectContextValue.selectedItems.size >= 2,
+          })}
+          onClick={e => {
+            // If clicked on dead space, reset selection.
 
-          if (e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) {
-            return
-          }
-          if (!(e.target instanceof HTMLElement)) {
-            return
-          }
-          if (e.target.closest('.multiselectable-message') != null) {
-            // Clicked on a message. This is handled
-            // by the message click handler.
-            return
-          }
+            if (e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) {
+              return
+            }
+            if (!(e.target instanceof HTMLElement)) {
+              return
+            }
+            if (e.target.closest('.multiselectable-message') != null) {
+              // Clicked on a message. This is handled
+              // by the message click handler.
+              return
+            }
 
-          focusAndMultiselectContextValue.resetSelection()
-        }}
-      >
-        <ol aria-label={tx('messages')}>
-          <RovingTabindexProvider wrapperElementRef={messageListRef}>
-            <MessageMultiselectContext.Provider
-              value={focusAndMultiselectContextValue}
-            >
-              {messageListItems.length === 0 && (
-                <EmptyChatMessage chat={chat} />
-              )}
-              {activeView.map(messageId => {
-                if (messageId.kind === 'dayMarker') {
-                  return (
-                    <DayMarker
-                      key={`daymarker-${messageId.timestamp}`}
-                      timestamp={messageId.timestamp}
-                    />
-                  )
-                }
-
-                if (messageId.kind === 'message') {
-                  const message = messageCache[messageId.msg_id]
-                  if (message?.kind === 'message') {
+            focusAndMultiselectContextValue.resetSelection()
+          }}
+        >
+          <ol aria-label={tx('messages')}>
+            <RovingTabindexProvider wrapperElementRef={messageListRef}>
+              <MessageMultiselectContext.Provider
+                value={focusAndMultiselectContextValue}
+              >
+                {messageListItems.length === 0 && (
+                  <EmptyChatMessage chat={chat} />
+                )}
+                {activeView.map(messageId => {
+                  if (messageId.kind === 'dayMarker') {
                     return (
-                      <MessageWrapper
-                        key={messageId.msg_id}
-                        key2={`${messageId.msg_id}`}
-                        chat={chat}
-                        message={message}
-                        conversationType={conversationType}
-                        unreadMessageInViewIntersectionObserver={
-                          unreadMessageInViewIntersectionObserver
-                        }
+                      <DayMarker
+                        key={`daymarker-${messageId.timestamp}`}
+                        timestamp={messageId.timestamp}
                       />
                     )
-                  } else if (message?.kind === 'loadingError') {
-                    return (
-                      <MessageLoadingError
-                        messageId={messageId}
-                        message={message}
-                      />
-                    )
-                  } else {
-                    // setTimeout tells it to call method in next event loop iteration, so after rendering
-                    // it is debounced later so we can call it here multiple times and it's ok
-                    setTimeout(loadMissingMessages)
-                    return <MessageLoading messageId={messageId} />
                   }
+
+                  if (messageId.kind === 'message') {
+                    const message = messageCache[messageId.msg_id]
+                    if (message?.kind === 'message') {
+                      return (
+                        <MessageWrapper
+                          key={messageId.msg_id}
+                          key2={`${messageId.msg_id}`}
+                          chat={chat}
+                          message={message}
+                          conversationType={conversationType}
+                          unreadMessageInViewIntersectionObserver={
+                            unreadMessageInViewIntersectionObserver
+                          }
+                        />
+                      )
+                    } else if (message?.kind === 'loadingError') {
+                      return (
+                        <MessageLoadingError
+                          messageId={messageId}
+                          message={message}
+                        />
+                      )
+                    } else {
+                      // setTimeout tells it to call method in next event loop iteration, so after rendering
+                      // it is debounced later so we can call it here multiple times and it's ok
+                      setTimeout(loadMissingMessages)
+                      return <MessageLoading messageId={messageId} />
+                    }
+                  }
+                })}
+              </MessageMultiselectContext.Provider>
+            </RovingTabindexProvider>
+          </ol>
+        </div>
+
+        <div role='status' style={{ display: 'contents' }}>
+          {focusAndMultiselectContextValue.selectedItems.size > 0 && (
+            <div className='num-selected-messages-status'>
+              {tx(
+                'n_selected',
+                focusAndMultiselectContextValue.selectedItems.size.toString(),
+                {
+                  quantity: focusAndMultiselectContextValue.selectedItems.size,
                 }
-              })}
-            </MessageMultiselectContext.Provider>
-          </RovingTabindexProvider>
-        </ol>
-      </div>
+              )}
+            </div>
+          )}
+        </div>
+      </>
     )
   },
   (prevProps, nextProps) => {


### PR DESCRIPTION
<img width="450" alt="image" src="https://github.com/user-attachments/assets/cffd9d90-2417-4752-bc43-a45b07cbe93a" />
<img width="450" alt="image" src="https://github.com/user-attachments/assets/56320934-470a-4dbb-be6d-f39238392a92" />


This is different from how we display it on Delta Chat android and iOS
where we display the number of selected messages
as a replacement to the chat name.
But I think that this is better because such display is more common
and thus more familiar to users on desktop.
Namely this design is inspired by file explorers
on Windows and some Linux OSes, which have a similarly positioned
and styled status bar.

The left border color could used some more work, but the idea is there.

Addresses https://github.com/deltachat/deltachat-desktop/pull/6268#issuecomment-4421685886.
