### PR TITLE
feat: allow to open WebXDC apps in draft

### DIFF
--- a/packages/frontend/src/components/attachment/messageAttachment.tsx
+++ b/packages/frontend/src/components/attachment/messageAttachment.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useMemo, useState } from 'react'
 import classNames from 'classnames'
 import { filesize } from 'filesize'
 
-import { openAttachmentInShell } from '../message/messageFunctions'
+import { openAttachmentInShell, openWebxdc } from '../message/messageFunctions'
 import {
   isDisplayableByFullscreenMedia,
   isImage,
@@ -335,7 +335,20 @@ export function DraftAttachment({
   } else if (isViewTypeWebxdc) {
     const iconUrl = runtime.getWebxdcIconURL(selectedAccountId(), attachment.id)
     return (
-      <div className='media-attachment-webxdc'>
+      <button
+        type='button'
+        className='media-attachment-webxdc'
+        // TODO check accessibility
+        onClick={() =>
+          openWebxdc(
+            // TODO unsafe typecast, need to un-shittify `openWebxdc` parameters.
+            { ...attachment, chatId: window.__selectedChatId } as T.Message,
+            webxdcInfoFetch?.result?.ok
+              ? webxdcInfoFetch.result.value
+              : undefined
+          )
+        }
+      >
         <img className='icon' src={iconUrl} alt='' />
         <div className='text-part'>
           <div className='name'>
@@ -349,7 +362,7 @@ export function DraftAttachment({
           </div>
           <div className='size'>{filesize(attachment.fileBytes ?? 0)}</div>
         </div>
-      </div>
+      </button>
     )
   } else {
     const { file, fileName, fileBytes, fileMime } = attachment

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -237,6 +237,7 @@ const Composer = forwardRef<
 
           const preSendDraftState = draftState
           const sendMessagePromise = sendMessage(accountId, chatId, {
+            id: draftState.id,
             text: draftState.text,
             file: draftState.file || undefined,
             filename: draftState.fileName || undefined,
@@ -245,6 +246,7 @@ const Composer = forwardRef<
                 ? draftState.quote.messageId
                 : null,
             viewtype: draftState.viewType,
+            reuseExistingDraft: true
           })
           // _Immediately_ clear the draft from React state.
           // This does _not_ remove the draft from the back-end yet.

--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -40,6 +40,7 @@ export type DraftObject = Pick<
 
 function emptyDraft(): DraftObject {
   return {
+    // TODO probably don't want an invalid id?
     id: 0,
     text: '',
     file: null,
@@ -187,15 +188,39 @@ export function useDraft(
   const saveAndRefetchDraft_ = useCallback(
     async (chatId: number, draft: DraftObject) => {
       if (!isDraftEmpty(draft)) {
-        await BackendRemote.rpc.miscSetDraft(
-          accountId,
-          chatId,
-          draft.text,
-          draft.file !== '' ? draft.file : null,
-          draft.fileName,
-          draft.quote?.kind === 'WithMessage' ? draft.quote.messageId : null,
-          draft.viewType
-        )
+        if ('setDraft' in BackendRemote.rpc) {
+          await BackendRemote.rpc.setDraft(
+            accountId,
+            chatId,
+            {
+              id: draft.id,
+              text: draft.text,
+              file: draft.file,
+              filename: draft.fileName,
+              quotedMessageId:
+                draft.quote?.kind === 'WithMessage'
+                  ? draft.quote.messageId
+                  : null,
+              viewtype: draft.viewType,
+              // IDK
+              html: null,
+              location: null,
+              overrideSenderName: null,
+              quotedText: null,
+            }
+          )
+        } else {
+          await BackendRemote.rpc.miscSetDraft(
+            accountId,
+            chatId,
+            // draft.id,
+            draft.text,
+            draft.file !== '' ? draft.file : null,
+            draft.fileName,
+            draft.quote?.kind === 'WithMessage' ? draft.quote.messageId : null,
+            draft.viewType
+          )
+        }
       } else {
         await BackendRemote.rpc.removeDraft(accountId, chatId)
       }


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/2722.

TODO:
- [ ] Close the app window when the draft gets deleted
  or replaced with a draft with another ID:
  probably need to fire the "message deleted" event from Core?
- [ ] Style, accessibility: see TODOs.
