### PR TITLE
feat: group notifications by chat

### DIFF
--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -57,6 +57,11 @@ function createNotification(data: DcNotification): Notification {
   }
 
   const notificationOptions: Electron.NotificationConstructorOptions = {
+    groupId:
+      data.chatId !== 0 && data.accountId !== 0
+        ? `account:${data.accountId}_chat:${data.chatId}`
+        : undefined,
+    // groupTitle
     title: data.title,
     // https://www.electronjs.org/docs/latest/tutorial/notifications#linux
     // says

--- a/packages/target-electron/src/notifications.ts
+++ b/packages/target-electron/src/notifications.ts
@@ -61,7 +61,6 @@ function createNotification(data: DcNotification): Notification {
       data.chatId !== 0 && data.accountId !== 0
         ? `account:${data.accountId}_chat:${data.chatId}`
         : undefined,
-    // groupTitle
     title: data.title,
     // https://www.electronjs.org/docs/latest/tutorial/notifications#linux
     // says


### PR DESCRIPTION
FYI this doesn't seem to do much on Windows 10 though.
Probably also need to specify `groupTitle`.
On Linux this also does nothing for now.
