### PR TITLE
fix: msg multiselect: don't reset on button click

### DIFF
--- a/packages/e2e-tests/tests/message-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/message-list-multiselect.spec.ts
@@ -197,6 +197,55 @@ test.describe('clickable elements', () => {
     await image.click()
     await closeDialogButton.click()
   })
+
+  test("normally clicking interactive element doesn't change selection", async () => {
+    await getMessage(4).click()
+    await expectSelectedMessages([])
+    await getMessage(2).click({ modifiers: ['ControlOrMeta'] })
+    await expectSelectedMessages([2])
+
+    await image.click()
+    await closeDialogButton.click()
+    await expectSelectedMessages([2])
+
+    await getMessage(42).click({ modifiers: ['ControlOrMeta'] })
+    await expectSelectedMessages([2, 42])
+
+    await image.click()
+    await closeDialogButton.click()
+    await expectSelectedMessages([2, 42])
+  })
+
+  test('message three-dot menu', async () => {
+    await getMessage(4).click()
+    await expectSelectedMessages([])
+
+    await getMessage(2).click({ modifiers: ['ControlOrMeta'] })
+    await getMessage(4).click({ modifiers: ['ControlOrMeta'] })
+    await getMessage(7).click({ modifiers: ['ControlOrMeta'] })
+    await expectSelectedMessages([2, 4, 7])
+
+    for (const i of [4, 2, 7]) {
+      await getMessage(i).hover()
+      await getMessage(i)
+        .getByRole('button', { name: 'Message actions' })
+        .click()
+      await expectSelectedMessages([2, 4, 7])
+      await page.getByRole('menuitem', { name: 'Delete' }).click()
+      await expect(page.getByRole('dialog')).toContainText('Delete 3 messages?')
+      await page.keyboard.press('Escape')
+      await expectSelectedMessages([2, 4, 7])
+    }
+
+    await expectSelectedMessages([2, 4, 7])
+    await getMessage(3).hover()
+    await getMessage(3).getByRole('button', { name: 'Message actions' }).click()
+    // Not multiselect member - reset selection.
+    await expectSelectedMessages([])
+    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    await expect(page.getByRole('dialog')).toContainText('Delete this message?')
+    await page.keyboard.press('Escape')
+  })
 })
 
 test('Click on dead space', async () => {

--- a/packages/e2e-tests/tests/message-list-multiselect.spec.ts
+++ b/packages/e2e-tests/tests/message-list-multiselect.spec.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from '@playwright/test'
+import { expect, type Locator, type Page } from '@playwright/test'
 import path from 'path'
 
 import {
@@ -132,60 +132,71 @@ test.describe('Ctrl + Click', () => {
   })
 })
 
-test("Ctrl+Click and Shift+Click don't activate clickable elements", async () => {
-  await getMessage(4).click()
-  await expectSelectedMessages([])
+test.describe('clickable elements', () => {
+  let image!: Locator
+  let link!: Locator
+  let closeDialogButton!: Locator
+  test.beforeAll(async () => {
+    // Prepare a message with an image and a link.
+    const fileChooserPromise = page.waitForEvent('filechooser')
+    await page.getByRole('button', { name: 'Attach' }).click()
+    await page.getByRole('menuitem', { name: 'Image' }).click()
+    const fileChooser = await fileChooserPromise
+    await fileChooser.setFiles(imagePath)
+    await expect(
+      page.getByRole('region', { name: 'Write a message' }).getByRole('img')
+    ).toBeVisible()
+    await textarea().fill(
+      getMessageText(42) + '\nhttps://localhost/somepage.html'
+    )
+    await textarea().press('ControlOrMeta+Enter')
 
-  // Prepare a message with an image and a link.
-  const fileChooserPromise = page.waitForEvent('filechooser')
-  await page.getByRole('button', { name: 'Attach' }).click()
-  await page.getByRole('menuitem', { name: 'Image' }).click()
-  const fileChooser = await fileChooserPromise
-  await fileChooser.setFiles(imagePath)
-  await expect(
-    page.getByRole('region', { name: 'Write a message' }).getByRole('img')
-  ).toBeVisible()
-  await textarea().fill(
-    getMessageText(42) + '\nhttps://localhost/somepage.html'
-  )
-  await textarea().press('ControlOrMeta+Enter')
-
-  const image = getMessage(42).getByRole('img')
-  const link = getMessage(42).getByRole('link', {
-    name: 'https://localhost/somepage.html',
+    image = getMessage(42).getByRole('img')
+    link = getMessage(42).getByRole('link', {
+      name: 'https://localhost/somepage.html',
+    })
+    closeDialogButton = page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Close' })
   })
-  // Normally clicking the image opens the "View Image" dialog.
-  await image.click()
-  const closeDialogButton = page
-    .getByRole('dialog')
-    .getByRole('button', { name: 'Close' })
-  await closeDialogButton.click()
+  test.afterAll(async () => {
+    await getMessage(2).click()
+    await expectSelectedMessages([])
 
-  await getMessage(2).click({ modifiers: ['ControlOrMeta'] })
-  await expectSelectedMessages([2])
+    await image.click({ button: 'right' })
+    await page.getByRole('menuitem', { name: 'Delete' }).click()
+    await page
+      .getByRole('dialog')
+      .getByRole('button', { name: 'Delete' })
+      .last()
+      .click()
+  })
 
-  await link.click({ modifiers: ['ControlOrMeta'] })
-  await expectSelectedMessages([2, 42])
-  // If a "view image" dialog has been opened then the rest should not work,
-  // because the dialog makes outside content inert.
-  await image.click({ modifiers: ['ControlOrMeta'] })
-  await expectSelectedMessages([2])
-  await link.click({ modifiers: ['Shift'] })
-  await expectSelectedMessages([42])
+  test("Ctrl+Click and Shift+Click don't activate clickable elements", async () => {
+    await getMessage(4).click()
+    await expectSelectedMessages([])
 
-  await expect(closeDialogButton).not.toBeVisible()
+    // Normally clicking the image opens the "View Image" dialog.
+    await image.click()
+    await closeDialogButton.click()
 
-  await image.click()
-  await closeDialogButton.click()
+    await getMessage(2).click({ modifiers: ['ControlOrMeta'] })
+    await expectSelectedMessages([2])
 
-  // Clean up.
-  await image.click({ button: 'right' })
-  await page.getByRole('menuitem', { name: 'Delete' }).click()
-  await page
-    .getByRole('dialog')
-    .getByRole('button', { name: 'Delete' })
-    .last()
-    .click()
+    await link.click({ modifiers: ['ControlOrMeta'] })
+    await expectSelectedMessages([2, 42])
+    // If a "view image" dialog has been opened then the rest should not work,
+    // because the dialog makes outside content inert.
+    await image.click({ modifiers: ['ControlOrMeta'] })
+    await expectSelectedMessages([2])
+    await link.click({ modifiers: ['Shift'] })
+    await expectSelectedMessages([42])
+
+    await expect(closeDialogButton).not.toBeVisible()
+
+    await image.click()
+    await closeDialogButton.click()
+  })
 })
 
 test('Click on dead space', async () => {

--- a/packages/frontend/src/components/message/focusAndMultiselect.tsx
+++ b/packages/frontend/src/components/message/focusAndMultiselect.tsx
@@ -57,7 +57,8 @@ export function useMessageFocusAndMultiselectContextValue(props: {
     // Only enter "multi-select mode" on Shift + Click or Ctrl + Click.
     // Multi-selecting messages is not something that people do all the time.
     // It's annoying that a message keeps being displayed as selected
-    // even though all you did is click a link inside of it.
+    // even though all you did is click on its bubble
+    // to focus it or to select text or something.
     { onNormalClick: 'unselectAll' }
   )
   // Memoized because it is used as a context value.

--- a/packages/frontend/src/hooks/useMultiselect.ts
+++ b/packages/frontend/src/hooks/useMultiselect.ts
@@ -109,6 +109,14 @@ export function useMultiselect<T>(
      * @default 'resetSelectionToClickedItem'
      */
     onNormalClick?: 'resetSelectionToClickedItem' | 'unselectAll'
+    /**
+     * When `true`, clicking an interactive child (button, link, etc)
+     * of a multiselectable element without Ctrl or Shift does not
+     * change the selection.
+     *
+     * @default true
+     */
+    onNormalClickIgnoreInteractiveChildren?: boolean
   }
 ) {
   // TODO feat: a way to set initially active item?
@@ -267,6 +275,31 @@ export function useMultiselect<T>(
         return true // shouldPreventDefault
       }
 
+      function isTargetAnInteractiveChild(): boolean {
+        if (!(event.target instanceof Element)) {
+          return false
+        }
+        // The clicked element could be an element inside a button.
+        const interactiveWrapper = event.target.closest(
+          // Probably not a full list, but good enough.
+          'button,a,input,textarea,select,video,audio'
+        )
+        return (
+          // `event.currentTarget` is the element
+          // which has the event listener attached,
+          // i.e. the multiselectable element.
+          event.currentTarget.contains(interactiveWrapper) &&
+          interactiveWrapper !== event.currentTarget
+        )
+      }
+      if (
+        (options?.onNormalClickIgnoreInteractiveChildren ?? true) &&
+        isTargetAnInteractiveChild()
+      ) {
+        lastActivatedItem.current = item
+        return false
+      }
+
       switch (onNormalClick) {
         case 'resetSelectionToClickedItem': {
           if (
@@ -294,7 +327,13 @@ export function useMultiselect<T>(
       lastActivatedItem.current = item
       return false
     },
-    [onNormalClick, onSelectContiguous, onSelectionChange, toggleItemSelection]
+    [
+      onNormalClick,
+      onSelectContiguous,
+      onSelectionChange,
+      options?.onNormalClickIgnoreInteractiveChildren,
+      toggleItemSelection,
+    ]
   )
   const onClick = useCallback(
     (event: React.MouseEvent, item: T) => {


### PR DESCRIPTION
For example, clicking on a
- link
- "Start WebXDC app" button
- "React" button
- video and audio (voice message) controls

will not change selection now.

This also covers the three-dot hover button,
clicking on which would annoyingly reset selection previously.

This issue was mentioned in comment:
https://github.com/deltachat/deltachat-desktop/pull/6268#issuecomment-4421606119

Hide whitespace for easier review. The first commit only affects tests.