### PR TITLE
improvement: hide DB id of loading messages

### DIFF
--- a/packages/frontend/src/components/message/MessageList.tsx
+++ b/packages/frontend/src/components/message/MessageList.tsx
@@ -1005,6 +1005,10 @@ function MessageLoading({
     ref
   )
 
+  useEffect(() => {
+    log.warn(`Rendered message ${messageId.msg_id} that is not loaded yet`)
+  }, [messageId.msg_id])
+
   return (
     <div className='info-message' id={String(messageId.msg_id)}>
       <div
@@ -1020,7 +1024,7 @@ function MessageLoading({
         onKeyDown={focusAndMultiselect.onKeyDown}
         onFocus={focusAndMultiselect.onFocus}
       >
-        {tx('loading')} Message {messageId.msg_id}
+        {tx('loading')}
       </div>
     </div>
   )


### PR DESCRIPTION
Normally we should not render messages that are still loading,
but if it does happen, let's not show the ugly internals.
Still, log the message ID.

This also removes yet another untranslated string.

Addresses https://github.com/deltachat/deltachat-desktop/pull/6591#discussion_r3646092744.
