### PR TITLE
chore: remove `target` from most `tsconfig.json`s

### DIFF
--- a/packages/e2e-tests/tsconfig.json
+++ b/packages/e2e-tests/tsconfig.json
@@ -3,7 +3,6 @@
     "noEmit": true,
     "sourceMap": true,
     "module": "nodenext",
-    "target": "ES2022",
     "allowJs": false,
     "esModuleInterop": true
   },

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -4,7 +4,6 @@
     "outDir": "../../tsc-dist/renderer",
     "sourceMap": true,
     "module": "preserve",
-    "target": "es2022",
     "jsx": "react",
     "allowJs": false,
     "esModuleInterop": true,

--- a/packages/runtime/tsconfig.json
+++ b/packages/runtime/tsconfig.json
@@ -3,7 +3,6 @@
     "rootDir": ".",
     "sourceMap": true,
     "module": "preserve",
-    "target": "es2018",
     "allowJs": false,
     "esModuleInterop": true
   }

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -3,7 +3,6 @@
     "declaration": true,
     "sourceMap": true,
     "module": "preserve",
-    "target": "es2022",
     "allowJs": false,
     "resolveJsonModule": true
   },

--- a/packages/target-browser/tsconfig.json
+++ b/packages/target-browser/tsconfig.json
@@ -3,7 +3,6 @@
     "noEmit": true,
     "sourceMap": true,
     "module": "preserve",
-    "target": "es2022",
     "lib": [],
     "allowJs": false,
     "esModuleInterop": true,

--- a/packages/target-electron/runtime-electron/tsconfig.json
+++ b/packages/target-electron/runtime-electron/tsconfig.json
@@ -3,7 +3,6 @@
     "declaration": true,
     "sourceMap": true,
     "module": "NodeNext",
-    "target": "es2022",
     "allowJs": false,
     "moduleResolution": "NodeNext"
   }

--- a/packages/target-electron/tsconfig.json
+++ b/packages/target-electron/tsconfig.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "sourceMap": true,
     "module": "esnext",
-    "target": "es2022",
+    "target": "es2025",
     "allowJs": false,
     "esModuleInterop": true,
     "moduleResolution": "bundler"

--- a/packages/target-tauri/runtime-tauri/tsconfig.json
+++ b/packages/target-tauri/runtime-tauri/tsconfig.json
@@ -3,7 +3,6 @@
     "declaration": true,
     "sourceMap": true,
     "module": "preserve",
-    "target": "es2018",
     "allowJs": false,
     "moduleResolution": "bundler"
   }

--- a/packages/target-tauri/tauri-html-email-view/tsconfig.json
+++ b/packages/target-tauri/tauri-html-email-view/tsconfig.json
@@ -3,7 +3,6 @@
     "declaration": true,
     "sourceMap": true,
     "module": "preserve",
-    "target": "es2018",
     "allowJs": false,
     "moduleResolution": "bundler"
   }

--- a/packages/target-tauri/tsconfig.json
+++ b/packages/target-tauri/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
     "useDefineForClassFields": true,
     "module": "preserve",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],

--- a/packages/target-tauri/webxdc-js-implementation/tsconfig.json
+++ b/packages/target-tauri/webxdc-js-implementation/tsconfig.json
@@ -3,7 +3,6 @@
     "declaration": true,
     "sourceMap": true,
     "module": "preserve",
-    "target": "es2018",
     "allowJs": false,
     "moduleResolution": "bundler"
   }


### PR DESCRIPTION
Since TypeScript v6, it defaults to current-year ES version:
https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#simple-default-changes

This should improve performance a little,
thanks to not polyfilling stuff.

I only kept the value for target-electron (which is run in Node).
The rest basically always runs in close-to-latest Chromium.
The only target we actually support in production is Electron,
and we keep it up to date somewhat, so yep.

I smoke-tested this.

TODO:
- [x] Merge the base