### PR TITLE
perf: wait for idle before loading "recent apps"

### DIFF
--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -576,6 +576,12 @@ function AppIcon({ accountId, app }: { accountId: number; app: T.Message }) {
 // since "recent apps" is a lower-priority widget.
 const throttledFetchLastUsedApps = asyncThrottle(
   async (accountId: number, chatId: number, smallScreenMode: boolean) => {
+    // We don't provide a timeout, so this can result
+    // in possibly indefinite wait,
+    // but it's fine, because this widget is not irreplaceable:
+    // we have the "Gallery" dialog.
+    await new Promise(r => requestIdleCallback(r))
+
     const maxIcons = smallScreenMode ? 1 : 3
     const mediaIds = await BackendRemote.rpc.getChatMedia(
       accountId,

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -1,5 +1,12 @@
 import styles from './styles.module.scss'
-import React, { useCallback, useContext, useId, useMemo, useRef } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import MessageListAndComposer from '../message/MessageListAndComposer'
@@ -9,7 +16,7 @@ import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
 import { Avatar } from '../Avatar'
 import MailingListProfile from '../dialogs/MailingListProfile'
 import { useSettingsStore } from '../../stores/settings'
-import { BackendRemote } from '../../backend-com'
+import { BackendRemote, onDCEvent } from '../../backend-com'
 import Button from '../Button'
 import Icon, { IconButton } from '../Icon'
 import useDialog from '../../hooks/dialog/useDialog'
@@ -24,7 +31,7 @@ import { openWebxdc } from '../message/messageFunctions'
 
 import type { T } from '@deltachat/jsonrpc-client'
 import { runtime } from '@deltachat-desktop/runtime-interface'
-import { useRpcFetch } from '../../hooks/useFetch'
+import { useFetch, useRpcFetch } from '../../hooks/useFetch'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { useChatContextMenu } from '../chat/ChatContextMenu'
 import useContextMenu from '../../hooks/useContextMenu'
@@ -38,6 +45,8 @@ import {
 } from '../message/focusAndMultiselect'
 import { useMessageList } from '../../stores/messagelist'
 import Composer from '../composer/Composer'
+import asyncThrottle from '@jcoreio/async-throttle'
+import { useWebxdcMessageSentListener } from '../../hooks/useWebxdcMessageSent'
 
 const log = getLogger('ChatView')
 
@@ -92,11 +101,9 @@ export function ChatView(
 }
 export function ChatViewInner({
   accountId,
-  lastUsedApps,
   chatId,
 }: {
   accountId: number
-  lastUsedApps: T.Message[]
   chatId: T.BasicChat['id']
 }) {
   const tx = useTranslationFunction()
@@ -156,9 +163,7 @@ export function ChatViewInner({
             </>
           )}
         </div>
-        {chatWithLinger && (
-          <ChatNavButtons chat={chatWithLinger} lastUsedApps={lastUsedApps} />
-        )}
+        {chatWithLinger && <ChatNavButtons chat={chatWithLinger} />}
       </nav>
       <RecoverableCrashScreen reset_on_change_key={chatId}>
         <MessageMultiselectContext.Provider
@@ -416,13 +421,7 @@ function ChatHeading({ chat, hidden }: { chat: T.FullChat; hidden: boolean }) {
   )
 }
 
-function ChatNavButtons({
-  chat,
-  lastUsedApps,
-}: {
-  chat: T.FullChat
-  lastUsedApps: T.Message[]
-}) {
+function ChatNavButtons({ chat }: { chat: T.FullChat }) {
   const tx = useTranslationFunction()
   const { openMainViewContextMenu } = useChatContextMenu()
   const onClickThreeDotMenu = useCallback(
@@ -441,14 +440,10 @@ function ChatNavButtons({
     })
   }, [openDialog, chatId])
 
-  const hasLastUsedApps = lastUsedApps && lastUsedApps.length > 0
-
   return (
     <div className='views' data-no-drag-region>
       <div className={styles.appsGroup}>
-        {hasLastUsedApps && (
-          <AppIcons accountId={selectedAccountId()} apps={lastUsedApps} />
-        )}
+        <AppIcons accountId={selectedAccountId()} chatId={chatId} />
         <IconButton
           onClick={openMediaViewDialog}
           aria-label={tx('apps_and_media')}
@@ -570,16 +565,87 @@ function AppIcon({ accountId, app }: { accountId: number; app: T.Message }) {
   )
 }
 
+// Throttle in case the user switches chats very rapidly,
+// e.g. by holding down Ctrl + PageDown.
+//
+// TODO a debounce would probably be more appropriate here,
+// given that the operation is relatively expensive,
+// but I haven't looked for an `asyncDebounce` function.
+//
+// Throttled globally instead of at component, per-chat level,
+// since "recent apps" is a lower-priority widget.
+const throttledFetchLastUsedApps = asyncThrottle(
+  async (accountId: number, chatId: number, smallScreenMode: boolean) => {
+    const maxIcons = smallScreenMode ? 1 : 3
+    const mediaIds = await BackendRemote.rpc.getChatMedia(
+      accountId,
+      chatId,
+      'Webxdc',
+      null,
+      null
+    )
+    // mediaIds holds the ids of the last updated apps,
+    // in reverse order
+    mediaIds.reverse()
+    const firstFew = mediaIds.slice(0, maxIcons)
+
+    // TODO perf: if the current throttled fetch was canceled
+    // before the next line got executed, we could bail here.
+    const mediaLoadResult = await BackendRemote.rpc.getMessages(
+      accountId,
+      firstFew
+    )
+    const lastUpdatedApps = firstFew
+      .map((id: number) => {
+        if (mediaLoadResult[id]?.kind === 'message') {
+          return mediaLoadResult[id]
+        }
+        return null
+      })
+      .filter(app => app !== null)
+
+    return lastUpdatedApps
+  },
+  50
+)
+
 function AppIcons({
   accountId,
-  apps,
+  chatId,
 }: {
-  accountId: number | undefined
-  apps: T.Message[]
+  accountId: number
+  chatId: T.BasicChat['id']
 }) {
   const tx = useTranslationFunction()
+  const { smallScreenMode } = useContext(ScreenContext)
 
-  if (!accountId || !apps || apps.length === 0) {
+  const lastUsedAppsFetch = useFetch(throttledFetchLastUsedApps, [
+    accountId,
+    chatId,
+    smallScreenMode,
+  ])
+  if (lastUsedAppsFetch.result?.ok === false) {
+    log.error('Failed to fetch last used apps', lastUsedAppsFetch.result.err)
+  }
+
+  // Listen for Webxdc messages being sent to the current chat
+  useWebxdcMessageSentListener(accountId, chatId, () => {
+    // Refresh Webxdc apps list when a Webxdc message is sent
+    lastUsedAppsFetch.refresh()
+  })
+
+  useEffect(() => {
+    return onDCEvent(accountId, 'WebxdcInstanceDeleted', () => {
+      lastUsedAppsFetch.refresh()
+    })
+  }, [accountId, lastUsedAppsFetch])
+
+  const apps =
+    lastUsedAppsFetch.result?.ok && lastUsedAppsFetch.result.value.length > 0
+      ? lastUsedAppsFetch.result.value
+      : []
+
+  if (apps.length === 0) {
     return null
   }
   return (

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -5,14 +5,12 @@ import React, {
   useEffect,
   useCallback,
   useContext,
-  useMemo,
 } from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import ChatList from '../../chat/ChatList'
 import ConnectivityToast from '../../ConnectivityToast'
 import SettingsStoreInstance from '../../../stores/settings'
-import { BackendRemote, onDCEvent } from '../../../backend-com'
 import ChatListHeader from './ChatListHeader'
 import { ChatView } from '../../ChatView/ChatView'
 import useChat from '../../../hooks/chat/useChat'
@@ -23,12 +21,9 @@ import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import { KeybindAction } from '../../../keybindings'
 import { ScreenContext } from '../../../contexts/ScreenContext'
 import MediaView from '../../dialogs/MediaView'
-import { useWebxdcMessageSentListener } from '../../../hooks/useWebxdcMessageSent'
 
 import CreateChat from '../../dialogs/CreateChat'
 import CommandPalette from '../../dialogs/CommandPalette'
-import asyncThrottle from '@jcoreio/async-throttle'
-import { useFetch } from '../../../hooks/useFetch'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { GlobalVoiceMessagePlayer } from '../../GlobalVoiceMessagePlayer/GlobalVoiceMessagePlayer'
 
@@ -172,75 +167,6 @@ export default function MainScreen({ accountId }: Props) {
     })
   })
 
-  // Throttle in case the user switches chats very rapidly,
-  // e.g. by holding down Ctrl + PageDown.
-  //
-  // TODO a debounce would probably be more appropriate here,
-  // given that the operation is relatively expensive,
-  // but I haven't looked for an `asyncDebounce` function.
-  const throttledFetchLastUsedApps = useMemo(
-    () =>
-      asyncThrottle(
-        async (accountId: number, chatId: number, smallScreenMode: boolean) => {
-          const maxIcons = smallScreenMode ? 1 : 3
-          const mediaIds = await BackendRemote.rpc.getChatMedia(
-            accountId,
-            chatId,
-            'Webxdc',
-            null,
-            null
-          )
-          // mediaIds holds the ids of the last updated apps,
-          // in reverse order
-          mediaIds.reverse()
-          const firstFew = mediaIds.slice(0, maxIcons)
-
-          // TODO perf: if the current throttled fetch was canceled
-          // before the next line got executed, we could bail here.
-          const mediaLoadResult = await BackendRemote.rpc.getMessages(
-            accountId,
-            firstFew
-          )
-          const lastUpdatedApps = firstFew
-            .map((id: number) => {
-              if (mediaLoadResult[id]?.kind === 'message') {
-                return mediaLoadResult[id]
-              }
-              return null
-            })
-            .filter(app => app !== null)
-
-          return lastUpdatedApps
-        },
-        50
-      ),
-    []
-  )
-  const lastUsedAppsFetch = useFetch(
-    throttledFetchLastUsedApps,
-    accountId != undefined && chatId != undefined
-      ? [accountId, chatId, smallScreenMode]
-      : null
-  )
-  if (lastUsedAppsFetch?.result?.ok === false) {
-    log.error('Failed to fetch last used apps', lastUsedAppsFetch.result.err)
-  }
-
-  // Listen for Webxdc messages being sent to the current chat
-  useWebxdcMessageSentListener(accountId || 0, chatId || 0, () => {
-    // Refresh Webxdc apps list when a Webxdc message is sent
-    lastUsedAppsFetch?.refresh()
-  })
-
-  useEffect(() => {
-    if (!accountId) {
-      return
-    }
-    return onDCEvent(accountId, 'WebxdcInstanceDeleted', () => {
-      lastUsedAppsFetch?.refresh()
-    })
-  }, [accountId, lastUsedAppsFetch])
-
   // There is another `load()` in `ScreenController.selectAccount()`,
   // but that is not enough because we also need to reload settings
   // after an unconfigured account becomes a configured one,
@@ -263,11 +189,6 @@ export default function MainScreen({ accountId }: Props) {
 
   const isSearchActive = queryStr.length > 0 || queryChatId !== null
   const showArchivedChats = !isSearchActive && archivedChatsSelected
-
-  const lastUsedApps =
-    lastUsedAppsFetch?.result?.ok && lastUsedAppsFetch.result.value.length > 0
-      ? lastUsedAppsFetch.result.value
-      : []
 
   return (
     <div
@@ -317,11 +238,7 @@ export default function MainScreen({ accountId }: Props) {
 
         <GlobalVoiceMessagePlayer />
       </div>
-      <ChatView
-        className={styles.chatView}
-        accountId={accountId}
-        lastUsedApps={lastUsedApps}
-      />
+      <ChatView className={styles.chatView} accountId={accountId} />
       {!chatListShouldBeHidden && <ConnectivityToast />}
     </div>
   )

--- a/packages/frontend/src/hooks/useWebxdcMessageSent.ts
+++ b/packages/frontend/src/hooks/useWebxdcMessageSent.ts
@@ -28,7 +28,7 @@ export function notifyWebxdcMessageSent(
 /**
  * A notifier that allows components to subscribe to Webxdc message sent events.
  * For cases where DC Event 'MsgsChanged' is not sufficient
- * (like on MainScreen where we want to update AppIcons immediately when a
+ * (like in AppIcons where we want to update the list immediately when a
  * Webxdc message is sent).
  */
 export function useWebxdcMessageSentNotifier() {


### PR DESCRIPTION
Again, this is a lower-priority widget, and `get_chat_media`
is not super cheap (takes ~50ms on my machine
with no other concurrent request).
Still this doesn't delay the load significantly,
no longer than half a second,
at least when the machine is idle otherwise.

Related:
- https://github.com/chatmail/core/pull/7325

Marking as draft because the base is not merged.
