### PR TITLE
feat: support pinned messages

### DIFF
--- a/_locales/_untranslated_en.json
+++ b/_locales/_untranslated_en.json
@@ -91,5 +91,17 @@
   },
   "webxdc_store_url_explain_2_desktop": {
     "message": "This is different from the same feature on Android and iOS.\nThis must be the path containing the xdcget-lock.json file."
+  },
+  "pinned_message": {
+    "message": "Pinned message"
+  },
+  "pinned_message_position": {
+    "message": "%1$d/%2$d"
+  },
+  "message_pinned_by_you": {
+    "message": "You pinned a message."
+  },
+  "message_pinned_by_other": {
+    "message": "Message pinned by %1$s."
   }
 }

--- a/packages/frontend/scss/message/_message.scss
+++ b/packages/frontend/scss/message/_message.scss
@@ -260,6 +260,14 @@ $info-text-max-width: 400px;
       );
     }
 
+    .pinned-message-icon {
+      @include mixins.color-svg(
+        './images/pin.svg',
+        var(--messageMetadataIconColorIncoming),
+        100%
+      );
+    }
+
     .date,
     .edited,
     .viewCount {
@@ -309,6 +317,14 @@ $info-text-max-width: 400px;
     .saved-message-icon {
       @include mixins.color-svg(
         './images/icons/bookmark-filled.svg',
+        var(--messageMetadataIconColorOutgoing),
+        100%
+      );
+    }
+
+    .pinned-message-icon {
+      @include mixins.color-svg(
+        './images/pin.svg',
         var(--messageMetadataIconColorOutgoing),
         100%
       );
@@ -402,6 +418,10 @@ $info-text-max-width: 400px;
         white,
         100%
       );
+    }
+
+    .pinned-message-icon {
+      @include mixins.color-svg('./images/pin.svg', white, 100%);
     }
   }
 

--- a/packages/frontend/scss/message/_metadata.scss
+++ b/packages/frontend/scss/message/_metadata.scss
@@ -35,6 +35,10 @@
       );
     }
 
+    .pinned-message-icon {
+      @include mixins.color-svg('./images/pin.svg', white, 100%);
+    }
+
     .status-icon.sending {
       background-color: white;
     }
@@ -93,12 +97,14 @@
   .location-icon,
   .email-icon,
   .saved-message-icon,
+  .pinned-message-icon,
   .viewCountIcon {
     display: inline-block;
   }
   .location-icon,
   .email-icon,
