### PR TITLE
Fix prepare release previews

### DIFF
--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -122,6 +122,9 @@ jobs:
       - name: WINDOWS install rsync
         if: runner.os == 'Windows'
         run: choco install --no-progress -y rsync
+      - name: MAC install rsync
+        if: runner.os == 'macOS'
+        run: brew install rsync
       - name: upload folder
         id: upload
         shell: bash
@@ -134,6 +137,7 @@ jobs:
           echo -e "$SSH_KEY" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
           SSH_BIN=ssh
+          RSYNC_BIN=rsync
           if [ "$RUNNER_OS" = "Windows" ]; then
             # cwRsync is cygwin based and fails with "dup() in/out/err failed"
             # when it starts the msys2 ssh of Git for Windows, so use its own.
@@ -141,10 +145,18 @@ jobs:
             test -n "$SSH_BIN" || { echo "ssh.exe of cwRsync not found"; exit 1; }
             # cygwin binaries do not understand the /c/... paths of Git bash
             SSH_BIN=$(cygpath -m "$SSH_BIN")
+            # cygwin reads the ACLs written by msys2's chmod as 0750, so the key
+            # has to be restricted to the current user via windows ACLs instead
+            icacls __TEMP_INPUT_KEY_FILE /inheritance:r /grant:r "$USERNAME:R" >/dev/null
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            # /usr/bin/rsync is openrsync, whose --server command is rejected by
+            # rrsync ("invalid rsync-command syntax or options")
+            RSYNC_BIN="$(brew --prefix)/bin/rsync"
+            test -x "$RSYNC_BIN" || { echo "rsync from homebrew not found"; exit 1; }
           fi
           # The key is restricted to rrsync, so the target directory is configured in
           # authorized_keys on the server
-          rsync -rvz \
+          "$RSYNC_BIN" -rvz \
             -e "$SSH_BIN -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
             packages/target-electron/dist/preview/ "$SSH_USER@download.delta.chat:"
         continue-on-error: true

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -119,14 +119,25 @@ jobs:
           dir preview
           cd ..
       # Upload Step
+      - name: WINDOWS install rsync
+        if: runner.os == 'Windows'
+        run: choco install --no-progress -y rsync
       - name: upload folder
         id: upload
         shell: bash
         if: contains(github.event.pull_request.body, '#public-preview')  || contains(github.event.pull_request.title, 'prepare release')
+        env:
+          SSH_KEY: ${{ secrets.KEY }}
+          SSH_USER: ${{ secrets.USERNAME }}
         run: |
