### PR TITLE
test: CI E2E: remove useless Docker repo checkout

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,14 +46,6 @@ jobs:
         with:
           show-progress: false
           persist-credentials: false
-      - name: Checkout chatmail Docker setup
-        if: ${{ matrix.start_local_relay }}
-        uses: actions/checkout@v6
-        with:
-          repository: chatmail/docker
-          path: .ci/docker
-          show-progress: false
-          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: 22.x


### PR DESCRIPTION
We use the prebuild `ghcr.io/chatmail/docker:main` a few steps below.
