### PR TITLE
improvement: add Slovenian language

### DIFF
--- a/_locales/_languages.json
+++ b/_locales/_languages.json
@@ -42,6 +42,7 @@
   "sk": "Slovenčina",
   "sq": "Shqip",
   "sr": "Српски",
+  "sl": "Slovenščina",
   "sv": "Svenska",
   "ta": "தமிழ்",
   "te": "తెలుగు",


### PR DESCRIPTION
It's ready, according to
`./bin/translations/find_complete_translations.sh`.
Not sure why it's still not in the list after so many
`pnpm translations:update`s.

<img width="294" height="96" alt="image" src="https://github.com/user-attachments/assets/17f23271-7d80-4ca8-8ab3-ffc376fe8dd9" />

I took the string from https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes.