### PR TITLE
test: reactivate unencrypted tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -97,6 +97,7 @@ jobs:
           name: e2e-report-${{ matrix.relay }}
           path: |
             packages/e2e-tests/playwright-report
+            packages/e2e-tests/playwright-report-public
             chatmail-logs
           if-no-files-found: ignore
           retention-days: 10

--- a/packages/e2e-tests/.gitignore
+++ b/packages/e2e-tests/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 /test-results/
 /playwright-report/
+/playwright-report-public/
 /blob-report/
 /playwright/.cache/
 /data/*

--- a/packages/e2e-tests/playwright-helper.ts
+++ b/packages/e2e-tests/playwright-helper.ts
@@ -399,6 +399,35 @@ export async function getProfile(
   }
 }
 
+/**
+ * Toggle the "Enforce Encryption for All Relays" setting
+ * Unencrypted ("New Email") chats can only be created when it is disabled.
+ */
+export async function setForceEncryption(
+  page: Page,
+  accountId: string,
+  enabled: boolean
+): Promise<void> {
+  await page.getByTestId(`account-item-${accountId}`).click({ button: 'right' })
+  await page.getByTestId('open-settings-menu-item').click()
+  await page.getByTestId('open-advanced-settings').click()
+  await page.getByTestId('open-transport-settings').click()
+  await page.getByLabel('Edit Relay').first().click()
+  await page.locator('#show-advanced-button').click()
+  const switchInput = page.getByRole('checkbox', {
+    name: 'Enforce Encryption for All Relays',
+  })
+  if ((await switchInput.isChecked()) !== enabled) {
+    await switchInput.press('Space')
+  }
+  await expect(switchInput).toBeChecked({ checked: enabled })
+  await page.getByTestId('ok').click()
+  // Wait for the re-configuration to finish and the edit dialog to close.
+  await expect(page.locator('#addr')).not.toBeVisible({ timeout: 60_000 })
+  await page.getByTestId('transports-settings-close').click()
+  await page.getByTestId('settings-advanced-close').click()
+}
+
 export async function createProfiles(
   number: number,
   existingProfiles: User[],

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -62,14 +62,16 @@ export default defineConfig<TestOptions>({
         isChatmail: true, // create profiles on a dedicated chatmail server
       },
     },
-    // Our non chatmail server is too unreliable right now to be used in CI
-    // {
-    //   name: 'non-chatmail',
-    //   use: {
-    //     ...devices['Desktop Chrome'],
-    //     isChatmail: false, // create profiles on a dedicated non-chatmail server
-    //   },
-    // },
+    {
+      name: 'non-chatmail',
+      // Only the tests that need plain (non-chatmail) email accounts.
+      // They skip themselves if DC_MAIL_SERVER is not configured.
+      testMatch: /unencrypted-group-tests\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        isChatmail: false, // create profiles on a dedicated non-chatmail server
+      },
+    },
   ],
 
   webServer: Array.from({ length: NUM_APP_INSTANCES }, (_, _index) => {

--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -92,13 +92,13 @@ test('create profiles', async ({ browserName, isChatmail }) => {
   expect(existingProfiles.length).toBe(numberOfProfiles)
 })
 
-test('check "New E-Mail" option presence', async ({ isChatmail }) => {
+test('check "New Email" option presence', async ({ isChatmail }) => {
   await page.locator('#new-chat-button').click()
 
   await expect(page.getByRole('button', { name: 'New Group' })).toBeVisible()
 
   // Since we're on a Chatmail server, this button is not supposed to be shown.
-  const newEmailButton = page.getByRole('button', { name: 'New E-Mail' })
+  const newEmailButton = page.getByRole('button', { name: 'New Email' })
   if (isChatmail) {
     await expect(newEmailButton).not.toBeVisible()
     // Same button, but double-check, by ID.

--- a/packages/e2e-tests/tests/group-tests.spec.ts
+++ b/packages/e2e-tests/tests/group-tests.spec.ts
@@ -85,13 +85,13 @@ test('create group', async () => {
   await expect(badgeNumber).toHaveText('1')
 })
 
-test('check "New E-Mail" option presence', async ({ isChatmail }) => {
+test('check "New Email" option presence', async ({ isChatmail }) => {
   await page.locator('#new-chat-button').click()
 
   await expect(page.getByRole('button', { name: 'New Group' })).toBeVisible()
 
   // Since we're on a Chatmail server, this button is not supposed to be shown.
-  const newEmailButton = page.getByRole('button', { name: 'New E-Mail' })
+  const newEmailButton = page.getByRole('button', { name: 'New Email' })
   if (isChatmail) {
     await expect(newEmailButton).not.toBeVisible()
     // Same button, but double-check, by ID.

--- a/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
+++ b/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
@@ -11,6 +11,8 @@ import {
   clickThroughTestIds,
   getUser,
   createChat,
+  mailServerUrl,
+  mailServerToken,
 } from '../playwright-helper.js'
 
 test.describe.configure({
@@ -35,6 +37,10 @@ test.beforeAll(async ({ browser, isChatmail }) => {
       'Non encrypted groups are not possible on chatmail accounts'
     )
   }
+  test.skip(
+    !mailServerUrl || mailServerToken == undefined,
+    'DC_MAIL_SERVER / DC_MAIL_SERVER_TOKEN are not configured'
+  )
   const contextForProfileCreation = await browser.newContext()
   const pageForProfileCreation = await contextForProfileCreation.newPage()
   await reloadPage(pageForProfileCreation)

--- a/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
+++ b/packages/e2e-tests/tests/unencrypted-group-tests.spec.ts
@@ -13,6 +13,7 @@ import {
   createChat,
   mailServerUrl,
   mailServerToken,
+  setForceEncryption,
 } from '../playwright-helper.js'
 
 test.describe.configure({
@@ -47,6 +48,7 @@ test.beforeAll(async ({ browser, isChatmail }) => {
 
   existingProfiles =
     (await loadExistingProfiles(pageForProfileCreation)) ?? existingProfiles
+  test.setTimeout(180_000)
 
   await createProfiles(
     numberOfProfiles,
@@ -54,6 +56,14 @@ test.beforeAll(async ({ browser, isChatmail }) => {
     pageForProfileCreation,
     browser.browserType().name(),
     isChatmail
+  )
+
+  // Unencrypted ("New Email") chats can only be created when
+  // force_encryption is disabled
+  await setForceEncryption(
+    pageForProfileCreation,
+    getUser(0, existingProfiles).id,
+    false
   )
 
   await contextForProfileCreation.close()
@@ -82,7 +92,7 @@ test.afterAll(async ({ browser }) => {
 /**
  * create an unencrypted group with plain email contacts
  */
-test('check "New E-Mail" option is shown and a chat can be created', async () => {
+test('check "New Email" option is shown and a chat can be created', async () => {
   const userA = existingProfiles[0]
   const userB = existingProfiles[1]
   const userC = existingProfiles[2]
@@ -93,7 +103,7 @@ test('check "New E-Mail" option is shown and a chat can be created', async () =>
   await page.locator('#new-chat-button').click()
 
   // Since we're on a non-chatmail server, this button is supposed to be shown.
-  const newEmailButton = page.getByRole('button', { name: 'New E-Mail' })
+  const newEmailButton = page.getByRole('button', { name: 'New Email' })
   await expect(newEmailButton).toBeVisible()
 
   await newEmailButton.click()
@@ -104,21 +114,24 @@ test('check "New E-Mail" option is shown and a chat can be created', async () =>
   ).not.toBeVisible()
   await page.locator('#addmember').click()
 
-  await page.getByTestId('add-member-search').fill(emailUserB)
+  const searchInput = page.getByTestId('add-member-search')
+  await searchInput.fill(emailUserB)
 
   const contactRowA = page
     .locator('.styles_module_addMemberContactList li button')
     .filter({ hasText: emailUserB })
     .first()
   await contactRowA.click()
+  await expect(searchInput).toHaveValue('')
 
-  await page.getByTestId('add-member-search').fill(emailUserC)
+  await searchInput.fill(emailUserC)
 
   const contactRowB = page
     .locator('.styles_module_addMemberContactList li button')
     .filter({ hasText: emailUserC })
     .first()
   await contactRowB.click()
+  await expect(searchInput).toHaveValue('')
 
   await page.getByTestId('ok').click()
 
@@ -152,11 +165,9 @@ test('check appropriate members are shown for new encrypted group', async () => 
   const contactList = page.getByTestId('add-member-dialog').locator('li button')
   // only self and the verified user should be visible
   await expect(contactList).toHaveCount(2)
-  // TODO: this should show the contact by name but it fails with a
-  // screenshot showing the mail address instead of the name ??
   await addMemberDialog
     .locator('.contact-list-item')
-    .filter({ hasText: userD.address })
+    .filter({ hasText: userD.name })
     .click()
   const contactShouldNotBeListed = addMemberDialog
     .locator('.contact-list-item')
@@ -244,12 +255,16 @@ test('chat list item context menu', async () => {
   await chatListItem.click({
     button: 'right',
   })
-  // "Leave Group" does not apply to unencrypted groups.
-  await expect(page.getByRole('menuitem', { name: 'Delete' })).toBeVisible()
-  await expect(
-    page.getByRole('menuitem', { name: 'Leave Group' })
-  ).not.toBeVisible()
-  await expect(page.getByRole('menuitem')).toHaveCount(5)
+  // "Leave Group" does not apply to unencrypted groups,
+  // "Delete" is shown instead.
+  await expect(page.getByRole('menuitem')).toHaveText([
+    'Pin Chat',
+    'Unread',
+    'Mute Notifications',
+    'Archive Chat',
+    'View Profile',
+    'Delete',
+  ])
 
   await page.getByRole('menuitem').first().press('Escape')
   await expect(page.getByRole('menuitem')).not.toBeVisible()


### PR DESCRIPTION
Maybe if we just use it for the unencrypted tests it will be reliable enough to use the mailserver?