### PR TITLE
feat: react to channel messages

### DIFF
--- a/packages/e2e-tests/tests/group-tests.spec.ts
+++ b/packages/e2e-tests/tests/group-tests.spec.ts
@@ -14,6 +14,8 @@ import {
   test,
   createGroupChat,
   createChat,
+  selectChat,
+  sendMessage,
 } from '../playwright-helper.js'
 
 test.describe.configure({
@@ -737,6 +739,75 @@ test('add channel description and verify subscriber sees it', async () => {
     channelDescription
   )
   await page.keyboard.press('Escape')
+})
+
+test.describe('channel reactions', () => {
+  let userA = existingProfiles[0]!
+  let userB = existingProfiles[1]!
+  const chatListItem = () =>
+    page.getByLabel('Chats').getByRole('tab', { name: channelName })
+  const messageText = 'My post 123.\nLike and subscribe.'
+  const message = () =>
+    page
+      .getByRole('list', { name: 'Messages' })
+      .getByRole('listitem')
+      .filter({ hasText: messageText })
+      .locator('.message') // Just the bubble and not the whole row
+
+  test.beforeAll(async () => {
+    userA = existingProfiles[0]!
+    userB = existingProfiles[1]!
+
+    await switchToProfile(page, userA.id)
+    await selectChat(page, channelName)
+    await sendMessage(page, channelName, messageText)
+
+    await expect(message()).not.toContainText('😂')
+  })
+
+  test('owner can unmute channel', async () => {
+    await switchToProfile(page, userA.id)
+
+    // Channels are muted by default
+    await expect(chatListItem().getByLabel('Mute')).toBeVisible()
+    await chatListItem().click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Unmute' }).click()
+    await expect(chatListItem().getByLabel('Mute')).not.toBeVisible()
+
+    await chatListItem().click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Mute Notifications' }).click()
+    await page.getByRole('menuitem', { name: 'Mute forever' }).click()
+  })
+
+  test('react', async () => {
+    await switchToProfile(page, userB.id)
+    await selectChat(page, channelName)
+
+    await message().click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'React' }).click()
+
+    await expect(page.getByRole('menu').getByRole('menuitemradio')).toHaveText([
+      '👍',
+      '👎',
+      '❤️',
+      '😂',
+      '🙁',
+    ])
+
+    // No "Arbitrary emoji" button
+    await expect(page.getByRole('menu').getByRole('menuitem')).not.toBeVisible()
+    await expect(page.getByRole('menu').locator('> *')).toHaveCount(5)
+
+    await page.getByRole('menuitemradio', { name: '😂' }).click()
+    await expect(message()).toContainText('😂')
+  })
+
+  test('owner sees the reaction', async () => {
+    await switchToProfile(page, userA.id)
+    await selectChat(page, channelName)
+
+    await expect(message()).toContainText('😂')
+  })
 })
 
 test('channel profile three-dot menu shows encryption info', async () => {

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -15,6 +15,7 @@ import {
   RovingTabindexProvider,
   useRovingTabindex,
 } from '../../contexts/RovingTabindex'
+import useChat from '../../hooks/chat/useChat'
 
 const log = getLogger('ReactionsBar')
 
@@ -32,6 +33,7 @@ export default function ReactionsBar({
   myReaction,
 }: Props) {
   const tx = useTranslationFunction()
+  const { chatWithLinger } = useChat()
 
   const reactionsBarRef = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -113,7 +115,11 @@ export default function ReactionsBar({
                 onClick={() => toggleReaction(myReaction)}
               />
             )}
-            <MoreEmojisButton onClick={handleShowAllEmojis} />
+            {chatWithLinger != undefined &&
+              chatWithLinger.chatType !== 'InBroadcast' &&
+              chatWithLinger.chatType !== 'OutBroadcast' && (
+                <MoreEmojisButton onClick={handleShowAllEmojis} />
+              )}
           </RovingTabindexProvider>
         </div>
       )}

--- a/packages/frontend/src/components/ReactionsBar/useReactionsBar.ts
+++ b/packages/frontend/src/components/ReactionsBar/useReactionsBar.ts
@@ -46,7 +46,14 @@ export default function useReactionsBar(): UseReactionsBar {
 
 /** Returns true if user should be able to send reactions to a message */
 export function showReactionsUi(message: T.Message, chat: T.FullChat): boolean {
-  return chat.canSend && !message.isInfo && message.originalMsgId === null
+  return (
+    (chat.canSend ||
+      (chat.chatType === 'InBroadcast' &&
+        chat.contactIds.includes(C.DC_CONTACT_ID_SELF) &&
+        !chat.isContactRequest)) &&
+    !message.isInfo &&
+    message.originalMsgId === null
+  )
 }
 
 function getMyReaction(reactions: T.Message['reactions']): string | undefined {

--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -378,6 +378,9 @@ async function flushNotifications(accountId: number) {
             )
             if (chat.chatType === 'Group') {
               // only show mentions for group chats
+              //
+              // for outgoing channels reactions should not trigger
+              // a notification if the owner muted the channel
               return notification
             }
           }


### PR DESCRIPTION
Partially addresses
https://github.com/deltachat/deltachat-desktop/issues/6632.

What's left is the "Reactions" dialog for incoming channels,
which IMO can be kept for a follow-up.
Currently it simply displays either 0 or a single reaction from self.
However I'd say that this is not critical,
because reactions are already displayed inline on the message itself.
Although the list might get truncated on narrow screens.