### PR TITLE
fix: scroll message down after image is loaded or after remote edit

### DIFF
--- a/packages/frontend/src/stores/chat/chat_view_reducer.ts
+++ b/packages/frontend/src/stores/chat/chat_view_reducer.ts
@@ -92,7 +92,15 @@ export class ChatViewReducer {
     }
   }
 
-  static fetchedIncomingMessages(prevState: ChatViewState): ChatViewState {
+  /**
+   * Scroll to the bottom of the messages list, but only if it is already
+   * scrolled close to the bottom (we don't force the scroll to bottom
+   * if the user has scrolled to another position already)
+   * `lastKnownScrollHeight` must be captured _before_ the content change
+   * is rendered, so that the proximity check in `MessageList` compares
+   * the scroll position against the old content height.
+   */
+  static scrollToBottomIfClose(prevState: ChatViewState): ChatViewState {
     const {
       lastKnownScrollHeight,
       // lastKnownScrollTop,
@@ -106,6 +114,10 @@ export class ChatViewReducer {
       },
       lastKnownScrollHeight,
     }
+  }
+
+  static fetchedIncomingMessages(prevState: ChatViewState): ChatViewState {
+    return ChatViewReducer.scrollToBottomIfClose(prevState)
   }
 
   static unlockScroll(prevState: ChatViewState): ChatViewState {

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -341,7 +341,15 @@ export class MessageListStore extends Store<MessageListState> {
         return modifiedState
       }, 'unlockScroll')
     },
-    messageChanged: (message: Type.Message) => {
+    messageChanged: (
+      message: Type.Message,
+      /**
+       * Should be true if the change can make the message taller,
+       * as it could be the case for incoming image messages
+       * (when the download finishes) or for edited messages
+       */
+      scrollToBottomIfClose: boolean = false
+    ) => {
       const messageLoadResult: Type.MessageLoadResult = {
         kind: 'message',
         ...message,
@@ -353,6 +361,9 @@ export class MessageListStore extends Store<MessageListState> {
             ...state.messageCache,
             [message.id]: messageLoadResult,
           },
+          viewState: scrollToBottomIfClose
+            ? ChatViewReducer.scrollToBottomIfClose(state.viewState)
+            : state.viewState,
         }
         return modifiedState
       }, 'messageChanged')
@@ -755,7 +766,24 @@ export class MessageListStore extends Store<MessageListState> {
               this.accountId,
               messageId
             )
-            this.reducer.messageChanged(message)
+            const oldMessage = this.state.messageCache[messageId]
+            // When the download of a partially-downloaded message finishes,
+            // it can become much taller (when the image is rendered)
+            const downloadFinished =
+              oldMessage?.kind === 'message' &&
+              oldMessage.downloadState !== 'Done' &&
+              message.downloadState === 'Done'
+            // Same for a message that just got edited (e.g. from another
+            // device): it can become taller.
+            // https://github.com/deltachat/deltachat-desktop/issues/4698
+            const edited =
+              oldMessage?.kind === 'message' &&
+              message.isEdited &&
+              oldMessage.text !== message.text
+            // Scroll down if message height might have changed
+            // (only if we're close to the bottom)
+            const messageHeightMightHaveChanged = downloadFinished || edited
+            this.reducer.messageChanged(message, messageHeightMightHaveChanged)
           } catch (error) {
             this.log.warn('failed to fetch message with id', messageId, error)
             // ignore not found and other errors


### PR DESCRIPTION
fixes #6236 
fixes #4698
