### PR TITLE
refactor: remove outdated comment

### DIFF
--- a/packages/frontend/src/components/MessageListView.tsx
+++ b/packages/frontend/src/components/MessageListView.tsx
@@ -19,7 +19,6 @@ export default function MessageListView({
           // Note that `key` has not always been here.
           // Some downstream components still try to support variable `chatId`.
           // To name a few:
-          // - `useDraft`'s `abortController`.
           // - `hasChatChanged` in `MessageList`.
           // - `useHasChanged2(chatId)` in `Composer`.
           //


### PR DESCRIPTION
We removed the `abortController` in
cd5ceb57f38d1bc4927dc619808ec1bc876446c3
(https://github.com/deltachat/deltachat-desktop/pull/5676).
