### PR TITLE
remove: unused userFeedback

### DIFF
--- a/packages/frontend/scss/_global.scss
+++ b/packages/frontend/scss/_global.scss
@@ -1,4 +1,3 @@
-@use 'sass:map';
 @use 'variables';
 
 * {
@@ -128,36 +127,6 @@ code {
   background-color: rgba(0, 0, 0, 0.25);
   border-radius: 0.8pt;
   padding: 0.4pt 3pt;
-}
-
-// toast for errors and success messages
-.user-feedback {
-  position: fixed;
-  top: 60px;
-  text-align: center;
-  width: 100%;
-  z-index: map.get(variables.$z-index, user-feedback);
-  pointer-events: none;
-
-  p {
-    display: inline-block;
-    text-align: center;
-    font-style: italic;
-    font-weight: bold;
-    padding: 10px 15px;
-    background-color: #696868;
-    border-radius: 50px;
-    color: white;
-    font-size: medium;
-    max-width: 90%;
-    pointer-events: all;
-  }
-  &.error p {
-    background-color: #b73a3a;
-  }
-  &.success p {
-    background-color: #415e6b;
-  }
 }
 
 .crash-screen {

--- a/packages/frontend/scss/_variables.scss
+++ b/packages/frontend/scss/_variables.scss
@@ -44,11 +44,8 @@ $z-index: (
   // ============
   emoji-sticker-picker: 10,
 
-  user-feedback: 100,
-
   account-hover-info: 200,
 
-  // toast for errors and success messages
   absolute-positioning-helper: 1000
 );
 

--- a/packages/frontend/src/ScreenController.tsx
+++ b/packages/frontend/src/ScreenController.tsx
@@ -27,11 +27,6 @@ import { NextVoiceMessagePlayerProvider } from './contexts/NextVoiceMessagePlaye
 
 const log = getLogger('renderer/ScreenController')
 
-export interface userFeedback {
-  type: 'error' | 'success'
-  text: string
-}
-
 export enum Screens {
   Welcome = 'welcome',
   Main = 'main',
@@ -49,7 +44,6 @@ function isSmallScreenMode(): boolean {
 
 export default class ScreenController extends Component {
   state: {
-    message: userFeedback | false
     screen: Screens
     smallScreenMode: boolean
   }
@@ -60,13 +54,10 @@ export default class ScreenController extends Component {
   constructor(public props: {}) {
     super(props)
     this.state = {
-      message: false,
       screen: Screens.Loading,
       smallScreenMode: isSmallScreenMode(),
     }
 
-    this.userFeedback = this.userFeedback.bind(this)
-    this.userFeedbackClick = this.userFeedbackClick.bind(this)
     this.changeScreen = this.changeScreen.bind(this)
     this.addAndSelectAccount = this.addAndSelectAccount.bind(this)
     this.selectAccount = this.selectAccount.bind(this)
@@ -76,7 +67,6 @@ export default class ScreenController extends Component {
     this.onExitWelcomeScreen = this.onExitWelcomeScreen.bind(this)
     this.updateSmallScreenMode = this.updateSmallScreenMode.bind(this)
 
-    window.__userFeedback = this.userFeedback.bind(this)
     window.__changeScreen = this.changeScreen.bind(this)
     window.__selectAccount = this.selectAccount.bind(this)
     window.__screen = this.state.screen
@@ -238,28 +228,10 @@ export default class ScreenController extends Component {
     this.changeScreen(Screens.NoAccountSelected)
   }
 
-  userFeedback(message: userFeedback | false, clickToClose = false) {
-    if (message !== false && this.state.message === message) return // one at a time, cowgirl
-    this.setState({ message })
-    if (!clickToClose && message && message.type !== 'error') {
-      window.setTimeout(() => {
-        this.userFeedback(false)
-      }, 3000)
-    }
-  }
-
-  userFeedbackClick() {
-    this.userFeedback(false)
-  }
-
   changeScreen(screen: Screens) {
     log.debug('Changing screen to:', screen)
     this.setState({ screen })
     window.__screen = screen
-    if (Screens.Welcome) {
-      // remove user feedback error message - https://github.com/deltachat/deltachat-desktop/issues/2261
-      this.userFeedback(false)
-    }
   }
 
   updateSmallScreenMode() {
@@ -337,17 +309,8 @@ export default class ScreenController extends Component {
   render() {
     return (
       <div data-testid={`selected-account:${this.selectedAccountId}`}>
-        {this.state.message && (
-          <div
-            onClick={this.userFeedbackClick}
-            className={`user-feedback ${this.state.message.type}`}
-          >
-            <p>{this.state.message.text}</p>
-          </div>
-        )}
         <ScreenContext.Provider
           value={{
-            userFeedback: this.userFeedback,
             changeScreen: this.changeScreen,
             screen: this.state.screen,
             smallScreenMode: this.state.smallScreenMode,

--- a/packages/frontend/src/contexts/ScreenContext.tsx
+++ b/packages/frontend/src/contexts/ScreenContext.tsx
@@ -1,9 +1,8 @@
 import { createContext } from 'react'
 
-import type { Screens, userFeedback } from '../ScreenController'
+import type { Screens } from '../ScreenController'
 
 export const ScreenContext = createContext({
-  userFeedback: (_message: false | userFeedback) => {},
   changeScreen: (_screen: Screens) => {},
   screen: null as Screens | null,
   smallScreenMode: false as boolean,

--- a/packages/frontend/src/global.d.ts
+++ b/packages/frontend/src/global.d.ts
@@ -1,4 +1,4 @@
-import { userFeedback, Screens } from './ScreenController'
+import { Screens } from './ScreenController'
 
 import '@deltachat-desktop/shared/global.d.ts'
 import type { useMessageList } from './stores/messagelist'
@@ -7,7 +7,6 @@ import type { T } from '@deltachat/jsonrpc-client'
 declare global {
   interface Window {
     exp: todo
-    __userFeedback: (message: userFeedback | false) => void
     __changeScreen: (screen: Screens) => void
     __selectAccount: (accountId: number) => Promise<void>
     readonly __selectedAccountId: number | undefined


### PR DESCRIPTION
We want to get rid of userFeedback since quite some time. It is often displayed behind the backdrop of dialogs and it is not clear how to close it and the core errors were often thrown async and with no useful error message wich confused the user.

Some of the userFeedback were moved to a dialog (delete message error, send empty message on edit, backup success),

Core errors are now not shown at all in the UI - same as on Android/iOS

Following issues might need a better solution:

- [ ] showing an additional dialog after copy-to-clipboard action in QR dialog might be superfluous
- [ ] showing an error dialog after submitting an empty message when editing might be superfluous
- [ ] ErrorSelfNotInGroup should be handled in all neccessary scenarios see #6703
