### PR TITLE
fix: don't announce reactions on chat open/scroll

### DIFF
--- a/packages/frontend/src/components/Reactions/index.tsx
+++ b/packages/frontend/src/components/Reactions/index.tsx
@@ -60,11 +60,15 @@ export default function Reactions(props: Props) {
 
   return (
     <div className={styles.reactions}>
-      {reactions.slice(0, visibleEmojis).map(({ emoji, isFromSelf, count }) => {
+      {reactions.map(({ emoji, isFromSelf, count }, index) => {
         return (
           <span
             className={classNames(styles.emoji, {
               [styles.isFromSelf]: isFromSelf,
+              // Instead of not rendering hidden reactions at all,
+              // hide them with CSS,
+              // so as to not trigger `aria-live` announcements on resize.
+              'visually-hidden': index >= visibleEmojis,
             })}
             key={emoji}
           >
@@ -74,7 +78,10 @@ export default function Reactions(props: Props) {
         )
       })}
       {reactions.length > visibleEmojis && (
-        <span className={classNames(styles.emoji, styles.emojiCount)}>
+        <span
+          aria-hidden
+          className={classNames(styles.emoji, styles.emojiCount)}
+        >
           +{hiddenReactionsCount}
         </span>
       )}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1111,9 +1111,7 @@ export default function Message(props: {
               tabindexForInteractiveContents={tabindexForInteractiveContents}
             />
             <div
-              // TODO the "+1" count aria-live announcment is perhaps not great
-              // out of context.
-              // Also the "show ReactionsDialog" button gets announced.
+              // TODO the "show ReactionsDialog" button also gets announced.
               aria-live='polite'
               aria-relevant='all'
             >


### PR DESCRIPTION
Also don't announce the changes on window resize.
Only announce when the actual list of reactions changes, as intended.

Reproducible at least with Orca reader. Just open a chat
that has some messages with reactions, and you'll hear it.
Then also scroll up and you'll hear it more.

I suspect that this has to do with the fact that `messageWidth`
is initially 0 for all messages
and only gets updated inside of `useEffect`,
resuling in all reactions being initially collapsed.

Relevant:
- https://github.com/deltachat/deltachat-desktop/pull/4885
- https://github.com/deltachat/deltachat-desktop/pull/5051