-  .saved-message-icon {
+  .saved-message-icon,
+  .pinned-message-icon {
     width: 12px;
     height: 12px;
     margin-inline-end: 4px;

--- a/packages/frontend/src/components/ChatView/ChatView.tsx
+++ b/packages/frontend/src/components/ChatView/ChatView.tsx
@@ -1,5 +1,12 @@
 import styles from './styles.module.scss'
-import React, { useCallback, useContext, useId, useMemo } from 'react'
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+} from 'react'
 import { C } from '@deltachat/jsonrpc-client'
 
 import MessageListAndComposer from '../message/MessageListAndComposer'
@@ -9,7 +16,7 @@ import { RecoverableCrashScreen } from '../screens/RecoverableCrashScreen'
 import { Avatar } from '../Avatar'
 import MailingListProfile from '../dialogs/MailingListProfile'
 import { useDesktopSettingsStore } from '../../stores/settings'
-import { BackendRemote } from '../../backend-com'
+import { BackendRemote, onDCEvent } from '../../backend-com'
 import Button from '../Button'
 import Icon, { IconButton } from '../Icon'
 import useDialog from '../../hooks/dialog/useDialog'
@@ -149,6 +156,7 @@ export function ChatViewInner({
           <ChatNavButtons chat={chatWithLinger} lastUsedApps={lastUsedApps} />
         )}
       </nav>
+      <PinnedMessageBar accountId={accountId} chatId={chatWithLinger.id} />
       <RecoverableCrashScreen reset_on_change_key={chatWithLinger.id}>
         <MessageMultiselectContext.Provider
           value={focusAndMultiselectContextValue}
@@ -161,6 +169,191 @@ export function ChatViewInner({
         </MessageMultiselectContext.Provider>
       </RecoverableCrashScreen>
     </>
+  )
+}
+
+type PinnedMessagesState = {
+  ids: number[]
+  activeId: number | null
+}
+
+function PinnedMessageBar({
+  accountId,
+  chatId,
+}: {
+  accountId: number
+  chatId: number
+}) {
+  const tx = useTranslationFunction()
+  const { jumpToMessage } = useMessage()
+  const [pinnedMessages, setPinnedMessages] = useState<PinnedMessagesState>({
+    ids: [],
+    activeId: null,
+  })
+  const [loadedMessage, setLoadedMessage] = useState<{
+    id: number
+    message: T.Message
+  } | null>(null)
+
+  const reloadPinnedMessages = useCallback(async () => {
+    try {
+      const ids = await BackendRemote.rpc.getPinnedMessages(accountId, chatId)
+      setPinnedMessages(previous => {
+        const hasNewMessage = ids.some(id => !previous.ids.includes(id))
+        const keepActiveMessage =
+          previous.activeId !== null && ids.includes(previous.activeId)
+        const activeId =
+          ids.length === 0
+            ? null
+            : hasNewMessage || !keepActiveMessage
+              ? ids[ids.length - 1]
+              : previous.activeId
+
+        return { ids, activeId }
+      })
+    } catch (error) {
+      log.error('Could not load pinned messages', error)
+    }
+  }, [accountId, chatId])
+
+  useEffect(() => {
+    const initialReloadTimeout = window.setTimeout(() => {
+      void reloadPinnedMessages()
+    }, 0)
+
+    const cleanup = [
+      onDCEvent(accountId, 'MsgsChanged', event => {
+        if (event.chatId === chatId) {
+          void reloadPinnedMessages()
+        }
+      }),
+      onDCEvent(accountId, 'IncomingMsg', event => {
+        if (event.chatId === chatId) {
+          void reloadPinnedMessages()
+        }
+      }),
+    ]
+    return () => {
+      window.clearTimeout(initialReloadTimeout)
+      cleanup.forEach(removeListener => removeListener())
+    }
+  }, [accountId, chatId, reloadPinnedMessages])
+
+  const activeId = pinnedMessages.activeId
+  useEffect(() => {
+    let outdated = false
+    if (activeId === null) {
+      return
+    }
+
+    BackendRemote.rpc
+      .getMessage(accountId, activeId)
+      .then(message => {
+        if (!outdated) {
+          setLoadedMessage({ id: activeId, message })
+        }
+      })
+      .catch(error => {
+        if (!outdated) {
+          log.error('Could not load pinned message', error)
+        }
+      })
+
+    return () => {
+      outdated = true
+    }
+  }, [accountId, activeId])
+
+  const activeMessage =
+    loadedMessage?.id === activeId ? loadedMessage.message : null
+
+  const summary = useMemo(() => {
+    if (activeMessage === null) {
+      return tx('loading')
+    }
+    if (activeMessage.text.trim()) {
+      return activeMessage.text.trim()
+    }
+    if (activeMessage.fileName) {
+      return activeMessage.fileName
+    }
+
+    switch (activeMessage.viewType) {
+      case 'Image':
+        return tx('image')
+      case 'Gif':
+        return tx('gif')
+      case 'Sticker':
+        return tx('sticker')
+      case 'Audio':
+        return tx('audio')
+      case 'Voice':
+        return tx('voice_message')
+      case 'Video':
+        return tx('video')
+      case 'File':
+        return tx('file')
+      case 'Webxdc':
+        return tx('webxdc_app')
+      case 'Vcard':
+        return tx('contact')
+      case 'Call':
+      case 'Text':
+      case 'Unknown':
+        return tx('pinned_message')
+    }
+  }, [activeMessage, tx])
+
+  const activeIndex =
+    activeId === null ? -1 : pinnedMessages.ids.indexOf(activeId)
+  if (activeId === null || activeIndex < 0) {
+    return null
+  }
+
+  const position = tx('pinned_message_position', [
+    String(activeIndex + 1),
+    String(pinnedMessages.ids.length),
+  ])
+  const showCurrentPinnedMessage = async () => {
+    try {
+      await jumpToMessage({
+        accountId,
+        msgId: activeId,
+        msgChatId: chatId,
+        focus: true,
+        scrollIntoViewArg: { block: 'center' },
+      })
+
+      setPinnedMessages(previous => {
+        const index = previous.ids.indexOf(activeId)
+        if (index < 0) {
+          return previous
+        }
+        const nextIndex = index === 0 ? previous.ids.length - 1 : index - 1
+        return { ...previous, activeId: previous.ids[nextIndex] }
+      })
+    } catch (error) {
+      log.error('Could not jump to pinned message', error)
+    }
+  }
+
+  return (
+    <button
+      type='button'
+      className={styles.pinnedMessageBar}
+      onClick={() => void showCurrentPinnedMessage()}
+      aria-label={`${tx('pinned_message')}: ${summary}, ${position}`}
+      title={tx('show_in_chat')}
+    >
+      <span className={styles.pinnedMessageIcon} aria-hidden='true' />
+      <span className={styles.pinnedMessageContent}>
+        <strong>{tx('pinned_message')}</strong>
+        <span className={styles.pinnedMessageSummary}>{summary}</span>
+      </span>
+      <span className={styles.pinnedMessagePosition} aria-hidden='true'>
+        {position}
+      </span>
+    </button>
   )
 }
 

--- a/packages/frontend/src/components/ChatView/styles.module.scss
+++ b/packages/frontend/src/components/ChatView/styles.module.scss
@@ -1,4 +1,5 @@
 @use '../../../scss/main_screen/_navbar';
+@use '../../../scss/mixins';
 
 .chatAndNavbar {
   display: flex;
@@ -91,6 +92,62 @@
       margin: 0.5rem 1rem;
     }
   }
