### PR TITLE
fix: avoid horizontal scrollbar

### DIFF
--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -247,7 +247,7 @@ audio {
 // used in alert & confirmation dialogs
 p.whitespace {
   white-space: break-spaces;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 // Only for screen-readers.

--- a/packages/frontend/scss/dialogs/_qr-code.scss
+++ b/packages/frontend/scss/dialogs/_qr-code.scss
@@ -55,7 +55,7 @@
 
 .copy-content-preview {
   background-color: var(--buttonSecondaryBackground);
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   word-break: break-all;
   padding: 10px;
 }

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -122,8 +122,6 @@ $info-text-max-width: 400px;
         unicode-bidi: plaintext;
 
         overflow-wrap: break-word;
-        word-wrap: break-word;
-        word-break: break-word;
         white-space: pre-wrap;
         cursor: default;
 
@@ -215,6 +213,8 @@ $info-text-max-width: 400px;
   }
 
   .download {
+    overflow-wrap: break-word;
+
     span.failed {
       color: var(--colorDanger);
       font-weight: bold;
@@ -479,6 +479,7 @@ $info-text-max-width: 400px;
     opacity: 0.9;
     color: var(--infoMessageBubbleText);
     outline-offset: 4px;
+    overflow-wrap: break-word;
 
     .status-icon.sending {
       background-color: var(--infoMessageBubbleText);

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -24,7 +24,7 @@ $info-text-max-width: 400px;
   // Messages in the "Saved Messages" might
   // have an extra "show in chat" button
   &.has-original-msg-button {
-    --shortcut-menu-width: 110px;
+    --shortcut-menu-width: 80px;
   }
 
   & > .author-avatar {
@@ -479,7 +479,7 @@ $info-text-max-width: 400px;
     opacity: 0.9;
     color: var(--infoMessageBubbleText);
     outline-offset: 4px;
-    overflow-wrap: break-word;
+    overflow-wrap: anywhere;
 
     .status-icon.sending {
       background-color: var(--infoMessageBubbleText);

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -21,6 +21,12 @@ $info-text-max-width: 400px;
   align-items: stretch;
   max-width: 75%;
 
+  // Messages in the "Saved Messages" might
+  // have an extra "show in chat" button
+  &.has-original-msg-button {
+    --shortcut-menu-width: 110px;
+  }
+
   & > .author-avatar {
     @include mixins.button-reset;
 
@@ -79,6 +85,9 @@ $info-text-max-width: 400px;
     position: relative;
     display: inline-block;
     max-width: 100%;
+    // Flexible column: allow it to shrink below its content's intrinsic width
+    // so the fixed avatar and shortcut-menu columns always fit within the row.
+    min-width: 0;
     border-radius: 16px;
     --msg-container-padding-horizontal: 12px;
     --msg-container-padding-top: 10px;
@@ -642,7 +651,7 @@ $info-text-max-width: 400px;
     @include mixins.button-reset;
 
     display: inline-block;
-    max-width: 40vw;
+    max-width: 100%;
     font-size: 13px;
     font-weight: 300;
     line-height: 18px;

--- a/packages/frontend/src/components/ReactionsBar/useReactionsBar.ts
+++ b/packages/frontend/src/components/ReactionsBar/useReactionsBar.ts
@@ -46,7 +46,7 @@ export default function useReactionsBar(): UseReactionsBar {
 
 /** Returns true if user should be able to send reactions to a message */
 export function showReactionsUi(message: T.Message, chat: T.FullChat): boolean {
-  return chat.canSend && !message.isInfo
+  return chat.canSend && !message.isInfo && message.originalMsgId === null
 }
 
 function getMyReaction(reactions: T.Message['reactions']): string | undefined {

--- a/packages/frontend/src/components/ShortcutMenu/styles.module.scss
+++ b/packages/frontend/src/components/ShortcutMenu/styles.module.scss
@@ -4,10 +4,10 @@ $transitionDuration: 50ms;
 .shortcutMenu {
   align-items: center;
   display: flex;
-  flex: 0 0 $shortcutMenuWidth;
+  flex: 0 0 var(--shortcut-menu-width, #{$shortcutMenuWidth});
   column-gap: 4px;
   justify-content: space-between;
-  width: $shortcutMenuWidth;
+  width: var(--shortcut-menu-width, #{$shortcutMenuWidth});
 
   visibility: var(--shortcut-menu-visibility);
   opacity: var(--shortcut-menu-multiplier);

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -975,6 +975,7 @@ export default function Message(props: {
           error: status === 'error',
           forwarded: message.isForwarded,
           'has-html': hasHtml,
+          'has-original-msg-button': message.originalMsgId !== null,
         }
       )}
       id={message.id.toString()}


### PR DESCRIPTION
resolves #6483  

Mainly 2 changes: 
1. reserve space for the "show in chat" button for saved messages
2. add overflow-wrap rule for .download and info messages

Long author name in an info message with missing overflow-wrap

<img width="427" alt="image" src="https://github.com/user-attachments/assets/599f09fe-68ad-4e00-9caf-4ff5cc9b4a69" />


Note: the shortcut menu in "Saved Messages" needs a fix width of 110px - together with avatar and margins that means the width of the message could shrink down to 146px width before the small screen brakpoint hides the chatlist. Maybe acceptable since it only applies to a rare use case (only saved messages and screen width > 720 & < 900. To avoid that we would have to adapt the break points or hide the shortcut menu buttons for reactions and context menu.

Window width 721px
<img width="650"  alt="image" src="https://github.com/user-attachments/assets/54a12258-242e-41f9-832f-cd38916224e7" />
