### PR TITLE
improvement: notifications: extraneous app name

### DIFF
--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -1,4 +1,3 @@
-import { appName } from '@deltachat-desktop/shared/constants'
 import { getLogger } from '@deltachat-desktop/shared/logger'
 import { NOTIFICATION_TYPE } from '@deltachat-desktop/shared/constants'
 import { BackendRemote } from '../backend-com'
@@ -167,7 +166,6 @@ async function showNotification(
 
   if (!DesktopSettingsStoreInstance.state?.showNotificationContent) {
     runtime.showNotification({
-      title: appName,
       body: tx('notify_new_message'),
       icon: null,
       chatId,
@@ -263,7 +261,6 @@ async function showGroupedNotification(
 
   if (!DesktopSettingsStoreInstance.state?.showNotificationContent) {
     runtime.showNotification({
-      title: appName,
       body: tx('new_messages'),
       icon: null,
       chatId: 0,

--- a/packages/shared/shared-types.d.ts
+++ b/packages/shared/shared-types.d.ts
@@ -166,7 +166,7 @@ export interface BuildInfo {
 }
 
 export interface DcNotification {
-  title: string
+  title?: string
   body: string
   /**
    * path to image that should be shown instead of icon

--- a/packages/target-browser/runtime-browser/runtime.ts
+++ b/packages/target-browser/runtime-browser/runtime.ts
@@ -460,7 +460,7 @@ class BrowserRuntime implements Runtime {
     }
 
     this.log.info('notify-icon', { icon }) // todo rm
-    const notification = new Notification(title, {
+    const notification = new Notification(title ?? '', {
       body,
       icon,
       tag: `${accountId}.${chatId}.${messageId}`,


### PR DESCRIPTION
The app name is already included in the notification
(tested on Windows and Linux KDE),
so let's not say it twice.

Before / after:

<img width="328" height="86" alt="Screenshot_20260903_before" src="https://github.com/user-attachments/assets/f254851b-64e7-45a0-84f5-bddbc435c8a3" /> <img width="328" height="86" alt="Screenshot_20260903_after" src="https://github.com/user-attachments/assets/f54d979d-db53-4ed6-9a00-de6706e2fa97" />
