### PR TITLE
feat: add min height for dialogs

### DIFF
--- a/packages/e2e-tests/tests/chat-context-menu.spec.ts
+++ b/packages/e2e-tests/tests/chat-context-menu.spec.ts
@@ -376,7 +376,6 @@ test.describe('Chat List Context Menu - Single Selection', () => {
       'Mute Notifications',
       'Archive Chat',
       'View Profile',
-      'Encryption Info',
       'Block Contact',
       'Delete',
     ])
@@ -398,8 +397,6 @@ test.describe('Chat List Context Menu - Single Selection', () => {
       'Mute Notifications',
       'Archive Chat',
       'View Profile',
-      'Encryption Info',
-      'Clone Chat',
       'Leave Group',
     ])
 
@@ -452,12 +449,14 @@ test.describe('Chat List Context Menu - Single Selection', () => {
     await switchToProfile(page, userA.id)
 
     await openChatListContextMenu(page, userB.name)
-    await page.getByRole('menuitem', { name: 'Encryption Info' }).click()
+    await page.getByRole('menuitem', { name: 'View Profile' }).click()
+    await page.locator('#view-profile-menu').click()
+    await page.getByTestId('encryption-info').click()
 
     // Verify encryption info dialog opens
-    await expect(page.getByRole('dialog')).toBeVisible()
-    await expect(page.getByRole('dialog')).toContainText('Encryption')
+    await expect(page.getByRole('dialog').last()).toContainText('Encryption')
 
+    await page.keyboard.press('Escape')
     await page.keyboard.press('Escape')
   })
 
@@ -467,13 +466,16 @@ test.describe('Chat List Context Menu - Single Selection', () => {
     await switchToProfile(page, userA.id)
 
     await openChatListContextMenu(page, groupName)
-    await page.getByRole('menuitem', { name: 'Clone Chat' }).click()
+    await page.getByRole('menuitem', { name: 'View Profile' }).click()
+    await page.getByTestId('view-group-menu').click()
+    await page.getByTestId('clone-chat').click()
 
-    // Verify clone chat dialog opens
-    await expect(page.getByRole('dialog')).toBeVisible()
-    // The clone dialog should show create group interface
+    // Verify clone chat dialog opens,
     await expect(page.locator('.group-name-input')).toBeVisible()
+    // it should show the create group interface
 
+    // close clone dialog and group profile dialog
+    await page.keyboard.press('Escape')
     await page.keyboard.press('Escape')
   })
 })