+}
+
+.pinnedMessageBar {
+  @include mixins.button-reset;
+
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 50px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 7px 14px;
+  border-bottom: var(--outlineProperties);
+  background-color: var(--globalBackground);
+  color: var(--globalText);
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--globalHoverBg);
+  }
+}
+
+.pinnedMessageIcon {
+  @include mixins.color-svg('./images/pin.svg', var(--globalLinkColor));
+
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+}
+
+.pinnedMessageContent {
+  min-width: 0;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+
+  strong {
+    color: var(--globalLinkColor);
+    font-size: 13px;
+    line-height: 18px;
+  }
+}
+
+.pinnedMessageSummary {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 14px;
+  line-height: 18px;
+}
+
+.pinnedMessagePosition {
+  flex-shrink: 0;
+  opacity: 0.7;
+  font-size: 12px;
 }
 
 .webxdcIcons {

--- a/packages/frontend/src/components/message/Message.tsx
+++ b/packages/frontend/src/components/message/Message.tsx
@@ -300,6 +300,13 @@ function buildContextMenu(
   // - https://github.com/deltachat/deltachat-android/blob/52c01976821803fa2d8a177f93576fa4082ef5bd/src/main/java/org/thoughtcrime/securesms/ConversationFragment.java#L332-L332
   const showReply = chat.canSend && !message.isInfo
 
+  const showPin =
+    chat.canSend &&
+    message.id > C.DC_MSG_ID_DAYMARKER &&
+    !message.isInfo &&
+    message.state !== C.DC_STATE_OUT_DRAFT &&
+    message.state !== C.DC_STATE_OUT_FAILED
+
   // See
   // - https://github.com/deltachat/deltachat-desktop/issues/4695.
   // - https://github.com/deltachat/deltachat-desktop/issues/5365.
@@ -358,6 +365,16 @@ function buildContextMenu(
           ])
         }
       },
