### PR TITLE
refactor: fix linter warning for `appListUrl`, remove dead class name

### DIFF
--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -103,7 +103,7 @@ export function AppPicker({ onAppSelected }: Props) {
     )
     const apps = getJsonFromBase64(response.blob) as AppInfo[]
     if (apps == null) {
-      throw new Error(`Received \`null\` response from ${appStoreUrl}`)
+      throw new Error(`Received \`null\` response from ${appListUrl}`)
     }
     apps.sort((a: AppInfo, b: AppInfo) => {
       const dateA = new Date(a.date)

--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -347,9 +347,9 @@ export function AppPicker({ onAppSelected }: Props) {
         )}
         <div className={styles.appPickerList}>
           {appsFetch.loading ? (
-            <div className={styles.offlineMessage}>{tx('loading')}</div>
+            <div>{tx('loading')}</div>
           ) : appsFetch.result.ok !== true ? (
-            <div className={styles.offlineMessage}>
+            <div>
               {isOffline
                 ? tx('offline')
                 : tx(


### PR DESCRIPTION
The issue was introduced in 50de20982d2620640e175ec6d593f0ce04fce4d9
(https://github.com/deltachat/deltachat-desktop/pull/6217).

~~Partially~~ supersedes https://github.com/deltachat/deltachat-desktop/pull/6516.
