### PR TITLE
perf: JSON-RPC IPC: `.invoke` -> `.send`

### DIFF
--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -92,7 +92,7 @@ class ElectronTransport extends BaseTransport {
   }
   _send(message: yerpc.Message): void {
     const serialized = JSON.stringify(message)
-    ipcBackend.invoke('json-rpc-request', serialized)
+    ipcBackend.send('json-rpc-request', serialized)
     if (logJsonrpcConnection) {
       const sentAt = performance.now()
       idToRequestMap.set(message.id, { message, sentAt })

--- a/packages/target-electron/src/deltachat/controller.ts
+++ b/packages/target-electron/src/deltachat/controller.ts
@@ -142,7 +142,7 @@ export default class DeltaChatController {
       this.account_manager.send(JSON.stringify(message))
     })
 
-    ipcMain.handle('json-rpc-request', (_ev, message) => {
+    ipcMain.on('json-rpc-request', (_ev, message) => {
       this.account_manager.send(message)
     })
 


### PR DESCRIPTION
[`invoke` docs](https://www.electronjs.org/docs/latest/api/ipc-renderer#ipcrendererinvokechannel-args)
state:
> If you do not need a response to the message,
> consider using ipcRenderer.send.

I haven't performed measurements, but this should be better
at least in theory.
