### PR TITLE
fix: set correct WMClass

### DIFF
--- a/packages/target-electron/build/gen-electron-builder-config.js
+++ b/packages/target-electron/build/gen-electron-builder-config.js
@@ -31,14 +31,21 @@ const build = {}
 build['appId'] = 'chat.delta.desktop.electron'
 build['extraMetadata'] = {
   //@ts-ignore
-  // restore old name before mono-repo
   name: 'deltachat-desktop',
+  // Electron derives the Linux window class (X11 WM_CLASS / Wayland app_id)
+  // from `desktopName` in package.json. It must match the name of the
+  // installed desktop file (`<executableName>.desktop`)
+  // see https://github.com/deltachat/deltachat-desktop/issues/6505
+  //@ts-ignore
+  desktopName: 'deltachat-desktop.desktop',
 }
 
 if (previewBuild) {
   build.appId = 'chat.delta.desktop.electron.dev'
   //@ts-ignore
   build.extraMetadata.name = 'deltachat-desktop-dev'
+  //@ts-ignore
+  build.extraMetadata.desktopName = 'deltachat-desktop-dev.desktop'
   //@ts-ignore
   build.extraMetadata.productName = 'DeltaChat-DevBuild'
   const p = JSON.parse(


### PR DESCRIPTION
resolves #6505 

see https://www.electronjs.org/docs/latest/api/app#appsetdesktopnamename-linux

Here are some related links:
https://github.com/Foundry376/Mailspring/pull/2657
https://github.com/signalapp/Signal-Desktop/issues/7515

Edit:
See https://www.electron.build/docs/linux/#window-association-desktopname

This changes:
WM_CLASS: 	deltachat => deltachat-desktop
StartupWMClass: DeltaChat => deltachat-desktop

That's what I found in my local test with the .deb build.

Packages that ship their own .desktop file need to follow, e.g. flathub
(currently `deltachat`) and nixpkgs (currently `DeltaChat`).

