### PR TITLE
chore: upgrade Electron to v44

### DIFF
--- a/packages/target-electron/package.json
+++ b/packages/target-electron/package.json
@@ -82,7 +82,7 @@
     "application-config": "^3.0.0",
     "chai": "^5.1.1",
     "debounce": "^1.2.0",
-    "electron": "^42.9.0",
+    "electron": "^44.0.0",
     "electron-builder": "^26.15.7",
     "esbuild": "^0.28.1",
     "mocha": "^10.7.0",

--- a/packages/target-electron/src/deltachat/link-clicks.ts
+++ b/packages/target-electron/src/deltachat/link-clicks.ts
@@ -73,9 +73,9 @@ async function promptToCopy(win: BrowserWindow, url: string) {
       buttons: [tx('no'), tx('menu_copy_link_to_clipboard')],
       message: tx('ask_copy_unopenable_link_to_clipboard', url),
     })
-    .then(({ response }) => {
+    .then(async ({ response }) => {
       if (response == 1) {
-        clipboard.writeText(url)
+        await clipboard.writeText(url)
       }
     })
 }

--- a/packages/target-electron/src/electron-context-menu.ts
+++ b/packages/target-electron/src/electron-context-menu.ts
@@ -127,10 +127,14 @@ const create = (win: BrowserWindow) => {
         label: tx('menu_copy_link_to_clipboard'),
         visible: props.linkURL.length !== 0 && props.mediaType === 'none',
         click() {
-          electron.clipboard.write({
-            bookmark: props.linkText,
-            text: props.linkURL,
-          })
+          electron.clipboard.write([
+            new electron.ClipboardItem({
+              'electron application/bookmark': {
+                title: props.linkText,
+                url: props.linkURL,
+              },
+            }),
+          ])
         },
       }),
       copyImage: () => ({

--- a/packages/target-electron/src/index.ts
+++ b/packages/target-electron/src/index.ts
@@ -487,7 +487,7 @@ app.on('web-contents-created', (_ev, contents) => {
           userCancelledDialogAtLeastOnce = true
           return
         case 1: {
-          clipboard.writeText(asciiUrl)
+          await clipboard.writeText(asciiUrl)
           break
         }
         case 2: {

--- a/packages/target-electron/src/ipc.ts
+++ b/packages/target-electron/src/ipc.ts
@@ -2,6 +2,7 @@ import { copyFile, writeFile, mkdir, rm, readFile } from 'fs/promises'
 import {
   app as rawApp,
   clipboard,
+  ClipboardItem,
   dialog,
   ipcMain,
   nativeImage,
@@ -374,23 +375,31 @@ export async function init(cwd: string, logHandler: LogHandler) {
   ipcMain.handle('electron.clipboard.readText', () => {
     return clipboard.readText()
   })
-  ipcMain.handle('electron.clipboard.readImage', () => {
-    const image = clipboard.readImage()
-
-    // Electron just returns an empty base64 string (for example
-    // 'data:image/png;base64,' when no image was in the clipboard),
-    // we check that here and more conveniently return null instead
-    if (image.isEmpty()) {
-      return null
+  ipcMain.handle('electron.clipboard.readImage', async () => {
+    const items = await clipboard.read()
+    // TODO bruh why only jpeg and PNG.
+    for (const mimeType of ['image/png', 'image/jpeg']) {
+      const item = items.find(item => item.types.includes(mimeType))
+      if (!item) {
+        continue
+      }
+      const blob = (await item.getType(mimeType)) as Blob
+      const buffer = Buffer.from(await blob.arrayBuffer())
+      return `data:${mimeType};base64,${buffer.toString('base64')}`
     }
-
-    return image.toDataURL()
+    // No image in the clipboard
+    return null
   })
   ipcMain.handle('electron.clipboard.writeText', (_ev, text) => {
     return clipboard.writeText(text)
   })
   ipcMain.handle('electron.clipboard.writeImage', (_ev, path) => {
-    return clipboard.writeImage(nativeImage.createFromPath(path))
+    const png = nativeImage.createFromPath(path).toPNG()
+    return clipboard.write([
+      new ClipboardItem({
+        'image/png': new Blob([new Uint8Array(png)], { type: 'image/png' }),
+      }),
+    ])
   })
 
   ipcMain.handle(

--- a/packages/target-electron/src/windows/html_email.ts
+++ b/packages/target-electron/src/windows/html_email.ts
@@ -572,10 +572,14 @@ const createContextMenu = (win: BrowserWindow, webContents: WebContents) => {
           id: 'copyLink',
           label: tx('menu_copy_link_to_clipboard'),
           click() {
-            electron.clipboard.write({
-              bookmark: props.linkText,
-              text: props.linkURL,
-            })
+            electron.clipboard.write([
+              new electron.ClipboardItem({
+                'electron application/bookmark': {
+                  title: props.linkText,
+                  url: props.linkURL,
+                },
+              }),
+            ])
           },
         })
       )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -437,8 +437,8 @@ importers:
         specifier: ^1.2.0
         version: 1.2.1
       electron:
-        specifier: ^42.9.0
-        version: 42.9.0(supports-color@8.1.1)
+        specifier: ^44.0.0
+        version: 44.0.0(supports-color@8.1.1)
       electron-builder:
         specifier: ^26.15.7
         version: 26.15.7(electron-builder-squirrel-windows@26.15.7)(supports-color@8.1.1)
@@ -1975,8 +1975,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@42.9.0:
-    resolution: {integrity: sha512-xyKfPbHP43Jx22Z1hItLR4KB5h3/avb5BIX4xaQZ6uPPRY4cQxuHnRVrKCGbSsMa/9zd0bBT4TAVNVuVjYcYtw==}
+  electron@44.0.0:
+    resolution: {integrity: sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -2115,6 +2115,7 @@ packages:
   eslint@9.39.2:
     resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5606,7 +5607,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@42.9.0(supports-color@8.1.1):
+  electron@44.0.0(supports-color@8.1.1):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@8.1.1)


### PR DESCRIPTION
Note that there are a couple of systems for which Electron 44 dropped support:
https://www.electronjs.org/blog/electron-44-0

TODO:
- [ ] Some of the `clipboard` migrations are AI-generated,
  I did so mainly to avoid build errors for now
  to test different things.
  Those changes will need extra consideration, maybe a rewrite.
- [ ] Wait for FreeBSD to upgrade Electron
  before using its new features.
