### PR TITLE
fix: require authentication for /background static file route

### DIFF
--- a/packages/target-browser/src/index.ts
+++ b/packages/target-browser/src/index.ts
@@ -199,7 +199,7 @@ app.get('/stickers/:account/:?pack/:filename', authMiddleWare, (req, res) => {
   res.send('req.params' + JSON.stringify(req.params))
 })
 
-app.use('/background', express.static(join(DATA_DIR, 'background')))
+app.use('/background', authMiddleWare, express.static(join(DATA_DIR, 'background')))
 
 app.use('/backend-api', BackendApiRoute)
 app.use(helpRoute)


### PR DESCRIPTION
Add `authMiddleWare` to the `/background` static file route to prevent unauthenticated access to user-provided background images.

## Changes
- Added `authMiddleWare` to the `/background` express static mount in `packages/target-browser/src/index.ts`

## Why
The `/background` route serves user-uploaded or user-selected background images from `DATA_DIR/background`. Without authentication, these files are accessible to anyone who can reach the server, bypassing the session-based auth that protects the rest of the application. This brings the route in line with other protected endpoints like `/blobs`, `/download-backup`, and `/log`.

## Semgrep Finding Details
The `/background` static file mount is registered without `authMiddleWare`, so files under `DATA_DIR/background` are served without authentication. The backend API copies selected or uploaded background images into this directory, meaning this route can expose user-provided background files outside the authenticated application session.

pellepelleyan@gmail.com requested this Autofix PR for [this finding](https://semgrep.dev/orgs/ohmix/ai-findings/904697653).