### PR TITLE
fix: add bottom margin to copy dialog

### DIFF
--- a/packages/frontend/scss/dialogs/_qr-code.scss
+++ b/packages/frontend/scss/dialogs/_qr-code.scss
@@ -58,4 +58,5 @@
   overflow-wrap: break-word;
   word-break: break-all;
   padding: 10px;
+  margin-bottom: 20px;
 }


### PR DESCRIPTION
Margin was missing between buttons and content

<img width="1116" height="516" alt="image" src="https://github.com/user-attachments/assets/a4530231-58a5-484a-a766-98a6b73e6597" />
