### PR TITLE
fix: update "Reactions" dialog live

### DIFF
--- a/packages/frontend/src/components/Reactions/index.tsx
+++ b/packages/frontend/src/components/Reactions/index.tsx
@@ -13,7 +13,7 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 // most used emojis come first in this list.
 
 type Props = {
-  message: Pick<T.Message, 'reactions'> & {
+  message: Pick<T.Message, 'id' | 'reactions'> & {
     reactions: NonNullable<T.Message['reactions']>
   }
   chatType: T.FullChat['chatType']

--- a/packages/frontend/src/components/Reactions/index.tsx
+++ b/packages/frontend/src/components/Reactions/index.tsx
@@ -13,7 +13,9 @@ import useTranslationFunction from '../../hooks/useTranslationFunction'
 // most used emojis come first in this list.
 
 type Props = {
-  reactions: T.Reactions
+  message: Pick<T.Message, 'reactions'> & {
+    reactions: NonNullable<T.Message['reactions']>
+  }
   chatType: T.FullChat['chatType']
   tabindexForInteractiveContents: -1 | 0
   messageWidth: number
@@ -25,7 +27,7 @@ export default function Reactions(props: Props) {
   const { messageWidth, chatType } = props
 
   const { openDialog } = useDialog()
-  const { reactions } = props.reactions
+  const { reactions } = props.message.reactions
 
   // Compute visibleEmojis and hiddenReactionsCount from props
   const { visibleEmojis, hiddenReactionsCount } = useMemo(() => {
@@ -55,7 +57,7 @@ export default function Reactions(props: Props) {
 
   const handleClick = () => {
     openDialog(ReactionsDialog, {
-      reactions: props.reactions,
+      message: props.message,
       // Subscribers of a channel only get to know the accumulated reactions,
       // not who reacted with what.
       showContacts: chatType !== 'InBroadcast',

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
@@ -1,10 +1,16 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, {
+  useEffect,
+  useEffectEvent,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import classNames from 'classnames'
 
 import Dialog, { DialogBody, DialogContent, DialogHeader } from '../../Dialog'
 import useTranslationFunction from '../../../hooks/useTranslationFunction'
 import { selectedAccountId } from '../../../ScreenController'
-import { BackendRemote } from '../../../backend-com'
+import { BackendRemote, onDCEvent } from '../../../backend-com'
 import { AvatarFromContact } from '../../Avatar'
 import ContactName from '../../ContactName'
 
@@ -18,9 +24,13 @@ import {
   RovingTabindexProvider,
   useRovingTabindex,
 } from '../../../contexts/RovingTabindex'
+import { useRpcFetch } from '../../../hooks/useFetch'
+import { default as asyncThrottle } from '@jcoreio/async-throttle'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { BasicMessageInfo } from '../MessageDetail/BasicMessageInfo'
 
 export type Props = {
-  message: Pick<T.Message, 'reactions'>
+  message: Pick<T.Message, 'id' | 'reactions'>
   /**
    * Whether it is known who reacted with what. This is not the case for
    * subscribers of a channel, they only know the accumulated reactions.
@@ -34,29 +44,69 @@ type ContactWithReaction = T.Contact & {
 }
 
 export default function ReactionsDialog({
-  message,
+  message: originalMessage,
   showContacts,
   onClose,
 }: Props & DialogProps) {
   const tx = useTranslationFunction()
 
+  /**
+   * The `originalMessage` prop will not update as reactions change,
+   * so we have to update it ourselves.
+   * Similar to {@linkcode BasicMessageInfo}.
+   */
+  const [originalIsOutdated, setOriginalIsOutdated] = useState(false)
+  const freshMessageFetch = useRpcFetch(
+    useMemo(
+      () =>
+        asyncThrottle(
+          BackendRemote.rpc.getMessage.bind(BackendRemote.rpc),
+          250
+        ),
+      []
+    ),
+    originalIsOutdated ? [selectedAccountId(), originalMessage.id] : null
+  )
+  const refresh = useEffectEvent(() => freshMessageFetch?.refresh())
+  useEffect(() => {
+    return onDCEvent(selectedAccountId(), 'ReactionsChanged', ({ msgId }) => {
+      if (msgId !== originalMessage.id) {
+        return
+      }
+
+      setOriginalIsOutdated(true)
+      refresh()
+    })
+  }, [originalMessage.id])
+  const message = freshMessageFetch?.lingeringResult?.ok
+    ? freshMessageFetch.lingeringResult.value
+    : originalMessage
+
   return (
     <Dialog width={400} onClose={onClose}>
       <DialogHeader title={tx('reactions')} onClose={onClose} />
       <DialogBody>
-        <DialogContent>
-          {message.reactions == null ||
-          message.reactions.reactions.length === 0 ? (
-            <p>{tx('n_reactions', (0).toLocaleString(), { quantity: 0 })}</p>
-          ) : showContacts ? (
-            <ReactionsDialogList
-              reactionsByContact={message.reactions.reactionsByContact}
-              onClose={onClose}
-            />
-          ) : (
-            <AccumulatedReactionsList reactions={message.reactions.reactions} />
-          )}
-        </DialogContent>
+        <div
+          aria-live='polite'
+          aria-relevant='all'
+          style={{ display: 'contents' }}
+        >
+          <DialogContent>
+            {message.reactions == null ||
+            message.reactions.reactions.length === 0 ? (
+              <p>{tx('n_reactions', (0).toLocaleString(), { quantity: 0 })}</p>
+            ) : showContacts ? (
+              <ReactionsDialogList
+                reactionsByContact={message.reactions.reactionsByContact}
+                onClose={onClose}
+              />
+            ) : (
+              <AccumulatedReactionsList
+                reactions={message.reactions.reactions}
+              />
+            )}
+          </DialogContent>
+        </div>
       </DialogBody>
     </Dialog>
   )

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
@@ -20,7 +20,9 @@ import {
 } from '../../../contexts/RovingTabindex'
 
 export type Props = {
-  reactions: T.Reactions
+  message: Pick<T.Message, 'reactions'> & {
+    reactions: NonNullable<T.Message['reactions']>
+  }
   /**
    * Whether it is known who reacted with what. This is not the case for
    * subscribers of a channel, they only know the accumulated reactions.
@@ -34,7 +36,7 @@ type ContactWithReaction = T.Contact & {
 }
 
 export default function ReactionsDialog({
-  reactions,
+  message,
   showContacts,
   onClose,
 }: Props & DialogProps) {
@@ -47,11 +49,11 @@ export default function ReactionsDialog({
         <DialogContent>
           {showContacts ? (
             <ReactionsDialogList
-              reactionsByContact={reactions.reactionsByContact}
+              reactionsByContact={message.reactions.reactionsByContact}
               onClose={onClose}
             />
           ) : (
-            <AccumulatedReactionsList reactions={reactions.reactions} />
+            <AccumulatedReactionsList reactions={message.reactions.reactions} />
           )}
         </DialogContent>
       </DialogBody>

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
@@ -20,9 +20,7 @@ import {
 } from '../../../contexts/RovingTabindex'
 
 export type Props = {
-  message: Pick<T.Message, 'reactions'> & {
-    reactions: NonNullable<T.Message['reactions']>
-  }
+  message: Pick<T.Message, 'reactions'>
   /**
    * Whether it is known who reacted with what. This is not the case for
    * subscribers of a channel, they only know the accumulated reactions.
@@ -47,7 +45,10 @@ export default function ReactionsDialog({
       <DialogHeader title={tx('reactions')} onClose={onClose} />
       <DialogBody>
         <DialogContent>
-          {showContacts ? (
+          {message.reactions == null ||
+          message.reactions.reactions.length === 0 ? (
+            <p>{tx('n_reactions', (0).toLocaleString(), { quantity: 0 })}</p>
+          ) : showContacts ? (
             <ReactionsDialogList
               reactionsByContact={message.reactions.reactionsByContact}
               onClose={onClose}

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -1117,7 +1117,11 @@ export default function Message(props: {
             >
               {message.reactions && (
                 <Reactions
-                  reactions={message.reactions}
+                  message={
+                    message as typeof message & {
+                      reactions: typeof message.reactions
+                    }
+                  }
                   chatType={chat.chatType}
                   tabindexForInteractiveContents={
                     tabindexForInteractiveContents


### PR DESCRIPTION
What can happen if a reaction is removed while the dialog is still open:

<img width="383" height="131" alt="Screenshot_20260821" src="https://github.com/user-attachments/assets/902c5aea-1d30-45d4-9fa0-17f05ac8438f" />

