### PR TITLE
perf: avoid unneeded messagelist renders

### DIFF
--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -593,6 +593,11 @@ test.describe('Ctrl + Up shortcut', () => {
   // A little stupid, but works I guess.
   test.beforeEach(async () => {
     await selectChatByName(page, chatName)
+    // Wait for the messages to be loaded:
+    // the shortcut does nothing as long as they aren't.
+    await expect(
+      page.getByLabel('Messages').getByText(getMessageText(numMessages - 1))
+    ).toBeVisible()
   })
 
   async function up() {

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBarContext.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBarContext.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 
 import AbsolutePositioningHelper from '../AbsolutePositioningHelper'
 import OutsideClickHelper from '../OutsideClickHelper'
@@ -25,19 +25,24 @@ export const ReactionsBarContext =
 export const ReactionsBarProvider = ({ children }: PropsWithChildren<{}>) => {
   const [barArgs, setBarArgs] = useState<ShowReactionBar | null>(null)
 
-  const showReactionsBar = (args: ShowReactionBar) => {
+  const showReactionsBar = useCallback((args: ShowReactionBar) => {
     setBarArgs(args)
-  }
+  }, [])
 
-  const hideReactionsBar = () => {
+  const hideReactionsBar = useCallback(() => {
     setBarArgs(null)
-  }
+  }, [])
 
-  const value: ReactionsBarValue = {
-    showReactionsBar,
-    hideReactionsBar,
-    isReactionsBarShown: barArgs !== null,
-  }
+  const isReactionsBarShown = barArgs !== null
+
+  const value: ReactionsBarValue = useMemo(
+    () => ({
+      showReactionsBar,
+      hideReactionsBar,
+      isReactionsBarShown,
+    }),
+    [showReactionsBar, hideReactionsBar, isReactionsBarShown]
+  )
 
   useEffect(() => {
     const hideOnEscape = (event: KeyboardEvent) => {
@@ -49,7 +54,7 @@ export const ReactionsBarProvider = ({ children }: PropsWithChildren<{}>) => {
     return () => {
       window.removeEventListener('keyup', hideOnEscape)
     }
-  }, [barArgs])
+  }, [barArgs, hideReactionsBar])
 
   return (
     <ReactionsBarContext.Provider value={value}>

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -980,16 +980,6 @@ export const MessageListInner = React.memo(
         </div>
       </>
     )
-  },
-  (prevProps, nextProps) => {
-    const areEqual: boolean =
-      prevProps.activeView === nextProps.activeView &&
-      prevProps.messageCache === nextProps.messageCache &&
-      prevProps.oldestFetchedMessageIndex ===
-        nextProps.oldestFetchedMessageIndex &&
-      prevProps.onScroll === nextProps.onScroll &&
-      prevProps.onWheel === nextProps.onWheel
-    return areEqual
   }
 )
 

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -670,14 +670,17 @@ export default function MessageList({
     }
   }, [])
 
+  const messagesDisplayContextValue = useMemo(
+    () => ({
+      context: 'chat_messagelist' as const,
+      chatId: chat.id,
+      isDeviceChat: chat.isDeviceChat,
+    }),
+    [chat.id, chat.isDeviceChat]
+  )
+
   return (
-    <MessagesDisplayContext.Provider
-      value={{
-        context: 'chat_messagelist',
-        chatId: chat.id,
-        isDeviceChat: chat.isDeviceChat,
-      }}
-    >
+    <MessagesDisplayContext.Provider value={messagesDisplayContextValue}>
       <MessageListInner
         onScroll={onScroll}
         onScrollEnd={onScrollEnd}
@@ -749,11 +752,14 @@ export const MessageListInner = React.memo(
       loadMissingMessages,
     } = props
 
-    const conversationType: ConversationType = {
-      hasMultipleParticipants: chat.chatType !== 'Single',
-      isDeviceChat: chat.isDeviceChat as boolean,
-      chatType: chat.chatType,
-    }
+    const conversationType: ConversationType = useMemo(
+      () => ({
+        hasMultipleParticipants: chat.chatType !== 'Single',
+        isDeviceChat: chat.isDeviceChat as boolean,
+        chatType: chat.chatType,
+      }),
+      [chat.chatType, chat.isDeviceChat]
+    )
 
     useKeyBindingAction(KeybindAction.MessageList_PageUp, () => {
       if (messageListRef.current) {
@@ -1128,7 +1134,9 @@ function JumpDownButton({
   )
 }
 
-export function DayMarker(props: { timestamp: number }) {
+export const DayMarker = React.memo(function DayMarker(props: {
+  timestamp: number
+}) {
   const { timestamp } = props
   const tx = useTranslationFunction()
 
@@ -1161,4 +1169,4 @@ export function DayMarker(props: { timestamp: number }) {
       </div>
     </li>
   )
-}
+})

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -293,7 +293,6 @@ export default function MessageList({
     // Don't flash the button during a programmatic smooth scroll —
     // we already know we're scrolling to the bottom.
     if (pendingProgrammaticSmoothScrollTo.current === null) {
-      // React bails out of re-rendering if the value didn't change.
       setShowJumpDownButton(newShowJumpDownButton)
     }
     if (!newShowJumpDownButton) {

--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -107,7 +107,6 @@ export default function MessageList({
   } = messageListStore
   const {
     oldestFetchedMessageListItemIndex,
-    newestFetchedMessageListItemIndex,
     messageCache,
     messageListItems,
     viewState,
@@ -281,17 +280,21 @@ export default function MessageList({
       messageListRef.current.scrollTop -
       messageListRef.current.clientHeight
 
+    const {
+      newestFetchedMessageListItemIndex: newestFetchedIndex,
+      messageListItems: currentMessageListItems,
+    } = messageListStore.getState()
+
     const isNewestMessageLoaded =
-      newestFetchedMessageListItemIndex === messageListItems.length - 1
+      newestFetchedIndex === currentMessageListItems.length - 1
     const newShowJumpDownButton =
       !isNewestMessageLoaded ||
       distanceToBottom > maxScrollToBottomDistanceConsideredShort
     // Don't flash the button during a programmatic smooth scroll —
     // we already know we're scrolling to the bottom.
     if (pendingProgrammaticSmoothScrollTo.current === null) {
-      if (newShowJumpDownButton != showJumpDownButton) {
-        setShowJumpDownButton(newShowJumpDownButton)
-      }
+      // React bails out of re-rendering if the value didn't change.
+      setShowJumpDownButton(newShowJumpDownButton)
     }
     if (!newShowJumpDownButton) {
       clearJumpStack()
@@ -324,10 +327,8 @@ export default function MessageList({
     clearJumpStack,
     fetchMoreBottom,
     fetchMoreTop,
-    messageListItems.length,
-    newestFetchedMessageListItemIndex,
+    messageListStore,
     scheduler,
-    showJumpDownButton,
   ])
   const onScrollEnd = useCallback((_ev: Event) => {
     clearTimeout(pendingProgrammaticSmoothScrollTimeout.current)

--- a/packages/frontend/src/components/message/MessageWrapper.tsx
+++ b/packages/frontend/src/components/message/MessageWrapper.tsx
@@ -17,8 +17,6 @@ type RenderMessageProps = {
 
 const log = getLogger('renderer/message/MessageWrapper')
 
-// `React.memo`, so that a single changed message doesn't re-render
-// every other message in the list.
 export const MessageWrapper = React.memo(function MessageWrapper(
   props: RenderMessageProps
 ) {

--- a/packages/frontend/src/components/message/MessageWrapper.tsx
+++ b/packages/frontend/src/components/message/MessageWrapper.tsx
@@ -17,7 +17,11 @@ type RenderMessageProps = {
 
 const log = getLogger('renderer/message/MessageWrapper')
 
-export function MessageWrapper(props: RenderMessageProps) {
+// `React.memo`, so that a single changed message doesn't re-render
+// every other message in the list.
+export const MessageWrapper = React.memo(function MessageWrapper(
+  props: RenderMessageProps
+) {
   const observerRef = useRef<HTMLDivElement>(null)
   const state = props.message.state
   const shouldInViewObserve =
@@ -73,4 +77,4 @@ export function MessageWrapper(props: RenderMessageProps) {
       )}
     </li>
   )
-}
+})

--- a/packages/frontend/src/components/message/focusAndMultiselect.tsx
+++ b/packages/frontend/src/components/message/focusAndMultiselect.tsx
@@ -66,7 +66,11 @@ export function useMessageFocusAndMultiselectContextValue(props: {
     // even though all you did is click a link inside of it.
     { onNormalClick: 'unselectAll' }
   )
-  return { ...multiselect, resetSelection }
+  // Memoized because it is used as a context value.
+  return useMemo(
+    () => ({ ...multiselect, resetSelection }),
+    [multiselect, resetSelection]
+  )
 }
 
 export function useMessageFocusAndMultiselect(

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -273,14 +273,25 @@ export const ChatProvider = ({
     }
   }, [accountId, chatWithLinger, chatId, refreshChat])
 
-  const value: ChatContextValue = {
-    chatWithLinger,
-    chatNoLinger,
-    loadingChat: chatFetch?.loading ?? false,
-    chatId,
-    selectChat,
-    unselectChat,
-  }
+  const loadingChat = chatFetch?.loading ?? false
+  const value: ChatContextValue = useMemo(
+    () => ({
+      chatWithLinger,
+      chatNoLinger,
+      loadingChat,
+      chatId,
+      selectChat,
+      unselectChat,
+    }),
+    [
+      chatWithLinger,
+      chatNoLinger,
+      loadingChat,
+      chatId,
+      selectChat,
+      unselectChat,
+    ]
+  )
 
   return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>
 }

--- a/packages/frontend/src/contexts/ContextMenuContext.tsx
+++ b/packages/frontend/src/contexts/ContextMenuContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useState } from 'react'
+import React, { createContext, useCallback, useMemo, useState } from 'react'
 
 import { ContextMenuLayer } from '../components/ContextMenu'
 
@@ -38,9 +38,12 @@ export function ContextMenuProvider({ children }: PropsWithChildren<{}>) {
     )
   }, [])
 
-  const value = {
-    openContextMenu: openContextMenuFn,
-  }
+  const value = useMemo(
+    () => ({
+      openContextMenu: openContextMenuFn,
+    }),
+    [openContextMenuFn]
+  )
 
   return (
     <ContextMenuContext.Provider value={value}>

--- a/packages/frontend/src/contexts/RovingTabindex.tsx
+++ b/packages/frontend/src/contexts/RovingTabindex.tsx
@@ -6,6 +6,7 @@ import React, {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 
@@ -255,15 +256,18 @@ export function RovingTabindexProvider({
     [activeElement, classNameOfTargetElements, direction, wrapperElementRef]
   )
 
+  const value: ContextValue = useMemo(
+    () => ({
+      activeElement,
+      onKeydown,
+      setActiveElement,
+      classNameOfTargetElements,
+    }),
+    [activeElement, onKeydown, classNameOfTargetElements]
+  )
+
   return (
-    <RovingTabindexContext.Provider
-      value={{
-        activeElement,
-        onKeydown,
-        setActiveElement,
-        classNameOfTargetElements,
-      }}
-    >
+    <RovingTabindexContext.Provider value={value}>
       {children}
     </RovingTabindexContext.Provider>
   )

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -447,6 +447,11 @@ export function useDraft(
     if (!currQuote) {
       if (upOrDown === KeybindAction.Composer_SelectReplyToUp) {
         const id = messageIds[messageIds.length - 1]
+        if (id == undefined) {
+          // No quotable messages in the cache. Either the chat is empty,
+          // or the messages haven't been loaded yet
+          return
+        }
         const fromCache = messageListState.messageCache[id]
         quoteAndJumpToMessage(fromCache?.kind === 'message' ? fromCache : id)
       }

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -227,10 +227,6 @@ export class MessageListStore extends Store<MessageListState> {
     super(defaultState(), 'MessageListStore')
   }
 
-  /**
-   * Cache {@linkcode MessageListStore.activeView} and return the cached reference
-   * if nothing changed, so that it doesn't trigger `React.memo` to rerender.
-   */
   private activeViewCache: {
     items: T.MessageListItem[]
     start: number
@@ -238,6 +234,10 @@ export class MessageListStore extends Store<MessageListState> {
     view: T.MessageListItem[]
   } | null = null
 
+  /**
+   * Cache {@linkcode MessageListStore.activeView} and return the cached reference
+   * if nothing changed, so that it doesn't trigger `React.memo` to rerender.
+   */
   get activeView() {
     const items = this.state.messageListItems
     const start = this.state.oldestFetchedMessageListItemIndex

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -227,11 +227,35 @@ export class MessageListStore extends Store<MessageListState> {
     super(defaultState(), 'MessageListStore')
   }
 
+  /**
+   * Cache {@linkcode MessageListStore.activeView} and return the cached reference
+   * if nothing changed, so that it doesn't trigger `React.memo` to rerender.
+   */
+  private activeViewCache: {
+    items: T.MessageListItem[]
+    start: number
+    end: number
+    view: T.MessageListItem[]
+  } | null = null
+
   get activeView() {
+    const items = this.state.messageListItems
     const start = this.state.oldestFetchedMessageListItemIndex
     const end = this.state.newestFetchedMessageListItemIndex
-    const view = getView(this.state.messageListItems, start, end)
+
+    const cache = this.activeViewCache
+    if (
+      cache !== null &&
+      cache.items === items &&
+      cache.start === start &&
+      cache.end === end
+    ) {
+      return cache.view
+    }
+
+    const view = getView(items, start, end)
     // this.log.debug('get activeView', { end, start, view })
+    this.activeViewCache = { items, start, end, view }
     return view
   }
 


### PR DESCRIPTION
We had several places where non memoized objects triggered unnecessary renderings. Although the effect in production mode is quite small it is remarkable in dev mode and avoids superfluous rendering without introducing significant new logic. 