### PR TITLE
fix: Ctrl + Up: incorrect quote order sometimes

### DIFF
--- a/packages/frontend/src/hooks/chat/useDraft.ts
+++ b/packages/frontend/src/hooks/chat/useDraft.ts
@@ -436,13 +436,19 @@ export function useDraft(
      *
      * see https://github.com/deltachat/deltachat-desktop/blob/77a1f88a351df49e5df38a14c3a1704a76ecdcb3/packages/frontend/src/components/message/Message.tsx#L274-L278
      */
-    const messageIds = Object.keys(messageListState.messageCache)
-      .map(Number)
-      .filter(
-        id =>
+    const messageIds = messageListState.messageListItems
+      .filter((item): item is { kind: 'message'; msg_id: number } => {
+        if (item.kind !== 'message') {
+          return false
+        }
+        const id = item.msg_id
+
+        return (
           messageListState.messageCache[id]?.kind === 'message' &&
           messageListState.messageCache[id]?.isInfo === false
-      )
+        )
+      })
+      .map(({ msg_id }) => msg_id)
     const currQuote = draftState.quote
     if (!currQuote) {
       if (upOrDown === KeybindAction.Composer_SelectReplyToUp) {


### PR DESCRIPTION
The code assumes that `messageListItems` is always sorted by ID,
but it's not the case, i.e. in reality sometimes
a message with a lower ID occurs _after_ a message with a higher ID.
This is why we have `timestamp_sort` on messages:
https://github.com/chatmail/core/blob/b351b64e4ae78658f894f51412f89aca4e6ce822/src/chat.rs#L3195-L3202.

This is gonna be especially noticeable if/when
we start preserving draft message ID
(see https://github.com/deltachat/deltachat-desktop/issues/2722):
if you start drafting a message and receive one in the chat,
the received message will have a higher ID than the draft;
when the draft is finally sent,
it will occur _after_ the received message.
