### PR TITLE
fix: Tauri: WebXDC: deny `tools` permission

### DIFF
--- a/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
+++ b/packages/target-tauri/src-tauri/src/webxdc/webxdc_scheme.rs
@@ -307,6 +307,7 @@ const PERMISSIONS_POLICY_DENY_ALL: &str = concat!(
     "serial=(), ",
     "sync-xhr=(), ",
     "storage-access=(), ",
+    "tools=(), ",
     "usb=(), ",
     "web-share=(), ",
     "window-management=(), ",


### PR DESCRIPTION
It was recently added
https://github.com/w3c/webappsec-permissions-policy/pull/585.
