### PR TITLE
fix: add Arabic and Telugu languages

### DIFF
--- a/bin/translations/build-shared-convert-translations.mjs
+++ b/bin/translations/build-shared-convert-translations.mjs
@@ -38,10 +38,10 @@ async function xmlToJson(filename) {
     await writeFile(newFile, JSON.stringify(res, null, 2))
   }
 
-  if (!js.resources || !js.resources.string || !js.resources.plurals)
+  if (!js.resources)
     return done()
 
-  js.resources.string.forEach(string => {
+  js.resources.string?.forEach(string => {
     const name = string._attributes.name
     if (!name) return error(string)
     let text = string._text
@@ -53,7 +53,7 @@ async function xmlToJson(filename) {
     }
   })
 
-  js.resources.plurals.forEach(plural => {
+  js.resources.plurals?.forEach(plural => {
     const name = plural._attributes.name
     if (!name) return error(plural)
 


### PR DESCRIPTION
They are in the list of available languages but each has 0 strings.
The fact that the two languages' translations
don't have any strings that are plural
makes the script bail early as if this is an error.

<img width="288" height="167" alt="image" src="https://github.com/user-attachments/assets/14c11b44-9054-42e8-a92c-4637fe10ab07" />

This bug has existed for at least 8 years,
a63f319bafcff2282b159a98ceeeee8d24cd2b70
(https://github.com/deltachat/deltachat-desktop/pull/422).
