### PR TITLE
refactor: move "recent apps" code deeper

### DIFF
--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -1,5 +1,12 @@
 import styles from './styles.module.scss'
-import React, { useCallback, useContext, useId, useMemo, useRef } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import MessageListAndComposer from '../message/MessageListAndComposer'
@@ -9,7 +16,7 @@ import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
 import { Avatar } from '../Avatar'
 import MailingListProfile from '../dialogs/MailingListProfile'
 import { useSettingsStore } from '../../stores/settings'
-import { BackendRemote } from '../../backend-com'
+import { BackendRemote, onDCEvent } from '../../backend-com'
 import Button from '../Button'
 import Icon, { IconButton } from '../Icon'
 import useDialog from '../../hooks/dialog/useDialog'
@@ -24,7 +31,7 @@ import { openWebxdc } from '../message/messageFunctions'
 
 import type { T } from '@deltachat/jsonrpc-client'
 import { runtime } from '@deltachat-desktop/runtime-interface'
-import { useRpcFetch } from '../../hooks/useFetch'
+import { useFetch, useRpcFetch } from '../../hooks/useFetch'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { useChatContextMenu } from '../chat/ChatContextMenu'
 import useContextMenu from '../../hooks/useContextMenu'
@@ -38,6 +45,8 @@ import {
 } from '../message/focusAndMultiselect'
 import { useMessageList } from '../../stores/messagelist'
 import Composer from '../composer/Composer'
+import asyncThrottle from '@jcoreio/async-throttle'
+import { useWebxdcMessageSentListener } from '../../hooks/useWebxdcMessageSent'
 
 const log = getLogger('ChatView')
 
@@ -92,11 +101,9 @@ export function ChatView(
 }
 export function ChatViewInner({
   accountId,
-  lastUsedApps,
   chatId,
 }: {
   accountId: number
-  lastUsedApps: T.Message[]
   chatId: T.BasicChat['id']
 }) {
   const tx = useTranslationFunction()
@@ -156,9 +163,7 @@ export function ChatViewInner({
             </>
           )}
         </div>
-        {chatWithLinger && (
-          <ChatNavButtons chat={chatWithLinger} lastUsedApps={lastUsedApps} />
-        )}
+        {chatWithLinger && <ChatNavButtons chat={chatWithLinger} />}
       </nav>
       <RecoverableCrashScreen reset_on_change_key={chatId}>
         <MessageMultiselectContext.Provider
@@ -416,13 +421,7 @@ function ChatHeading({ chat, hidden }: { chat: T.FullChat; hidden: boolean }) {
   )
 }
 
