### PR TITLE
fix: don't send whitespace-only message

### DIFF
--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -103,6 +103,44 @@ async function typeText(text: string) {
   await expect(textarea).toHaveText(text)
 }
 
+test("doesn't send empty message", async () => {
+  await createDummyChat(page, 'empty message test')
+  await selectChatByName(page, 'empty message test')
+  await textarea.fill('123')
+  await page.getByRole('button', { name: 'Send' }).click()
+  const messages = page
+    .getByRole('list', { name: 'Messages' })
+    .getByRole('listitem')
+    .filter({ hasNotText: 'Messages are end-to-end encrypted' })
+    .filter({ hasNotText: 'Others will only see this group after you sent a' })
+    .filter({ hasNotText: 'Today' })
+  await expect(messages).toHaveCount(1)
+
+  await textarea.fill('     ')
+  await textarea.press('ControlOrMeta+Enter')
+  await textarea.press('ControlOrMeta+Enter')
+  await textarea.press('ControlOrMeta+Enter')
+  await page.getByRole('button', { name: 'Send' }).click()
+  await page.getByRole('button', { name: 'Send' }).click()
+  await page.getByRole('button', { name: 'Send' }).click()
+  await expect(textarea).toHaveText('     ')
+  await expect(messages).toHaveCount(1)
+
+  await textarea.fill('\n')
+  await textarea.press('ControlOrMeta+Enter')
+  await page.getByRole('button', { name: 'Send' }).click()
+  await expect(textarea).toHaveText('\n')
+  await expect(messages).toHaveCount(1)
+
+  await textarea.fill('\na')
+  await textarea.press('ControlOrMeta+Enter')
+  await expect(textarea).toBeEmpty()
+  await expect(messages).toHaveCount(2)
+
+  // Clean up
+  await deleteChat(page, 'empty message test')
+})
+
 test("doesn't send the same message twice on multiple clicks", async () => {
   await selectChat(1)
   const messageText = `somee messageee foo ${Math.random()}`

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -224,7 +224,7 @@ const Composer = forwardRef<
           if (chatId === null) {
             throw new Error('chat id is undefined')
           }
-          if (!(draftState.text.length > 0) && !draftState.file) {
+          if (!(draftState.text.trim().length > 0) && !draftState.file) {
             log.debug(`Empty message: don't send it...`)
             return
           }


### PR DESCRIPTION
We have the same check on Android:
https://github.com/deltachat/deltachat-android/blob/d5f627be501dc9ad1d314b62b36708f8afa2242b/src/main/java/org/thoughtcrime/securesms/ConversationActivity.java#L1653-L1668
(though Android also shows a toast, which I think is too much).

When it comes to limiting what users can do,
there needs to be a good reason for it.
It's perhaps funny to confuse your friends
with a goofy-looking empty message, but it's only funny once.
A more common, in my eyes, use case is when the user is just fiddling
with the message input not knowing what to write and types in
just spaces or just newlines and presses "send"
expecting that this will not send the message,
like it is on basically all other messengers,
and on other Delta Chat clients.
