### PR TITLE
fix: use native `<dialog>.closedby`

### DIFF
--- a/packages/frontend/src/components/AccountListSidebar/EditPrivateTagDialog.tsx
+++ b/packages/frontend/src/components/AccountListSidebar/EditPrivateTagDialog.tsx
@@ -29,7 +29,7 @@ export function EditPrivateTagDialog({
   }
 
   return (
-    <Dialog onClose={onClose} canOutsideClickClose={true}>
+    <Dialog onClose={onClose} closedby='any'>
       <DialogHeader title={tx('profile_tag')} />
       <DialogBody>
         <DialogContent>

--- a/packages/frontend/src/components/Dialog/Dialog.tsx
+++ b/packages/frontend/src/components/Dialog/Dialog.tsx
@@ -9,8 +9,7 @@ const DEFAULT_WIDTH = 500
 type Props = React.PropsWithChildren<{
   /**
    * This will be invoked when the dialog is closed e.g. with
-   * outside click ({@linkcode canOutsideClickClose})
-   * or {@linkcode canEscapeKeyClose}.
+   * outside click or Escape key.
    *
    * You must respect this callback and unrender this component
    * when the callback is invoked, otherwise it can so happen
@@ -18,8 +17,10 @@ type Props = React.PropsWithChildren<{
    * (this has to do with `showModal`).
    */
   onClose: ((result?: any) => void) | undefined
-  canEscapeKeyClose?: boolean
-  canOutsideClickClose?: boolean
+  /**
+   * @default 'any'
+   */
+  closedby?: HTMLDialogElement['closedBy'] & ('any' | 'closerequest' | 'none')
   /** whether backdrop can be used to drag window around on tauri, used on onboarding screen and deletion screen */
   backdropDragAreaOnTauriRuntime?: boolean
   className?: string
@@ -42,8 +43,6 @@ type Props = React.PropsWithChildren<{
 const Dialog = React.memo<Props>(
   ({
     children,
-    canOutsideClickClose = true,
-    canEscapeKeyClose = true,
     backdropDragAreaOnTauriRuntime,
     width = DEFAULT_WIDTH,
     height,
@@ -54,48 +53,9 @@ const Dialog = React.memo<Props>(
   }) => {
     const dialog = useRef<HTMLDialogElement>(null)
 
-    const onClick = canOutsideClickClose
-      ? (ev: React.MouseEvent<HTMLDialogElement>) => {
-          if (!dialog.current) {
-            return
-          }
-          // pressing a button with Spacebar inside a dialog
-          // triggers the `onClick` event.
-          // Let's ignore such "clicks" here.
-          if (ev.screenX == 0 && ev.screenY == 0) {
-            return
-          }
-          ev.stopPropagation()
-          // that is the way to check if we clicked on dialog::backdrop
-          const rect = dialog.current.getBoundingClientRect()
-          const isInDialog =
-            rect.top <= ev.clientY &&
-            ev.clientY <= rect.top + rect.height &&
-            rect.left <= ev.clientX &&
-            ev.clientX <= rect.left + rect.width
-          if (!isInDialog) {
-            const cancelEvent = new Event('cancel')
-            dialog.current.dispatchEvent(cancelEvent)
-            // cancel event doesn't trigger dialog close
-            dialog.current.close()
-          }
-        }
-      : () => {}
-
     const onClose = (value: any) => {
       props.onClose && props.onClose(value)
       dialog.current!.style.display = 'none'
-    }
-
-    const onCancel = (ev: React.BaseSyntheticEvent) => {
-      if (!canEscapeKeyClose) {
-        ev.preventDefault()
-      }
-    }
-    const onKeyDown = (ev: React.KeyboardEvent) => {
-      if (ev.code === 'Escape') {
-        onCancel(ev)
-      }
     }
 
     useEffect(() => {
@@ -130,10 +90,8 @@ const Dialog = React.memo<Props>(
     }
     return (
       <dialog
-        onClick={onClick}
         onClose={onClose}
-        onCancel={onCancel}
-        onKeyDown={onKeyDown}
+        closedby={props.closedby ?? 'any'}
         ref={dialog}
         data-no-drag-region
         data-tauri-drag-region={

--- a/packages/frontend/src/components/Dialog/DialogWithHeader.tsx
+++ b/packages/frontend/src/components/Dialog/DialogWithHeader.tsx
@@ -11,11 +11,11 @@ type Props = React.PropsWithChildren<
     fixed?: boolean
     height?: number
     onClickBack?: () => void
-    canOutsideClickClose?: boolean
     title: string
     width?: number
     dataTestid?: string
-  } & DialogProps
+  } & DialogProps &
+    Pick<Parameters<typeof Dialog>[0], 'closedby'>
 >
 
 const DialogWithHeader = React.memo<Props>(props => {
@@ -26,7 +26,7 @@ const DialogWithHeader = React.memo<Props>(props => {
       className={props.className}
       width={props.width}
       height={props.height}
-      canOutsideClickClose={props.canOutsideClickClose}
+      closedby={props.closedby}
       dataTestid={props.dataTestid}
     >
       <DialogHeader

--- a/packages/frontend/src/components/ImageCropper/index.tsx
+++ b/packages/frontend/src/components/ImageCropper/index.tsx
@@ -453,12 +453,7 @@ export default function ImageCropper({
     }
   })
   return (
-    <Dialog
-      canEscapeKeyClose
-      onClose={onClose}
-      canOutsideClickClose={false}
-      width={500}
-    >
+    <Dialog onClose={onClose} closedby='closerequest' width={500}>
       <DialogHeader title={tx('ImageEditorHud_crop')} />
       <DialogBody>
         <DialogContent className={styles.imageCropperDialogContent}>

--- a/packages/frontend/src/components/Settings/Backup.tsx
+++ b/packages/frontend/src/components/Settings/Backup.tsx
@@ -132,7 +132,7 @@ function ExportProgressDialog({ onClose }: DialogProps) {
   }, [accountId])
 
   return (
-    <Dialog onClose={() => {}} canOutsideClickClose={false}>
+    <Dialog onClose={() => {}} closedby='closerequest'>
       <DialogHeader title={tx('export_backup_desktop')} />
       <DialogBody>
         <DialogContent>

--- a/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
+++ b/packages/frontend/src/components/dialogs/AddMember/AddMemberDialog.tsx
@@ -34,7 +34,7 @@ export function AddMemberDialog({
 
   return (
     <Dialog
-      canOutsideClickClose={false}
+      closedby='closerequest'
       fixed
       onClose={onClose}
       dataTestid='add-member-dialog'

--- a/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConfigureProgressDialog.tsx
@@ -143,11 +143,7 @@ export function ConfigureProgressDialog({
   }, [accountId])
 
   return (
-    <Dialog
-      onClose={onClose}
-      canEscapeKeyClose={false}
-      canOutsideClickClose={false}
-    >
+    <Dialog onClose={onClose} closedby='none'>
       <DialogBody>
         <DialogContent>
           <DeltaProgressBar progress={progress} />

--- a/packages/frontend/src/components/dialogs/ConnectivityDialog.tsx
+++ b/packages/frontend/src/components/dialogs/ConnectivityDialog.tsx
@@ -16,7 +16,7 @@ export default function ConnectivityDialog({ onClose }: DialogProps) {
   const tx = useTranslationFunction()
 
   return (
-    <Dialog onClose={onClose} canOutsideClickClose={true}>
+    <Dialog onClose={onClose} closedby='any'>
       <DialogHeader title={tx('connectivity')} onClose={onClose} />
       <ConnectivityDialogInner />
     </Dialog>

--- a/packages/frontend/src/components/dialogs/CreateChat/index.tsx
+++ b/packages/frontend/src/components/dialogs/CreateChat/index.tsx
@@ -681,7 +681,7 @@ export function CreateGroup(props: CreateGroupProps) {
   }
 
   return (
-    <Dialog width={400} onClose={onClose} canOutsideClickClose={false} fixed>
+    <Dialog width={400} onClose={onClose} closedby='closerequest' fixed>
       <DialogHeader
         title={
           titleOverride ??
@@ -799,7 +799,7 @@ export function CreateBroadcastList(props: CreateBroadcastListProps) {
   }
 
   return (
-    <Dialog width={400} onClose={onClose} canOutsideClickClose={false} fixed>
+    <Dialog width={400} onClose={onClose} closedby='closerequest' fixed>
       <DialogHeader title={tx('new_channel')} />
       <form onSubmit={submitForm}>
         <DialogBody>

--- a/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
+++ b/packages/frontend/src/components/dialogs/EditAccountAndPasswordDialog.tsx
@@ -39,7 +39,7 @@ export default function EditAccountAndPasswordDialog({
   const forceEncryption = settingsStore?.settings.force_encryption !== '0'
 
   return (
-    <Dialog canOutsideClickClose={false} onClose={onClose}>
+    <Dialog closedby='closerequest' onClose={onClose}>
       <DialogHeader
         title={
           // forceEncryption is false if account is not

--- a/packages/frontend/src/components/dialogs/EditProfileDialog/index.tsx
+++ b/packages/frontend/src/components/dialogs/EditProfileDialog/index.tsx
@@ -32,7 +32,7 @@ export default function EditProfileDialog({ onClose, ...props }: Props) {
   const tx = useTranslationFunction()
 
   return (
-    <Dialog canOutsideClickClose={false} onClose={onClose}>
+    <Dialog closedby='closerequest' onClose={onClose}>
       <DialogHeader
         title={
           props.settingsStore.settings.team_profile === '1'

--- a/packages/frontend/src/components/dialogs/Log/index.tsx
+++ b/packages/frontend/src/components/dialogs/Log/index.tsx
@@ -199,7 +199,7 @@ export function LogDialog({ onClose }: DialogProps) {
       onClose={onClose}
       // Disable canOutsideClickClose, because it interferes with text selection.
       // When you accidentally let go of the mouse button outside the dialog, it closes.
-      canOutsideClickClose={false}
+      closedby='closerequest'
     >
       <DialogHeader onClose={onClose} title={tx('pref_log_header')} />
       <DialogBody className={styles.dialogBody}>

--- a/packages/frontend/src/components/dialogs/Log/index.tsx
+++ b/packages/frontend/src/components/dialogs/Log/index.tsx
@@ -193,14 +193,7 @@ export function LogDialog({ onClose }: DialogProps) {
   }
 
   return (
-    <Dialog
-      width={800}
-      height={1000}
-      onClose={onClose}
-      // Disable canOutsideClickClose, because it interferes with text selection.
-      // When you accidentally let go of the mouse button outside the dialog, it closes.
-      closedby='closerequest'
-    >
+    <Dialog width={800} height={1000} onClose={onClose} closedby='any'>
       <DialogHeader onClose={onClose} title={tx('pref_log_header')} />
       <DialogBody className={styles.dialogBody}>
         <DialogContent className={styles.dialogContent}>

--- a/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
+++ b/packages/frontend/src/components/dialogs/ProxyConfiguration/index.tsx
@@ -388,8 +388,7 @@ export default function ProxyConfiguration(
       fixed
       width={500}
       dataTestid='proxy-dialog'
-      canOutsideClickClose={false}
-      canEscapeKeyClose={isValid}
+      closedby={isValid ? 'closerequest' : 'none'}
     >
       <DialogHeader
         title={tx('proxy_settings')}

--- a/packages/frontend/src/components/dialogs/QrCodeCopyConfirmationDialog.tsx
+++ b/packages/frontend/src/components/dialogs/QrCodeCopyConfirmationDialog.tsx
@@ -41,11 +41,7 @@ export default function QrCodeCopyConfirmationDialog({
   }
 
   return (
-    <Dialog
-      onClose={onClose}
-      canEscapeKeyClose={true}
-      canOutsideClickClose={true}
-    >
+    <Dialog onClose={onClose} closedby='any'>
       <DialogBody>
         <DialogContent>
           <p>{message}</p>

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupProgressDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/ReceiveBackupProgressDialog.tsx
@@ -73,7 +73,7 @@ export function ReceiveBackupProgressDialog({
     <DialogWithHeader
       onClose={onClose}
       title={tx('multidevice_receiver_title')}
-      canOutsideClickClose={false}
+      closedby='closerequest'
     >
       <DialogBody>
         <DialogContent>

--- a/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
+++ b/packages/frontend/src/components/dialogs/SetupMultiDevice/SendBackupDialog.tsx
@@ -133,12 +133,7 @@ export function SendBackupDialog({ onClose }: DialogProps) {
   }, [onClose, openConfirmationDialog, stage, tx, wasCopied])
 
   return (
-    <Dialog
-      canEscapeKeyClose={true}
-      canOutsideClickClose={false}
-      onClose={cancel}
-      width={500}
-    >
+    <Dialog closedby='closerequest' onClose={cancel} width={500}>
       <DialogHeader
         title={tx('multidevice_title')}
         onClose={cancel}

--- a/packages/frontend/src/components/dialogs/Transports/index.tsx
+++ b/packages/frontend/src/components/dialogs/Transports/index.tsx
@@ -161,7 +161,7 @@ export default function TransportsDialog(
       onClose={onClose}
       width={500}
       dataTestid='transports-dialog'
-      canOutsideClickClose={true}
+      closedby='any'
     >
       <DialogHeader
         title={tx('transports')}

--- a/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
+++ b/packages/frontend/src/components/dialogs/ViewGroup/index.tsx
@@ -643,12 +643,7 @@ function ShowQRDialog({
   const tx = useTranslationFunction()
 
   return (
-    <Dialog
-      onClose={onClose}
-      canOutsideClickClose={true}
-      fixed
-      dataTestid='group-invite-qr'
-    >
+    <Dialog onClose={onClose} closedby='any' fixed dataTestid='group-invite-qr'>
       <DialogHeader title={tx('qrshow_title')} onClose={onClose} />
       <QrCodeShowQrInner
         qrCode={qrCode}
@@ -706,7 +701,11 @@ function EditGroupNameDialog({
     groupImage !== initialGroupImage
 
   return (
-    <Dialog onClose={onClose} canOutsideClickClose={!haveUnsavedChanges} fixed>
+    <Dialog
+      onClose={onClose}
+      closedby={haveUnsavedChanges ? 'closerequest' : 'any'}
+      fixed
+    >
       <DialogHeader title={!isBroadcast ? tx('tab_group') : tx('channel')} />
       <form action={onClickOk}>
         <DialogBody>

--- a/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
+++ b/packages/frontend/src/components/dialogs/ViewProfile/menu.tsx
@@ -172,7 +172,11 @@ function EditContactNameDialog({
   const haveUnsavedChanges = contactName !== initialGroupName
 
   return (
-    <Dialog canOutsideClickClose={!haveUnsavedChanges} fixed onClose={onClose}>
+    <Dialog
+      closedby={haveUnsavedChanges ? 'closerequest' : 'any'}
+      fixed
+      onClose={onClose}
+    >
       <DialogHeader title={tx('menu_edit_name')} />
       <DialogBody>
         <DialogContent>

--- a/packages/frontend/src/components/screens/AccountDeletionScreen/AccountDeletionScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountDeletionScreen/AccountDeletionScreen.tsx
@@ -60,7 +60,7 @@ export default function AccountDeletionScreen({
     <div className={styles.AccountDeletionScreen}>
       <ImageBackdrop variant='deletion'>
         <Dialog
-          canEscapeKeyClose={true}
+          closedby='any'
           backdropDragAreaOnTauriRuntime
           fixed={true}
           onClose={onCancel}

--- a/packages/frontend/src/components/screens/AccountSetupScreen.tsx
+++ b/packages/frontend/src/components/screens/AccountSetupScreen.tsx
@@ -100,7 +100,7 @@ export default function AccountSetupScreen({
 
   return (
     <ImageBackdrop variant='welcome'>
-      <Dialog canOutsideClickClose={false} onClose={() => {}} fixed>
+      <Dialog closedby='closerequest' onClose={() => {}} fixed>
         <DialogHeader title={tx('manual_account_setup_option')} />
         <DialogBody>
           <DialogContent>

--- a/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
+++ b/packages/frontend/src/components/screens/WelcomeScreen/index.tsx
@@ -68,9 +68,8 @@ export default function WelcomeScreen({ selectedAccountId, ...props }: Props) {
       <Dialog
         fixed
         width={400}
-        canEscapeKeyClose={hasConfiguredAccounts}
+        closedby={hasConfiguredAccounts ? 'closerequest' : 'none'}
         backdropDragAreaOnTauriRuntime
-        canOutsideClickClose={false}
         onClose={onClose}
         dataTestid='onboarding-dialog'
         allowDefaultFocus={true}


### PR DESCRIPTION
This is mostly a refactor, but also a fix to the bug
where doing `mousedown` on a dialog
and then `mouseup` on its backdrop would still close the dialog.

Also change `LogDialog.closedby` `closerequest` -> `any`,
as desired.

The mapping is simple:
- `closedby='any'` when
  `canOutsideClickClose === true && canEscapeKeyClose === true`
  (default)
- `closedby='closerequest'` when
  `canOutsideClickClose === false && canEscapeKeyClose === true`
- `closedby='none'` when
  `canOutsideClickClose === false && canEscapeKeyClose === false`

This also makes "Back" work as "Escape" (good for mobile devices).

I have tested that this doesn't re-introduce
the "double Escape always closes the dialog" bug
(2bc987abc41a542ccbc12a20029b0e42d5ee2f46,
https://github.com/deltachat/deltachat-desktop/issues/4397).
One can test this on the "progress" dialog when making a new account.

Note that `HTMLDialogElement.closedby` is not yet supported
by WebKit (Safari), which is used by Tauri:
https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dialog#closedby