### PR TITLE
docs: correct latest CHANGELOG (DC version)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Relay list not syncing to devices with Delta Chat versions older than 2.55.0.
+- Relay list not syncing to devices with Delta Chat versions older than 2.56.0.
   If you recently added a second device and it can't receive and send messages,
   upgrade your main device to 2.57.0 and then add that second device again.
 


### PR DESCRIPTION
This is what the Core git log looks like:

```
* ca1fe8e35 (tag: v2.56.0) chore(release): prepare for 2.56.0
* 61898b478 fix: revert 207c2e6e4c1bec43204c3b8a46fcbbff67d54b3f because some users reported problems with it
* 5c1e69523 api!: remove all oauth support and drop DC_LP_AUTH flags
* 1721c0316 feat: do not set backup_time in exported databases
* 398ddac0b chore: bump version to 2.56.0-dev
* 35d7b4e21 (tag: v2.55.0) chore(release): prepare for 2.55.0
```

The commit that removed OAuth was released in 2.56,
so version 2.55 was the last one that required the `oauth2` field,
so syncing from 2.56 to 2.55 also doesn't work.
