### PR TITLE
perf: don't reload global settings on acc switch

### DIFF
--- a/packages/frontend/src/components/AppPicker/index.tsx
+++ b/packages/frontend/src/components/AppPicker/index.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames'
 import { filesize } from 'filesize'
 import moment from 'moment'
 import { C } from '@deltachat/jsonrpc-client'
-import { useSettingsStore } from '../../stores/settings'
+import { useDesktopSettingsStore } from '../../stores/settings'
 import { defaultAppStoreBaseUrl } from '@deltachat-desktop/shared/state'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 
@@ -72,7 +72,7 @@ type Props = {
 
 export function AppPicker({ onAppSelected }: Props) {
   const tx = useTranslationFunction()
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedCategory, setSelectedCategory] = useState(AppCategoryEnum.home)
   const [selectedAppInfo, setSelectedAppInfo] = useState<AppInfo | null>(null)
@@ -84,15 +84,16 @@ export function AppPicker({ onAppSelected }: Props) {
   ]
 
   const appStoreUrl: `${string}/` = useMemo(() => {
-    if (settingsStore == undefined) {
-      log.warn('settingsStore not initialized yet, using default appStoreUrl')
+    if (desktopSettingsStore == undefined) {
+      log.warn(
+        'desktopSettingsStore not initialized yet, using default appStoreUrl'
+      )
       return defaultAppStoreBaseUrl
     }
-    const res =
-      settingsStore.desktopSettings.appStoreBaseUrl || defaultAppStoreBaseUrl
+    const res = desktopSettingsStore.appStoreBaseUrl || defaultAppStoreBaseUrl
     // Ensure that it ends with a slash.
     return res.endsWith('/') ? (res as `${string}/`) : (`${res}/` as const)
-  }, [settingsStore])
+  }, [desktopSettingsStore])
   const appListUrl = appStoreUrl + 'xdcget-lock.json'
 
   const fetchApps = useCallback(async (appListUrl: string) => {

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -8,7 +8,7 @@ import useChat from '../../hooks/chat/useChat'
 import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
 import { Avatar } from '../Avatar'
 import MailingListProfile from '../dialogs/MailingListProfile'
-import { useSettingsStore } from '../../stores/settings'
+import { useDesktopSettingsStore } from '../../stores/settings'
 import { BackendRemote } from '../../backend-com'
 import Button from '../Button'
 import Icon, { IconButton } from '../Icon'
@@ -348,7 +348,7 @@ function ChatNavButtons({
     [openMainViewContextMenu, chat]
   )
   const chatId = chat.id
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
   const { openDialog } = useDialog()
 
   const openMediaViewDialog = useCallback(() => {
@@ -375,7 +375,7 @@ function ChatNavButtons({
           size={22}
         />
       </div>
-      {settingsStore?.desktopSettings.enableOnDemandLocationStreaming && (
+      {desktopSettingsStore?.enableOnDemandLocationStreaming && (
         <IconButton
           onClick={() => openMapWebxdc(selectedAccountId(), chatId)}
           aria-label={tx('tab_map')}

--- a/packages/frontend/src/components/Gallery.tsx
+++ b/packages/frontend/src/components/Gallery.tsx
@@ -20,7 +20,7 @@ import {
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { BackendRemote, onDCEvent, Type } from '../backend-com'
 import { selectedAccountId } from '../ScreenController'
-import SettingsStoreInstance, { SettingsStoreState } from '../stores/settings'
+import { DesktopSettingsStoreInstance } from '../stores/settings'
 import FullscreenMedia, {
   NeighboringMediaMode,
 } from './dialogs/FullscreenMedia'
@@ -32,6 +32,7 @@ import {
 } from '../contexts/RovingTabindex'
 import InfiniteLoader from 'react-window-infinite-loader'
 import { T } from '@deltachat/jsonrpc-client'
+import type { DesktopSettingsType } from '@deltachat-desktop/shared/shared-types'
 import { useTranslationWritingDirection } from '../hooks/useTranslationFunction'
 
 const log = getLogger('renderer/Gallery')
@@ -133,7 +134,8 @@ export default class Gallery extends Component<
       galleryImageKeepAspectRatio: false,
     }
 
-    this.settingsStoreListener = this.settingsStoreListener.bind(this)
+    this.desktopSettingsStoreListener =
+      this.desktopSettingsStoreListener.bind(this)
   }
 
   reset() {
@@ -150,11 +152,10 @@ export default class Gallery extends Component<
 
   componentDidMount() {
     this.onSelect(this.state.currentTab)
-    SettingsStoreInstance.subscribe(this.settingsStoreListener)
+    DesktopSettingsStoreInstance.subscribe(this.desktopSettingsStoreListener)
     this.setState({
       galleryImageKeepAspectRatio:
-        SettingsStoreInstance.state?.desktopSettings
-          .galleryImageKeepAspectRatio,
+        DesktopSettingsStoreInstance.state?.galleryImageKeepAspectRatio,
     })
 
     // It's possible to delete messages right from the gallery,
@@ -186,15 +187,14 @@ export default class Gallery extends Component<
   }
 
   componentWillUnmount() {
-    SettingsStoreInstance.unsubscribe(this.settingsStoreListener)
+    DesktopSettingsStoreInstance.unsubscribe(this.desktopSettingsStoreListener)
     this.cleanup.forEach(f => f())
   }
 
-  settingsStoreListener(state: SettingsStoreState | null) {
+  desktopSettingsStoreListener(state: DesktopSettingsType | null) {
     if (state) {
       this.setState({
-        galleryImageKeepAspectRatio:
-          state.desktopSettings.galleryImageKeepAspectRatio,
+        galleryImageKeepAspectRatio: state.galleryImageKeepAspectRatio,
       })
     }
   }

--- a/packages/frontend/src/components/NoChatSelected.tsx
+++ b/packages/frontend/src/components/NoChatSelected.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 
 import useTranslationFunction from '../hooks/useTranslationFunction'
 import { getBackgroundImageStyle } from './message/MessageListAndComposer'
-import { useSettingsStore } from '../stores/settings'
+import { useDesktopSettingsStore } from '../stores/settings'
 
 export default function NoChatSelected() {
   const tx = useTranslationFunction()
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
-  const style: React.CSSProperties = settingsStore
-    ? getBackgroundImageStyle(settingsStore.desktopSettings)
+  const style: React.CSSProperties = desktopSettingsStore
+    ? getBackgroundImageStyle(desktopSettingsStore)
     : {}
 
   return (

--- a/packages/frontend/src/components/RuntimeAdapter.tsx
+++ b/packages/frontend/src/components/RuntimeAdapter.tsx
@@ -11,7 +11,7 @@ import useDialog from '../hooks/dialog/useDialog'
 import WebxdcSaveToChatDialog from './dialogs/WebxdcSendToChat'
 import { saveLastChatId } from '../backend/chat'
 import useChat from '../hooks/chat/useChat'
-import SettingsStoreInstance from '../stores/settings'
+import { DesktopSettingsStoreInstance } from '../stores/settings'
 import { SCAN_CONTEXT_TYPE } from '../hooks/useProcessQr'
 
 type Props = {
@@ -105,11 +105,11 @@ export default function RuntimeAdapter({
 
   useEffect(() => {
     runtime.onToggleNotifications = () => {
-      const settings = SettingsStoreInstance.getState()
-      if (settings) {
-        SettingsStoreInstance.effect.setDesktopSetting(
+      const desktopSettings = DesktopSettingsStoreInstance.getState()
+      if (desktopSettings) {
+        DesktopSettingsStoreInstance.effect.set(
           'notifications',
-          !settings.desktopSettings.notifications
+          !desktopSettings.notifications
         )
       }
     }

--- a/packages/frontend/src/components/Settings/Appearance.tsx
+++ b/packages/frontend/src/components/Settings/Appearance.tsx
@@ -7,7 +7,8 @@ import {
   RC_Config,
   Theme,
 } from '@deltachat-desktop/shared/shared-types'
-import SettingsStoreInstance, {
+import {
+  DesktopSettingsStoreInstance,
   SettingsStoreState,
 } from '../../stores/settings'
 import { getLogger } from '@deltachat-desktop/shared/logger'
@@ -60,7 +61,7 @@ export default function Appearance({
 
   const setTheme = async (theme: string) => {
     if (await setThemeFunction(theme)) {
-      SettingsStoreInstance.effect.setDesktopSetting('activeTheme', theme)
+      DesktopSettingsStoreInstance.effect.set('activeTheme', theme)
       await ThemeManager.refresh()
     }
   }
@@ -116,14 +117,11 @@ export default function Appearance({
           desktopSettings={desktopSettings}
           onChange={(val: string) => {
             val.startsWith('#')
-              ? SettingsStoreInstance.effect.setDesktopSetting(
+              ? DesktopSettingsStoreInstance.effect.set(
                   'chatViewBgImg',
                   `color: ${val}`
                 )
-              : SettingsStoreInstance.effect.setDesktopSetting(
-                  'chatViewBgImg',
-                  val
-                )
+              : DesktopSettingsStoreInstance.effect.set('chatViewBgImg', val)
           }}
         />
       </DialogContent>
@@ -228,7 +226,7 @@ function BackgroundSelector({
         if (runtime.getRuntimeInfo().target !== 'browser') {
           setLastPath(url)
         }
-        SettingsStoreInstance.effect.setDesktopSetting(
+        DesktopSettingsStoreInstance.effect.set(
           'chatViewBgImg',
           await runtime.saveBackgroundImage(url, false)
         )
@@ -238,7 +236,7 @@ function BackgroundSelector({
         }
         break
       case SetBackgroundAction.presetImage:
-        SettingsStoreInstance.effect.setDesktopSetting(
+        DesktopSettingsStoreInstance.effect.set(
           'chatViewBgImg',
           await runtime.saveBackgroundImage(
             (ev.target as any).dataset.url,

--- a/packages/frontend/src/components/Settings/DesktopSettingsSwitch.tsx
+++ b/packages/frontend/src/components/Settings/DesktopSettingsSwitch.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 
 import { DesktopSettingsType } from '@deltachat-desktop/shared/shared-types'
-import SettingsStoreInstance, { useSettingsStore } from '../../stores/settings'
+import {
+  DesktopSettingsStoreInstance,
+  useDesktopSettingsStore,
+} from '../../stores/settings'
 import SettingsSwitch from './SettingsSwitch'
 
 type Props = {
@@ -24,13 +27,13 @@ export default function DesktopSettingsSwitch({
   disabledValue,
   callback,
 }: Props) {
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
-  const disabledFinal: boolean = disabled || settingsStore == null
+  const disabledFinal: boolean = disabled || desktopSettingsStore == null
   const value =
     disabledFinal === true && typeof disabledValue !== 'undefined'
       ? disabledValue
-      : settingsStore?.desktopSettings[settingsKey] === true
+      : desktopSettingsStore?.[settingsKey] === true
 
   return (
     <SettingsSwitch
@@ -38,14 +41,11 @@ export default function DesktopSettingsSwitch({
       description={description}
       value={value}
       onChange={async () => {
-        if (settingsStore == null) {
+        if (desktopSettingsStore == null) {
           return
         }
-        const newValue = !settingsStore.desktopSettings[settingsKey]
-        await SettingsStoreInstance.effect.setDesktopSetting(
-          settingsKey,
-          newValue
-        )
+        const newValue = !desktopSettingsStore[settingsKey]
+        await DesktopSettingsStoreInstance.effect.set(settingsKey, newValue)
         callback?.(newValue)
       }}
       disabled={disabledFinal}

--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 
-import SettingsStoreInstance, {
-  useSettingsStore,
-  type SettingsStoreState,
+import {
+  DesktopSettingsStoreInstance,
+  useDesktopSettingsStore,
 } from '../../stores/settings'
 import DesktopSettingsSwitch from './DesktopSettingsSwitch'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
@@ -23,17 +23,18 @@ import { getLogger } from '@deltachat-desktop/shared/logger'
 import { DeltaInput } from '../Login-Styles'
 import SettingsSelector from './SettingsSelector'
 import { defaultAppStoreBaseUrl } from '@deltachat-desktop/shared/state'
+import type { DesktopSettingsType } from '@deltachat-desktop/shared/shared-types'
 
 const log = getLogger('ExperimentalFeatures')
 
 export function ExperimentalFeatures() {
   const tx = useTranslationFunction()
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
   const { openDialog } = useDialog()
 
   const showExperimentalInfoDialog = async (
     settingsKey: keyof Pick<
-      SettingsStoreState['desktopSettings'],
+      DesktopSettingsType,
       'enableOnDemandLocationStreaming'
     >,
     updatedValue: boolean
@@ -82,10 +83,9 @@ export function ExperimentalFeatures() {
       <SettingsSelector
         onClick={() => openDialog(AppPickerUrlDialog)}
         currentValue={
-          settingsStore == undefined
+          desktopSettingsStore == undefined
             ? undefined
-            : settingsStore.desktopSettings.appStoreBaseUrl ||
-              defaultAppStoreBaseUrl
+            : desktopSettingsStore.appStoreBaseUrl || defaultAppStoreBaseUrl
         }
       >
         {tx('webxdc_store_url')}
@@ -108,21 +108,21 @@ export function ExperimentalFeatures() {
 
 function SyncAllAccountsSwitch() {
   const tx = useTranslationFunction()
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
   return (
     <SettingsSwitch
       label={tx('pref_background_sync_disabled')}
       description={tx('explain_background_sync_disabled')}
-      value={settingsStore?.desktopSettings.syncAllAccounts !== true}
-      disabled={settingsStore == null}
+      value={desktopSettingsStore?.syncAllAccounts !== true}
+      disabled={desktopSettingsStore == null}
       onChange={() => {
-        if (settingsStore == null) {
+        if (desktopSettingsStore == null) {
           return
         }
-        SettingsStoreInstance.effect.setDesktopSetting(
+        DesktopSettingsStoreInstance.effect.set(
           'syncAllAccounts',
-          !settingsStore.desktopSettings.syncAllAccounts
+          !desktopSettingsStore.syncAllAccounts
         )
       }}
     />
@@ -131,7 +131,7 @@ function SyncAllAccountsSwitch() {
 
 function AppPickerUrlDialog({ onClose }: DialogProps) {
   const tx = useTranslationFunction()
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
   return (
     <Dialog onClose={onClose}>
@@ -143,7 +143,7 @@ function AppPickerUrlDialog({ onClose }: DialogProps) {
             log.error('App picker URL form submitted, but URL is', url)
             return
           }
-          SettingsStoreInstance.effect.setDesktopSetting(
+          DesktopSettingsStoreInstance.effect.set(
             'appStoreBaseUrl',
             url === '' ? undefined : url
           )
@@ -156,14 +156,14 @@ function AppPickerUrlDialog({ onClose }: DialogProps) {
             <p className='whitespace'>
               {tx('webxdc_store_url_explain_2_desktop')}
             </p>
-            {settingsStore && (
+            {desktopSettingsStore && (
               <DeltaInput
                 value={undefined}
                 placeholder={defaultAppStoreBaseUrl}
                 onChange={() => {}}
                 type='url'
                 name='url'
-                defaultValue={settingsStore.desktopSettings.appStoreBaseUrl}
+                defaultValue={desktopSettingsStore.appStoreBaseUrl}
               />
             )}
           </DialogContent>

--- a/packages/frontend/src/components/Settings/Notifications.tsx
+++ b/packages/frontend/src/components/Settings/Notifications.tsx
@@ -12,6 +12,7 @@ import SettingsSwitch from './SettingsSwitch'
 import SettingsSelector from './SettingsSelector'
 import SmallSelectDialog from '../SmallSelectDialog'
 import SettingsStoreInstance, {
+  DesktopSettingsStoreInstance,
   useSettingsStore,
   WhoCanCallMe,
 } from '../../stores/settings'
@@ -60,10 +61,7 @@ export default function Notifications({ desktopSettings }: Props) {
       title: tx('pref_in_chat_sounds'),
       onSave: async (volume_: string) => {
         const volume = Number(volume_)
-        SettingsStoreInstance.effect.setDesktopSetting(
-          'inChatSoundsVolume',
-          volume
-        )
+        DesktopSettingsStoreInstance.effect.set('inChatSoundsVolume', volume)
       },
     })
   }

--- a/packages/frontend/src/components/Settings/Settings.tsx
+++ b/packages/frontend/src/components/Settings/Settings.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useCallback } from 'react'
 
-import { useSettingsStore } from '../../stores/settings'
+import {
+  useDesktopSettingsStore,
+  useSettingsStore,
+} from '../../stores/settings'
 import { SendBackupDialog } from '../dialogs/SetupMultiDevice'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { donationUrl } from '@deltachat-desktop/shared/constants'
@@ -145,6 +148,7 @@ function SettingsSectionDialog(
   const { settingsMode, onClose: closeThisDialog } = props
   const tx = useTranslationFunction()
   const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
   const closeThisAndParent = useCallback(() => {
     closeThisDialog()
@@ -175,8 +179,8 @@ function SettingsSectionDialog(
             {...commonHeaderProps}
           />
           <DialogBody>
-            {settingsStore != null && (
-              <Notifications desktopSettings={settingsStore.desktopSettings} />
+            {desktopSettingsStore != null && (
+              <Notifications desktopSettings={desktopSettingsStore} />
             )}
             <SettingsEndSeparator />
           </DialogBody>
@@ -186,10 +190,10 @@ function SettingsSectionDialog(
         <>
           <DialogHeader title={tx('pref_appearance')} {...commonHeaderProps} />
           <DialogBody>
-            {settingsStore != null && (
+            {settingsStore != null && desktopSettingsStore != null && (
               <Appearance
                 rc={settingsStore.rc}
-                desktopSettings={settingsStore.desktopSettings}
+                desktopSettings={desktopSettingsStore}
                 settingsStore={settingsStore}
               />
             )}

--- a/packages/frontend/src/components/composer/Composer.tsx
+++ b/packages/frontend/src/components/composer/Composer.tsx
@@ -17,7 +17,7 @@ import { getLogger } from '@deltachat-desktop/shared/logger'
 import { EmojiAndStickerPicker } from './EmojiAndStickerPicker'
 import { Quote } from '../message/Message'
 import { DraftAttachment } from '../attachment/messageAttachment'
-import { useSettingsStore } from '../../stores/settings'
+import { useDesktopSettingsStore } from '../../stores/settings'
 import { BackendRemote, EffectfulBackendActions, Type } from '../../backend-com'
 import { selectedAccountId } from '../../ScreenController'
 import { runtime } from '@deltachat-desktop/runtime-interface'
@@ -533,7 +533,7 @@ const Composer = forwardRef<
         }
       }
 
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
   const focusMessageInput = useCallback(() => {
     // Only one of these is actually rendered at any given moment.
@@ -546,12 +546,12 @@ const Composer = forwardRef<
   }, [chatId, focusMessageInput])
 
   const ariaSendShortcut: string = useMemo(() => {
-    if (settingsStore == undefined) {
+    if (desktopSettingsStore == undefined) {
       return ''
     }
 
     const firstShortcut = enterKeySendsKeyboardShortcuts(
-      settingsStore.desktopSettings.enterKeySends
+      desktopSettingsStore.enterKeySends
     )[0].keyBindings[0]
 
     if (!Array.isArray(firstShortcut) || !firstShortcut.includes('Enter')) {
@@ -560,7 +560,7 @@ const Composer = forwardRef<
     }
 
     return firstShortcut.join('+')
-  }, [settingsStore])
+  }, [desktopSettingsStore])
 
   if (chatId === null) {
     return <section ref={ref}>Error, chatid missing</section>
@@ -746,7 +746,7 @@ const Composer = forwardRef<
               selectedChat={selectedChat}
             />
           )}
-          {settingsStore && !recording && (
+          {desktopSettingsStore && !recording && (
             <>
               <ComposerMessageInput
                 text={draftState.text}
@@ -761,7 +761,7 @@ const Composer = forwardRef<
                 hidden={messageEditing.isEditingModeActive}
                 isMessageEditingMode={false}
                 ref={regularMessageInputRef}
-                enterKeySends={settingsStore?.desktopSettings.enterKeySends}
+                enterKeySends={desktopSettingsStore.enterKeySends}
                 loadingDraft={draftIsLoading}
                 sendMessageOrEditRequest={
                   (!messageEditing.isEditingModeActive
@@ -783,7 +783,7 @@ const Composer = forwardRef<
                 isMessageEditingMode={true}
                 hidden={!messageEditing.isEditingModeActive}
                 ref={editMessageInputRef}
-                enterKeySends={settingsStore?.desktopSettings.enterKeySends}
+                enterKeySends={desktopSettingsStore.enterKeySends}
                 loadingDraft={false}
                 sendMessageOrEditRequest={
                   messageEditing.doSendEditRequest ?? (() => {})

--- a/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
+++ b/packages/frontend/src/components/dialogs/KeybindingCheatSheet.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 
-import { useSettingsStore } from '../../stores/settings'
+import { useDesktopSettingsStore } from '../../stores/settings'
 import { getKeybindings, ShortcutGroup } from '../KeyboardShortcutHint'
 import Dialog, { DialogBody, DialogHeader, DialogHeading } from '../Dialog'
 import useTranslationFunction from '../../hooks/useTranslationFunction'
@@ -11,7 +11,7 @@ export default function KeybindingCheatSheet(props: DialogProps) {
   const { onClose } = props
   const tx = useTranslationFunction()
 
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
   useEffect(() => {
     window.__keybindingsDialogOpened = true
@@ -27,30 +27,28 @@ export default function KeybindingCheatSheet(props: DialogProps) {
       </DialogHeader>
       <DialogBody className='shortcuts-dialog-body'>
         <div className='shortcuts-grid'>
-          {settingsStore &&
-            getKeybindings(settingsStore.desktopSettings).map(
-              (entry, index) => {
-                if (entry.type === 'header') {
-                  return (
-                    <div
-                      key={`header-${index}-${entry.title}`}
-                      className='shortcuts-section-title'
-                    >
-                      <h4>{entry.title}</h4>
-                    </div>
-                  )
-                } else {
-                  const { action } = entry
-                  return (
-                    <ShortcutGroup
-                      title={action.title}
-                      keyBindings={action.keyBindings}
-                      key={`shortcut-${index}-${action.title}`}
-                    />
-                  )
-                }
+          {desktopSettingsStore &&
+            getKeybindings(desktopSettingsStore).map((entry, index) => {
+              if (entry.type === 'header') {
+                return (
+                  <div
+                    key={`header-${index}-${entry.title}`}
+                    className='shortcuts-section-title'
+                  >
+                    <h4>{entry.title}</h4>
+                  </div>
+                )
+              } else {
+                const { action } = entry
+                return (
+                  <ShortcutGroup
+                    title={action.title}
+                    keyBindings={action.keyBindings}
+                    key={`shortcut-${index}-${action.title}`}
+                  />
+                )
               }
-            )}
+            })}
         </div>
       </DialogBody>
     </Dialog>

--- a/packages/frontend/src/components/message/MessageListAndComposer.tsx
+++ b/packages/frontend/src/components/message/MessageListAndComposer.tsx
@@ -10,7 +10,7 @@ import type ComposerMessageInput from '../composer/ComposerMessageInput'
 import { DesktopSettingsType } from '@deltachat-desktop/shared/shared-types'
 import { runtime } from '@deltachat-desktop/runtime-interface'
 import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
-import { useSettingsStore } from '../../stores/settings'
+import { useDesktopSettingsStore } from '../../stores/settings'
 import ConfirmSendingFiles from '../dialogs/ConfirmSendingFiles'
 import { ReactionsBarProvider } from '../ReactionsBar'
 import useDialog from '../../hooks/dialog/useDialog'
@@ -215,11 +215,11 @@ export default function MessageListAndComposer({
     editMessageInputRef.current?.focus()
   }, [])
 
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
   // If you want to update this, don't forget to update
   // the `.background-preview` element as well.
-  const style = settingsStore
-    ? getBackgroundImageStyle(settingsStore.desktopSettings)
+  const style = desktopSettingsStore
+    ? getBackgroundImageStyle(desktopSettingsStore)
     : {}
 
   return (

--- a/packages/frontend/src/stores/messagelist.ts
+++ b/packages/frontend/src/stores/messagelist.ts
@@ -14,7 +14,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 import { debounce } from 'debounce'
 import { getLogger } from '@deltachat-desktop/shared/logger'
-import { useSettingsStore } from './settings'
+import { useDesktopSettingsStore } from './settings'
 import { shouldShowOSNotificationForCurrentChat } from '../system-integration/notifications'
 
 const log = getLogger('messagelist')
@@ -96,14 +96,14 @@ export function useMessageList(
   // even though we only depend on `volume`,
   // but let's hope the React compiler will take care of this
   // when it's released.
-  const settingsStore = useSettingsStore()[0]
+  const desktopSettingsStore = useDesktopSettingsStore()[0]
 
   const incomingMessageAudioElement = useMemo(() => {
     const el = document.createElement('audio')
     el.src = './audio/sound_in.wav'
     return el
   }, [])
-  const volume = settingsStore?.desktopSettings.inChatSoundsVolume
+  const volume = desktopSettingsStore?.inChatSoundsVolume
   if (volume != null) {
     // Note that `volume` could be 0.
     // eslint-disable-next-line react-hooks/immutability

--- a/packages/frontend/src/stores/settings.ts
+++ b/packages/frontend/src/stores/settings.ts
@@ -31,7 +31,6 @@ export interface SettingsStoreState {
       team_profile: '0' | '1'
     }[P]
   }
-  desktopSettings: DesktopSettingsType
   rc: RC_Config
 }
 
@@ -61,6 +60,61 @@ export const enum WhoCanCallMe {
 export const mentionsEnabledDefaultVal: SettingsStoreState['settings']['ui.mentions_enabled'] =
   '1'
 
+class DesktopSettingsStore extends Store<DesktopSettingsType | null> {
+  reducer = {
+    setState: (newState: DesktopSettingsType) => {
+      this.setState(_state => {
+        return newState
+      }, 'setState')
+    },
+    set: <T extends keyof DesktopSettingsType>(
+      key: T,
+      value: DesktopSettingsType[T]
+    ) => {
+      this.setState(state => {
+        if (state == null) {
+          this.log.warn(
+            'trying to update local version of desktop settings object, but it was not loaded yet'
+          )
+          return
+        }
+        return {
+          ...state,
+          [key]: value,
+        }
+      }, 'set')
+    },
+  }
+  effect = {
+    load: async () => {
+      this.reducer.setState(await runtime.getDesktopSettings())
+    },
+    set: async <T extends keyof DesktopSettingsType>(
+      key: T,
+      value: (string | number | boolean | undefined) & DesktopSettingsType[T]
+    ) => {
+      try {
+        await runtime.setDesktopSetting(key, value)
+        if (key === 'syncAllAccounts') {
+          if (value) {
+            BackendRemote.rpc.startIoForAllAccounts()
+          } else {
+            BackendRemote.rpc.stopIoForAllAccounts()
+          }
+          if (SettingsStoreInstance.state?.accountId) {
+            BackendRemote.rpc.startIo(SettingsStoreInstance.state?.accountId)
+          }
+          throttledUpdateBadgeCounter()
+          window.__updateAccountListSidebar?.()
+        }
+        this.reducer.set(key, value)
+      } catch (error) {
+        this.log.error('failed to apply desktop setting:', error)
+      }
+    },
+  }
+}
+
 class SettingsStore extends Store<SettingsStoreState | null> {
   reducer = {
     setState: (newState: SettingsStoreState | null) => {
@@ -76,26 +130,6 @@ class SettingsStore extends Store<SettingsStoreState | null> {
           selfContact,
         }
       }, 'setSelfContact')
-    },
-    setDesktopSetting: <T extends keyof DesktopSettingsType>(
-      key: T,
-      value: DesktopSettingsType[T]
-    ) => {
-      this.setState(state => {
-        if (state === null) {
-          this.log.warn(
-            'trying to update local version of desktop settings object, but it was not loaded yet'
-          )
-          return
-        }
-        return {
-          ...state,
-          desktopSettings: {
-            ...state.desktopSettings,
-            [key]: value,
-          },
-        }
-      }, 'setDesktopSetting')
     },
     setCoreSetting: (
       key: keyof SettingsStoreState['settings'],
@@ -129,13 +163,12 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         throw new Error('can not load settings when no account is selected')
       }
 
-      const [settings, selfContact, desktopSettings] = await Promise.all([
+      const [settings, selfContact] = await Promise.all([
         BackendRemote.rpc.batchGetConfig(
           accountId,
           settingsKeys as unknown as Array<(typeof settingsKeys)[number]>
         ) as Promise<SettingsStoreState['settings']>,
         BackendRemote.rpc.getContact(accountId, C.DC_CONTACT_ID_SELF),
-        runtime.getDesktopSettings(),
       ])
 
       if (settings['ui.mentions_enabled'] == null) {
@@ -147,7 +180,6 @@ class SettingsStore extends Store<SettingsStoreState | null> {
         settings,
         selfContact,
         accountId,
-        desktopSettings,
         rc,
       })
     },
@@ -172,29 +204,6 @@ class SettingsStore extends Store<SettingsStoreState | null> {
           }
           return { ...state, settings: { ...state.settings, [key]: newValue } }
         }, 'set')
-      }
-    },
-    setDesktopSetting: async <T extends keyof DesktopSettingsType>(
-      key: T,
-      value: (string | number | boolean | undefined) & DesktopSettingsType[T]
-    ) => {
-      try {
-        await runtime.setDesktopSetting(key, value)
-        if (key === 'syncAllAccounts') {
-          if (value) {
-            BackendRemote.rpc.startIoForAllAccounts()
-          } else {
-            BackendRemote.rpc.stopIoForAllAccounts()
-          }
-          if (this.state?.accountId) {
-            BackendRemote.rpc.startIo(this.state.accountId)
-          }
-          throttledUpdateBadgeCounter()
-          window.__updateAccountListSidebar?.()
-        }
-        this.reducer.setDesktopSetting(key, value)
-      } catch (error) {
-        this.log.error('failed to apply desktop setting:', error)
       }
     },
     setCoreSetting: async (
@@ -239,11 +248,19 @@ onReady(() => {
   })
 
   runtime.onDesktopSettingChanged = (key, value) => {
-    SettingsStoreInstance.reducer.setDesktopSetting(key, value)
+    DesktopSettingsStoreInstance.reducer.set(key, value)
   }
+  DesktopSettingsStoreInstance.effect.load()
 })
 
 const SettingsStoreInstance = new SettingsStore(null, 'SettingsStore')
 export const useSettingsStore = () => useStore(SettingsStoreInstance)
+const DesktopSettingsStoreInstance = new DesktopSettingsStore(
+  null,
+  'DesktopSettingsStore'
+)
+export const useDesktopSettingsStore = () =>
+  useStore(DesktopSettingsStoreInstance)
 
 export default SettingsStoreInstance
+export { DesktopSettingsStoreInstance }

--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -4,7 +4,8 @@ import { NOTIFICATION_TYPE } from '@deltachat-desktop/shared/constants'
 import { BackendRemote } from '../backend-com'
 
 import { runtime } from '@deltachat-desktop/runtime-interface'
-import SettingsStoreInstance, {
+import {
+  DesktopSettingsStoreInstance,
   mentionsEnabledDefaultVal,
 } from '../stores/settings'
 import AccountNotificationStoreInstance from '../stores/accountNotifications'
@@ -89,8 +90,8 @@ function incomingMessageHandler(
   log.debug('incomingMessageHandler: ', { chatId, messageId })
 
   if (
-    SettingsStoreInstance.state &&
-    !SettingsStoreInstance.state.desktopSettings.notifications
+    DesktopSettingsStoreInstance.state &&
+    !DesktopSettingsStoreInstance.state.notifications
   ) {
     // notifications are turned off for whole app
     log.debug(
@@ -164,7 +165,7 @@ async function showNotification(
 ) {
   const tx = window.static_translate
 
-  if (!SettingsStoreInstance.state?.desktopSettings.showNotificationContent) {
+  if (!DesktopSettingsStoreInstance.state?.showNotificationContent) {
     runtime.showNotification({
       title: appName,
       body: tx('notify_new_message'),
@@ -260,7 +261,7 @@ async function showGroupedNotification(
 ) {
   const tx = window.static_translate
 
-  if (!SettingsStoreInstance.state?.desktopSettings.showNotificationContent) {
+  if (!DesktopSettingsStoreInstance.state?.showNotificationContent) {
     runtime.showNotification({
       title: appName,
       body: tx('new_messages'),


### PR DESCRIPTION
Basically split off the `desktopSettings` part of the `SettingsStore`.

This addresses this comment https://github.com/deltachat/deltachat-desktop/issues/4200#issuecomment-4048983680.

We do `SettingsStoreInstance.effect.clear()` on every account switch,
which also makes `desktopSettings` inaccessible until the next
`.effect.load()`.
`desktopSettings` is not tied to a single account
so it doesn't need to be reloaded.

One visible effect of this is the flash of the chat background image
which falls back to the default while we're loading
the next account's settings.

This is gonna be more important when we introduce
chat list section resizing, where it would also flash
the default value.

Also I think this is nicer code-wise.

I used AI for updating all the referenced of `desktopSettings`,
since that part is trivial.
The `stores/settings.ts` changes are hand-written,
the rest is AI-generated, and skimmed through by me.
