### PR TITLE
fix: do not always create a team profile

### DIFF
--- a/packages/frontend/src/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/InstantOnboardingScreen.tsx
@@ -188,7 +188,8 @@ export default function InstantOnboardingScreen({
 
     try {
       await Promise.all([
-        SettingsStoreInstance.effect.setCoreSetting('team_profile', '1'),
+        isTeamProfile &&
+          SettingsStoreInstance.effect.setCoreSetting('team_profile', '1'),
         saveDisplayName(),
       ])
       // Automatically create a "chatmail" account


### PR DESCRIPTION
Since the introduction of team profiles,
all profiles were created with `team_profile` core setting set regardless of the user choice.
It is visible in the hover overlay on top of each profile as well.

Fixes #6683