### PR TITLE
style: remove `cursor: pointer` on non-clickable

### DIFF
--- a/packages/frontend/src/components/Reactions/styles.module.scss
+++ b/packages/frontend/src/components/Reactions/styles.module.scss
@@ -1,5 +1,4 @@
 .reactions {
-  cursor: pointer;
   margin-inline-end: 10px;
   position: relative;
   line-height: 1; // So that it doesn't change the message height.
@@ -48,4 +47,5 @@
   inset: 0;
   border: none;
   background: transparent;
+  cursor: pointer;
 }


### PR DESCRIPTION
The button doesn't actually fill the parent completely
for some reason, so sometimes it so happens that you click
but nothing happens.

Maybe it'd be better to make the button match the parent,
but let's keep that for later (or never).
