### PR TITLE
refactor: move `Runtime` desktopSettings closer

### DIFF
--- a/packages/runtime/runtime.ts
+++ b/packages/runtime/runtime.ts
@@ -54,11 +54,19 @@ export interface Runtime {
     sentTime: string,
     content: string
   ): void
+
   getDesktopSettings(): Promise<DesktopSettingsType>
   setDesktopSetting(
     key: keyof DesktopSettingsType,
     value: string | number | boolean | undefined
   ): Promise<void>
+  onDesktopSettingChanged:
+    | (<T extends keyof DesktopSettingsType>(
+        key: T,
+        value: DesktopSettingsType[T]
+      ) => void)
+    | undefined
+
   /**
    * initializes runtime stuff
    * - sets the LogHandler
@@ -212,12 +220,6 @@ export interface Runtime {
     | undefined
   onResumeFromSleep: (() => void) | undefined
   onToggleNotifications: (() => void) | undefined
-  onDesktopSettingChanged:
-    | (<T extends keyof DesktopSettingsType>(
-        key: T,
-        value: DesktopSettingsType[T]
-      ) => void)
-    | undefined
 
   checkMediaAccess: (mediaType: MediaType) => Promise<MediaAccessStatus>
 

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -151,12 +151,6 @@ class BrowserRuntime implements Runtime {
   // not used in browser - other reasons
   onResumeFromSleep: (() => void) | undefined
   onOpenQrUrl: ((url: string) => void) | undefined
-  onDesktopSettingChanged:
-    | (<T extends keyof DesktopSettingsType>(
-        key: T,
-        value: DesktopSettingsType[T]
-      ) => void)
-    | undefined
   onToggleNotifications: (() => void) | undefined
 
   // #endregion
@@ -287,6 +281,18 @@ class BrowserRuntime implements Runtime {
   setLocale(_locale: string): Promise<void> {
     throw new Error('Method not implemented.')
   }
+
+  async getDesktopSettings(): Promise<DesktopSettingsType> {
+    const request = await fetch('/backend-api/config')
+    if (!request.ok) {
+      throw new Error('getDesktopSettings request failed')
+    }
+    const config = await request.json()
+    if (config.locale === null) {
+      config.locale = navigator.language
+    }
+    return config
+  }
   async setDesktopSetting(
     key: keyof DesktopSettingsType,
     value: string | number | boolean | undefined
@@ -307,6 +313,13 @@ class BrowserRuntime implements Runtime {
       throw new Error('setDesktopSettings request failed')
     }
   }
+  onDesktopSettingChanged:
+    | (<T extends keyof DesktopSettingsType>(
+        key: T,
+        value: DesktopSettingsType[T]
+      ) => void)
+    | undefined
+
   async getAvailableThemes(): Promise<Theme[]> {
     return (await fetch('/themes.json')).json()
   }
@@ -519,17 +532,6 @@ class BrowserRuntime implements Runtime {
       throw new Error('this.runtime_info is not set')
     }
     return this.runtime_info
-  }
-  async getDesktopSettings(): Promise<DesktopSettingsType> {
-    const request = await fetch('/backend-api/config')
-    if (!request.ok) {
-      throw new Error('getDesktopSettings request failed')
-    }
-    const config = await request.json()
-    if (config.locale === null) {
-      config.locale = navigator.language
-    }
-    return config
   }
   getWebxdcIconURL(_accountId: number, _msgId: number): string {
     this.log.critical('getWebxdcIconURL Method not implemented.')

--- a/packages/target-electron/runtime-electron/runtime.ts
+++ b/packages/target-electron/runtime-electron/runtime.ts
@@ -158,12 +158,6 @@ class ElectronRuntime implements Runtime {
   onThemeUpdate: (() => void) | undefined
   onChooseLanguage: ((locale: string) => Promise<void>) | undefined
   onToggleNotifications: (() => void) | undefined
-  onDesktopSettingChanged:
-    | (<T extends keyof DesktopSettingsType>(
-        key: T,
-        value: DesktopSettingsType[T]
-      ) => void)
-    | undefined
   emitUIFullyReady(): void {
     ipcBackend.send('frontendReady')
   }
@@ -312,6 +306,7 @@ class ElectronRuntime implements Runtime {
   restartApp(): void {
     ipcBackend.invoke('restart_app')
   }
+
   getDesktopSettings(): Promise<DesktopSettingsType> {
     return ipcBackend.invoke('get-desktop-settings')
   }
@@ -321,6 +316,13 @@ class ElectronRuntime implements Runtime {
   ): Promise<void> {
     return ipcBackend.invoke('set-desktop-setting', key, value)
   }
+  onDesktopSettingChanged:
+    | (<T extends keyof DesktopSettingsType>(
+        key: T,
+        value: DesktopSettingsType[T]
+      ) => void)
+    | undefined
+
   getWebxdcIconURL(accountId: number, msgId: number): string {
     return `webxdc-icon:${accountId}.${msgId}`
   }


### PR DESCRIPTION
Just move the declarations, nothing else.
