### PR TITLE
fix: close all dialogs when switching accounts

### DIFF
--- a/packages/e2e-tests/tests/basic-tests.spec.ts
+++ b/packages/e2e-tests/tests/basic-tests.spec.ts
@@ -617,6 +617,28 @@ test('correct handling of changed profile displaynames', async () => {
   ).toBeVisible()
 })
 
+test('switching profile closes dialogs of the previous profile', async () => {
+  const userA = getUser(0, existingProfiles)
+  const userB = getUser(1, existingProfiles)
+  await switchToProfile(page, userA.id)
+  await selectChat(page, userB.name)
+
+  await page.getByRole('button', { name: 'Apps & Media' }).click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+
+  // While a modal dialog is open, the account sidebar can't be clicked,
+  // so call window.__selectAccount with another accountId directly
+  await page.evaluate(
+    accountId => (window as any).__selectAccount(Number(accountId)),
+    userB.id
+  )
+  await expect(page.getByTestId(`selected-account:${userB.id}`)).toHaveCount(1)
+
+  // The dialog belongs to the previous profile, so it must not stay open,
+  // see https://github.com/deltachat/deltachat-desktop/issues/6602
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+})
+
 test('delete profiles', async () => {
   if (existingProfiles.length < 1) {
     throw new Error('Not existing profiles to delete!')

--- a/packages/frontend/src/ScreenController.tsx
+++ b/packages/frontend/src/ScreenController.tsx
@@ -161,6 +161,10 @@ export default class ScreenController extends Component {
       return
     }
 
+    // All dialogs should be closed when switching accounts
+    // as long as we do not update account related state in dialogs
+    window.__closeAllDialogs?.()
+
     // Since we automatically invalidate `chatId` when `accountId` changes
     // in `ChatContext`, one might think that it's not necessary
     // to explicitly `unselectChat()` here.


### PR DESCRIPTION
resolves #6602