### PR TITLE
refactor: remove fallback composer resizing code

### DIFF
--- a/packages/frontend/scss/composer/_composer.scss
+++ b/packages/frontend/scss/composer/_composer.scss
@@ -154,16 +154,12 @@
       line-height: $line-height;
       margin-top: 8px;
       margin-bottom: 8px;
-      overflow-y: hidden;
       background-color: var(--composerBg);
       color: var(--composerText);
 
-      &.use-field-sizing-css-prop {
-        field-sizing: content;
-        max-height: calc(var(--maxLines) * $line-height);
-
-        overflow-y: auto;
-      }
+      field-sizing: content;
+      max-height: calc(var(--maxLines) * $line-height);
+      overflow-y: auto;
 
       &::placeholder {
         color: var(--composerPlaceholderText);
@@ -173,10 +169,6 @@
       // might be enough, (or it might not, we'll see).
       &:focus {
         outline: none;
-      }
-
-      &.scroll {
-        overflow-y: scroll;
       }
 
       // The "edit message" mode hides the .attachment-button.

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -7,7 +7,6 @@ import { I18nContext } from '../../contexts/I18nContext'
 
 const log = getLogger('renderer/composer/ComposerMessageInput')
 
-const browserSupportsCSSFieldSizing = CSS.supports('field-sizing', 'content')
 const maxLines = 9
 
 type ComposerMessageInputProps = {
@@ -48,14 +47,11 @@ export default class ComposerMessageInput extends React.Component<
   static contextType = DialogContext
   declare context: React.ContextType<typeof DialogContext>
 
-  composerSize: number
   setCursorPosition: number | false
   textareaRef: React.RefObject<HTMLTextAreaElement | null>
   constructor(props: ComposerMessageInputProps) {
     super(props)
 
-    this.composerSize = 48
-    this.setComposerSize = this.setComposerSize.bind(this)
     this.setCursorPosition = false
     this.onKeyDown = this.onKeyDown.bind(this)
     this.onChange = this.onChange.bind(this)
@@ -72,10 +68,6 @@ export default class ComposerMessageInput extends React.Component<
 
   componentWillUnmount() {
     ActionEmitter.unRegisterHandler(KeybindAction.Composer_Focus, this.focus)
-  }
-
-  setComposerSize(size: number) {
-    this.composerSize = size
   }
 
   focus() {
@@ -116,12 +108,6 @@ export default class ComposerMessageInput extends React.Component<
       ) {
         this.moveCursorToTheEnd()
       }
-    }
-    if (
-      !browserSupportsCSSFieldSizing &&
-      prevProps.chatId === this.props.chatId
-    ) {
-      this.resizeTextareaAndComposer()
     }
   }
 
@@ -177,41 +163,6 @@ export default class ComposerMessageInput extends React.Component<
     }
   }
 
-  resizeTextareaAndComposer() {
-    const maxScrollHeight = maxLines * 24
-
-    const el = this.textareaRef.current
-
-    if (!el) {
-      return
-    }
-
-    // We need to set the textarea height first to `auto` to get the real needed
-    // scrollHeight. Ugly hack.
-    el.style.height = 'auto'
-    const scrollHeight = el.scrollHeight
-
-    if (scrollHeight + 16 === this.composerSize) {
-      el.style.height = scrollHeight + 'px'
-      return
-    }
-
-    if (scrollHeight > maxScrollHeight && el.classList.contains('scroll')) {
-      el.style.height = maxScrollHeight + 'px'
-      return
-    }
-
-    if (scrollHeight < maxScrollHeight) {
-      this.setComposerSize(scrollHeight + 16)
-      el.style.height = scrollHeight + 'px'
-      el.classList.remove('scroll')
-    } else {
-      this.setComposerSize(maxScrollHeight + 16)
-      el.style.height = maxScrollHeight + 'px'
-      el.classList.add('scroll')
-    }
-  }
-
   insertStringAtCursorPosition(str: string) {
     const textareaElem = this.textareaRef.current
     if (!textareaElem) {
@@ -238,12 +189,7 @@ export default class ComposerMessageInput extends React.Component<
       <I18nContext.Consumer>
         {({ writingDirection }) => (
           <textarea
-            className={
-              'create-or-edit-message-input' +
-              (browserSupportsCSSFieldSizing
-                ? ' use-field-sizing-css-prop'
-                : '')
-            }
+            className='create-or-edit-message-input'
             style={{ '--maxLines': maxLines } as React.CSSProperties}
             id={
               this.props.isMessageEditingMode


### PR DESCRIPTION
`resizeTextareaAndComposer` is already unused in Electron.

All modern browsers support `field-sizing`,
including Firefox and Safari,
which was not the case back when we introduced the new approach:
de05e38515039feaf940295fc366066ed8baa4c8
(https://github.com/deltachat/deltachat-desktop/pull/5637).

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/field-sizing

I have tested this on Firefox but not Safari.
