### PR TITLE
test: don't fail "app picker URL" on second run

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -433,40 +433,62 @@ test('add app from picker to chat', async () => {
   expect(finalAppIconsCount).toBeGreaterThan(initialAppIconsCount)
 })
 
-test('custom app picker URL', async () => {
-  const userA = existingProfiles[0]
-  const userB = existingProfiles[1]
-  await switchToProfile(page, userA.id)
-  await selectChat(page, userB.name)
+test.describe('custom app picker URL', () => {
+  test.afterAll(async () => {
+    // Restore the default value, so that the next time the test doesn't fail
+    // because unfortunately the config file is persisted between test runs.
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Escape')
+    }
 
-  // It's the default URL but with different casing.
-  // The behavior will remain the same network-wise,
-  // but this still allows us to check that the setting change is stored
-  // and that the picker still works after that.
-  const newUrl = 'HTTPS://APPS.testRUN.ORG/'
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('button', { name: 'Advanced' }).click()
+    await page.getByRole('button', { name: 'App Picker URL' }).click()
+    await page.getByRole('dialog').last().getByRole('textbox').clear()
+    await page.keyboard.press('Enter')
 
-  await page.getByRole('button', { name: 'Settings' }).click()
-  await page.getByRole('button', { name: 'Advanced' }).click()
-  const advancedDialog = page
-    .getByRole('dialog')
-    .filter({ hasText: 'Advanced' })
-    .filter({ hasText: 'Experimental' })
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Escape')
+    }
+  })
 
-  await expect(advancedDialog).not.toContainText(newUrl, { ignoreCase: false })
-  await page.getByRole('button', { name: 'App Picker URL' }).click()
-  await page.getByRole('dialog').last().getByRole('textbox').fill(newUrl)
-  await page.keyboard.press('Enter')
-  await expect(advancedDialog).toContainText(newUrl, { ignoreCase: false })
+  test('works', async () => {
+    const userA = existingProfiles[0]
+    const userB = existingProfiles[1]
+    await switchToProfile(page, userA.id)
+    await selectChat(page, userB.name)
 
-  await page.keyboard.press('Escape')
-  await page.keyboard.press('Escape')
+    // It's the default URL but with different casing.
+    // The behavior will remain the same network-wise,
+    // but this still allows us to check that the setting change is stored
+    // and that the picker still works after that.
+    const newUrl = 'HTTPS://APPS.testRUN.ORG/'
 
-  await page.getByRole('button', { name: 'Attach' }).click()
-  await page.getByRole('menuitem', { name: 'App' }).click()
-  await page.getByRole('button', { name: 'Poll' }).first().click()
-  await page.getByRole('button', { name: 'Add to Chat' }).click()
-  await page.getByRole('button', { name: 'Send', exact: true }).click()
-  await expect(page.locator(`.message`).last()).toContainText('Poll')
+    await page.getByRole('button', { name: 'Settings' }).click()
+    await page.getByRole('button', { name: 'Advanced' }).click()
+    const advancedDialog = page
+      .getByRole('dialog')
+      .filter({ hasText: 'Advanced' })
+      .filter({ hasText: 'Experimental' })
+
+    await expect(advancedDialog).not.toContainText(newUrl, {
+      ignoreCase: false,
+    })
+    await page.getByRole('button', { name: 'App Picker URL' }).click()
+    await page.getByRole('dialog').last().getByRole('textbox').fill(newUrl)
+    await page.keyboard.press('Enter')
+    await expect(advancedDialog).toContainText(newUrl, { ignoreCase: false })
+
+    await page.keyboard.press('Escape')
+    await page.keyboard.press('Escape')
+
+    await page.getByRole('button', { name: 'Attach' }).click()
+    await page.getByRole('menuitem', { name: 'App' }).click()
+    await page.getByRole('button', { name: 'Poll' }).first().click()
+    await page.getByRole('button', { name: 'Add to Chat' }).click()
+    await page.getByRole('button', { name: 'Send', exact: true }).click()
+    await expect(page.locator(`.message`).last()).toContainText('Poll')
+  })
 })
 
 test('recent apps context menu', async () => {


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/6515.

Ideally I'd prefer to nuke the data folder when the tests have run,
but we don't have the facilities for that yet.
