### PR TITLE
improvement: move msg select counter to header

### DIFF
--- a/packages/frontend/scss/message/_message-list.scss
+++ b/packages/frontend/scss/message/_message-list.scss
@@ -206,18 +206,4 @@
       }
     }
   }
-
-  .num-selected-messages-status {
-    position: absolute;
-    bottom: 0;
-    inset-inline-start: 0;
-    border-start-end-radius: 0.25rem;
-    $borderColor: color-mix(in srgb, var(--contextMenuBorder) 50%, transparent);
-    border-block-start: 1px solid $borderColor;
-    border-inline-end: 1px solid $borderColor;
-
-    background: var(--composerBg);
-    padding: 0.5rem 0.625rem;
-    line-height: 1;
-  }
 }

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -35,7 +35,10 @@ import classNames from 'classnames'
 
 const log = getLogger('ChatView')
 
-export function ChatView({
+export function ChatView(props: Parameters<typeof ChatViewInner>[0]) {
+  return <ChatViewInner {...props}/>
+}
+export function ChatViewInner({
   accountId,
   lastUsedApps,
   className,

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -36,7 +36,7 @@ import classNames from 'classnames'
 const log = getLogger('ChatView')
 
 export function ChatView(
-  props: Parameters<typeof ChatViewInner>[0] & {
+  props: Omit<Parameters<typeof ChatViewInner>[0], 'chatWithLinger'> & {
     className?: string
   }
 ) {
@@ -60,6 +60,7 @@ export function ChatView(
           // We do not and should actually rely on any kind of cross-chat state.
           key={`${props.accountId}_${chatWithLinger.id}`}
           {...props}
+          chatWithLinger={chatWithLinger}
         />
       ) : (
         <>
@@ -75,12 +76,14 @@ export function ChatView(
 export function ChatViewInner({
   accountId,
   lastUsedApps,
+  chatWithLinger,
 }: {
   accountId: number | undefined
   lastUsedApps: T.Message[]
+  chatWithLinger: NonNullable<ReturnType<typeof useChat>['chatWithLinger']>
 }) {
   const tx = useTranslationFunction()
-  const { chatWithLinger, unselectChat } = useChat()
+  const { unselectChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
   return (

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -105,6 +105,8 @@ export function ChatViewInner({
   )
   const focusAndMultiselectContextValue =
     useMessageFocusAndMultiselectContextValue({ messageIds })
+  const numSelectedMessages = focusAndMultiselectContextValue.selectedItems.size
+  const showMessageMultiselectCounter = numSelectedMessages > 0
 
   return (
     <>
@@ -122,7 +124,26 @@ export function ChatViewInner({
           </span>
         )}
         <div className={styles.chatNavbarHeadingWrapper} data-tauri-drag-region>
-          {chatWithLinger && <ChatHeading chat={chatWithLinger} />}
+          {chatWithLinger && (
+            <>
+              <div role='status' style={{ display: 'contents' }}>
+                {showMessageMultiselectCounter && (
+                  <div className={styles.messageMultiselectCounter}>
+                    {tx('n_selected', numSelectedMessages.toString(), {
+                      quantity: numSelectedMessages,
+                    })}
+                  </div>
+                )}
+              </div>
+              <ChatHeading
+                chat={chatWithLinger}
+                // Why `hidden` instead of simply not rendering?
+                // Because this component contains the accessible title
+                // for the "ChatView" section (`id='chat-section-heading'`).
+                hidden={showMessageMultiselectCounter}
+              />
+            </>
+          )}
         </div>
         {chatWithLinger && (
           <ChatNavButtons chat={chatWithLinger} lastUsedApps={lastUsedApps} />
@@ -187,7 +208,7 @@ function chatSubtitle(chat: T.FullChat, firstContact: T.Contact | null) {
   return 'ErrTitle'
 }
 
-function ChatHeading({ chat }: { chat: T.FullChat }) {
+function ChatHeading({ chat, hidden }: { chat: T.FullChat; hidden: boolean }) {
   const tx = useTranslationFunction()
   const { openDialog } = useDialog()
   const openViewGroupDialog = useOpenViewGroupDialog()
@@ -259,7 +280,12 @@ function ChatHeading({ chat }: { chat: T.FullChat }) {
   )
 
   return (
-    <div className='navbar-heading' data-no-drag-region>
+    <div
+      className={classNames('navbar-heading', {
+        'visually-hidden': hidden,
+      })}
+      data-no-drag-region
+    >
       <Avatar
         displayName={chat.name}
         color={chat.color}
@@ -299,6 +325,8 @@ function ChatHeading({ chat }: { chat: T.FullChat }) {
         aria-label={buttonLabel}
         data-testid='chat-info-button'
         className='navbar-heading-chat-info-button'
+        // Ensure that it can't be tab-focused.
+        disabled={hidden}
       ></button>
     </div>
   )

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -36,7 +36,22 @@ import classNames from 'classnames'
 const log = getLogger('ChatView')
 
 export function ChatView(props: Parameters<typeof ChatViewInner>[0]) {
-  return <ChatViewInner {...props}/>
+  const { chatWithLinger } = useChat()
+  return (
+    <ChatViewInner
+      // Note that `key` has not always been here.
+      // Some downstream components still try to support variable `chatId`.
+      // To name a few:
+      // - `hasChatChanged` in `MessageList`.
+      // - `useHasChanged2(chatId)` in `Composer`.
+      //
+      // However, most of that code is about resetting some state,
+      // so it probably can be removed.
+      // We do not and should actually rely on any kind of cross-chat state.
+      key={`${props.accountId}_${chatWithLinger?.id}`}
+      {...props}
+    />
+  )
 }
 export function ChatViewInner({
   accountId,
@@ -92,20 +107,7 @@ function MessageListView({
   if (chatWithLinger && accountId) {
     return (
       <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
-        <MessageListAndComposer
-          // Note that `key` has not always been here.
-          // Some downstream components still try to support variable `chatId`.
-          // To name a few:
-          // - `hasChatChanged` in `MessageList`.
-          // - `useHasChanged2(chatId)` in `Composer`.
-          //
-          // However, most of that code is about resetting some state,
-          // so it probably can be removed.
-          // We do not and should actually rely on any kind of cross-chat state.
-          key={`${accountId}_${chatWithLinger.id}`}
-          accountId={accountId}
-          chat={chatWithLinger}
-        />
+        <MessageListAndComposer accountId={accountId} chat={chatWithLinger} />
       </RecoverableCrashScreen>
     )
   }

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -35,43 +35,56 @@ import classNames from 'classnames'
 
 const log = getLogger('ChatView')
 
-export function ChatView(props: Parameters<typeof ChatViewInner>[0]) {
+export function ChatView(
+  props: Parameters<typeof ChatViewInner>[0] & {
+    className?: string
+  }
+) {
   const { chatWithLinger } = useChat()
   return (
-    <ChatViewInner
-      // Note that `key` has not always been here.
-      // Some downstream components still try to support variable `chatId`.
-      // To name a few:
-      // - `hasChatChanged` in `MessageList`.
-      // - `useHasChanged2(chatId)` in `Composer`.
-      //
-      // However, most of that code is about resetting some state,
-      // so it probably can be removed.
-      // We do not and should actually rely on any kind of cross-chat state.
-      key={`${props.accountId}_${chatWithLinger?.id}`}
-      {...props}
-    />
+    <section
+      role='region'
+      aria-labelledby='chat-section-heading'
+      className={classNames(props.className, styles.chatAndNavbar)}
+    >
+      {chatWithLinger ? (
+        <ChatViewInner
+          // Note that `key` has not always been here.
+          // Some downstream components still try to support variable `chatId`.
+          // To name a few:
+          // - `hasChatChanged` in `MessageList`.
+          // - `useHasChanged2(chatId)` in `Composer`.
+          //
+          // However, most of that code is about resetting some state,
+          // so it probably can be removed.
+          // We do not and should actually rely on any kind of cross-chat state.
+          key={`${props.accountId}_${chatWithLinger.id}`}
+          {...props}
+        />
+      ) : (
+        <>
+          {/* Dummy header to reduce layout shifting
+          when unselecting/selecting a chat. */}
+          <nav className={styles.chatNavbar} data-tauri-drag-region></nav>
+          <NoChatSelected />
+        </>
+      )}
+    </section>
   )
 }
 export function ChatViewInner({
   accountId,
   lastUsedApps,
-  className,
 }: {
   accountId: number | undefined
   lastUsedApps: T.Message[]
-  className?: string
 }) {
   const tx = useTranslationFunction()
   const { chatWithLinger, unselectChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
   return (
-    <section
-      role='region'
-      aria-labelledby='chat-section-heading'
-      className={classNames(className, styles.chatAndNavbar)}
-    >
+    <>
       <nav className={styles.chatNavbar} data-tauri-drag-region>
         {smallScreenMode && (
           <span data-no-drag-region>
@@ -93,7 +106,7 @@ export function ChatViewInner({
         )}
       </nav>
       <MessageListView accountId={accountId} />
-    </section>
+    </>
   )
 }
 

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -36,7 +36,11 @@ import classNames from 'classnames'
 const log = getLogger('ChatView')
 
 export function ChatView(
-  props: Omit<Parameters<typeof ChatViewInner>[0], 'chatWithLinger'> & {
+  props: Omit<
+    Parameters<typeof ChatViewInner>[0],
+    'accountId' | 'chatWithLinger'
+  > & {
+    accountId: T.Account['id'] | undefined
     className?: string
   }
 ) {
@@ -47,7 +51,7 @@ export function ChatView(
       aria-labelledby='chat-section-heading'
       className={classNames(props.className, styles.chatAndNavbar)}
     >
-      {chatWithLinger ? (
+      {props.accountId != undefined && chatWithLinger ? (
         <ChatViewInner
           // Note that `key` has not always been here.
           // Some downstream components still try to support variable `chatId`.
@@ -59,7 +63,7 @@ export function ChatView(
           // so it probably can be removed.
           // We do not and should actually rely on any kind of cross-chat state.
           key={`${props.accountId}_${chatWithLinger.id}`}
-          {...props}
+          {...(props as typeof props & { accountId: typeof props.accountId })}
           chatWithLinger={chatWithLinger}
         />
       ) : (
@@ -78,7 +82,7 @@ export function ChatViewInner({
   lastUsedApps,
   chatWithLinger,
 }: {
-  accountId: number | undefined
+  accountId: number
   lastUsedApps: T.Message[]
   chatWithLinger: NonNullable<ReturnType<typeof useChat>['chatWithLinger']>
 }) {
@@ -108,27 +112,11 @@ export function ChatViewInner({
           <ChatNavButtons chat={chatWithLinger} lastUsedApps={lastUsedApps} />
         )}
       </nav>
-      <MessageListView accountId={accountId} />
-    </>
-  )
-}
-
-function MessageListView({
-  accountId,
-}: {
-  accountId?: number
-}): React.JSX.Element {
-  const { chatWithLinger } = useChat()
-
-  if (chatWithLinger && accountId) {
-    return (
       <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
         <MessageListAndComposer accountId={accountId} chat={chatWithLinger} />
       </RecoverableCrashScreen>
-    )
-  }
-
-  return <NoChatSelected />
+    </>
+  )
 }
 
 /**

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -1,5 +1,5 @@
 import styles from './styles.module.scss'
-import React, { useCallback, useContext, useId } from 'react'
+import React, { useCallback, useContext, useId, useMemo } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import MessageListAndComposer from '../message/MessageListAndComposer'
@@ -32,6 +32,11 @@ import { ContextMenuContext } from '../../contexts/ContextMenuContext'
 import { mouseEventToPosition } from '../../utils/mouseEventToPosition'
 import useMessage from '../../hooks/chat/useMessage'
 import classNames from 'classnames'
+import {
+  MessageMultiselectContext,
+  useMessageFocusAndMultiselectContextValue,
+} from '../message/focusAndMultiselect'
+import { useMessageList } from '../../stores/messagelist'
 
 const log = getLogger('ChatView')
 
@@ -90,6 +95,17 @@ export function ChatViewInner({
   const { unselectChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
+  const messageListData = useMessageList(accountId, chatWithLinger.id)
+  const messageIds = useMemo(
+    () =>
+      messageListData.state.messageListItems
+        .filter(v => v.kind !== 'dayMarker')
+        .map(v => v.msg_id),
+    [messageListData.state.messageListItems]
+  )
+  const focusAndMultiselectContextValue =
+    useMessageFocusAndMultiselectContextValue({ messageIds })
+
   return (
     <>
       <nav className={styles.chatNavbar} data-tauri-drag-region>
@@ -113,7 +129,15 @@ export function ChatViewInner({
         )}
       </nav>
       <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
-        <MessageListAndComposer accountId={accountId} chat={chatWithLinger} />
+        <MessageMultiselectContext.Provider
+          value={focusAndMultiselectContextValue}
+        >
+          <MessageListAndComposer
+            accountId={accountId}
+            chat={chatWithLinger}
+            messageListData={messageListData}
+          />
+        </MessageMultiselectContext.Provider>
       </RecoverableCrashScreen>
     </>
   )

--- a/packages/frontend/src/components/ChatView/styles.module.scss
+++ b/packages/frontend/src/components/ChatView/styles.module.scss
@@ -72,6 +72,13 @@
         background-color: var(--navBarButtonHover);
       }
     }
+
+    .messageMultiselectCounter {
+      font-size: large;
+      font-weight: bold;
+      line-height: normal;
+      margin: 0.5rem 1rem;
+    }
   }
 }
 

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useState,
   useMemo,
+  useContext,
 } from 'react'
 import classNames from 'classnames'
 import moment from 'moment'
@@ -33,7 +34,6 @@ import {
 import {
   useMessageFocusAndMultiselect,
   MessageMultiselectContext,
-  useMessageFocusAndMultiselectContextValue,
 } from './focusAndMultiselect'
 import { marknoticedChat } from '../../backend/chat'
 
@@ -857,13 +857,9 @@ export const MessageListInner = React.memo(
       // over the lifetime of this component.
     })
 
-    const messageIds = useMemo(
-      () =>
-        messageListItems.filter(v => v.kind !== 'dayMarker').map(v => v.msg_id),
-      [messageListItems]
+    const focusAndMultiselectContextValue = useContext(
+      MessageMultiselectContext
     )
-    const focusAndMultiselectContextValue =
-      useMessageFocusAndMultiselectContextValue({ messageIds })
 
     if (!loaded) {
       return (
@@ -911,53 +907,49 @@ export const MessageListInner = React.memo(
         >
           <ol aria-label={tx('messages')}>
             <RovingTabindexProvider wrapperElementRef={messageListRef}>
-              <MessageMultiselectContext.Provider
-                value={focusAndMultiselectContextValue}
-              >
-                {messageListItems.length === 0 && (
-                  <EmptyChatMessage chat={chat} />
-                )}
-                {activeView.map(messageId => {
-                  if (messageId.kind === 'dayMarker') {
+              {messageListItems.length === 0 && (
+                <EmptyChatMessage chat={chat} />
+              )}
+              {activeView.map(messageId => {
+                if (messageId.kind === 'dayMarker') {
+                  return (
+                    <DayMarker
+                      key={`daymarker-${messageId.timestamp}`}
+                      timestamp={messageId.timestamp}
+                    />
+                  )
+                }
+
+                if (messageId.kind === 'message') {
+                  const message = messageCache[messageId.msg_id]
+                  if (message?.kind === 'message') {
                     return (
-                      <DayMarker
-                        key={`daymarker-${messageId.timestamp}`}
-                        timestamp={messageId.timestamp}
+                      <MessageWrapper
+                        key={messageId.msg_id}
+                        key2={`${messageId.msg_id}`}
+                        chat={chat}
+                        message={message}
+                        conversationType={conversationType}
+                        unreadMessageInViewIntersectionObserver={
+                          unreadMessageInViewIntersectionObserver
+                        }
                       />
                     )
+                  } else if (message?.kind === 'loadingError') {
+                    return (
+                      <MessageLoadingError
+                        messageId={messageId}
+                        message={message}
+                      />
+                    )
+                  } else {
+                    // setTimeout tells it to call method in next event loop iteration, so after rendering
+                    // it is debounced later so we can call it here multiple times and it's ok
+                    setTimeout(loadMissingMessages)
+                    return <MessageLoading messageId={messageId} />
                   }
-
-                  if (messageId.kind === 'message') {
-                    const message = messageCache[messageId.msg_id]
-                    if (message?.kind === 'message') {
-                      return (
-                        <MessageWrapper
-                          key={messageId.msg_id}
-                          key2={`${messageId.msg_id}`}
-                          chat={chat}
-                          message={message}
-                          conversationType={conversationType}
-                          unreadMessageInViewIntersectionObserver={
-                            unreadMessageInViewIntersectionObserver
-                          }
-                        />
-                      )
-                    } else if (message?.kind === 'loadingError') {
-                      return (
-                        <MessageLoadingError
-                          messageId={messageId}
-                          message={message}
-                        />
-                      )
-                    } else {
-                      // setTimeout tells it to call method in next event loop iteration, so after rendering
-                      // it is debounced later so we can call it here multiple times and it's ok
-                      setTimeout(loadMissingMessages)
-                      return <MessageLoading messageId={messageId} />
-                    }
-                  }
-                })}
-              </MessageMultiselectContext.Provider>
+                }
+              })}
             </RovingTabindexProvider>
           </ol>
         </div>

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -875,99 +875,81 @@ export const MessageListInner = React.memo(
     }
 
     return (
-      <>
-        <div
-          id='message-list'
-          ref={messageListRef}
-          onScroll={onScroll2}
-          onWheel={onWheel}
-          className={classNames({
-            'multiselected-one-or-more':
-              focusAndMultiselectContextValue.selectedItems.size >= 1,
-            'multiselected-two-or-more':
-              focusAndMultiselectContextValue.selectedItems.size >= 2,
-          })}
-          onClick={e => {
-            // If clicked on dead space, reset selection.
+      <div
+        id='message-list'
+        ref={messageListRef}
+        onScroll={onScroll2}
+        onWheel={onWheel}
+        className={classNames({
+          'multiselected-one-or-more':
+            focusAndMultiselectContextValue.selectedItems.size >= 1,
+          'multiselected-two-or-more':
+            focusAndMultiselectContextValue.selectedItems.size >= 2,
+        })}
+        onClick={e => {
+          // If clicked on dead space, reset selection.
 
-            if (e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) {
-              return
-            }
-            if (!(e.target instanceof HTMLElement)) {
-              return
-            }
-            if (e.target.closest('.multiselectable-message') != null) {
-              // Clicked on a message. This is handled
-              // by the message click handler.
-              return
-            }
+          if (e.ctrlKey || e.shiftKey || e.metaKey || e.altKey) {
+            return
+          }
+          if (!(e.target instanceof HTMLElement)) {
+            return
+          }
+          if (e.target.closest('.multiselectable-message') != null) {
+            // Clicked on a message. This is handled
+            // by the message click handler.
+            return
+          }
 
-            focusAndMultiselectContextValue.resetSelection()
-          }}
-        >
-          <ol aria-label={tx('messages')}>
-            <RovingTabindexProvider wrapperElementRef={messageListRef}>
-              {messageListItems.length === 0 && (
-                <EmptyChatMessage chat={chat} />
-              )}
-              {activeView.map(messageId => {
-                if (messageId.kind === 'dayMarker') {
+          focusAndMultiselectContextValue.resetSelection()
+        }}
+      >
+        <ol aria-label={tx('messages')}>
+          <RovingTabindexProvider wrapperElementRef={messageListRef}>
+            {messageListItems.length === 0 && <EmptyChatMessage chat={chat} />}
+            {activeView.map(messageId => {
+              if (messageId.kind === 'dayMarker') {
+                return (
+                  <DayMarker
+                    key={`daymarker-${messageId.timestamp}`}
+                    timestamp={messageId.timestamp}
+                  />
+                )
+              }
+
+              if (messageId.kind === 'message') {
+                const message = messageCache[messageId.msg_id]
+                if (message?.kind === 'message') {
                   return (
-                    <DayMarker
-                      key={`daymarker-${messageId.timestamp}`}
-                      timestamp={messageId.timestamp}
+                    <MessageWrapper
+                      key={messageId.msg_id}
+                      key2={`${messageId.msg_id}`}
+                      chat={chat}
+                      message={message}
+                      conversationType={conversationType}
+                      unreadMessageInViewIntersectionObserver={
+                        unreadMessageInViewIntersectionObserver
+                      }
                     />
                   )
+                } else if (message?.kind === 'loadingError') {
+                  return (
+                    <MessageLoadingError
+                      messageId={messageId}
+                      message={message}
+                    />
+                  )
+                } else {
+                  // setTimeout tells it to call method in next event loop iteration, so after rendering
+                  // it is debounced later so we can call it here multiple times and it's ok
+                  setTimeout(loadMissingMessages)
+                  return <MessageLoading messageId={messageId} />
                 }
-
-                if (messageId.kind === 'message') {
-                  const message = messageCache[messageId.msg_id]
-                  if (message?.kind === 'message') {
-                    return (
-                      <MessageWrapper
-                        key={messageId.msg_id}
-                        key2={`${messageId.msg_id}`}
-                        chat={chat}
-                        message={message}
-                        conversationType={conversationType}
-                        unreadMessageInViewIntersectionObserver={
-                          unreadMessageInViewIntersectionObserver
-                        }
-                      />
-                    )
-                  } else if (message?.kind === 'loadingError') {
-                    return (
-                      <MessageLoadingError
-                        messageId={messageId}
-                        message={message}
-                      />
-                    )
-                  } else {
-                    // setTimeout tells it to call method in next event loop iteration, so after rendering
-                    // it is debounced later so we can call it here multiple times and it's ok
-                    setTimeout(loadMissingMessages)
-                    return <MessageLoading messageId={messageId} />
-                  }
-                }
-              })}
-            </RovingTabindexProvider>
-          </ol>
-        </div>
-
-        <div role='status' style={{ display: 'contents' }}>
-          {focusAndMultiselectContextValue.selectedItems.size > 0 && (
-            <div className='num-selected-messages-status'>
-              {tx(
-                'n_selected',
-                focusAndMultiselectContextValue.selectedItems.size.toString(),
-                {
-                  quantity: focusAndMultiselectContextValue.selectedItems.size,
-                }
-              )}
-            </div>
-          )}
-        </div>
-      </>
+              }
+            })}
+          </RovingTabindexProvider>
+        </ol>
+      </div>
     )
   },
   (prevProps, nextProps) => {

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -863,10 +863,7 @@ export const MessageListInner = React.memo(
       [messageListItems]
     )
     const focusAndMultiselectContextValue =
-      useMessageFocusAndMultiselectContextValue({
-        messageIds,
-        wrapperElementRef: messageListRef,
-      })
+      useMessageFocusAndMultiselectContextValue({ messageIds })
 
     if (!loaded) {
       return (

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -15,7 +15,7 @@ import ConfirmSendingFiles from '../dialogs/ConfirmSendingFiles'
 import { ReactionsBarProvider } from '../ReactionsBar'
 import useDialog from '../../hooks/dialog/useDialog'
 import useMessage from '../../hooks/chat/useMessage'
-import { useMessageList } from '../../stores/messagelist'
+import type { useMessageList } from '../../stores/messagelist'
 import { IMAGE_EXTENSIONS } from '@deltachat-desktop/shared/constants'
 
 const log = getLogger('renderer/MessageListAndComposer')
@@ -23,6 +23,7 @@ const log = getLogger('renderer/MessageListAndComposer')
 type Props = {
   chat: T.FullChat
   accountId: number
+  messageListData: ReturnType<typeof useMessageList>
 }
 
 export function getBackgroundImageStyle(
@@ -92,7 +93,11 @@ function isImage(file: ParsedPath) {
   return IMAGE_EXTENSIONS.map(ext => '.' + ext).includes(file.ext.toLowerCase())
 }
 
-export default function MessageListAndComposer({ accountId, chat }: Props) {
+export default function MessageListAndComposer({
+  accountId,
+  chat,
+  messageListData,
+}: Props) {
   const conversationRef = useRef<HTMLDivElement>(null)
   const refComposer = useRef(null)
 
@@ -107,7 +112,7 @@ export default function MessageListAndComposer({ accountId, chat }: Props) {
     state: messageListState,
     fetchMoreBottom,
     fetchMoreTop,
-  } = useMessageList(accountId, chat.id)
+  } = messageListData
 
   const {
     draftState,

--- a/packages/frontend/src/components/message/focusAndMultiselect.tsx
+++ b/packages/frontend/src/components/message/focusAndMultiselect.tsx
@@ -1,10 +1,7 @@
 import React, { useCallback, useMemo, useState } from 'react'
 import type { T } from '@deltachat/jsonrpc-client'
 import { getLogger } from '@deltachat-desktop/shared/logger'
-import {
-  RovingTabindexProvider,
-  useRovingTabindex,
-} from '../../contexts/RovingTabindex'
+import { useRovingTabindex } from '../../contexts/RovingTabindex'
 import { useMultiselect } from '../../hooks/useMultiselect'
 
 const log = getLogger('messageFocusAndMultiselect')
@@ -24,9 +21,6 @@ export const MessageMultiselectContext =
   })
 
 export function useMessageFocusAndMultiselectContextValue(props: {
-  wrapperElementRef: Parameters<
-    typeof RovingTabindexProvider
-  >[0]['wrapperElementRef']
   messageIds: Array<T.Message['id']>
 }) {
   const [selectedMessages_, setSelectedMessages] = useState(


### PR DESCRIPTION
<img height="350" alt="image" src="https://github.com/user-attachments/assets/7da04a6f-2e2e-4321-bbbd-c252b507551f" /> 
<img height="350" alt="image" src="https://github.com/user-attachments/assets/e18fbb4e-700c-45e0-b085-71748d56e4d2" />


As requested in
- https://github.com/deltachat/deltachat-desktop/pull/6268#issuecomment-4421685886.
- https://github.com/deltachat/deltachat-desktop/pull/6458#issuecomment-4717197495.

Had to do a bunch of refactoring to make the message list state accessible to the chat header (lift state up).

FTR I don't think that this is a good change (see my comments on the linked issues/MRs).
