### PR TITLE
fix: make it possible to set 1-char group name

### DIFF
--- a/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
@@ -385,7 +385,7 @@ function ViewGroupInner(
         groupImage: string | null
       ) => {
         // TODO this check should be way earlier, you should not be able to "OK" the dialog if there is no group name
-        if (groupName.length > 1) {
+        if (groupName.length > 0) {
           setGroupName(groupName)
         }
         // Description can be empty, so always set it


### PR DESCRIPTION
The issue was introduced in
https://github.com/deltachat/deltachat-desktop/pull/2827/changes/560f30f87c34c6c2ef083fc812930cc1ac84988b.

The `.length > 1` check does not make sense for string in general
because some characters are more than 1 in length (e.g. emojis).
The intent was probably `>= 1`.
