### PR TITLE
feat: allow user to resize chat list

### DIFF
--- a/packages/frontend/scss/chat/_chat-list-item.scss
+++ b/packages/frontend/scss/chat/_chat-list-item.scss
@@ -215,6 +215,7 @@
     linear-gradient(grey 40px, transparent 0),
     linear-gradient(grey 40px, transparent 0),
     linear-gradient(grey 40px, transparent 0);
+  // TODO style: make this adapt to actual chat list width.
   background-size:
     56px 56px,
     200px 18px,

--- a/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
+++ b/packages/frontend/src/components/screens/MainScreen/MainScreen.tsx
@@ -11,7 +11,10 @@ import { C } from '@deltachat/jsonrpc-client'
 
 import ChatList from '../../chat/ChatList'
 import ConnectivityToast from '../../ConnectivityToast'
-import SettingsStoreInstance from '../../../stores/settings'
+import SettingsStoreInstance, {
+  DesktopSettingsStoreInstance,
+  useDesktopSettingsStore,
+} from '../../../stores/settings'
 import { BackendRemote, onDCEvent } from '../../../backend-com'
 import ChatListHeader from './ChatListHeader'
 import { ChatView } from '../../ChatView/ChatView'
@@ -31,6 +34,7 @@ import asyncThrottle from '@jcoreio/async-throttle'
 import { useFetch } from '../../../hooks/useFetch'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { GlobalVoiceMessagePlayer } from '../../GlobalVoiceMessagePlayer/GlobalVoiceMessagePlayer'
+import { debounce } from 'debounce'
 
 const log = getLogger('MainScreen')
 
