### PR TITLE
refactor: improve `openDialog` types

### DIFF
--- a/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
+++ b/packages/frontend/src/components/Settings/ExperimentalFeatures.tsx
@@ -56,10 +56,7 @@ export function ExperimentalFeatures() {
 
     message +=
       '\n\n• If you want to quit the experimental feature, you can disable it at "Settings / Advanced"'
-    openDialog(AlertDialog, {
-      message,
-      confirmLabel: tx('ok'),
-    })
+    openDialog(AlertDialog, { message })
   }
 
   return (

--- a/packages/frontend/src/components/chat/ChatContextMenu.tsx
+++ b/packages/frontend/src/components/chat/ChatContextMenu.tsx
@@ -529,10 +529,7 @@ export function useChatContextMenu(): {
         isGroup && {
           label: tx('clone_chat'),
           action: () => {
-            openDialog(CloneChat, {
-              setViewMode: 'createGroup',
-              chatTemplateId: relatedChat.id,
-            })
+            openDialog(CloneChat, { chatTemplateId: relatedChat.id })
           },
         },
       // Block contact

--- a/packages/frontend/src/components/dialogs/ViewGroup/ViewGroupMenu.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/ViewGroupMenu.tsx
@@ -51,10 +51,7 @@ export default function useViewGroupMenu({
     !isBroadcast && {
       label: tx('clone_chat'),
       action: () => {
-        openDialog(CloneChat, {
-          setViewMode: 'createGroup',
-          chatTemplateId: chat.id,
-        })
+        openDialog(CloneChat, { chatTemplateId: chat.id })
       },
       dataTestid: 'clone-chat',
     },

--- a/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
@@ -155,7 +155,6 @@ const useGroup = (accountId: number, initialGroupState: T.FullChat) => {
         )
       } catch (error) {
         openDialog(AlertDialog, {
-          title: tx('error'),
           message: tx(
             'error_x',
             `Failed to modify group members: ${unknownErrorToString(error)}`
@@ -183,7 +182,6 @@ const useGroup = (accountId: number, initialGroupState: T.FullChat) => {
         )
       } catch (error) {
         openDialog(AlertDialog, {
-          title: tx('error'),
           message: tx(
             'error_x',
             `Failed to modify group members: ${unknownErrorToString(error)}`

--- a/packages/frontend/src/contexts/DialogContext.tsx
+++ b/packages/frontend/src/contexts/DialogContext.tsx
@@ -15,7 +15,7 @@ type DialogElementConstructor<T> = JSXElementConstructor<DialogProps & T>
 
 export type OpenDialog = <T extends { [key: string]: any }>(
   dialogElement: DialogElementConstructor<T>,
-  additionalProps?: T
+  additionalProps?: Omit<T, 'onClose'> & Pick<Partial<DialogProps>, 'onClose'>
 ) => DialogId
 
 export type CloseDialog = (id: DialogId) => void


### PR DESCRIPTION
c3993f28eda53c2816169b9f0fc85a626473397b
(https://github.com/deltachat/deltachat-desktop/pull/5825)
made `onClose` work with `openDialog`,
and we already use it in some places
(search for `openDialog(\n|.){1,300}?^\s+OnClose[:,]`).
However, `onClose` doesn't appear in IDEs and its type
is basically `any`.

For reasons not completely clear,
this also disallows setting unknown properties
when calling `openDialog`, which I also had to fix here,
otherwise TypeScript complains.
These already don't actually do anything,
but also there is no need to try to make them work:
- `setViewType` was introduced in the very commit that introduced
  the `CloneChat` component itself. The prop was never used.
- `title: tx('error')` for `AlertDialog` is probably insignificant.
  We already provide the `error_x` text.
- `confirmLabel: tx('ok')` is already the default.
