### PR TITLE
refactor: rename `chatWithLinger` -> `chat`

### DIFF
--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -100,7 +100,7 @@ export function ChatViewInner({
   chatId: T.BasicChat['id']
 }) {
   const tx = useTranslationFunction()
-  const { unselectChat, chatWithLinger, oldChat } = useChat()
+  const { unselectChat, chat, oldChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
   const messageListData = useMessageList(accountId, chatId)
@@ -117,10 +117,7 @@ export function ChatViewInner({
   const showMessageMultiselectCounter = numSelectedMessages > 0
 
   return (
-    <div
-      style={{ display: 'contents' }}
-      aria-busy={chatWithLinger == undefined}
-    >
+    <div style={{ display: 'contents' }} aria-busy={chat == undefined}>
       <nav className={styles.chatNavbar} data-tauri-drag-region>
         {smallScreenMode && (
           <span data-no-drag-region>
@@ -135,7 +132,7 @@ export function ChatViewInner({
           </span>
         )}
         <div className={styles.chatNavbarHeadingWrapper} data-tauri-drag-region>
-          {chatWithLinger && (
+          {chat && (
             <>
               <div role='status' style={{ display: 'contents' }}>
                 {showMessageMultiselectCounter && (
@@ -147,7 +144,7 @@ export function ChatViewInner({
                 )}
               </div>
               <ChatHeading
-                chat={chatWithLinger}
+                chat={chat}
                 // Why `hidden` instead of simply not rendering?
                 // Because this component contains the accessible title
                 // for the "ChatView" section (`id='chat-section-heading'`).
@@ -156,18 +153,16 @@ export function ChatViewInner({
             </>
           )}
         </div>
-        {chatWithLinger && (
-          <ChatNavButtons chat={chatWithLinger} lastUsedApps={lastUsedApps} />
-        )}
+        {chat && <ChatNavButtons chat={chat} lastUsedApps={lastUsedApps} />}
       </nav>
       <RecoverableCrashScreen reset_on_change_key={chatId}>
         <MessageMultiselectContext.Provider
           value={focusAndMultiselectContextValue}
         >
-          {chatWithLinger ? (
+          {chat ? (
             <MessageListAndComposer
               accountId={accountId}
-              chat={chatWithLinger}
+              chat={chat}
               messageListData={messageListData}
             />
           ) : (

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -35,7 +35,7 @@ export default function ReactionsBar({
   myReaction,
 }: Props) {
   const tx = useTranslationFunction()
-  const { chatWithLinger } = useChat()
+  const { chat } = useChat()
   const openAlertDialog = useAlertDialog()
 
   const reactionsBarRef = useRef<HTMLDivElement>(null)
@@ -125,9 +125,9 @@ export default function ReactionsBar({
                 onClick={() => toggleReaction(myReaction)}
               />
             )}
-            {chatWithLinger != undefined &&
-              chatWithLinger.chatType !== 'InBroadcast' &&
-              chatWithLinger.chatType !== 'OutBroadcast' && (
+            {chat != undefined &&
+              chat.chatType !== 'InBroadcast' &&
+              chat.chatType !== 'OutBroadcast' && (
                 <MoreEmojisButton onClick={handleShowAllEmojis} />
               )}
           </RovingTabindexProvider>

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -47,7 +47,7 @@ export default function MainScreen({ accountId }: Props) {
   const [queryStr, setQueryStr] = useState('')
   const [queryChatId, setQueryChatId] = useState<null | number>(null)
   const [archivedChatsSelected, setArchivedChatsSelected] = useState(false)
-  const { chatId, chatWithLinger, selectChat, unselectChat } = useChat()
+  const { chatId, chat, selectChat, unselectChat } = useChat()
   const { smallScreenMode } = useContext(ScreenContext)
 
   // Small hack/misuse of keyBindingAction to setArchivedChatsSelected from
@@ -98,10 +98,10 @@ export default function MainScreen({ accountId }: Props) {
 
     // If we've searched a non-archive chat while being in archive mode
     // previously we want to get back to normal mode after cancelling
-    if (!chatWithLinger?.archived && archivedChatsSelected) {
+    if (!chat?.archived && archivedChatsSelected) {
       setArchivedChatsSelected(false)
     }
-  }, [archivedChatsSelected, chatWithLinger?.archived, searchChats])
+  }, [archivedChatsSelected, chat?.archived, searchChats])
 
   useEffect(() => {
     window.__chatlistSetSearch = searchChats

--- a/packages/frontend/src/contexts/ChatContext.tsx
+++ b/packages/frontend/src/contexts/ChatContext.tsx
@@ -21,23 +21,26 @@ export type ChatContextValue = {
    * {@linkcode ChatContextValue.chatId},
    * or `undefined` during initial load,
    * after {@linkcode ChatContextValue.selectChat}.
-   *
-   * `withLinger` means that the value of `chatWithLinger`
-   * does not change immediately when we start refreshing the chat
-   * (e.g. after `ChatModified` event),
-   * until the new chat's info gets loaded.
    */
-  chatWithLinger?: T.FullChat
+  chat?: T.FullChat
+  /**
+   * Same as {@linkcode ChatContextValue.chat}, but `undefined`
+   * while {@linkcode ChatContextValue.loading} == true.
+   */
   chatNoLinger?: T.FullChat
   /**
    * Right after {@linkcode ChatContextValue.selectChat},
-   * {@linkcode ChatContextValue.chatWithLinger} becomes `undefined`
+   * {@linkcode ChatContextValue.chat} becomes `undefined`
    * and the original chat migrates here.
    *
    * Can be useful for reducing layout shifts and flashing,
    * but be careful not to use this for anything effectful.
    */
   oldChat?: T.FullChat
+  /**
+   * `true` when {@linkcode ChatContextValue.chat} == undefined
+   * and when refreshing the chat e.g. after `ChatModified` event.
+   */
   loadingChat: boolean
   chatId?: number
   /**
@@ -138,7 +141,7 @@ export const ChatProvider = ({
     accountId === chatFetch.lingeringResult.value.accountId
       ? chatFetch.lingeringResult.value.chat
       : undefined
-  const chatWithLinger =
+  const chat =
     chatWithLinger_ != undefined && chatWithLinger_.id === chatId
       ? chatWithLinger_
       : undefined
@@ -266,7 +269,7 @@ export const ChatProvider = ({
         return
       }
 
-      if (!chatWithLinger) {
+      if (!chat) {
         return
       }
 
@@ -274,7 +277,7 @@ export const ChatProvider = ({
         return
       }
 
-      if (!chatWithLinger.contactIds.includes(contactId)) {
+      if (!chat.contactIds.includes(contactId)) {
         return
       }
 
@@ -294,12 +297,12 @@ export const ChatProvider = ({
       BackendRemote.off('ChatEphemeralTimerModified', onChatModified)
       BackendRemote.off('ContactsChanged', onContactsModified)
     }
-  }, [accountId, chatWithLinger, chatId, refreshChat])
+  }, [accountId, chat, chatId, refreshChat])
 
   const loadingChat = chatFetch?.loading ?? false
   const value: ChatContextValue = useMemo(
     () => ({
-      chatWithLinger,
+      chat,
       chatNoLinger,
       oldChat,
       loadingChat,
@@ -307,15 +310,7 @@ export const ChatProvider = ({
       selectChat,
       unselectChat,
     }),
-    [
-      chatWithLinger,
-      chatNoLinger,
-      oldChat,
-      loadingChat,
-      chatId,
-      selectChat,
-      unselectChat,
-    ]
+    [chat, chatNoLinger, oldChat, loadingChat, chatId, selectChat, unselectChat]
   )
 
   return <ChatContext.Provider value={value}>{children}</ChatContext.Provider>

--- a/packages/frontend/src/hooks/chat/useChatDialog.ts
+++ b/packages/frontend/src/hooks/chat/useChatDialog.ts
@@ -21,9 +21,9 @@ export default function useChatDialog() {
   const tx = useTranslationFunction()
   const openConfirmationDialog = useConfirmationDialog()
   const { openDialog } = useDialog()
-  const { chatWithLinger, selectChat, unselectChat } = useChat()
+  const { chat, selectChat, unselectChat } = useChat()
 
-  const chatContactIds = chatWithLinger?.contactIds
+  const chatContactIds = chat?.contactIds
   const openBlockContactById = useCallback(
     async (accountId: number, dmChatContact: number) => {
       const hasUserConfirmed = await openConfirmationDialog({


### PR DESCRIPTION
This basically reverts 9ed164b2911f574ae017621553f3fd689abfdf60
(https://github.com/deltachat/deltachat-desktop/pull/4551).

After the previous commit (1b9aa2fb161a2de0980766cd1235b906acadbcef)
(https://github.com/deltachat/deltachat-desktop/pull/6650)
this value is never the old chat,
so there is no need to be this explicit.

Marking as draft because the base is not merged yet.