@@ -41,6 +45,7 @@ type Props = {
 export default function MainScreen({ accountId }: Props) {
   // Automatically select last known chat when account changed
   useSelectLastChat(accountId)
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
   const tx = useTranslationFunction()
 
@@ -269,13 +274,23 @@ export default function MainScreen({ accountId }: Props) {
       ? lastUsedAppsFetch.result.value
       : []
 
+  const chatListSectionRef = useRef<HTMLDivElement>(null)
+  useSaveChatListWidth(chatListSectionRef)
+
   return (
     <div
       className={`main-screen ${smallScreenMode ? 'small-screen' : ''} ${
         !messageSectionShouldBeHidden ? 'chat-view-open' : ''
       }`}
     >
-      <div className={styles.chatListAndHeaderAndAudioPlayer}>
+      <div
+        ref={chatListSectionRef}
+        className={styles.chatListAndHeaderAndAudioPlayer}
+        style={{
+          ['--initialChatListAndHeaderAndAudioPlayerWidth' as keyof React.CSSProperties]:
+            desktopSettingsStore?.chatListSectionWidth,
+        }}
+      >
         <section
           className={styles.chatListAndHeader}
           role='region'
@@ -325,4 +340,46 @@ export default function MainScreen({ accountId }: Props) {
       {!chatListShouldBeHidden && <ConnectivityToast />}
     </div>
   )
+}
+
+function useSaveChatListWidth(ref: React.RefObject<HTMLElement | null>) {
+  const debouncedSave = useMemo(
+    () =>
+      debounce((width: string) => {
+        if (width === '') {
+          log.info(
+            `chat list resized, but its width not specified; normal if it was not resized by user; will not save`
+          )
+          return
+        }
+        if (!width.endsWith('px')) {
+          log.warn(
+            `chat list resized, but its width is not in pixels: "${width}", still proceeding`
+          )
+        }
+
+        log.info(`flushing new chat list width "${width}" to storage`)
+
+        DesktopSettingsStoreInstance.effect.set('chatListSectionWidth', width)
+      }, 5 * 60_000),
+    []
+  )
+
+  useEffect(() => {
+    const el = ref.current
+    if (el == undefined) {
+      log.warn("can't watch chat list resizing: ref.current is nullish")
+      return
+    }
+
+    const observer = new ResizeObserver(_entries => {
+      debouncedSave(el.style.width)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [debouncedSave, ref])
+
+  useEffect(() => {
+    return () => debouncedSave.flush()
+  })
 }

--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -66,8 +66,7 @@
   }
 }
 .chatView {
-  // Otherwise e.g. the contents of the gallery view
-  // (tabs, sepcifically) will refuse to shrink,
+  // Otherwise e.g. the contents of the section may refuse to shrink,
   // and this element (`.chatView`) will overflow the parent.
   // Also this ensures that `.chatListAndHeaderAndAudioPlayer`
   // and `.chatView` take respectively 3 and 8 parts

--- a/packages/frontend/src/components/screens/MainScreen/styles.module.scss
+++ b/packages/frontend/src/components/screens/MainScreen/styles.module.scss
@@ -14,15 +14,51 @@
   }
 }
 
+$chatListFraction: 3;
+$chatViewFraction: 8;
+$widthPixelsEstimate: 1000px;
 .chatListAndHeaderAndAudioPlayer {
   display: flex;
   flex-direction: column;
 
-  // See below, `.chatView`'s flex-grow.
-  width: 0;
-  flex-grow: 3;
+  resize: horizontal;
+  // Resize won't actually work without this.
+  overflow-x: hidden;
 
-  min-width: 295px;
+  // `width` will be overridden by the `element.style.width`
+  // when the user resizes it.
+  //
+  // Note that due to the fact that we use `flex-grow` and `flex-shrink`,
+  // the `width` property value does not equal the actual width of the elements,
+  // but rather just their relative sizes.
+  // The downside is that the size doesn't actually follow the user's cursor
+  // when they resize the chat list,
+  // and the width annoyingly jumps just as they start resizing it.
+  // The upside is that when they resize it, they specify
+  // the *relative sizes* of the two sections.
+  // Unfortunately this native resizing always sets `style.width` in pixels
+  // and not as a percentage or something.
+  width: var(
+    --initialChatListAndHeaderAndAudioPlayerWidth,
+    calc(
+      $widthPixelsEstimate * $chatListFraction /
+        ($chatListFraction + $chatViewFraction)
+    )
+  );
+  // `flex-grow` kicks in when the `width` of the the two sections combined
+  // is smaller than that of the parent.
+  // `flex-shrink` kicks in when it's smaller.
+  //
+  // I'm not gonna pretend like there is thorough understanding
+  // and deliberate calculation behind these values,
+  // but they feel pretty alright.
+  flex-grow: $chatListFraction;
+  flex-shrink: 1;
+
+  // TODO this should probably depend on the avatar size and padding,
+  // (and the scrollbar width?)
+  // Also if the proxy icon is disabled in the header then it overflows.
+  min-width: 5rem;
 
   .chatListAndHeader {
     display: flex;
@@ -65,12 +101,17 @@
     }
   }
 }
+:global(.main-screen.small-screen) {
+  .chatListAndHeaderAndAudioPlayer {
+    resize: unset;
+  }
+}
 .chatView {
-  // Otherwise e.g. the contents of the section may refuse to shrink,
-  // and this element (`.chatView`) will overflow the parent.
-  // Also this ensures that `.chatListAndHeaderAndAudioPlayer`
-  // and `.chatView` take respectively 3 and 8 parts
-  // of the width of the parent on wide screens.
-  width: 0;
-  flex-grow: 8;
+  // See above, `.chatListAndHeaderAndAudioPlayer`.
+  width: calc(
+    $widthPixelsEstimate * $chatViewFraction /
+      ($chatListFraction + $chatViewFraction)
+  );
+  flex-grow: $chatViewFraction;
+  flex-shrink: 1;
 }

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -13,6 +13,10 @@ type Bounds = {
 export interface DesktopSettingsType {
   bounds: Bounds | {}
   HTMLEmailWindowBounds: Bounds | undefined
+  /**
+   * Not the *exact* width, see comments in the CSS files.
+   */
+  chatListSectionWidth?: string
   chatViewBgImg?: string
   /**
    * @deprecated replaced by lastAccount,


### PR DESCRIPTION
[resize.webm](https://github.com/user-attachments/assets/d8031ef2-9868-4731-af1c-e382a0c058bc)

Note that this affects the default relative sizes of the sections, 
and reduces `min-width`
so for existing users the width will change as soon as they upgrade.

Again, the fact that it jumps as you start resizing it is not nice,
but I don't know a nice way to fix this without JS,
while preserving the "specify width as a fraction" nature.

For comparison, Element Desktop uses some JS to set `flex-grow`
on the sections.

The `flex-grow` and `flex-shrink` values might need adjustments
according to good taste, but I think it's already good enough.

I also removed the "refuse to shrink" comment as I suspect
that `width: 0;` is not necessary anymore,
plus we now need to set a different `width` value.

This is based on top of https://github.com/deltachat/deltachat-desktop/pull/6671 due to conflicts,
but this doesn't strictly require that MR. Let me know if you need me to rebase this onto main.