### PR TITLE
fix: "Edit" sometimes not moving cursor to the end

### DIFF
--- a/packages/e2e-tests/tests/composer.spec.ts
+++ b/packages/e2e-tests/tests/composer.spec.ts
@@ -841,6 +841,20 @@ test.describe('edit message', () => {
     await page.keyboard.press('ArrowUp')
     await expect(textareaNonEdit()).toHaveText('\n\n\n\n\n')
     await expect(composerSection).not.toContainText('Edit Message')
+
+    await textareaNonEdit().clear()
+  })
+  test('text cursor is placed at the end', async () => {
+    await textarea.focus()
+    await page.keyboard.press('ArrowUp')
+    await expect(textareaEdit()).toHaveText('M 3')
+    await expect(textareaEdit()).toBeFocused()
+
+    await page.keyboard.press('Backspace')
+    await page.keyboard.press('Backspace')
+    await expect(textareaEdit()).toHaveText('M')
+
+    await page.keyboard.press('Escape')
   })
 })
 

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -934,6 +934,7 @@ function useMessageEditing(
       // Wait until the new element is actually rendered, only then focus.
       setTimeout(() => {
         editMessageInputRef.current?.focus()
+        editMessageInputRef.current?.moveCursorToTheEnd()
       })
     }
     return () => {

--- a/packages/frontend/src/components/composer/ComposerMessageInput.tsx
+++ b/packages/frontend/src/components/composer/ComposerMessageInput.tsx
@@ -100,15 +100,6 @@ export default class ComposerMessageInput extends React.Component<ComposerMessag
       }
 
       this.setCursorPosition = false
-    } else {
-      // This is useful when entering / exiting the message editing mode.
-      if (
-        prevProps.hidden !== this.props.hidden &&
-        !this.props.hidden &&
-        this.props.text.length !== 0
-      ) {
-        this.moveCursorToTheEnd()
-      }
     }
     if (
       !browserSupportsCSSFieldSizing &&
@@ -118,7 +109,7 @@ export default class ComposerMessageInput extends React.Component<ComposerMessag
     }
   }
 
-  private moveCursorToTheEnd() {
+  moveCursorToTheEnd() {
     if (this.textareaRef.current == null) {
       log.warn(
         'Tried to move the cursor position to the end, ' +


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5716.

Let's move the cursor on the actual "enter edit message mode"
callback rather than by watching prop changes.

Also add a test for this. It doesn't cover the specific case
described in the issue, but at least it shows
that this functionality isn't completely broken.
