### PR TITLE
fix: QR code scanner in cut on the right when using a vertical camera

### DIFF
--- a/packages/frontend/src/components/QrReader/styles.module.scss
+++ b/packages/frontend/src/components/QrReader/styles.module.scss
@@ -6,7 +6,9 @@
 
 .qrReaderVideo {
   display: none;
-  height: 375px;
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
   left: 0;
   position: absolute;
   right: 0;


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6461.

This PR makes the qr scanner responsive and valid for both horizontal cameras and vertical cameras.
The previous code was working only with horizontal cameras while vertical cameras were cut as you can check on the screenshot of this issue: https://github.com/deltachat/deltachat-desktop/issues/6461

I've tested the solution on a device with horizontal camera (M2 Ashai Linux) and a device with vertical camera (FuriPhone FLX1s Linux Phone) and everything is fine :)

Enrico