-function ChatNavButtons({
-  chat,
-  lastUsedApps,
-}: {
-  chat: T.FullChat
-  lastUsedApps: T.Message[]
-}) {
+function ChatNavButtons({ chat }: { chat: T.FullChat }) {
   const tx = useTranslationFunction()
   const { openMainViewContextMenu } = useChatContextMenu()
   const onClickThreeDotMenu = useCallback(
@@ -441,14 +440,10 @@ function ChatNavButtons({
     })
   }, [openDialog, chatId])
 
-  const hasLastUsedApps = lastUsedApps && lastUsedApps.length > 0
-
   return (
     <div className='views' data-no-drag-region>
       <div className={styles.appsGroup}>
-        {hasLastUsedApps && (
-          <AppIcons accountId={selectedAccountId()} apps={lastUsedApps} />
-        )}
+        <AppIcons accountId={selectedAccountId()} chatId={chatId} />
         <IconButton
           onClick={openMediaViewDialog}
           aria-label={tx('apps_and_media')}
@@ -572,14 +567,79 @@ function AppIcon({ accountId, app }: { accountId: number; app: T.Message }) {
 
 function AppIcons({
   accountId,
-  apps,
+  chatId,
 }: {
-  accountId: number | undefined
-  apps: T.Message[]
+  accountId: number
+  chatId: T.BasicChat['id']
 }) {
   const tx = useTranslationFunction()
+  const { smallScreenMode } = useContext(ScreenContext)
 
-  if (!accountId || !apps || apps.length === 0) {
+  const throttledFetchLastUsedApps = useMemo(
+    () =>
+      asyncThrottle(
+        async (accountId: number, chatId: number, smallScreenMode: boolean) => {
+          const maxIcons = smallScreenMode ? 1 : 3
+          const mediaIds = await BackendRemote.rpc.getChatMedia(
+            accountId,
+            chatId,
+            'Webxdc',
+            null,
+            null
+          )
+          // mediaIds holds the ids of the last updated apps,
+          // in reverse order
+          mediaIds.reverse()
+          const firstFew = mediaIds.slice(0, maxIcons)
+
+          // TODO perf: if the current throttled fetch was canceled
+          // before the next line got executed, we could bail here.
+          const mediaLoadResult = await BackendRemote.rpc.getMessages(
+            accountId,
+            firstFew
+          )
+          const lastUpdatedApps = firstFew
+            .map((id: number) => {
+              if (mediaLoadResult[id]?.kind === 'message') {
+                return mediaLoadResult[id]
+              }
+              return null
+            })
+            .filter(app => app !== null)
+
+          return lastUpdatedApps
+        },
+        50
+      ),
+    []
+  )
+  const lastUsedAppsFetch = useFetch(throttledFetchLastUsedApps, [
+    accountId,
+    chatId,
+    smallScreenMode,
+  ])
+  if (lastUsedAppsFetch.result?.ok === false) {
+    log.error('Failed to fetch last used apps', lastUsedAppsFetch.result.err)
+  }
+
+  // Listen for Webxdc messages being sent to the current chat
+  useWebxdcMessageSentListener(accountId, chatId, () => {
+    // Refresh Webxdc apps list when a Webxdc message is sent
+    lastUsedAppsFetch.refresh()
+  })
+
+  useEffect(() => {
+    return onDCEvent(accountId, 'WebxdcInstanceDeleted', () => {
+      lastUsedAppsFetch.refresh()
+    })
+  }, [accountId, lastUsedAppsFetch])
+
+  const apps =
+    lastUsedAppsFetch.result?.ok && lastUsedAppsFetch.result.value.length > 0
+      ? lastUsedAppsFetch.result.value
+      : []
+
+  if (apps.length === 0) {
     return null
   }
   return (

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -5,14 +5,12 @@ import React, {
   useEffect,
   useCallback,
   useContext,
-  useMemo,
 } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import ChatList from '../../chat/ChatList'
 import ConnectivityToast from '../../ConnectivityToast'
 import SettingsStoreInstance from '../../../stores/settings'
-import { BackendRemote, onDCEvent } from '../../../backend-com'
 import ChatListHeader from './ChatListHeader'
 import { ChatView } from '../../ChatView/ChatView'
 import useChat from '../../../hooks/chat/useChat'
@@ -23,12 +21,9 @@ import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import { KeybindAction } from '../../../keybindings'
 import { ScreenContext } from '../../../contexts/ScreenContext'
 import MediaView from '../../dialogs/MediaView'
-import { useWebxdcMessageSentListener } from '../../../hooks/useWebxdcMessageSent'
 
 import CreateChat from '../../dialogs/CreateChat'
 import CommandPalette from '../../dialogs/CommandPalette'
-import asyncThrottle from '@jcoreio/async-throttle'
-import { useFetch } from '../../../hooks/useFetch'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { GlobalVoiceMessagePlayer } from '../../GlobalVoiceMessagePlayer/GlobalVoiceMessagePlayer'
 
@@ -172,75 +167,6 @@ export default function MainScreen({ accountId }: Props) {
     })
   })
 
-  // Throttle in case the user switches chats very rapidly,
-  // e.g. by holding down Ctrl + PageDown.
-  //
-  // TODO a debounce would probably be more appropriate here,
-  // given that the operation is relatively expensive,
-  // but I haven't looked for an `asyncDebounce` function.
-  const throttledFetchLastUsedApps = useMemo(
-    () =>
-      asyncThrottle(
-        async (accountId: number, chatId: number, smallScreenMode: boolean) => {
-          const maxIcons = smallScreenMode ? 1 : 3
-          const mediaIds = await BackendRemote.rpc.getChatMedia(
-            accountId,
-            chatId,
-            'Webxdc',
-            null,
-            null
-          )
-          // mediaIds holds the ids of the last updated apps,
-          // in reverse order
-          mediaIds.reverse()
-          const firstFew = mediaIds.slice(0, maxIcons)
-
-          // TODO perf: if the current throttled fetch was canceled
-          // before the next line got executed, we could bail here.
-          const mediaLoadResult = await BackendRemote.rpc.getMessages(
-            accountId,
-            firstFew
-          )
-          const lastUpdatedApps = firstFew
-            .map((id: number) => {
-              if (mediaLoadResult[id]?.kind === 'message') {
-                return mediaLoadResult[id]
-              }
-              return null
-            })
-            .filter(app => app !== null)
-
-          return lastUpdatedApps
-        },
-        50
-      ),
-    []
-  )
-  const lastUsedAppsFetch = useFetch(
-    throttledFetchLastUsedApps,
-    accountId != undefined && chatId != undefined
-      ? [accountId, chatId, smallScreenMode]
-      : null
-  )
-  if (lastUsedAppsFetch?.result?.ok === false) {
-    log.error('Failed to fetch last used apps', lastUsedAppsFetch.result.err)
-  }
-
-  // Listen for Webxdc messages being sent to the current chat
-  useWebxdcMessageSentListener(accountId || 0, chatId || 0, () => {
-    // Refresh Webxdc apps list when a Webxdc message is sent
-    lastUsedAppsFetch?.refresh()
-  })
-
-  useEffect(() => {
-    if (!accountId) {
-      return
-    }
-    return onDCEvent(accountId, 'WebxdcInstanceDeleted', () => {
-      lastUsedAppsFetch?.refresh()
-    })
-  }, [accountId, lastUsedAppsFetch])
-
   // There is another `load()` in `ScreenController.selectAccount()`,
   // but that is not enough because we also need to reload settings
   // after an unconfigured account becomes a configured one,
@@ -263,11 +189,6 @@ export default function MainScreen({ accountId }: Props) {
 
   const isSearchActive = queryStr.length > 0 || queryChatId !== null
   const showArchivedChats = !isSearchActive && archivedChatsSelected
-
-  const lastUsedApps =
-    lastUsedAppsFetch?.result?.ok && lastUsedAppsFetch.result.value.length > 0
-      ? lastUsedAppsFetch.result.value
-      : []
 
   return (
     <div
@@ -317,11 +238,7 @@ export default function MainScreen({ accountId }: Props) {
 
         <GlobalVoiceMessagePlayer />
       </div>
-      <ChatView
-        className={styles.chatView}
-        accountId={accountId}
-        lastUsedApps={lastUsedApps}
-      />
+      <ChatView className={styles.chatView} accountId={accountId} />
       {!chatListShouldBeHidden && <ConnectivityToast />}
     </div>
   )

--- a/packages/frontend/src/hooks/useWebxdcMessageSent.ts
+++ b/packages/frontend/src/hooks/useWebxdcMessageSent.ts
@@ -28,7 +28,7 @@ export function notifyWebxdcMessageSent(
 /**
  * A notifier that allows components to subscribe to Webxdc message sent events.
  * For cases where DC Event 'MsgsChanged' is not sufficient
- * (like on MainScreen where we want to update AppIcons immediately when a
+ * (like in AppIcons where we want to update the list immediately when a
  * Webxdc message is sent).
  */
 export function useWebxdcMessageSentNotifier() {


### PR DESCRIPTION
Cleans up `MainScreen` nicely IMO.
Originally this code had to be in `MainScreen`
because that was where the header was. See
3bc21041bfbafea2da9c297adcdffa28528e8480
(https://github.com/deltachat/deltachat-desktop/pull/5151).

This is not an entirely pure move. I also did the following:
- removed the conditions for handling `accountId` and `chatId`
  beind possibly `undefined`.
- Removed the comment about "why asyncThrottle", see below why.

With this commit, `asyncThrottle` does _not_ throttle
across different chats. This is because the place where `useFetch`
is behind `key={chatId}`.
But I think that overall the performance is improved:
we won't start loading the "recent apps"
until we have loaded the full chat,
which is good since "recent apps" is generally lower-priority thing.
This is how the JSON-RPC request log looks like now
when switching a chat:

```log
[JSONRPC] { method: 'marknoticed_chat', ... }
[JSONRPC] { method: 'set_config', ... }
[JSONRPC] { method: 'get_first_unread_message_of_chat', ... }
[JSONRPC] { method: 'get_message_list_items', ... }
[JSONRPC] { method: 'get_full_chat_by_id', ... }
[JSONRPC] { method: 'get_messages', ... }
[JSONRPC] { method: 'get_contact', ... }
[JSONRPC] { method: 'get_draft', ... }
[JSONRPC] { method: 'get_chat_media', ... }
[JSONRPC] { method: 'get_messages', ... }
[JSONRPC] { method: 'get_webxdc_info', ... }
```

Marking as draft because the base is not merged.
