### PR TITLE
improvement: channel "Reactions" dialog: pills

### DIFF
--- a/packages/e2e-tests/tests/group-tests.spec.ts
+++ b/packages/e2e-tests/tests/group-tests.spec.ts
@@ -820,14 +820,14 @@ test.describe('channel reactions', () => {
     await switchToProfile(page, userB.id)
     await selectChat(page, channelName)
 
-    const rows = (await openReactionsDialog(page, message())).getByRole(
-      'listitem'
-    )
+    const dialog = await openReactionsDialog(page, message())
+
+    await expect(dialog).toHaveText('1 reaction' + '😂 1')
+    await expect(dialog.getByRole('menuitemradio')).toHaveText(['😂 1'])
     // Subscribers don't get to know who reacted with what, so the rows are
     // the accumulated counts and not the contacts, which would be clickable
-    await expect(rows).toHaveCount(1)
-    await expect(rows.filter({ hasText: '😂' })).toContainText('1 reaction')
-    await expect(rows.getByRole('button')).toHaveCount(0)
+    await expect(dialog.getByRole('button')).toHaveCount(1)
+    await expect(dialog.getByRole('listitem')).not.toBeVisible()
   })
 
   test('owner sees the reaction', async () => {
@@ -847,6 +847,7 @@ test.describe('channel reactions', () => {
     await expect(rows).toHaveCount(1)
     // The row is a button, it opens the profile of the contact that reacted
     await expect(rows.getByRole('button')).toHaveCount(1)
+    await expect(rows.first()).toContainText(userB.name)
   })
 
   test('owner can only use the default reactions', async () => {

--- a/packages/frontend/src/components/Reactions/styles.module.scss
+++ b/packages/frontend/src/components/Reactions/styles.module.scss
@@ -7,6 +7,8 @@
 }
 
 .emoji {
+  // Basically the same as with `.accumulatedReactionsButton`
+  // in the "Reactions" dialog.
   background-color: var(--messageIncomingBg);
   border-radius: 24px;
   border: solid 1px rgba(100, 100, 100, 0.3);

--- a/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
+++ b/packages/frontend/src/components/ReactionsBar/ReactionsBar.tsx
@@ -18,6 +18,8 @@ import {
 import useChat from '../../hooks/chat/useChat'
 import useAlertDialog from '../../hooks/dialog/useAlertDialog'
 import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import ReactionsDialog from '../dialogs/ReactionsDialog'
 
 const log = getLogger('ReactionsBar')
 
@@ -29,6 +31,9 @@ type Props = {
 
 const DEFAULT_EMOJIS = ['👍', '👎', '❤️', '😂', '🙁']
 
+/**
+ * This is very similar to {@linkcode ReactionsDialog}.
+ */
 export default function ReactionsBar({
   onClick,
   messageId,

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/index.tsx
@@ -28,6 +28,10 @@ import { useRpcFetch } from '../../../hooks/useFetch'
 import { default as asyncThrottle } from '@jcoreio/async-throttle'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { BasicMessageInfo } from '../MessageDetail/BasicMessageInfo'
+import { unknownErrorToString } from '@deltachat-desktop/shared/unknownErrorToString'
+import useAlertDialog from '../../../hooks/dialog/useAlertDialog'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import ReactionsBar from '../../ReactionsBar'
 
 export type Props = {
   message: Pick<T.Message, 'id' | 'reactions'>
@@ -119,7 +123,11 @@ export default function ReactionsDialog({
               />
             ) : (
               <AccumulatedReactionsList
-                reactions={message.reactions.reactions}
+                message={
+                  message as typeof message & {
+                    reactions: typeof message.reactions
+                  }
+                }
               />
             )}
           </DialogContent>
@@ -129,24 +137,94 @@ export default function ReactionsDialog({
   )
 }
 
+/**
+ * This is very similar to {@linkcode ReactionsBar}.
+ */
 function AccumulatedReactionsList({
-  reactions,
+  message,
 }: {
-  reactions: T.Reactions['reactions']
+  message: Pick<T.Message, 'id' | 'reactions'> & {
+    reactions: NonNullable<T.Message['reactions']>
+  }
 }) {
+  const ref = useRef<HTMLUListElement>(null)
   const tx = useTranslationFunction()
+  const openAlertDialog = useAlertDialog()
+
+  const toggleReaction = async (emoji: string) => {
+    try {
+      await BackendRemote.rpc.sendReaction(
+        selectedAccountId(),
+        message.id,
+        emoji === message.reactions.reactions.find(v => v.isFromSelf)?.emoji
+          ? []
+          : [emoji]
+      )
+    } catch (error) {
+      openAlertDialog({
+        message: tx(
+          'error_x',
+          'failed to send reaction: ' + unknownErrorToString(error)
+        ),
+      })
+    }
+  }
 
   return (
-    <ul className={styles.reactionsDialogList}>
-      {reactions.map(({ emoji, count }) => (
-        <li key={emoji} className={styles.accumulatedReactionsListItem}>
-          <div className={styles.reactionsDialogEmoji}>{emoji}</div>
-          <div className={styles.accumulatedReactionsCount}>
-            {tx('n_reactions', [String(count)], { quantity: count })}
-          </div>
-        </li>
-      ))}
+    <ul
+      ref={ref}
+      className={styles.accumulatedReactionsList}
+      role='menubar'
+      aria-label={tx('react')}
+      aria-orientation='horizontal'
+    >
+      <RovingTabindexProvider wrapperElementRef={ref} direction='horizontal'>
+        {message.reactions.reactions.map(({ emoji, count, isFromSelf }) => (
+          <li role='presentation' key={emoji}>
+            <ReactionButton
+              key={emoji}
+              emoji={emoji}
+              count={count}
+              isChecked={isFromSelf}
+              onClick={() => toggleReaction(emoji)}
+            />
+          </li>
+        ))}
+      </RovingTabindexProvider>
     </ul>
+  )
+}
+
+function ReactionButton(props: {
+  emoji: string
+  count: number
+  isChecked: boolean
+  onClick: () => void
+}) {
+  const ref = useRef<HTMLButtonElement>(null)
+  const rovingTabindex = useRovingTabindex(ref)
+
+  return (
+    <button
+      ref={ref}
+      type='button'
+      role='menuitemradio'
+      aria-checked={props.isChecked}
+      onClick={props.onClick}
+      className={classNames(
+        rovingTabindex.className,
+        styles.accumulatedReactionsButton,
+        {
+          [styles.isFromSelf]: props.isChecked,
+        }
+      )}
+      tabIndex={rovingTabindex.tabIndex}
+      onKeyDown={rovingTabindex.onKeydown}
+      onFocus={rovingTabindex.setAsActiveElement}
+    >
+      <span className={styles.accumulatedReactionsEmoji}>{props.emoji}</span>{' '}
+      <span className={styles.accumulatedReactionsCount}>{props.count}</span>
+    </button>
   )
 }
 

--- a/packages/frontend/src/components/dialogs/ReactionsDialog/styles.module.scss
+++ b/packages/frontend/src/components/dialogs/ReactionsDialog/styles.module.scss
@@ -39,14 +39,31 @@
   text-align: center;
 }
 
-.accumulatedReactionsListItem {
-  align-items: center;
+.accumulatedReactionsList {
   display: flex;
-  padding-block: 8px;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.625rem;
+}
+
+.accumulatedReactionsButton {
+  @include mixins.button-reset;
+
+  padding: 0.125rem 0.5rem;
+
+  // Basically the same as with `.emoji` on message bubbles
+  border-radius: 999999px;
+  border: solid 1px rgba(100, 100, 100, 0.3);
+  background-color: var(--messageIncomingBg);
+  &.isFromSelf {
+    background-color: var(--messageOutgoingBg);
+  }
+}
+
+.accumulatedReactionsEmoji {
+  font-size: 1.125rem;
 }
 
 .accumulatedReactionsCount {
-  flex: 1;
-  margin-inline-end: 10px;
+  margin-inline: 0.125rem;
   overflow: hidden;
 }


### PR DESCRIPTION
Android switched to this look recently:
https://github.com/deltachat/deltachat-android/pull/4560.
It was also requested to do the same for Desktop:
https://github.com/deltachat/deltachat-desktop/issues/6632.

Before / after:

<img width="383" height="164" alt="Before" src="https://github.com/user-attachments/assets/729ae996-1925-4db9-b6ac-a113936c29c4" /> <img width="383" height="164" alt="After" src="https://github.com/user-attachments/assets/20898c9f-03b4-4a4a-b9c2-6cd39bc6fa98" />
