### PR TITLE
fix: guard for huge dimensions

### DIFF
--- a/packages/frontend/src/system-integration/notifications.ts
+++ b/packages/frontend/src/system-integration/notifications.ts
@@ -14,6 +14,42 @@ import { C, type T } from '@deltachat/jsonrpc-client'
 const log = getLogger('renderer/notifications')
 
 /**
+ * Notification icons are decoded by the main process, so we prevent images
+ * with absurd dimensions from consuming too much memory - a few kilobytes
+ * of png are enough, because decoding allocates `width * height * 4` bytes.
+ *
+ * Use the same limit core applies to webxdc icons in `get_webxdc_blob`.
+ */
+const MAX_ICON_SIZE = 4096
+
+/**
+ * The renderer reads the dimensions from the image header without
+ * decoding it, so this only costs a load and covers every known format
+ */
+async function checkedIcon(icon: string | null): Promise<string | null> {
+  if (!icon) {
+    return null
+  }
+  const [width, height] = await new Promise<[number, number]>(resolve => {
+    const image = new Image()
+    // on error the dimensions stay 0, which is rejected below
+    const done = () => resolve([image.naturalWidth, image.naturalHeight])
+    image.onload = done
+    image.onerror = done
+    image.src = icon.startsWith('data:') ? icon : runtime.transformBlobURL(icon)
+  })
+  if (width < 1 || height < 1) {
+    log.warn('not using a notification icon that could not be read')
+    return null
+  }
+  if (width > MAX_ICON_SIZE || height > MAX_ICON_SIZE) {
+    log.warn(`not using a notification icon of ${width}x${height}`)
+    return null
+  }
+  return icon
+}
+
+/**
  * Notification handling:
  *
  * - listens for incoming notifications
@@ -249,7 +285,7 @@ async function showNotification(
       runtime.showNotification({
         title: chatName,
         body: summaryPrefix ? `${summaryPrefix}: ${summaryText}` : summaryText,
-        icon,
+        icon: await checkedIcon(icon),
         iconIsAvatar,
         chatId,
         messageId,
@@ -298,7 +334,7 @@ async function showGroupedNotification(
           body: tx('chat_n_new_messages', String(msgCount), {
             quantity: msgCount,
           }),
-          icon: chatProfileImage || null,
+          icon: await checkedIcon(chatProfileImage || null),
           chatId: chatIds[0],
           messageId: 0, // just select chat on click, no specific message
           accountId,


### PR DESCRIPTION
If an image has (extrem) huge dimensions decoding it in the main process as NativeImage might cause memory issues since decoding allocates `width * height * 4` bytes and there is no memory limit in the main process

Using the renderer to get the natural dimensions is the cheapest way to check these values

