### PR TITLE
refactor: mark `DC_STR_PHASING_OUT` deprecated

### DIFF
--- a/packages/frontend/src/stockStrings.ts
+++ b/packages/frontend/src/stockStrings.ts
@@ -28,7 +28,6 @@ export async function updateCoreStrings() {
     | typeof C.DC_STR_SYNC_MSG_BODY
 
     // No string for these upstream yet. TODO.
-    | typeof C.DC_STR_PHASING_OUT
     | typeof C.DC_STR_MESSAGE_PINNED_BY_OTHER
     | typeof C.DC_STR_MESSAGE_PINNED_BY_YOU
     | typeof C.DC_STR_ADD_YOU
@@ -39,6 +38,7 @@ export async function updateCoreStrings() {
     // Deprecated, see
     // https://github.com/chatmail/core/blob/main/deltachat-ffi/deltachat.h
     | typeof C.DC_STR_E2E_AVAILABLE
+    | typeof C.DC_STR_PHASING_OUT
   >
   const strings: StockStringsSomeOmited = {
     [C.DC_STR_NOMESSAGES]: tx('chat_no_messages'),


### PR DESCRIPTION
Because it is:
https://github.com/chatmail/core/blob/70a01a6813073b614be8d513af20ac3af6a70286/deltachat-ffi/deltachat.h#L7286-L7287
