### PR TITLE
refactor: clarify that `useSecureJoin` is just fn

### DIFF
--- a/packages/frontend/src/hooks/useInstantOnboarding.ts
+++ b/packages/frontend/src/hooks/useInstantOnboarding.ts
@@ -37,7 +37,7 @@ type InstantOnboarding = {
 export default function useInstantOnboarding(): InstantOnboarding {
   const context = useContext(InstantOnboardingContext)
   const { openDialog } = useDialog()
-  const { secureJoin } = useSecureJoin()
+  const secureJoin = useSecureJoin()
 
   if (!context) {
     throw new Error(

--- a/packages/frontend/src/hooks/useProcessQr.ts
+++ b/packages/frontend/src/hooks/useProcessQr.ts
@@ -106,7 +106,7 @@ export default function useProcessQR() {
 
   const openMailtoLink = useOpenMailtoLink()
   const { startInstantOnboardingFlow } = useInstantOnboarding()
-  const { secureJoin } = useSecureJoin()
+  const secureJoin = useSecureJoin()
 
   const settingsStore = useSettingsStore()[0]
   const { selectChat } = useChat()

--- a/packages/frontend/src/hooks/useSecureJoin.ts
+++ b/packages/frontend/src/hooks/useSecureJoin.ts
@@ -88,7 +88,5 @@ export default function useSecureJoin() {
     [openConfirmationDialog, tx]
   )
 
-  return {
-    secureJoin,
-  }
+  return secureJoin
 }


### PR DESCRIPTION
The fact that it's a hook makes it seem like it probably has state
and other returned values, whereas it's just one function.
