### PR TITLE
fix: unify `mailto:` logic with `force_encryption`

### DIFF
--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -5,7 +5,6 @@ import useAlertDialog from './dialog/useAlertDialog'
 import useConfirmationDialog from './dialog/useConfirmationDialog'
 import useDialog from './dialog/useDialog'
 import useInstantOnboarding from './useInstantOnboarding'
-import InvalidUnencryptedMailDialog from '../components/dialogs/InvalidUnencryptedMail'
 import useOpenMailtoLink from './useOpenMailtoLink'
 import useSecureJoin from './useSecureJoin'
 import useTranslationFunction from './useTranslationFunction'
@@ -198,9 +197,6 @@ export default function useProcessQR() {
     [openConfirmationDialog, startInstantOnboardingFlow, tx]
   )
 
-  const forceEncryption =
-    (settingsStore && settingsStore?.settings.force_encryption === '1') ?? false
-
   const multiDeviceMode =
     (settingsStore && settingsStore.settings['bcc_self'] === '1') ?? false
 
@@ -256,12 +252,7 @@ export default function useProcessQR() {
 
       // Scanned string is actually a link to an email address
       if (url.toLowerCase().startsWith('mailto:')) {
-        if (forceEncryption) {
-          // accounts that enforce encryption can't send unencrypted email
-          openDialog(InvalidUnencryptedMailDialog)
-        } else {
-          await openMailtoLink(accountId, url)
-        }
+        await openMailtoLink(accountId, url)
         return callback?.()
       }
 
@@ -456,7 +447,6 @@ export default function useProcessQR() {
       startInstantOnboarding,
       selectChat,
       multiDeviceMode,
-      forceEncryption,
       addTransportDialog,
       tx,
     ]


### PR DESCRIPTION
`openMailtoLink` already has the `force_encryption` check,
in `createChatByEmail`, so let's simplify the code a bit.

Also in practice this allows one open the chat with an existing contact
by scanning a `mailto:` link with the QR reader.

TODO:
- [x] Merge the base into main
