### PR TITLE
fix: video background in quotes

### DIFF
--- a/packages/frontend/scss/message/_message-attachment.scss
+++ b/packages/frontend/scss/message/_message-attachment.scss
@@ -19,6 +19,8 @@
   @include mixins.button-reset;
   display: block;
 
+  --attachment-bottom-gap: 7px;
+
   // Entirely to ensure that images are centered if they aren't full width of bubble
   text-align: center;
   position: relative;
@@ -71,7 +73,7 @@
   &.content-below,
   /* needed to avoid metadata video controls overlap */
   &.video {
-    margin-bottom: 7px;
+    margin-bottom: var(--attachment-bottom-gap);
   }
   &.content-below {
     border-bottom-left-radius: 0px;

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -91,10 +91,11 @@ $info-text-max-width: 400px;
     border-radius: 16px;
     --msg-container-padding-horizontal: 12px;
     --msg-container-padding-top: 10px;
+    --msg-container-padding-bottom: 10px;
     padding-inline-end: var(--msg-container-padding-horizontal);
     padding-inline-start: var(--msg-container-padding-horizontal);
     padding-top: var(--msg-container-padding-top);
-    padding-bottom: 10px;
+    padding-bottom: var(--msg-container-padding-bottom);
 
     .msg-body {
       &.call {
@@ -334,9 +335,15 @@ $info-text-max-width: 400px;
 }
 
 .message.video-only {
-  .msg-container {
-    /* make the whole container black, as videos always have a black background */
+  .message-attachment-media {
+    /* Videos always have a black background,
+       extend it down to the bottom edge of the bubble,
+       as background for the metadata */
     background-color: #000;
+    padding-bottom: calc(
+      var(--attachment-bottom-gap) + var(--msg-container-padding-bottom)
+    );
+    margin-bottom: calc(-1 * var(--msg-container-padding-bottom));
   }
 }
 
@@ -404,11 +411,10 @@ $info-text-max-width: 400px;
   }
 }
 
-.message.type-sticker,
-.message.video-only {
+.message.type-sticker {
   .msg-container {
     .quote-background {
-      // `.msg-container` background is transparent or black,
+      // `.msg-container` background is transparent,
       // so let's explicitly apply the color just for the quote.
       background: var(--messageBg);
 


### PR DESCRIPTION
resolves #6606 

only the footer has now black background, not the whole message. (in fact it's only the attachment container which has an extended footer covering the lower message padding)
