### PR TITLE
refactor: unify account dir in target browser

### DIFF
--- a/docs/CLI_FLAGS.md
+++ b/docs/CLI_FLAGS.md
@@ -25,7 +25,8 @@ useful env vars you can set:
 | Variable (sometimes with value) | Effect |
 | ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `NODE_OPTIONS=--enable-source-maps` | Make stacktraces in errors useful by enabling source map support in the main process |
-| `DC_TEST_DIR=<dir>` | specify an alternative data directory |
+| `DC_TEST_DIR=<dir>` | specify an alternative data directory (electron target) |
+| `DATA_DIR=<dir>` | specify an alternative data directory (browser target) |
 | `DELTACHAT_LOCALE_DIR=<path>` | allows to specify an alternative translation data directory in development, the intended purpose is to be used together with `--translation-watch` [^1] |
 
 Most env vars can be set in .env files. Look fo a env.example in the related package for more info.

--- a/packages/target-browser/.env.example
+++ b/packages/target-browser/.env.example
@@ -5,3 +5,10 @@ WEB_PASSWORD=
 # optional
 # with NODE_ENV=test the server skips the above mentioned authentication
 NODE_ENV=
+
+# optional
+# directory this server instance keeps all its state in:
+# accounts, logs, TLS certificate, background images and runtime data.
+# Relative paths are resolved against the built server (packages/target-browser/dist),
+# the default is packages/target-browser/data
+# DATA_DIR=

--- a/packages/target-browser/src/config.ts
+++ b/packages/target-browser/src/config.ts
@@ -30,9 +30,7 @@ const privateCertPath = process.env['PRIVATE_CERTIFICATE_PATH']
   : join(DATA_DIR, 'certificate')
 export const PRIVATE_CERTIFICATE_KEY = join(privateCertPath, 'cert.key.pem')
 export const PRIVATE_CERTIFICATE_CERT = join(privateCertPath, 'cert.pem')
-export const DC_ACCOUNTS_DIR = process.env['DC_ACCOUNTS_DIR']
-  ? resolvePath(process.env['DC_ACCOUNTS_DIR'])
-  : join(DATA_DIR, 'accounts')
+export const ACCOUNTS_DIR = join(DATA_DIR, 'accounts')
 
 export const LOCALES_DIR = join(__dirname, '../../../_locales')
 

--- a/packages/target-browser/src/deltachat-rpc.ts
+++ b/packages/target-browser/src/deltachat-rpc.ts
@@ -1,5 +1,5 @@
 import { ChildProcessWithoutNullStreams, spawn } from 'child_process'
-import { DC_ACCOUNTS_DIR } from './config'
+import { ACCOUNTS_DIR } from './config'
 import { getRPCServerPath } from '@deltachat/stdio-rpc-server'
 import { BaseDeltaChat, yerpc } from '@deltachat/jsonrpc-client'
 import * as ws from 'ws'
@@ -22,7 +22,7 @@ class StdioServer {
     log.info('using deltachat-rpc-server at', { serverPath })
     this.serverProcess = spawn(serverPath, {
       env: {
-        DC_ACCOUNTS_PATH: DC_ACCOUNTS_DIR,
+        DC_ACCOUNTS_PATH: ACCOUNTS_DIR,
         RUST_LOG: process.env.RUST_LOG,
       },
     })
@@ -225,7 +225,7 @@ export async function startDeltaChat(): Promise<
               request.method === 'export_self_keys') &&
             request.params[1] === '<BROWSER>'
           ) {
-            request.params[1] = join(DC_ACCOUNTS_DIR, 'backups')
+            request.params[1] = join(ACCOUNTS_DIR, 'backups')
             return DCInstance.send(JSON.stringify(request))
           }
         }

--- a/packages/target-browser/src/index.ts
+++ b/packages/target-browser/src/index.ts
@@ -25,7 +25,7 @@ import {
   LOCALES_DIR,
   DATA_DIR,
   LOGS_DIR,
-  DC_ACCOUNTS_DIR,
+  ACCOUNTS_DIR,
   DC_FRONTEND_NO_TLS,
 } from './config'
 import { startDeltaChat } from './deltachat-rpc'
@@ -170,7 +170,7 @@ app.get('/blobs/:accountId/:filename', authMiddleWare, async (req, res) => {
 
 app.get('/download-backup/:filename', authMiddleWare, async (req, res) => {
   const filePath = resolvePath(
-    join(DC_ACCOUNTS_DIR, 'backups'),
+    join(ACCOUNTS_DIR, 'backups'),
     req.params.filename
   )
   res.download(filePath)


### PR DESCRIPTION
It was possible to set DC_ACCOUNTS_DIR in browser .env which breaks e2e tests. So this PR removes that variable and makes only use of DATA_DIR