### PR TITLE
improvement: deleteTransport instead of unpublish

### DIFF
--- a/packages/frontend/src/components/dialogs/Transports/index.tsx
+++ b/packages/frontend/src/components/dialogs/Transports/index.tsx
@@ -135,11 +135,7 @@ export default function TransportsDialog(
         return
       }
 
-      await BackendRemote.rpc.setTransportUnpublished(
-        accountId,
-        transport.addr,
-        true
-      )
+      await BackendRemote.rpc.deleteTransport(accountId, transport.addr)
       getTransports()
     },
     [accountId, getTransports, openConfirmationDialog, tx]


### PR DESCRIPTION
The "unpublush" API will be removed in the upcoming Core:
https://github.com/chatmail/core/commit/70a01a6813073b614be8d513af20ac3af6a70286.

Note that the `confirm_remove_relay_x` string still says
that the relay will be "gradually phased out", this is tracked in
https://github.com/deltachat/deltachat-android/issues/4637.
