### PR TITLE
chore: remove `sass` as `target-electron` dep

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -67,7 +67,7 @@
     "esbuild-plugin-inline-worker": "^0.1.1",
     "mocha": "catalog:",
     "normalize.css": "^8.0.1",
-    "sass": "catalog:",
+    "sass": "^1.102.0",
     "source-map-support": "^0.5.21",
     "ts-node": "^10.9.2",
     "typescript": "catalog:",

--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -62,7 +62,6 @@
     "@deltachat/calls-webapp": "catalog:",
     "escape-html": "^1.0.3",
     "mime-types": "catalog:",
-    "sass": "catalog:",
     "ws": "catalog:"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ catalogs:
     mocha:
       specifier: ^11.7.5
       version: 11.7.5
-    sass:
-      specifier: ^1.102.0
-      version: 1.102.0
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -254,7 +251,7 @@ importers:
         specifier: ^8.0.1
         version: 8.0.1
       sass:
-        specifier: 'catalog:'
+        specifier: ^1.102.0
         version: 1.102.0
       source-map-support:
         specifier: ^0.5.21
@@ -384,9 +381,6 @@ importers:
       mime-types:
         specifier: 'catalog:'
         version: 2.1.35
-      sass:
-        specifier: 'catalog:'
-        version: 1.102.0
       ws:
         specifier: 'catalog:'
         version: 8.21.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,6 @@ catalog:
   ws: ^8.18.0
 
   # tools / dev dependencies
-  sass: ^1.102.0
   typescript: ^6.0.3
   typescript-plugin-css-modules: ^5.2.0
   esbuild: ^0.28.1


### PR DESCRIPTION
Not entirely clear why it was added, probably by mistake,
as part of the mega-MRs
- https://github.com/deltachat/deltachat-desktop/pull/4074.
- https://github.com/deltachat/deltachat-desktop/pull/4940.

Now `sass` is only used by `packages/frontend`,
so we can move it from catalog directly to the `package.json`