+    },
+    // Pin or unpin for every participant and every device in this chat.
+    showPin && {
+      label: tx(message.isPinned ? 'unpin' : 'pin'),
+      action: () =>
+        BackendRemote.rpc.setPinnedMessageState(
+          accountId,
+          message.id,
+          !message.isPinned
+        ),
     },
     // Send emoji reaction
     showSendReaction && {
@@ -501,11 +518,17 @@ export default function Message(props: {
   conversationType: ConversationType
 }) {
   const { message, conversationType, chat } = props
-  const { viewType, text, hasLocation, hasHtml } = message
+  const { viewType, hasLocation, hasHtml } = message
   const direction = getDirection(message)
   const status = mapCoreMsgStatus2String(message.state)
 
   const tx = useTranslationFunction()
+  const text =
+    message.systemMessageType === 'MessagePinned'
+      ? message.fromId === C.DC_CONTACT_ID_SELF
+        ? tx('message_pinned_by_you')
+        : tx('message_pinned_by_other', message.sender.displayName)
+      : message.text
   const accountId = selectedAccountId()
 
   const { showReactionsBar } = useReactionsBar()
@@ -1096,6 +1119,7 @@ export default function Message(props: {
               timestamp={message.timestamp * 1000}
               encrypted={message.showPadlock}
               isSavedMessage={isOrHasSavedMessage}
+              isPinned={message.isPinned}
               onClickError={() =>
                 openDialog(AlertDialog, {
                   message: message.error

--- a/packages/frontend/src/components/message/MessageMetaData.tsx
+++ b/packages/frontend/src/components/message/MessageMetaData.tsx
@@ -29,6 +29,7 @@ type Props = {
   viewType: T.Viewtype
   chatType: T.ChatType
   isSavedMessage: boolean
+  isPinned: boolean
 }
 
 export default function MessageMetaData(props: Props) {
@@ -50,6 +51,7 @@ export default function MessageMetaData(props: Props) {
     viewType,
     chatType,
     isSavedMessage,
+    isPinned,
   } = props
 
   return (
@@ -81,6 +83,12 @@ export default function MessageMetaData(props: Props) {
       >
         {isSavedMessage && (
           <div aria-label={tx('saved')} className={'saved-message-icon'} />
+        )}
+        {isPinned && (
+          <div
+            aria-label={tx('pinned_message')}
+            className={'pinned-message-icon'}
+          />
         )}
       </div>
       {hasLocation && <span className={'location-icon'} />}

--- a/packages/frontend/src/stockStrings.ts
+++ b/packages/frontend/src/stockStrings.ts
@@ -29,8 +29,6 @@ export async function updateCoreStrings() {
 
     // No string for these upstream yet. TODO.
     | typeof C.DC_STR_PHASING_OUT
-    | typeof C.DC_STR_MESSAGE_PINNED_BY_OTHER
-    | typeof C.DC_STR_MESSAGE_PINNED_BY_YOU
     | typeof C.DC_STR_ADD_YOU
     | typeof C.DC_STR_ADD_YOU_BY
     | typeof C.DC_STR_REMOVE_YOU
@@ -193,6 +191,8 @@ export async function updateCoreStrings() {
     [C.DC_STR_CHANNEL_IMAGE_CHANGED]: tx('channel_image_changed'),
     [C.DC_STR_CHANNEL_NAME_CHANGED]: tx('channel_name_changed'),
     [C.DC_STR_MESSAGES_ARE_E2EE]: tx('messages_are_e2ee'),
+    [C.DC_STR_MESSAGE_PINNED_BY_YOU]: tx('message_pinned_by_you'),
+    [C.DC_STR_MESSAGE_PINNED_BY_OTHER]: tx('message_pinned_by_other'),
   }
 
   await BackendRemote.rpc.setStockStrings(strings)


### PR DESCRIPTION
## Summary

- add pin/unpin actions backed by the core pinned-message state, so pins stay shared across devices and participants
- show pinned-message indicators and a chat-top banner with navigation between pinned messages
- localize pin info messages and register the new core stock strings
- add English source keys to `_untranslated_en.json` for the regular translation workflow

## Testing

- `pnpm check:types`
- ESLint on the changed TypeScript files
- Prettier check on all changed files
- `pnpm build:electron`