### PR TITLE
fix: preserve line breaks in channel dialog descr, don't center text

### DIFF
--- a/packages/frontend/src/components/ProfileInfoHeader/styles.module.scss
+++ b/packages/frontend/src/components/ProfileInfoHeader/styles.module.scss
@@ -21,6 +21,12 @@
   user-select: text;
 }
 
+.description {
+  // Copy-pasted from `.group-profile-description` and `.statusText`.
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .address {
   color: #565656;
   margin-top: 0.25rem;

--- a/packages/frontend/src/components/ProfileInfoHeader/styles.module.scss
+++ b/packages/frontend/src/components/ProfileInfoHeader/styles.module.scss
@@ -22,6 +22,7 @@
 }
 
 .description {
+  text-align: initial;
   // Copy-pasted from `.group-profile-description` and `.statusText`.
   white-space: pre-wrap;
   word-break: break-word;


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6470.

We used to also center group descriptions, but we stopped doing that in
https://github.com/deltachat/deltachat-desktop/commit/12305f4b45d3926d7678f0185c5ffaea38f04667
(https://github.com/deltachat/deltachat-desktop/pull/6168).

<img width="350" alt="image" src="https://github.com/user-attachments/assets/4b57fa2b-c58f-4f76-977f-c42979b2adb2" />
