### PR TITLE
refactor: remove unused `newTransport` prop

### DIFF
--- a/packages/frontend/src/components/dialogs/Transports/index.tsx
+++ b/packages/frontend/src/components/dialogs/Transports/index.tsx
@@ -26,7 +26,6 @@ type Transport = Awaited<
 export default function TransportsDialog(
   props: DialogProps & {
     accountId: number
-    newTransport?: string
   }
 ) {
   const tx = useTranslationFunction()


### PR DESCRIPTION
It was never used.