-          echo -e "${{ secrets.KEY }}" >__TEMP_INPUT_KEY_FILE
+          trap 'rm -f __TEMP_INPUT_KEY_FILE' EXIT
+          echo -e "$SSH_KEY" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          scp -o StrictHostKeyChecking=no -v -i __TEMP_INPUT_KEY_FILE -P "22" -r packages/target-electron/dist/preview/* "${{ secrets.USERNAME }}"@"download.delta.chat":"/var/www/html/download/desktop/preview/"
+          # The key is restricted to rrsync, so the target directory is fixed in
+          # authorized_keys on the server and has to be addressed as "."
+          rsync -rvz --chmod=F644,D755 \
+            -e "ssh -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
+            packages/target-electron/dist/preview/ "$SSH_USER@download.delta.chat:."
         continue-on-error: true
       - name: 'Post links to details'
         if: steps.upload.outcome == 'success'

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -133,11 +133,20 @@ jobs:
           trap 'rm -f __TEMP_INPUT_KEY_FILE' EXIT
           echo -e "$SSH_KEY" >__TEMP_INPUT_KEY_FILE
           chmod 600 __TEMP_INPUT_KEY_FILE
-          # The key is restricted to rrsync, so the target directory is fixed in
-          # authorized_keys on the server and has to be addressed as "."
+          SSH_BIN=ssh
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # cwRsync is cygwin based and fails with "dup() in/out/err failed"
+            # when it starts the msys2 ssh of Git for Windows, so use its own.
+            SSH_BIN=$(find /c/ProgramData/chocolatey/lib/rsync -name ssh.exe | head -n1)
+            test -n "$SSH_BIN" || { echo "ssh.exe of cwRsync not found"; exit 1; }
+            # cygwin binaries do not understand the /c/... paths of Git bash
+            SSH_BIN=$(cygpath -m "$SSH_BIN")
+          fi
+          # The key is restricted to rrsync, so the target directory is configured in
+          # authorized_keys on the server
           rsync -rvz \
-            -e "ssh -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
-            packages/target-electron/dist/preview/ "$SSH_USER@download.delta.chat:."
+            -e "$SSH_BIN -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
+            packages/target-electron/dist/preview/ "$SSH_USER@download.delta.chat:"
         continue-on-error: true
       - name: 'Post links to details'
         if: steps.upload.outcome == 'success'

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -135,7 +135,7 @@ jobs:
           chmod 600 __TEMP_INPUT_KEY_FILE
           # The key is restricted to rrsync, so the target directory is fixed in
           # authorized_keys on the server and has to be addressed as "."
-          rsync -rvz --chmod=F644,D755 \
+          rsync -rvz \
             -e "ssh -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
             packages/target-electron/dist/preview/ "$SSH_USER@download.delta.chat:."
         continue-on-error: true

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -1,45 +1,44 @@
 # documentation: https://github.com/deltachat/sysadmin/tree/master/download.delta.chat
 name: Delete Preview Deliverables
 
-on: 
+on:
   pull_request:
     types: [closed]
     paths-ignore:
-      - 'docs/**'  # only trigger build if a file outside of /docs was changed
+      - 'docs/**' # only trigger build if a file outside of /docs was changed
 
 permissions: {}
 
 jobs:
   delete:
-
     runs-on: ubuntu-latest
     if: contains(github.event.pull_request.body, '#public-preview') || contains(github.event.pull_request.title, 'prepare release')
     steps:
-    - name: Get Branch Name
-      id: getid
-      run: |
-        export BRANCH_NAME=$(jq -r .pull_request.head.ref < $GITHUB_EVENT_PATH | sed 's/[^A-Za-z0-9._-]/_/g')
-        echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
-    - name: Delete builds
-      env:
-        BRANCH: ${{ steps.getid.outputs.branch }}
-        SSH_KEY: ${{ secrets.KEY }}
-        SSH_USER: ${{ secrets.USERNAME }}
-      run: |
-        trap 'rm -f __TEMP_INPUT_KEY_FILE' EXIT
-        echo -e "$SSH_KEY" >__TEMP_INPUT_KEY_FILE
-        chmod 600 __TEMP_INPUT_KEY_FILE
-        mkdir -p empty
-        # Syncing an empty directory with --delete removes the files matched by
-        # --include. --exclude='*' protects the previews of all other branches
-        # from being deleted as well - it must not be removed.
-        # The key is restricted to rrsync, so the target directory is fixed in
-        # authorized_keys on the server and has to be addressed as "."
-        rsync -rv --delete \
-          --include="deltachat-desktop.${BRANCH}.AppImage" \
-          --include="deltachat-desktop.${BRANCH}.portable.exe" \
-          --include="deltachat-desktop.${BRANCH}.dmg" \
-          --include="deltachat-desktop-mas.${BRANCH}.zip" \
-          --exclude='*' \
-          -e "ssh -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
-          empty/ "$SSH_USER@download.delta.chat:."
+      - name: Get Branch Name
+        id: getid
+        run: |
+          export BRANCH_NAME=$(jq -r .pull_request.head.ref < $GITHUB_EVENT_PATH | sed 's/[^A-Za-z0-9._-]/_/g')
+          echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+      - name: Delete builds
+        env:
+          BRANCH: ${{ steps.getid.outputs.branch }}
+          SSH_KEY: ${{ secrets.KEY }}
+          SSH_USER: ${{ secrets.USERNAME }}
+        run: |
+          trap 'rm -f __TEMP_INPUT_KEY_FILE' EXIT
+          echo -e "$SSH_KEY" >__TEMP_INPUT_KEY_FILE
+          chmod 600 __TEMP_INPUT_KEY_FILE
+          mkdir -p empty
+          # Syncing an empty directory with --delete removes the files matched by
+          # --include. --exclude='*' protects the previews of all other branches
+          # from being deleted as well - it must not be removed.
+          # The key is restricted to rrsync, so the target directory is configured in
+          # authorized_keys on the server
+          rsync -rv --delete \
+            --include="deltachat-desktop.${BRANCH}.AppImage" \
+            --include="deltachat-desktop.${BRANCH}.portable.exe" \
+            --include="deltachat-desktop.${BRANCH}.dmg" \
+            --include="deltachat-desktop-mas.${BRANCH}.zip" \
+            --exclude='*' \
+            -e "ssh -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
+            empty/ "$SSH_USER@download.delta.chat:"

--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -20,23 +20,26 @@ jobs:
       run: |
         export BRANCH_NAME=$(jq -r .pull_request.head.ref < $GITHUB_EVENT_PATH | sed 's/[^A-Za-z0-9._-]/_/g')
         echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
-    - name: Renaming
-      run: |
-        mkdir preview
-        # create empty file to copy it over the outdated deliverable on download.delta.chat
-        echo "This preview build is outdated and has been removed." > empty
-        cp empty preview/deltachat-desktop.${STEPS_GETID_OUTPUTS_BRANCH}.AppImage
-        cp empty preview/deltachat-desktop.${STEPS_GETID_OUTPUTS_BRANCH}.portable.exe
-        cp empty preview/deltachat-desktop.${STEPS_GETID_OUTPUTS_BRANCH}.dmg
-        cp empty preview/deltachat-desktop-mas.${STEPS_GETID_OUTPUTS_BRANCH}.zip
+    - name: Delete builds
       env:
-        STEPS_GETID_OUTPUTS_BRANCH: ${{ steps.getid.outputs.branch }}
-    - name: Replace builds with dummy files
-      uses: horochx/deploy-via-scp@bf9a636d9a475a714e375ba1cc455d1c5c861aef # v1.0.1
-      with:
-        user: ${{ secrets.USERNAME }}
-        key: ${{ secrets.KEY }}
-        host: "download.delta.chat"
-        port: 22
-        local: "preview/*"
-        remote: "/var/www/html/download/desktop/preview/"
+        BRANCH: ${{ steps.getid.outputs.branch }}
+        SSH_KEY: ${{ secrets.KEY }}
+        SSH_USER: ${{ secrets.USERNAME }}
+      run: |
+        trap 'rm -f __TEMP_INPUT_KEY_FILE' EXIT
+        echo -e "$SSH_KEY" >__TEMP_INPUT_KEY_FILE
+        chmod 600 __TEMP_INPUT_KEY_FILE
+        mkdir -p empty
+        # Syncing an empty directory with --delete removes the files matched by
+        # --include. --exclude='*' protects the previews of all other branches
+        # from being deleted as well - it must not be removed.
+        # The key is restricted to rrsync, so the target directory is fixed in
+        # authorized_keys on the server and has to be addressed as "."
+        rsync -rv --delete \
+          --include="deltachat-desktop.${BRANCH}.AppImage" \
+          --include="deltachat-desktop.${BRANCH}.portable.exe" \
+          --include="deltachat-desktop.${BRANCH}.dmg" \
+          --include="deltachat-desktop-mas.${BRANCH}.zip" \
+          --exclude='*' \
+          -e "ssh -o StrictHostKeyChecking=no -i __TEMP_INPUT_KEY_FILE -p 22" \
+          empty/ "$SSH_USER@download.delta.chat:."


### PR DESCRIPTION
The permissions on the server changed so we have to use rsync instead scp. With rsync we also can delete the files properly after merging/closing a PR since rsync supports that in contrast to scp

I added the keywords "prepare release" in the PR title to trigger the preview upload