### PR TITLE
fix: camera now working on pipewire based linux distributions

### DIFF
--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -28,7 +28,10 @@ rawApp.commandLine.appendSwitch('host-resolver-rules', hostRules)
 
 rawApp.commandLine.appendSwitch('disable-features', 'IsolateSandboxedIframes')
 
-rawApp.commandLine.appendSwitch('enable-features', 'WebRtcPipeWireCamera,WebRtcPipeWireScreenCapturer')
+rawApp.commandLine.appendSwitch(
+  'enable-features',
+  'WebRtcPipeWireCamera,WebRtcPipeWireScreenCapturer'
+)
 
 if (rc['version'] === true || rc['v'] === true) {
   // eslint-disable-next-line no-console

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -28,6 +28,8 @@ rawApp.commandLine.appendSwitch('host-resolver-rules', hostRules)
 
 rawApp.commandLine.appendSwitch('disable-features', 'IsolateSandboxedIframes')
 
+rawApp.commandLine.appendSwitch('enable-features', 'WebRtcPipeWireCamera,WebRtcPipeWireScreenCapturer')
+
 if (rc['version'] === true || rc['v'] === true) {
   // eslint-disable-next-line no-console
   console.info(BuildInfo.VERSION)


### PR DESCRIPTION
The camera was not working for Linux distributions that are using Pipewire

As a concrete case for example the camera was not working on Mobian and now I have the camera finally working on Deltachat :)

This conversation was useful to detect the cause of the issue: https://github.com/electron/electron/issues/45058

Enrico