### PR TITLE
refactor: print stack trace on `useFetch` err

### DIFF
--- a/packages/frontend/src/hooks/useFetch.ts
+++ b/packages/frontend/src/hooks/useFetch.ts
@@ -144,7 +144,7 @@ export function useFetchGeneric<F extends AsyncFNoArgs>(
               result: { ok: false, err },
               fetchId,
             })
-            log.errorWithoutStackTrace('error while executing fetch', err)
+            log.error(new Error('error while executing fetch', { cause: err }))
           }
         })
 


### PR DESCRIPTION
This has been brought up in
https://github.com/deltachat/deltachat-desktop/pull/5291#pullrequestreview-3019428286.
Turns out the stack is indeed somewhat useful after all,
at least in the dev tools (but not the log file):

<img width="229" height="161" alt="image" src="https://github.com/user-attachments/assets/ab90f2f9-a57d-49d2-b811-5e3307e39e0f" />
