### PR TITLE
fix: improve chatlist rendering on many changes

### DIFF
--- a/packages/frontend/src/components/chat/ChatContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatContextMenu.tsx
@@ -326,13 +326,31 @@ export function useChatContextMenu(): {
     activeChatId: number | null
   ) => {
     // only if chatListItems contains a single chat, we need the full chat
+    const singleChatItem =
+      chatListItems.length === 1 ? chatListItems[0] : undefined
     const selectedChat =
-      chatListItems.length === 1
-        ? await BackendRemote.rpc.getFullChatById(
-            accountId,
-            chatListItems[0].id
-          )
+      singleChatItem !== undefined
+        ? await BackendRemote.rpc.getFullChatById(accountId, singleChatItem.id)
         : undefined
+    // The passed `chatListItems` come from the chat list's cache, which is
+    // updated with a throttle, so right after an action (e.g. pin/unpin)
+    // they may still hold the previous state for a moment.
+    if (selectedChat !== undefined) {
+      chatListItems = [fullChatToChatListItem(selectedChat)]
+    } else {
+      try {
+        const freshItems = await BackendRemote.rpc.getChatlistItemsByEntries(
+          accountId,
+          chatListItems.map(chat => chat.id)
+        )
+        chatListItems = chatListItems.map(chat => {
+          const freshItem = freshItems[chat.id]
+          return freshItem?.kind === 'ChatListItem' ? freshItem : chat
+        })
+      } catch (err) {
+        log.error('failed to fetch current chatlist items for menu', err)
+      }
+    }
     return openContextMenuInternalHandler(
       event,
       selectedChat,

--- a/packages/frontend/src/components/chat/ChatList.tsx
+++ b/packages/frontend/src/components/chat/ChatList.tsx
@@ -55,6 +55,7 @@ import { useSettingsStore } from '../../stores/settings'
 import { useMultiselect } from '../../hooks/useMultiselect'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { useHasChanged2 } from '../../hooks/useHasChanged'
+import asyncThrottle from '@jcoreio/async-throttle'
 
 const log = getLogger('ChatList')
 const useMultiselectLog = getLogger('ChatListMultiselect')
@@ -816,23 +817,31 @@ export function useLogicVirtualChatList(
   useEffect(() => {
     const loadingChats = loadingChatsRef_.current
 
-    let debouncingChatlistItemRequests: { [chatid: number]: number } = {}
-
-    const updateChatListItem = async (chatId: number) => {
-      debouncingChatlistItemRequests[chatId] = 1
-      loadingChats.add(chatId)
-      const chats = await BackendRemote.rpc.getChatlistItemsByEntries(
-        accountId,
-        [chatId]
-      )
-      setChatCache(cache => ({ ...cache, ...chats }))
-      loadingChats.delete(chatId)
-      if (debouncingChatlistItemRequests[chatId] > 1) {
-        updateChatListItem(chatId)
-      } else {
-        debouncingChatlistItemRequests[chatId] = 0
+    // Batch `ChatlistItemChanged` events: collect the changed chat ids
+    // and update them with a single RPC call and a single `setChatCache`
+    // This reduces the number of re-renders bounded when many chats change
+    // in a short period, e.g. when a lot of messages arrive
+    const pendingChatIds = new Set<number>()
+    const flushPendingChatIds = asyncThrottle(async () => {
+      const chatIds = [...pendingChatIds]
+      pendingChatIds.clear()
+      if (chatIds.length === 0) {
+        return
       }
-    }
+      try {
+        const chats = await BackendRemote.rpc.getChatlistItemsByEntries(
+          accountId,
+          chatIds
+        )
+        setChatCache(cache => ({ ...cache, ...chats }))
+      } catch (err) {
+        log.error('failed to fetch changed chatlist items', err)
+      } finally {
+        for (const chatId of chatIds) {
+          loadingChats.delete(chatId)
+        }
+      }
+    }, 400)
 
     const removeListener = onDCEvent(
       accountId,
@@ -842,25 +851,19 @@ export function useLogicVirtualChatList(
           return
         }
         if (chatId !== null) {
-          if (
-            debouncingChatlistItemRequests[chatId] === undefined ||
-            debouncingChatlistItemRequests[chatId] === 0
-          ) {
-            updateChatListItem(chatId)
-          } else {
-            debouncingChatlistItemRequests[chatId] =
-              debouncingChatlistItemRequests[chatId] + 1
-          }
+          pendingChatIds.add(chatId)
+          loadingChats.add(chatId)
+          flushPendingChatIds.invokeIgnoreResult()
         } else {
-          // invalidate whole chatlist cache and reload everyhting that was visible before
+          // invalidate whole chatlist cache and reload everything that was visible before
+          pendingChatIds.clear()
           await reloadChats()
-          // reset debouncing
-          debouncingChatlistItemRequests = {}
         }
       }
     )
     return () => {
       removeListener()
+      flushPendingChatIds.cancel()
     }
   }, [accountId])
 

--- a/packages/frontend/src/components/chat/ChatListHelpers.tsx
+++ b/packages/frontend/src/components/chat/ChatListHelpers.tsx
@@ -4,6 +4,7 @@ import { debounce } from 'debounce'
 import { BackendRemote, onDCEvent } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { useFetch } from '../../hooks/useFetch'
+import { useStableArray } from '../../hooks/useStableArray'
 import asyncThrottle from '@jcoreio/async-throttle'
 
 const log = getLogger('renderer/helpers/ChatList')
@@ -210,10 +211,16 @@ function useChatListSimple(
     )
   }
 
+  // Make sure we return the previous array as long as the IDs and their
+  // order does not change, avoiding a re-render of the whole chat list.
+  const chatListIds = useStableArray(
+    chatListFetch?.lingeringResult?.ok
+      ? chatListFetch.lingeringResult.value
+      : []
+  )
+
   return {
-    chatListIds: chatListFetch?.lingeringResult?.ok
-      ? chatListFetch?.lingeringResult.value
-      : [],
+    chatListIds,
     chatListFetch,
   }
 }

--- a/packages/frontend/src/hooks/useStableArray.ts
+++ b/packages/frontend/src/hooks/useStableArray.ts
@@ -1,0 +1,24 @@
+import { useRef } from 'react'
+
+/**
+ * Returns the array from the previous render if the new array
+ * is shallowly equal to it, so that the returned value keeps
+ * a stable identity as long as the content doesn't change.
+ *
+ * Similar pattern as in {@link usePrevious2}:
+ * https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+ */
+export function useStableArray<T>(arr: T[]): T[] {
+  /* eslint-disable react-hooks/refs */
+  const prevRef = useRef(arr)
+  const prev = prevRef.current
+  if (prev === arr) {
+    return arr
+  }
+  if (prev.length === arr.length && arr.every((item, i) => item === prev[i])) {
+    return prev
+  }
+  prevRef.current = arr
+  return arr
+  /* eslint-enable react-hooks/refs */
+}


### PR DESCRIPTION
Fixes #5650

In my tests (with ~1000 unread messages) that already avoided the ui freeze.

Collecting ChatChanged events and throttling the loadChats as a first step.
Skip unneccessary rerenders as a second step

We possibly could delay the reload even more by taking  network status Connectivity.WORKING in account as an additional check to wait longer with refreshing the chat list.