### PR TITLE
perf: load messages without loading full chat

### DIFF
--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -49,6 +49,7 @@ export function ChatView(
     className?: string
   }
 ) {
+  const tx = useTranslationFunction()
   const { chatWithLinger } = useChat()
   return (
     <section
@@ -76,7 +77,15 @@ export function ChatView(
           {/* Dummy header to reduce layout shifting
           when unselecting/selecting a chat. */}
           <nav className={styles.chatNavbar} data-tauri-drag-region></nav>
-          <NoChatSelected />
+          <NoChatSelected
+            messages={
+              <div className='info-message big' style={{ alignSelf: 'center' }}>
+                <div className='bubble'>
+                  {tx('no_chat_selected_suggestion_desktop')}
+                </div>
+              </div>
+            }
+          />
         </>
       )}
     </section>

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -1,5 +1,5 @@
 import styles from './styles.module.scss'
-import React, { useCallback, useContext, useId, useMemo } from 'react'
+import React, { useCallback, useContext, useId, useMemo, useRef } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import MessageListAndComposer from '../message/MessageListAndComposer'
@@ -37,27 +37,25 @@ import {
   useMessageFocusAndMultiselectContextValue,
 } from '../message/focusAndMultiselect'
 import { useMessageList } from '../../stores/messagelist'
+import Composer from '../composer/Composer'
 
 const log = getLogger('ChatView')
 
 export function ChatView(
-  props: Omit<
-    Parameters<typeof ChatViewInner>[0],
-    'accountId' | 'chatWithLinger'
-  > & {
+  props: Omit<Parameters<typeof ChatViewInner>[0], 'accountId' | 'chatId'> & {
     accountId: T.Account['id'] | undefined
     className?: string
   }
 ) {
   const tx = useTranslationFunction()
-  const { chatWithLinger } = useChat()
+  const { chatId } = useChat()
   return (
     <section
       role='region'
       aria-labelledby='chat-section-heading'
       className={classNames(props.className, styles.chatAndNavbar)}
     >
-      {props.accountId != undefined && chatWithLinger ? (
+      {props.accountId != undefined && chatId != undefined ? (
         <ChatViewInner
           // Note that `key` has not always been here.
           // Some downstream components still try to support variable `chatId`.
@@ -68,9 +66,9 @@ export function ChatView(
           // However, most of that code is about resetting some state,
           // so it probably can be removed.
           // We do not and should actually rely on any kind of cross-chat state.
-          key={`${props.accountId}_${chatWithLinger.id}`}
+          key={`${props.accountId}_${chatId}`}
           {...(props as typeof props & { accountId: typeof props.accountId })}
-          chatWithLinger={chatWithLinger}
+          chatId={chatId}
         />
       ) : (
         <>
@@ -95,17 +93,17 @@ export function ChatView(
 export function ChatViewInner({
   accountId,
   lastUsedApps,
-  chatWithLinger,
+  chatId,
 }: {
   accountId: number
   lastUsedApps: T.Message[]
-  chatWithLinger: NonNullable<ReturnType<typeof useChat>['chatWithLinger']>
+  chatId: T.BasicChat['id']
 }) {
   const tx = useTranslationFunction()
-  const { unselectChat } = useChat()
+  const { unselectChat, chatWithLinger, oldChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
-  const messageListData = useMessageList(accountId, chatWithLinger.id)
+  const messageListData = useMessageList(accountId, chatId)
   const messageIds = useMemo(
     () =>
       messageListData.state.messageListItems
@@ -119,7 +117,10 @@ export function ChatViewInner({
   const showMessageMultiselectCounter = numSelectedMessages > 0
 
   return (
-    <>
+    <div
+      style={{ display: 'contents' }}
+      aria-busy={chatWithLinger == undefined}
+    >
       <nav className={styles.chatNavbar} data-tauri-drag-region>
         {smallScreenMode && (
           <span data-no-drag-region>
@@ -159,20 +160,93 @@ export function ChatViewInner({
           <ChatNavButtons chat={chatWithLinger} lastUsedApps={lastUsedApps} />
         )}
       </nav>
-      <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
+      <RecoverableCrashScreen reset_on_change_key={chatId}>
         <MessageMultiselectContext.Provider
           value={focusAndMultiselectContextValue}
         >
-          <MessageListAndComposer
-            accountId={accountId}
-            chat={chatWithLinger}
-            messageListData={messageListData}
-          />
+          {chatWithLinger ? (
+            <MessageListAndComposer
+              accountId={accountId}
+              chat={chatWithLinger}
+              messageListData={messageListData}
+            />
+          ) : (
+            <MessageListAndComposerPlaceholder
+              // Provide the old chat to reduce layout shifts.
+              // E.g. if the old chat had the composer hidden,
+              // this will keep the composer hidden while we're loading
+              // the new chat.
+              chat={oldChat ?? null}
+            />
+          )}
         </MessageMultiselectContext.Provider>
       </RecoverableCrashScreen>
-    </>
+    </div>
   )
 }
+
+/**
+ * To be displayed in place of a "real" {@linkcode MessageListAndComposer}
+ * while it's loading, to reduce flashing / layout shifts.
+ */
+function MessageListAndComposerPlaceholder({
+  chat,
+}: {
+  /**
+   * Can be the previous (old) chat, or just a dummy chat object.
+   */
+  chat: Parameters<typeof Composer>['0']['selectedChat'] | null
+}) {
+  const regularMessageInputRef: Parameters<
+    typeof Composer
+  >[0]['regularMessageInputRef'] = useRef(null)
+  const editMessageInputRef: Parameters<
+    typeof Composer
+  >[0]['editMessageInputRef'] = useRef(null)
+
+  return (
+    <NoChatSelected
+      composer={
+        chat && (
+          // `inert` to disable possible effectful interactions
+          // (e.g. sending a message, updating the draft, etc).
+          <div inert style={{ display: 'contents' }}>
+            <Composer
+              isContactRequest={chat.isContactRequest}
+              selectedChat={chat}
+              regularMessageInputRef={regularMessageInputRef}
+              editMessageInputRef={editMessageInputRef}
+              // If there _was_ a draft then we'll still flash a bit,
+              // but this is good enough.
+              draftState={{
+                id: 0,
+                text: '',
+                file: null,
+                fileBytes: 0,
+                fileMime: null,
+                fileName: null,
+                quote: null,
+                viewType: 'Text',
+                vcardContact: null,
+              }}
+              draftIsLoading={true}
+              updateDraftText={noop}
+              onSelectReplyToShortcut={noop}
+              removeQuote={noop}
+              addFileToDraft={() => Promise.resolve()}
+              removeFile={noop}
+              clearDraftState={noop}
+              setDraftState={noop}
+              messageCache={{}}
+            />
+          </div>
+        )
+      }
+      messages={null}
+    />
+  )
+}
+const noop = () => {}
 
 /**
  * @param chat

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -85,6 +85,7 @@ export function ChatView(
                 </div>
               </div>
             }
+            composer={null}
           />
         </>
       )}

--- a/packages/frontend/src/components/NoChatSelected.tsx
+++ b/packages/frontend/src/components/NoChatSelected.tsx
@@ -1,11 +1,13 @@
 import React from 'react'
 
-import useTranslationFunction from '../hooks/useTranslationFunction'
 import { getBackgroundImageStyle } from './message/MessageListAndComposer'
 import { useSettingsStore } from '../stores/settings'
 
-export default function NoChatSelected() {
-  const tx = useTranslationFunction()
+export default function NoChatSelected({
+  messages,
+}: {
+  messages: React.ReactNode
+}) {
   const settingsStore = useSettingsStore()[0]
 
   const style: React.CSSProperties = settingsStore
@@ -18,11 +20,7 @@ export default function NoChatSelected() {
         className='message-list-and-composer__message-list'
         style={{ display: 'flex' }}
       >
-        <div className='info-message big' style={{ alignSelf: 'center' }}>
-          <div className='bubble'>
-            {tx('no_chat_selected_suggestion_desktop')}
-          </div>
-        </div>
+        {messages}
       </div>
     </div>
   )

--- a/packages/frontend/src/components/NoChatSelected.tsx
+++ b/packages/frontend/src/components/NoChatSelected.tsx
@@ -5,8 +5,10 @@ import { useSettingsStore } from '../stores/settings'
 
 export default function NoChatSelected({
   messages,
+  composer,
 }: {
   messages: React.ReactNode
+  composer: React.ReactNode
 }) {
   const settingsStore = useSettingsStore()[0]
 
@@ -22,6 +24,7 @@ export default function NoChatSelected({
       >
         {messages}
       </div>
+      {composer}
     </div>
   )
 }

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -17,12 +17,27 @@ export type UnselectChat = () => void
 
 export type ChatContextValue = {
   /**
-   * `withLinger` means that after `selectChat()` the value of `chatWithLinger`
-   * does not change immediately (unlike `chatId`),
+   * This is always the chat with the same ID as
+   * {@linkcode ChatContextValue.chatId},
+   * or `undefined` during initial load,
+   * after {@linkcode ChatContextValue.selectChat}.
+   *
+   * `withLinger` means that the value of `chatWithLinger`
+   * does not change immediately when we start refreshing the chat
+   * (e.g. after `ChatModified` event),
    * until the new chat's info gets loaded.
    */
   chatWithLinger?: T.FullChat
   chatNoLinger?: T.FullChat
+  /**
+   * Right after {@linkcode ChatContextValue.selectChat},
+   * {@linkcode ChatContextValue.chatWithLinger} becomes `undefined`
+   * and the original chat migrates here.
+   *
+   * Can be useful for reducing layout shifts and flashing,
+   * but be careful not to use this for anything effectful.
+   */
+  oldChat?: T.FullChat
   loadingChat: boolean
   chatId?: number
   /**
@@ -112,7 +127,7 @@ export const ChatProvider = ({
   if (chatFetch?.result?.ok === false) {
     log.error('Failed to fetch chat', chatFetch.result.err)
   }
-  const chatWithLinger =
+  const chatWithLinger_ =
     chatFetch?.lingeringResult?.ok &&
     // Make sure that the chat belongs to the current account,
     // to prevent data leaking between accounts, and weird race-y bugs.
@@ -122,6 +137,14 @@ export const ChatProvider = ({
     // for the current `accountId`?
     accountId === chatFetch.lingeringResult.value.accountId
       ? chatFetch.lingeringResult.value.chat
+      : undefined
+  const chatWithLinger =
+    chatWithLinger_ != undefined && chatWithLinger_.id === chatId
+      ? chatWithLinger_
+      : undefined
+  const oldChat =
+    chatWithLinger_ != undefined && chatWithLinger_.id !== chatId
+      ? chatWithLinger_
       : undefined
   const chatNoLinger =
     chatFetch?.result?.ok &&
@@ -278,6 +301,7 @@ export const ChatProvider = ({
     () => ({
       chatWithLinger,
       chatNoLinger,
+      oldChat,
       loadingChat,
       chatId,
       selectChat,
@@ -286,6 +310,7 @@ export const ChatProvider = ({
     [
       chatWithLinger,
       chatNoLinger,
+      oldChat,
       loadingChat,
       chatId,
       selectChat,


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5235.

- `chatWithLinger` of `ChatContext` is never the old chat now.
  Instead it's `undefined` while loading.
  The old chat is available only as `oldChat`.
- `ChatViewInner` now needs to be able to handle
  `chatWithLinger == undefined`.
- `useMessageList` now takes `chatId`,
  which changes immediately as the new chat gets selected,
  instead of `chatWithLinger.id`,
  which is what the commit title is about.
  
Note that this introduces a bit of extra blinking,
namely in the chat header and possibly in the composer,
but I think this is fine, and maybe even good
as it provides more immediate feedback.

JSON-RPC logs now look like this:

```js
▲ [JSONRPC] { method: 'marknoticed_chat', ... }
▲ [JSONRPC] { method: 'set_config', ... }
▲ [JSONRPC] { method: 'get_first_unread_message_of_chat', ... }
▲ [JSONRPC] { method: 'get_message_list_items', ... }
▲ [JSONRPC] { method: 'get_full_chat_by_id', ... }
▲ [JSONRPC] { method: 'get_chat_media', ... }
▲ [JSONRPC] { method: 'get_messages', ... }
▲ [JSONRPC] { method: 'get_messages', ... }
▲ [JSONRPC] { method: 'get_contact', ... }
▲ [JSONRPC] { method: 'get_draft', ... }
▲ [JSONRPC] { method: 'get_messages', ... }
▲ [JSONRPC] { method: 'get_messages', ... }
```

We start loading messages even before we start loading the full chat.

I like how minimal this turned out to be, and glad that we're moving away from the lingering state. I think the introduced blinking due to "placeholder" state while the new chat is loading is fine. Maybe even good as it gives more immediate feedback when you select another chat.