### PR TITLE
fix: non-main chat list items: wrong aria-haspopup

### DIFF
--- a/packages/frontend/src/components/chat/ChatListItemRow.tsx
+++ b/packages/frontend/src/components/chat/ChatListItemRow.tsx
@@ -52,7 +52,9 @@ export type ChatListItemData = {
   onChatClick: (chatId: number) => void
   // onChatClick: (event: React.MouseEvent, chatId: number) => void
   // onChatFocus?: (chatId: number) => void
-  openContextMenu: ReturnType<typeof useChatContextMenu>['openContextMenu']
+  openContextMenu:
+    | ReturnType<typeof useChatContextMenu>['openContextMenu']
+    | undefined
   activeContextMenuChatIds: ReturnType<
     typeof useChatContextMenu
   >['activeContextMenuChatIds']
@@ -146,6 +148,11 @@ export const ChatListItemRowChat = React.memo<{
 
   const onContextMenu = useCallback(
     (event: React.MouseEvent) => {
+      if (openContextMenu == null) {
+        throw new Error(
+          'tried to open context menu, but its callback is nullish'
+        )
+      }
       // So, do we handle archive link multiselect here?
       if (chat == null) {
         // Probably still loading.
@@ -237,6 +244,10 @@ export const ChatListItemRowChat = React.memo<{
   const onContextMenuRef = useRef(onContextMenu)
   // eslint-disable-next-line react-hooks/refs
   onContextMenuRef.current = onContextMenu
+  const onContextMenuCallback = useCallback(
+    (event: React.MouseEvent) => onContextMenuRef.current(event),
+    []
+  )
 
   const multiselectOnFocus = multiselect?.onFocus
   const onFocus = useCallback(
@@ -276,10 +287,7 @@ export const ChatListItemRowChat = React.memo<{
           (event: React.FocusEvent) => onFocusRef.current(event),
           []
         )}
-        onContextMenu={useCallback(
-          (event: React.MouseEvent) => onContextMenuRef.current(event),
-          []
-        )}
+        onContextMenu={openContextMenu ? onContextMenuCallback : undefined}
         isContextMenuActive={activeContextMenuChatIds.includes(chatId)}
         aria-setsize={chatListIds.length}
         aria-posinset={index + 1}

--- a/packages/frontend/src/components/dialogs/SelectChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/SelectChat/index.tsx
@@ -195,7 +195,7 @@ function SelectChatList({
 
                     activeChatId: null,
                     activeContextMenuChatIds: [],
-                    openContextMenu: async () => {},
+                    openContextMenu: undefined,
                   }}
                 >
                   {ChatListItemRowChat}

--- a/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/index.tsx
@@ -334,7 +334,7 @@ export function ViewProfileInner({
 
                       activeChatId: null,
                       activeContextMenuChatIds: [],
-                      openContextMenu: async () => {},
+                      openContextMenu: undefined,
                     }}
                   >
                     {ChatListItemRowChat}


### PR DESCRIPTION
For example, in the dialog that opens
when you're going to "share contact",
or in a contact's "Chats in Common" section.

`onContextMenu` being non-null adds `aria-haspopup="menu"`
on chat list items, so we must specify a nullish value
instead of a no-op function.
