### PR TITLE
perf: build: enable tree-shaking for main process

### DIFF
--- a/packages/target-electron/bin/build.js
+++ b/packages/target-electron/bin/build.js
@@ -22,7 +22,6 @@ await build({
     'isomorphic-ws',
   ],
   entryPoints: ['src/index.ts'],
-  treeShaking: false,
   inject: ['src/cjs-shim.ts'],
   define: {
     BUILD_INFO_JSON_STRING: `"${BuildInfoString.replace(/"/g, '\\"')}"`,


### PR DESCRIPTION
It's not clear why it was disabled,
but things seem to work fine when I try it.
