### PR TITLE
improvement: use native `windowStatePersistence`

### DIFF
--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -11,8 +11,16 @@ type Bounds = {
 }
 
 export interface DesktopSettingsType {
-  bounds: Bounds | {}
-  HTMLEmailWindowBounds: Bounds | undefined
+  /**
+   * @deprecated replaced with native
+   * https://www.electronjs.org/docs/latest/tutorial/window-state-persistence
+   */
+  bounds?: Bounds | {}
+  /**
+   * @deprecated replaced with native
+   * https://www.electronjs.org/docs/latest/tutorial/window-state-persistence
+   */
+  HTMLEmailWindowBounds?: Bounds | undefined
   chatViewBgImg?: string
   /**
    * @deprecated replaced by lastAccount,

--- a/packages/shared/state.ts
+++ b/packages/shared/state.ts
@@ -5,8 +5,6 @@ export function getDefaultState(): DesktopSettingsType {
    * Persisted state. Must be JSON.
    */
   return {
-    bounds: {},
-    HTMLEmailWindowBounds: undefined,
     enterKeySends: false,
     notifications: true,
     showNotificationContent: true,

--- a/packages/target-electron/src/deltachat/webxdc.ts
+++ b/packages/target-electron/src/deltachat/webxdc.ts
@@ -326,7 +326,11 @@ export default class DCWebxdc {
         webxdcInfo['internetAccess']
       )
 
+      // const defaultSize2: Size = adjustSize(defaultSize)
+
       const webxdcWindow = new BrowserWindow({
+        name: `webxdc-window-${appId}`,
+        windowStatePersistence: true,
         webPreferences: {
           partition,
           sandbox: true,
@@ -363,6 +367,10 @@ export default class DCWebxdc {
 
       setContentProtection(webxdcWindow)
 
+      // TODO hmmm, here we also probably want to use the legacy bounds?
+      // I guess we can try to get them if they exist,
+      // and also delete them `persisted-state-restored`.
+      // orrrr, delete here right away.
       // reposition the window to last position (or default)
       this.getLastBounds(accountId, msg_id)
         .then(lastBounds => {
@@ -374,6 +382,7 @@ export default class DCWebxdc {
           // show after repositioning to avoid blinking
           webxdcWindow.show()
         })
+
       const appIconPromise = this.rpc
         .getWebxdcBlob(accountId, msg_id, webxdcInfo.icon)
         .then(blob => nativeImage.createFromBuffer(Buffer.from(blob, 'base64')))
@@ -517,6 +526,7 @@ export default class DCWebxdc {
       webxdcWindow.once('close', saveBounds.bind(this))
 
       webxdcWindow.once('ready-to-show', () => {
+        webxdcWindow.show()
         // also saving at the start, because this.webxdcCleanup uses this
         // to find out which webxdc apps were opened at some point in time.
         saveBounds()
@@ -922,24 +932,6 @@ export default class DCWebxdc {
    */
   get rpc() {
     return this.controller.jsonrpcRemote.rpc
-  }
-
-  async getLastBounds(
-    accountId: number,
-    msgId: number
-  ): Promise<Bounds | null> {
-    try {
-      const raw = await this.rpc.getConfig(
-        accountId,
-        `${BOUNDS_UI_CONFIG_PREFIX}.${msgId}`
-      )
-      if (raw) {
-        return JSON.parse(raw)
-      }
-    } catch (error) {
-      log.debug('failed to retrieve bounds for webxdc', error)
-    }
-    return null
   }
 
   setLastBounds(accountId: number, msgId: number, bounds: Bounds) {

--- a/packages/target-electron/src/windows/html_email.ts
+++ b/packages/target-electron/src/windows/html_email.ts
@@ -62,6 +62,7 @@ export function openHtmlEmailWindow(
     open_windows[window_id].focus()
     return
   }
+  // Deprecated, but keep this for a while, same as for `main-window`.
   const initialBounds = DesktopSettings.state.HTMLEmailWindowBounds || {
     height: 621,
     width: 800,
@@ -73,12 +74,16 @@ export function openHtmlEmailWindow(
     mainWindow.window?.webContents.getZoomFactor() || 1.0
 
   const window = (open_windows[window_id] = new electron.BrowserWindow({
+    // TODO there might be multiple HTML windows.
+    // Maybe just don't do `windowStatePersistence` on subsequent windows?
+    name: 'html-email-window',
     backgroundColor: '#282828',
     // backgroundThrottling: false, // do not throttle animations/timers when page is background
     darkTheme: true, // Forces dark theme (GTK+3)
     icon: appIcon(),
     show: false,
     title: `${truncateText(subject, 42)} – ${truncateText(from, 40)}`,
+    windowStatePersistence: true,
     height: initialBounds.height,
     width: initialBounds.width,
     x: initialBounds.x,
@@ -316,7 +321,6 @@ export function openHtmlEmailWindow(
         mainWindowZoomFactor * Math.pow(1.2, window.webContents.getZoomLevel())
       const windowZoomFactor = window.webContents.getZoomFactor()
 
-      const window_bounds = window.getBounds()
       const content_size = window.getContentSize()
       const new_w = bounds.width * windowZoomFactor
       const new_h = bounds.height * windowZoomFactor
@@ -329,14 +333,8 @@ export function openHtmlEmailWindow(
         height: new_h,
       })
       sandboxedView?.webContents.setZoomFactor(contentZoomFactor)
-      DesktopSettings.update({ HTMLEmailWindowBounds: window_bounds })
     }
   )
-
-  window.on('moved', () => {
-    const window_bounds = window.getBounds()
-    DesktopSettings.update({ HTMLEmailWindowBounds: window_bounds })
-  })
 
   const update_restrictions = async (allow_network: boolean) => {
     loadRemoteContent = allow_network

--- a/packages/target-electron/src/windows/main.ts
+++ b/packages/target-electron/src/windows/main.ts
@@ -1,4 +1,3 @@
-import debounce from 'debounce'
 import electron, { BrowserWindow, session } from 'electron'
 import { isAbsolute, join, sep } from 'path'
 import { platform } from 'os'
@@ -47,6 +46,11 @@ export function init(options: { hidden: boolean; hideMenuBar: boolean }) {
   const defaults = windowDefaults()
   const initialBounds = Object.assign(
     defaults.bounds,
+    // We've switched to the native `windowStatePersistence` API,
+    // but when the user launched the new version of the app
+    // for the first time, we should still restore the bounds
+    // from the previous launch, and those are only stored here.
+    // This can be removed after a few months or years.
     DesktopSettings.state.bounds
   )
 
@@ -54,12 +58,14 @@ export function init(options: { hidden: boolean; hideMenuBar: boolean }) {
 
   const mainWindow = (window = <ExtendedBrowserWindow>(
     new electron.BrowserWindow({
+      name: 'main-window',
       backgroundColor: '#282828',
       // backgroundThrottling: false, // do not throttle animations/timers when page is background
       darkTheme: true, // Forces dark theme (GTK+3)
       icon: appIcon(),
       show: false,
       title: appWindowTitle,
+      windowStatePersistence: true,
       height: initialBounds.height,
       width: initialBounds.width,
       x: initialBounds.x,
@@ -144,17 +150,6 @@ export function init(options: { hidden: boolean; hideMenuBar: boolean }) {
   mainWindow.webContents.on('did-finish-load', () => {
     rendererGone = false
   })
-
-  const saveBounds = debounce(() => {
-    const bounds = window?.getBounds()
-    if (bounds) {
-      DesktopSettings.update({ bounds })
-    }
-  }, 1000)
-
-  window.on('move', saveBounds)
-
-  window.on('resize', saveBounds)
 
   window.once('show', () => {
     if (DesktopSettings.state.zoomFactor !== undefined) {

--- a/packages/target-electron/src/windows/video-call.ts
+++ b/packages/target-electron/src/windows/video-call.ts
@@ -261,6 +261,9 @@ function openVideoCallWindow<D extends CallDirection>(
   }
 
   const win = new BrowserWindow({
+    // TODO hmm here also there might be multiple windows,
+    // same as with HTML.
+    // name
     webPreferences: {
       session: ses,
 
@@ -286,8 +289,6 @@ function openVideoCallWindow<D extends CallDirection>(
     // alwaysOnTop: main_window?.isAlwaysOnTop(),
   })
   setContentProtection(win)
-  // TODO maybe remember bounds.
-  //
   // Maybe we could add a setting for this, i.e. "Allow calls to bypass VPN".
   // win.webContents.setWebRTCIPHandlingPolicy()
 


### PR DESCRIPTION
The advantage is that it also keeps the maximized / minimized state,
which is most likely good for WebXDC games.

But maybe it's not super worth it
(we don't have that much code around bounds saving).

Note that we can do this migration one window at a time.
