### PR TITLE
test: if basic-tests fails, don't fail other tests

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -4,6 +4,7 @@ import {
   getUser,
   createProfiles,
   deleteProfile,
+  deleteAllProfiles,
   switchToProfile,
   User,
   loadExistingProfiles,
@@ -65,8 +66,18 @@ test.afterEach(async () => {
   }
 })
 
-test.afterAll(async () => {
+// We have the "delete profiles" test, but it won't run
+// if some other test fails, so let's ensure to deleteAllProfiles still.
+test.afterAll(async ({ browser }) => {
   await page?.close()
+
+  const context = await browser.newContext()
+  const pageForProfileDeletion = await context.newPage()
+  await reloadPage(pageForProfileDeletion)
+  existingProfiles =
+    (await loadExistingProfiles(pageForProfileDeletion)) ?? existingProfiles
+  await deleteAllProfiles(pageForProfileDeletion, existingProfiles)
+  await context.close()
 })
 
 test('create profiles', async ({ browserName, isChatmail }) => {


### PR DESCRIPTION
What usually happens is that if "edit message" test runs
but some test after that fails, then accounts won't be deleted.
Instead they will be reused by other tests.
Then "clear chat removes messages" will also fail,
because it expects 2 messages in the chat,
but the chat would contain messages from the `basic-tests`.
