### PR TITLE
fix: return focus on programmatic dialog close

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -592,6 +592,7 @@ test('correct handling of changed profile displaynames', async () => {
   await page.getByTestId('edit-contact-name').click()
   await page.getByTestId('edit-contact-name-input').fill(contactNameGivenByMe)
   await page.getByTestId('ok').click()
+  await expect(page.locator('#view-profile-menu')).toBeFocused()
   await page.getByTestId('dialog-header-close').click()
   // profile shows the name I gave to the contact
   await expect(chatHeading).toContainText(contactNameGivenByMe)

--- a/packages/e2e-tests/tests/qrcode-tests.spec.ts
+++ b/packages/e2e-tests/tests/qrcode-tests.spec.ts
@@ -236,6 +236,7 @@ test('onboarding with manual credentials', async ({ browserName }) => {
   expect(addressFromSettings).toEqual(address)
   await page.getByTestId('cancel').click()
   await page.getByTestId('transports-settings-close').click()
+  await expect(page.getByTestId('open-transport-settings')).toBeFocused()
   await page.getByTestId('settings-advanced-close').click()
   // needed in deleteAllProfiles
   existingProfiles.push({

--- a/packages/frontend/src/components/Dialog/Dialog.tsx
+++ b/packages/frontend/src/components/Dialog/Dialog.tsx
@@ -119,6 +119,7 @@ const Dialog = React.memo<Props>(
         }
       }
     }, [allowDefaultFocus])
+    // Make sure to properly close the dialog before it's removed from DOM.
     // This ensures that the focus is returned to the element which had focus
     // before the dialog was opened, not only on "Escape" key close
     // but also on programmatic `onClose`, which simply un-renders the <dialog>

--- a/packages/frontend/src/components/Dialog/Dialog.tsx
+++ b/packages/frontend/src/components/Dialog/Dialog.tsx
@@ -1,5 +1,5 @@
 import classNames from 'classnames'
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useLayoutEffect, useRef } from 'react'
 
 import styles from './styles.module.scss'
 import { runtime } from '@deltachat-desktop/runtime-interface'
@@ -119,6 +119,22 @@ const Dialog = React.memo<Props>(
         }
       }
     }, [allowDefaultFocus])
+    // This ensures that the focus is returned to the element which had focus
+    // before the dialog was opened, not only on "Escape" key close
+    // but also on programmatic `onClose`, which simply un-renders the <dialog>
+    // (see `DialogContext`).
+    // From docs:
+    // > Before your component is removed from the DOM,
+    // > React will run your cleanup function.
+    //
+    // See also
+    // https://github.com/whatwg/html/issues/5802#issuecomment-2207368917
+    useLayoutEffect(() => {
+      const el = dialog.current
+      return () => {
+        el?.close()
+      }
+    }, [])
 
     let style
 


### PR DESCRIPTION
Reproduction steps:
1. Focus the "New Chat" (bug plus) button.
2. Press Space.
3. Focus the "Close" button of the newly opened dialog.

Expected: focus is on the "New Chat" button.
Actual: nothing is focused, pressing tab focuses account list items.

The same goes for other dialogs, such as:
- Reactions
- Scan QR
- Gallery
- Setting

The context menu dialog is not affected by this bug.

This was brought up here:
https://github.com/deltachat/deltachat-desktop/pull/6700#discussion_r3902123858.
