### PR TITLE
fix: check for resume from sleep with setInterval

### DIFF
--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -87,6 +87,7 @@
     "esbuild": "^0.28.1",
     "mocha": "^10.7.0",
     "rc": "^1.2.8",
+    "sleeptime": "github:timrach/sleeptime",
     "typescript": "catalog:"
   }
 }

--- a/packages/target-electron/src/resume_from_sleep.ts
+++ b/packages/target-electron/src/resume_from_sleep.ts
@@ -1,4 +1,5 @@
 import { powerMonitor } from 'electron'
+import SleepTime from 'sleeptime'
 
 import { send } from './windows/main.js'
 
@@ -10,4 +11,18 @@ export function initialisePowerMonitor() {
   powerMonitor.on('resume', onResumeFromSleep)
   powerMonitor.on('unlock-screen', onResumeFromSleep)
   powerMonitor.on('user-did-become-active', onResumeFromSleep)
+
+  // Looks like `powerMonitor.on('resume'` doesn't work
+  // if certain permissions are not given to the app,
+  // so let's have this dumb `setInterval` check.
+  //
+  // It might fire false-positives, but we're generally fine with this,
+  // as `onResumeFromSleep` is only used for `rpc.maybeNetwork()`
+  // and updating timestamps, so it's only about performance basically.
+  new SleepTime(
+    onResumeFromSleep,
+    // `setInterval` period. `onResumeFromSleep` might be delayed
+    // by up to this amount of milliseconds.
+    10 * 1000
+  )
 }

--- a/packages/target-electron/src/sleeptime.d.ts
+++ b/packages/target-electron/src/sleeptime.d.ts
@@ -1,0 +1,8 @@
+declare module 'sleeptime' {
+  export default class SleepTime {
+    constructor(
+      wakeUpCallback: (diff: number, now: number) => void,
+      thresh?: number
+    )
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,9 @@ importers:
       rc:
         specifier: ^1.2.8
         version: 1.2.8
+      sleeptime:
+        specifier: github:timrach/sleeptime
+        version: https://codeload.github.com/timrach/sleeptime/tar.gz/f4740d3658e2075707ed6791671b62e591903be2
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2115,6 +2118,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3599,6 +3603,11 @@ packages:
   simple-update-notifier@2.0.0:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
+
+  sleeptime@https://codeload.github.com/timrach/sleeptime/tar.gz/f4740d3658e2075707ed6791671b62e591903be2:
+    resolution: {gitHosted: true, integrity: sha512-voXVWNE+jQk0YNqZbX2oAPESfF8by67ruzxsZ2NmO6TMIMm8/qd9/E03XdnG5M8Y7xy8DZunAUP9zag9jFAG0Q==, tarball: https://codeload.github.com/timrach/sleeptime/tar.gz/f4740d3658e2075707ed6791671b62e591903be2}
+    version: 1.0.1
+    engines: {node: '>= 0.10.29'}
 
   sort-keys@5.1.0:
     resolution: {integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==}
@@ -7490,6 +7499,8 @@ snapshots:
   simple-update-notifier@2.0.0:
     dependencies:
       semver: 7.7.4
+
+  sleeptime@https://codeload.github.com/timrach/sleeptime/tar.gz/f4740d3658e2075707ed6791671b62e591903be2: {}
 
   sort-keys@5.1.0:
     dependencies:


### PR DESCRIPTION
Closes https://github.com/deltachat/deltachat-desktop/issues/5915
and other similar issues.
This is a method independent of permissions.

I had to add the package directly from GitHub and not NPM
because the NPM version has a bug where it ignores
the `threshold` parameter.

- [ ] What I'm a bit worried about with this is performance.
  We'll be running something every 5 seconds.
  The code that runs is pretty small itself,
  but maybe it forces the engine to keep a lot of stuff loaded
  or something?
- [ ] Oops, also apparently the lib is buggy. `lasTickDidTrigger` only gets reset in the "diff is too big" situation, so it only works half of the time.