--- a/packages/e2e-tests/tests/chat-context-menu.spec.ts
+++ b/packages/e2e-tests/tests/chat-context-menu.spec.ts
@@ -472,7 +472,6 @@ test.describe('Chat List Context Menu - Single Selection', () => {
 
     // Verify clone chat dialog opens,
     await expect(page.locator('.group-name-input')).toBeVisible()
-    // it should show the create group interface
 
     // close clone dialog and group profile dialog
     await page.keyboard.press('Escape')

--- a/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/chat-list-multiselect.spec.ts
@@ -440,8 +440,6 @@ test.describe('context menu', () => {
       'Mute Notifications',
       'Archive Chat',
       'View Profile',
-      'Encryption Info',
-      'Clone Chat',
       'Leave Group',
     ])
     await page.keyboard.press('Escape')

--- a/packages/e2e-tests/tests/group-tests.spec.ts
+++ b/packages/e2e-tests/tests/group-tests.spec.ts
@@ -801,6 +801,33 @@ test('add channel description and verify subscriber sees it', async () => {
   await page.keyboard.press('Escape')
 })
 
+test('channel profile three-dot menu shows encryption info', async () => {
+  const userB = existingProfiles[1]
+
+  // userB is a subscriber, so opening the channel
+  // profile shows the MailingListProfile dialog
+  await switchToProfile(page, userB.id)
+  const channelChatItemB = page
+    .locator('.chat-list .chat-list-item')
+    .filter({ hasText: channelName })
+  await expect(channelChatItemB).toBeVisible()
+  await channelChatItemB.click()
+
+  await page.getByTestId('chat-info-button').click()
+
+  // Open the three-dot menu and pick "Encryption Info"
+  await page.getByTestId('mailing-list-profile-menu').click()
+  await page.getByTestId('encryption-info').click({ force: true })
+
+  const encryptionInfoDialog = page
+    .getByRole('dialog')
+    .filter({ hasText: 'Encryption Info' })
+  await expect(encryptionInfoDialog).toBeVisible()
+
+  await page.keyboard.press('Escape')
+  await page.keyboard.press('Escape')
+})
+
 test('channel main view shows Leave Channel instead of Delete Chat', async () => {
   const userB = existingProfiles[1]
 

--- a/packages/e2e-tests/tests/group-tests.spec.ts
+++ b/packages/e2e-tests/tests/group-tests.spec.ts
@@ -403,7 +403,8 @@ test('Edit group profile from context menu and rename group', async () => {
   // click edit group item
   await page.getByTestId('edit-group').click({ force: true })
   // open edit group profile dialog
-  await page.getByTestId('view-group-dialog-header-edit').click()
+  await page.getByTestId('view-group-menu').click()
+  await page.getByTestId('view-group-edit').click()
   await page.locator('#groupname').fill(groupName + ' edited')
   await page.getByTestId('ok').click()
   await expect(page.locator('.styles_module_displayName')).toHaveText(
@@ -435,7 +436,8 @@ test('Add group description', async () => {
   const descriptionDiv = page.locator('.group-profile-description')
 
   // Open edit dialog
-  await page.getByTestId('view-group-dialog-header-edit').click()
+  await page.getByTestId('view-group-menu').click()
+  await page.getByTestId('view-group-edit').click()
 
   // Add description
   await page.locator('#description').fill(groupDescription)
@@ -508,7 +510,8 @@ test('Update group description', async () => {
   await page.getByTestId('chat-info-button').click()
 
   // Open edit dialog
-  await page.getByTestId('view-group-dialog-header-edit').click()
+  await page.getByTestId('view-group-menu').click()
+  await page.getByTestId('view-group-edit').click()
 
   // Update description
   const descriptionInput = page.locator('#description')
@@ -566,7 +569,8 @@ test('Clear group description', async () => {
   await expect(descriptionDiv).toBeVisible()
 
   // Open edit dialog
-  await page.getByTestId('view-group-dialog-header-edit').click()
+  await page.getByTestId('view-group-menu').click()
+  await page.getByTestId('view-group-edit').click()
 
   // Clear description
   const descriptionInput = page.locator('#description')
@@ -752,7 +756,8 @@ test('add channel description and verify subscriber sees it', async () => {
   await channelChatItem.click()
 
   await page.getByTestId('chat-info-button').click()
-  await page.getByTestId('view-group-dialog-header-edit').click()
+  await page.getByTestId('view-group-menu').click()
+  await page.getByTestId('view-group-edit').click()
 
   await page.locator('#description').fill(channelDescription)
   await page.getByTestId('ok').click()

--- a/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
+++ b/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
@@ -220,7 +220,7 @@ test('check group dialog for unencrypted group has appropriate entries', async (
   await expect(dialog.locator('#showqrcode')).not.toBeVisible({ timeout: 1 })
 
   await dialog.getByTestId('view-group-menu').click()
-  // The three-dot menu should not show have an "Edit" entry for unencrypted groups.
+  // The three-dot menu should not have an "Edit" entry for unencrypted groups.
   await expect(page.getByTestId('view-group-edit')).not.toBeVisible({
     timeout: 1,
   })

--- a/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
+++ b/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
@@ -215,12 +215,17 @@ test('check group dialog for unencrypted group has appropriate entries', async (
   ).not.toBeVisible({ timeout: 1 })
   await expect(dialog.locator('#addmember')).not.toBeVisible({ timeout: 1 })
   await expect(
-    dialog.getByTestId('view-group-dialog-header-edit')
-  ).not.toBeVisible({ timeout: 1 })
-  await expect(
     dialog.getByRole('button', { name: 'QR Invite Code' })
   ).not.toBeVisible({ timeout: 1 })
   await expect(dialog.locator('#showqrcode')).not.toBeVisible({ timeout: 1 })
+
+  await dialog.getByTestId('view-group-menu').click()
+  // The three-dot menu should not show have an "Edit" entry for unencrypted groups.
+  await expect(page.getByTestId('view-group-edit')).not.toBeVisible({
+    timeout: 1,
+  })
+  await expect(page.getByTestId('encryption-info')).toBeVisible()
+  await page.keyboard.press('Escape')
 
   await page.getByTestId('view-group-dialog-header-close').click()
 })
@@ -238,7 +243,7 @@ test('chat list item context menu', async () => {
   await expect(
     page.getByRole('menuitem', { name: 'Leave Group' })
   ).not.toBeVisible()
-  await expect(page.getByRole('menuitem')).toHaveCount(7)
+  await expect(page.getByRole('menuitem')).toHaveCount(5)
 
   await page.getByRole('menuitem').first().press('Escape')
   await expect(page.getByRole('menuitem')).not.toBeVisible()

--- a/packages/frontend/scss/dialogs/_group-styles.scss
+++ b/packages/frontend/scss/dialogs/_group-styles.scss
@@ -85,3 +85,13 @@ input.group-name-input {
   word-break: break-word;
   user-select: text;
 }
+
+.group-member-filter {
+  padding-block: 0 10px;
+  padding-inline: 20px 10px;
+  margin-top: 10px;
+  position: relative;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--separatorColor);
+}

--- a/packages/frontend/scss/dialogs/_group-styles.scss
+++ b/packages/frontend/scss/dialogs/_group-styles.scss
@@ -86,7 +86,8 @@ input.group-name-input {
   user-select: text;
 }
 
-.group-member-filter {
+.group-member-filter,
+.group-member-filter-no-result {
   padding-block: 0 10px;
   padding-inline: 20px 10px;
   margin-top: 10px;
@@ -94,4 +95,8 @@ input.group-name-input {
   display: flex;
   align-items: center;
   border-bottom: 1px solid var(--separatorColor);
+}
+
+.group-member-filter-no-result {
+  margin-bottom: 20px;
 }

--- a/packages/frontend/src/components/Dialog/Dialog.tsx
+++ b/packages/frontend/src/components/Dialog/Dialog.tsx
@@ -25,6 +25,9 @@ type Props = React.PropsWithChildren<{
   className?: string
   fixed?: boolean
   height?: number
+  /** lower bound for the dialog height in px. Unlike {@linkcode height} this
+   * still lets the dialog grow with its content (up to its `max-height`). */
+  minHeight?: number
   width?: number
   // takes full screen and is transparent
   unstyled?: boolean
@@ -47,6 +50,7 @@ const Dialog = React.memo<Props>(
     backdropDragAreaOnTauriRuntime,
     width = DEFAULT_WIDTH,
     height,
+    minHeight,
     unstyled = false,
     allowDefaultFocus = false,
     noTopPadding = false,
@@ -126,6 +130,7 @@ const Dialog = React.memo<Props>(
       style = {
         width: width && `${width}px`,
         height: height && `${height}px`,
+        minHeight: minHeight && `${minHeight}px`,
       }
     }
     return (

--- a/packages/frontend/src/components/chat/ChatContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatContextMenu.tsx
@@ -305,7 +305,6 @@ export function useChatContextMenu(): {
     openDeleteChatsDialog,
     openLeaveGroupOrChannelDialog,
     openClearChatDialog,
-    openEncryptionInfoDialog,
   } = useChatDialog()
   const openViewGroupDialog = useOpenViewGroupDialog()
   const openViewProfileDialog = useOpenViewProfileDialog()
@@ -506,19 +505,6 @@ export function useChatContextMenu(): {
       archive,
       { type: 'separator' },
       ...(!isMainView ? viewEditMenuItems : []),
-      // Encryption info for channels and mailing lists
-      // since they don't expose it through the ViewGroup menu
-      isMainView &&
-        relatedChat &&
-        (relatedChat.chatType === 'InBroadcast' ||
-          relatedChat.chatType === 'Mailinglist') && {
-          label: tx('encryption_info_title_desktop'),
-          action: () =>
-            openEncryptionInfoDialog({
-              chatId: relatedChat.id,
-              dmChatContact: null,
-            }),
-        },
       // Clone Group
       isMainView &&
         relatedChat &&

--- a/packages/frontend/src/components/chat/ChatContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatContextMenu.tsx
@@ -284,33 +284,6 @@ function buildViewEditMenuItems(
 }
 
 /**
- * Builds encryption info menu item
- */
-function buildEncryptionInfoMenuItem(
-  fullChat: T.FullChat,
-  tx: ReturnType<typeof useTranslationFunction>,
-  openEncryptionInfoDialog: ReturnType<
-    typeof useChatDialog
-  >['openEncryptionInfoDialog']
-): ContextMenuItem | false {
-  return (
-    !fullChat.isDeviceChat &&
-    !fullChat.isSelfTalk && {
-      label: tx('encryption_info_title_desktop'),
-      action: () =>
-        openEncryptionInfoDialog({
-          chatId: fullChat.id,
-          // https://github.com/chatmail/core/blob/a3328ea2de1e675b1418b4e2ca0c23f88828c558/deltachat-jsonrpc/src/api/types/chat_list.rs#L130-L146
-          dmChatContact:
-            fullChat.chatType === 'Single' && fullChat.contactIds.length > 0
-              ? fullChat.contactIds[0]
-              : null,
-        }),
-    }
-  )
-}
-
-/**
  * provides a context menu for chat list items
  * and for the 3dot menu in main chat view
  */
@@ -329,7 +302,6 @@ export function useChatContextMenu(): {
   const { openDialog } = useDialog()
   const {
     openBlockFirstContactOfChatDialog,
-    openEncryptionInfoDialog,
     openDeleteChatsDialog,
     openLeaveGroupOrChannelDialog,
     openClearChatDialog,
@@ -475,13 +447,6 @@ export function useChatContextMenu(): {
             tx
           )
 
-    // Encryption info is only shown in chatlist and
-    // only if a single chat is selected
-    const encryptionInfoItem =
-      relatedChat !== undefined
-        ? buildEncryptionInfoMenuItem(relatedChat, tx, openEncryptionInfoDialog)
-        : null
-
     const ephemeralMessagesMenuItem = isMainView &&
       relatedChat &&
       relatedChat.canSend &&
@@ -540,9 +505,9 @@ export function useChatContextMenu(): {
       archive,
       { type: 'separator' },
       ...(!isMainView ? viewEditMenuItems : []),
-      !isMainView && encryptionInfoItem,
       // Clone Group
-      relatedChat &&
+      isMainView &&
+        relatedChat &&
         isGroup && {
           label: tx('clone_chat'),
           action: () => {

--- a/packages/frontend/src/components/chat/ChatContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatContextMenu.tsx
@@ -305,6 +305,7 @@ export function useChatContextMenu(): {
     openDeleteChatsDialog,
     openLeaveGroupOrChannelDialog,
     openClearChatDialog,
+    openEncryptionInfoDialog,
   } = useChatDialog()
   const openViewGroupDialog = useOpenViewGroupDialog()
   const openViewProfileDialog = useOpenViewProfileDialog()
@@ -505,6 +506,19 @@ export function useChatContextMenu(): {
       archive,
       { type: 'separator' },
       ...(!isMainView ? viewEditMenuItems : []),
+      // Encryption info for channels and mailing lists
+      // since they don't expose it through the ViewGroup menu
+      isMainView &&
+        relatedChat &&
+        (relatedChat.chatType === 'InBroadcast' ||
+          relatedChat.chatType === 'Mailinglist') && {
+          label: tx('encryption_info_title_desktop'),
+          action: () =>
+            openEncryptionInfoDialog({
+              chatId: relatedChat.id,
+              dmChatContact: null,
+            }),
+        },
       // Clone Group
       isMainView &&
         relatedChat &&

--- a/packages/frontend/src/components/dialogs/MailingListProfile.tsx
+++ b/packages/frontend/src/components/dialogs/MailingListProfile.tsx
@@ -1,6 +1,7 @@
-import React from 'react'
+import React, { useContext } from 'react'
 
 import Dialog, { DialogBody, DialogContent, DialogHeader } from '../Dialog'
+import HeaderButton from '../Dialog/HeaderButton'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
 
 import { type T } from '@deltachat/jsonrpc-client'
@@ -9,6 +10,9 @@ import ProfileInfoHeader from '../ProfileInfoHeader'
 import { shouldDisableClickForFullscreen } from '../Avatar'
 import { BackendRemote } from '../../backend-com'
 import { useRpcFetch } from '../../hooks/useFetch'
+import { ContextMenuItem } from '../ContextMenu'
+import { ContextMenuContext } from '../../contexts/ContextMenuContext'
+import useChatDialog from '../../hooks/chat/useChatDialog'
 
 /**
  * This dialog is used to display the profile of a mailing list
@@ -30,6 +34,8 @@ export default function MailingListProfile(
 
   const tx = useTranslationFunction()
 
+  const onClickMenu = useMailingListProfileMenu(chat)
+
   const descriptionFetch = useRpcFetch(
     BackendRemote.rpc.getChatDescription,
     chat.chatType === 'InBroadcast' ? [accountId, chat.id] : null
@@ -43,7 +49,16 @@ export default function MailingListProfile(
 
   return (
     <Dialog onClose={onClose} fixed>
-      <DialogHeader title={title} onClose={onClose} />
+      <DialogHeader title={title} onClose={onClose}>
+        <HeaderButton
+          id='mailing-list-profile-menu'
+          data-testid='mailing-list-profile-menu'
+          onClick={onClickMenu}
+          icon='more_vert'
+          iconSize={24}
+          aria-label={tx('menu_more_options')}
+        />
+      </DialogHeader>
       <DialogBody>
         <DialogContent>
           <ProfileInfoHeader
@@ -58,4 +73,36 @@ export default function MailingListProfile(
       </DialogBody>
     </Dialog>
   )
+}
+
+/**
+ * Three-dot menu for the mailing list / channel (recipient side) profile.
+ * just to be consistent with other profiles, although the menu has only one item
+ */
+function useMailingListProfileMenu(chat: T.BasicChat) {
+  const { openContextMenu } = useContext(ContextMenuContext)
+  const { openEncryptionInfoDialog } = useChatDialog()
+  const tx = useTranslationFunction()
+
+  const menu: (ContextMenuItem | false)[] = [
+    {
+      label: tx('encryption_info_title_desktop'),
+      action: () =>
+        openEncryptionInfoDialog({ chatId: chat.id, dmChatContact: null }),
+      dataTestid: 'encryption-info',
+    },
+  ]
+
+  return (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    const boundingBox = event.currentTarget.getBoundingClientRect()
+
+    const [x, y] = [boundingBox.x + 3, boundingBox.y + boundingBox.height - 2]
+    event.preventDefault() // prevent default runtime context menu from opening
+
+    openContextMenu({
+      x,
+      y,
+      items: menu,
+    })
+  }
 }

--- a/packages/frontend/src/components/dialogs/ViewGroup/GroupSearchInput.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/GroupSearchInput.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useRef } from 'react'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+import Icon from '../../Icon'
+
+import styles from './styles.module.scss'
+
+type Props = {
+  onChange: (value: string) => void
+  value: string
+  id: string
+  /** called when the user closes the filter input */
+  onCollapse: () => void
+}
+
+/**
+ * Text input to filter the member list of the group profile dialog.
+ *
+ * The X button clears the input, or closes it if it is already empty.
+ */
+export default function GroupSearchInput(props: Props) {
+  const tx = useTranslationFunction()
+  const { onChange, value, id, onCollapse } = props
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const hasValue = value.length > 0
+
+  return (
+    <div className={styles.searchInputContainer}>
+      <input
+        id={id}
+        placeholder={tx('search')}
+        aria-label={tx('search')}
+        onChange={event => onChange(event.target.value)}
+        value={value}
+        className={styles.searchInput}
+        data-no-drag-region
+        ref={inputRef}
+        spellCheck={false}
+      />
+      <button
+        type='button'
+        aria-label={hasValue ? tx('clear_search') : tx('close')}
+        className={styles.searchInputButton}
+        data-no-drag-region
+        onClick={() => {
+          if (hasValue) {
+            onChange('')
+          } else {
+            onCollapse()
+          }
+        }}
+      >
+        <Icon className={styles.searchInputButtonIcon} icon='cross' size={20} />
+      </button>
+    </div>
+  )
+}

--- a/packages/frontend/src/components/dialogs/ViewGroup/ViewGroupMenu.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/ViewGroupMenu.tsx
@@ -1,0 +1,75 @@
+import React, { useContext } from 'react'
+import type { T } from '@deltachat/jsonrpc-client'
+
+import { ContextMenuItem } from '../../ContextMenu'
+import { ContextMenuContext } from '../../../contexts/ContextMenuContext'
+import { CloneChat } from '../CreateChat'
+import useChatDialog from '../../../hooks/chat/useChatDialog'
+import useDialog from '../../../hooks/dialog/useDialog'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+
+export default function useViewGroupMenu({
+  chat,
+  allowEdit,
+  isBroadcast,
+  onClickEdit,
+  showMemberFilter,
+  onShowMemberFilter,
+}: {
+  chat: T.FullChat
+  allowEdit: boolean
+  isBroadcast: boolean
+  onClickEdit: () => void
+  showMemberFilter: boolean
+  onShowMemberFilter: () => void
+}) {
+  const { openContextMenu } = useContext(ContextMenuContext)
+  const { openEncryptionInfoDialog } = useChatDialog()
+  const { openDialog } = useDialog()
+  const tx = useTranslationFunction()
+
+  const menu: (ContextMenuItem | false)[] = [
+    allowEdit && {
+      label: tx('global_menu_edit_desktop'),
+      action: onClickEdit,
+      dataTestid: 'view-group-edit',
+    },
+    !showMemberFilter && {
+      label: tx('search'),
+      action: onShowMemberFilter,
+      dataTestid: 'show-member-filter',
+    },
+    {
+      type: 'separator',
+    },
+    {
+      label: tx('encryption_info_title_desktop'),
+      action: () =>
+        openEncryptionInfoDialog({ chatId: chat.id, dmChatContact: null }),
+      dataTestid: 'encryption-info',
+    },
+    !isBroadcast && {
+      label: tx('clone_chat'),
+      action: () => {
+        openDialog(CloneChat, {
+          setViewMode: 'createGroup',
+          chatTemplateId: chat.id,
+        })
+      },
+      dataTestid: 'clone-chat',
+    },
+  ]
+
+  return (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+    const boundingBox = event.currentTarget.getBoundingClientRect()
+
+    const [x, y] = [boundingBox.x + 3, boundingBox.y + boundingBox.height - 2]
+    event.preventDefault() // prevent default runtime context menu from opening
+
+    openContextMenu({
+      x,
+      y,
+      items: menu,
+    })
+  }
+}

--- a/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useState, useRef } from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useRef,
+} from 'react'
 import { parseAndRenderMessage } from '../../message/MessageParser'
 import { C } from '@deltachat/jsonrpc-client'
 import type { T } from '@deltachat/jsonrpc-client'
@@ -60,9 +66,26 @@ export default function ViewGroup(
   } & DialogProps
 ) {
   const { chat, onClose } = props
+
+  // Freeze the dialog height to avoid resizing when filtering the member list
+  // It is reset to `undefined` when the filter is closed.
+  const [dialogMinHeight, setDialogMinHeight] = useState<number | undefined>(
+    undefined
+  )
+
   return (
-    <Dialog width={400} onClose={onClose} fixed dataTestid='view-group-dialog'>
-      <ViewGroupInner onClose={onClose} chat={chat} />
+    <Dialog
+      width={400}
+      minHeight={dialogMinHeight}
+      onClose={onClose}
+      fixed
+      dataTestid='view-group-dialog'
+    >
+      <ViewGroupInner
+        onClose={onClose}
+        chat={chat}
+        setDialogMinHeight={setDialogMinHeight}
+      />
     </Dialog>
   )
 }
@@ -262,9 +285,12 @@ function ViewGroupInner(
     chat: T.FullChat & {
       chatType: 'Group' | 'OutBroadcast'
     }
+    // Sets a lower bound for the dialog height while the
+    // member filter is open (pass `undefined` to remove it again).
+    setDialogMinHeight: (height: number | undefined) => void
   } & DialogProps
 ) {
-  const { chat, onClose } = props
+  const { chat, onClose, setDialogMinHeight } = props
   const isBroadcast = chat.chatType === 'OutBroadcast'
   const { openDialog } = useDialog()
   const accountId = selectedAccountId()
@@ -294,6 +320,28 @@ function ViewGroupInner(
 
   const [showMemberFilter, setShowMemberFilter] = useState(false)
 
+  const openMemberFilter = useCallback(() => {
+    setShowMemberFilter(true)
+  }, [])
+
+  const closeMemberFilter = useCallback(() => {
+    setShowMemberFilter(false)
+    setMemberFilter('')
+    setDialogMinHeight(undefined)
+  }, [setDialogMinHeight])
+
+  // Freeze the dialog height while the member filter is open,
+  // so it doesn't shrink when the member list gets shorter
+  useLayoutEffect(() => {
+    if (!showMemberFilter) {
+      return
+    }
+    const dialogEl = groupMemberContactListWrapperRef.current?.closest('dialog')
+    if (dialogEl) {
+      setDialogMinHeight(dialogEl.offsetHeight)
+    }
+  }, [showMemberFilter, setDialogMinHeight])
+
   // Open the member filter with Ctrl+F (Cmd+F on macOS)
   // The global keybinding handler is disabled while a dialog is open
   useEffect(() => {
@@ -321,12 +369,12 @@ function ViewGroupInner(
       }
 
       ev.preventDefault()
-      setShowMemberFilter(true)
+      openMemberFilter()
     }
 
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [])
+  }, [openMemberFilter])
 
   const showRemoveGroupMemberConfirmationDialog = useCallback(
     async (contact: T.Contact) => {
@@ -421,7 +469,7 @@ function ViewGroupInner(
     isBroadcast,
     onClickEdit,
     showMemberFilter,
-    onShowMemberFilter: () => setShowMemberFilter(true),
+    onShowMemberFilter: openMemberFilter,
   })
 
   const filterContacts = useCallback(
@@ -486,10 +534,7 @@ function ViewGroupInner(
               id='group-member-filter'
               onChange={setMemberFilter}
               value={memberFilter}
-              onCollapse={() => {
-                setShowMemberFilter(false)
-                setMemberFilter('')
-              }}
+              onCollapse={closeMemberFilter}
             />
           </div>
         )}

--- a/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
@@ -298,7 +298,7 @@ function ViewGroupInner(
   // The global keybinding handler is disabled while a dialog is open
   useEffect(() => {
     const onKeyDown = (ev: KeyboardEvent) => {
-      // copied from
+      // copied from `keybindings.ts`
       const { isMac } = runtime.getRuntimeInfo()
       const modifierPressed = isMac ? ev.metaKey && !ev.ctrlKey : ev.ctrlKey
       if (

--- a/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
@@ -493,6 +493,11 @@ function ViewGroupInner(
             />
           </div>
         )}
+        {filterContacts(groupContacts).length === 0 && memberFilter !== '' && (
+          <div className='group-member-filter-no-result'>
+            {tx('search_no_result_for_x', memberFilter)}
+          </div>
+        )}
         <div
           className='group-member-contact-list-wrapper'
           ref={groupMemberContactListWrapperRef}
@@ -547,7 +552,7 @@ function ViewGroupInner(
             aria-busy
           ></div>
         )}
-        {pastContacts.length > 0 && (
+        {filterContacts(pastContacts).length > 0 && (
           <>
             <div id='view-group-past-members-title' className='group-separator'>
               {tx('past_members')}

--- a/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
@@ -1,40 +1,45 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react'
-import { parseAndRenderMessage } from '../message/MessageParser'
+import { parseAndRenderMessage } from '../../message/MessageParser'
 import { C } from '@deltachat/jsonrpc-client'
 import type { T } from '@deltachat/jsonrpc-client'
 
-import { QrCodeShowQrInner } from './QrCode'
-import { ContactList } from '../contact/ContactList'
+import { QrCodeShowQrInner } from '../QrCode'
+import { ContactList } from '../../contact/ContactList'
 import {
   PseudoListItemShowQrCode,
   PseudoListItemAddMember,
-} from '../helpers/PseudoListItem'
-import ViewProfile from './ViewProfile'
+} from '../../helpers/PseudoListItem'
+import ViewProfile from '../ViewProfile'
 import { avatarInitial } from '@deltachat-desktop/shared/avatarInitial'
-import { shouldDisableClickForFullscreen as shouldDisableFullscreenAvatar } from '../Avatar'
-import { DeltaInput, DeltaTextarea } from '../Login-Styles'
-import { BackendRemote, onDCEvent } from '../../backend-com'
-import { selectedAccountId } from '../../ScreenController'
+import { shouldDisableClickForFullscreen as shouldDisableFullscreenAvatar } from '../../Avatar'
+import { DeltaInput, DeltaTextarea } from '../../Login-Styles'
+import { BackendRemote, onDCEvent } from '../../../backend-com'
+import { selectedAccountId } from '../../../ScreenController'
 import Dialog, {
   DialogBody,
   DialogContent,
   DialogHeader,
   OkCancelFooterAction,
-} from '../Dialog'
-import useConfirmationDialog from '../../hooks/dialog/useConfirmationDialog'
-import useDialog from '../../hooks/dialog/useDialog'
-import useTranslationFunction from '../../hooks/useTranslationFunction'
-import { LastUsedSlot } from '../../utils/lastUsedPaths'
-import ProfileInfoHeader from '../ProfileInfoHeader'
-import ImageSelector from '../ImageSelector'
-import { modifyGroup } from '../../backend/group'
+} from '../../Dialog'
+import HeaderButton from '../../Dialog/HeaderButton'
+import useConfirmationDialog from '../../../hooks/dialog/useConfirmationDialog'
+import useDialog from '../../../hooks/dialog/useDialog'
+import useTranslationFunction from '../../../hooks/useTranslationFunction'
+import { LastUsedSlot } from '../../../utils/lastUsedPaths'
+import ProfileInfoHeader from '../../ProfileInfoHeader'
+import ImageSelector from '../../ImageSelector'
+import { modifyGroup } from '../../../backend/group'
 
-import type { DialogProps } from '../../contexts/DialogContext'
-import ImageCropper from '../ImageCropper'
-import { AddMemberDialog } from './AddMember/AddMemberDialog'
-import { RovingTabindexProvider } from '../../contexts/RovingTabindex'
-import { copyToBlobDir } from '../../utils/copyToBlobDir'
-import AlertDialog from './AlertDialog'
+import type { DialogProps } from '../../../contexts/DialogContext'
+import ImageCropper from '../../ImageCropper'
+import { AddMemberDialog } from '../AddMember/AddMemberDialog'
+import { RovingTabindexProvider } from '../../../contexts/RovingTabindex'
+import { copyToBlobDir } from '../../../utils/copyToBlobDir'
+import AlertDialog from '../AlertDialog'
+import GroupSearchInput from './GroupSearchInput'
+import useViewGroupMenu from './ViewGroupMenu'
+import { matchesLetterShortcut } from '../../../keybindings'
+import { runtime } from '@deltachat-desktop/runtime-interface'
 import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 const log = getLogger('ViewGroup')
@@ -271,6 +276,8 @@ function ViewGroupInner(
   const groupMemberContactListWrapperRef = useRef<HTMLDivElement>(null)
   const groupPastMemberContactListWrapperRef = useRef<HTMLDivElement>(null)
 
+  const [memberFilter, setMemberFilter] = useState('')
+
   const {
     group,
     groupName,
@@ -284,6 +291,42 @@ function ViewGroupInner(
     removeMember,
     setGroupImage,
   } = useGroup(accountId, chat)
+
+  const [showMemberFilter, setShowMemberFilter] = useState(false)
+
+  // Open the member filter with Ctrl+F (Cmd+F on macOS)
+  // The global keybinding handler is disabled while a dialog is open
+  useEffect(() => {
+    const onKeyDown = (ev: KeyboardEvent) => {
+      // copied from
+      const { isMac } = runtime.getRuntimeInfo()
+      const modifierPressed = isMac ? ev.metaKey && !ev.ctrlKey : ev.ctrlKey
+      if (
+        ev.repeat ||
+        ev.isComposing ||
+        ev.shiftKey ||
+        !modifierPressed ||
+        !matchesLetterShortcut(ev, 'f')
+      ) {
+        return
+      }
+
+      // to be specific, only react when this
+      // dialog is the topmost modal dialog
+      const dialogEl =
+        groupMemberContactListWrapperRef.current?.closest('dialog')
+      const modals = document.querySelectorAll('dialog:modal')
+      if (!dialogEl || modals[modals.length - 1] !== dialogEl) {
+        return
+      }
+
+      ev.preventDefault()
+      setShowMemberFilter(true)
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   const showRemoveGroupMemberConfirmationDialog = useCallback(
     async (contact: T.Contact) => {
@@ -372,23 +415,46 @@ function ViewGroupInner(
     [onClose, openDialog]
   )
 
+  const onClickViewGroupMenu = useViewGroupMenu({
+    chat,
+    allowEdit,
+    isBroadcast,
+    onClickEdit,
+    showMemberFilter,
+    onShowMemberFilter: () => setShowMemberFilter(true),
+  })
+
+  const filterContacts = useCallback(
+    (contacts: T.Contact[]) => {
+      if (!showMemberFilter || memberFilter === '') {
+        return contacts
+      }
+      const needle = memberFilter.toLowerCase()
+      return contacts.filter(
+        contact =>
+          contact.displayName.toLowerCase().includes(needle) ||
+          contact.address.toLowerCase().includes(needle)
+      )
+    },
+    [showMemberFilter, memberFilter]
+  )
+
   return (
     <>
-      {allowEdit && (
-        <DialogHeader
-          title={!isBroadcast ? tx('tab_group') : tx('channel')}
-          onClickEdit={onClickEdit}
-          onClose={onClose}
-          dataTestid='view-group-dialog-header'
+      <DialogHeader
+        title={!isBroadcast ? tx('tab_group') : tx('channel')}
+        onClose={onClose}
+        dataTestid='view-group-dialog-header'
+      >
+        <HeaderButton
+          id='view-group-menu'
+          data-testid='view-group-menu'
+          onClick={onClickViewGroupMenu}
+          icon='more_vert'
+          iconSize={24}
+          aria-label={tx('menu_more_options')}
         />
-      )}
-      {!allowEdit && (
-        <DialogHeader
-          title={tx('tab_group')}
-          onClose={onClose}
-          dataTestid='view-group-dialog-header'
-        />
-      )}
+      </DialogHeader>
       <DialogBody>
         <DialogContent>
           <ProfileInfoHeader
@@ -414,6 +480,19 @@ function ViewGroupInner(
             </div>
           )}
         </DialogContent>
+        {showMemberFilter && (
+          <div className='group-member-filter'>
+            <GroupSearchInput
+              id='group-member-filter'
+              onChange={setMemberFilter}
+              value={memberFilter}
+              onCollapse={() => {
+                setShowMemberFilter(false)
+                setMemberFilter('')
+              }}
+            />
+          </div>
+        )}
         <div
           className='group-member-contact-list-wrapper'
           ref={groupMemberContactListWrapperRef}
@@ -422,7 +501,7 @@ function ViewGroupInner(
           <RovingTabindexProvider
             wrapperElementRef={groupMemberContactListWrapperRef}
           >
-            {!chatDisabled && group.isEncrypted && (
+            {!chatDisabled && group.isEncrypted && memberFilter === '' && (
               <>
                 {!isBroadcast && (
                   <PseudoListItemAddMember
@@ -443,7 +522,7 @@ function ViewGroupInner(
               ></div>
             )}
             <ContactList
-              contacts={groupContacts}
+              contacts={filterContacts(groupContacts)}
               showRemove={!chatDisabled && group.isEncrypted}
               onClick={contact => {
                 if (contact.id === C.DC_CONTACT_ID_SELF) {
@@ -481,7 +560,7 @@ function ViewGroupInner(
                 wrapperElementRef={groupPastMemberContactListWrapperRef}
               >
                 <ContactList
-                  contacts={pastContacts}
+                  contacts={filterContacts(pastContacts)}
                   showRemove={false}
                   onClick={contact => {
                     if (contact.id === C.DC_CONTACT_ID_SELF) {

--- a/packages/frontend/src/components/dialogs/ViewGroup/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/ViewGroup/styles.module.scss
@@ -1,0 +1,41 @@
+$borderRadius: 10px;
+$closeButtonSize: 30px;
+
+.searchInputContainer {
+  position: relative;
+  display: flex;
+  flex: 1;
+  width: 100%;
+  align-items: center;
+}
+
+.searchInput {
+  border: 0;
+  margin: 0;
+  caret-color: var(--colorPrimary);
+  flex: 1;
+  font-size: 14px;
+  height: $closeButtonSize;
+  padding: 0;
+  width: 100%;
+  outline: none;
+  background-color: transparent;
+}
+
+.searchInputButton {
+  align-items: center;
+  background-color: transparent;
+  border-radius: $borderRadius;
+  border: 0;
+  display: flex;
+  height: $closeButtonSize;
+  justify-content: center;
+  padding: 0;
+  min-width: $closeButtonSize;
+  position: absolute;
+  inset-inline-end: 0;
+}
+
+.searchInputButtonIcon {
+  background-color: currentcolor;
+}


### PR DESCRIPTION
- freeze the min height to avoid too frequent resizing
- release it again when resizing is wanted

The idea is to freeze the dynamic dialog height when resizing is unwanted by setting the new prop minHeight in dialogs 

See https://github.com/deltachat/deltachat-desktop/pull/6456#issuecomment-4793117466

This could also be used for the contact list, where search/filtering is also happening